### PR TITLE
fix(ci): add issues permission for Release-Please label creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   release-please:


### PR DESCRIPTION
## 🔧 Permission Fix

### 📋 問題
Release-Pleaseワークフローで以下のエラーが発生:
```
You do not have permission to create labels on this repository
```

### ✅ 解決策
GitHub ActionsのpermissionsにIssues権限を追加:
```yaml
permissions:
  contents: write
  pull-requests: write
  issues: write  # ← 追加
```

### 🎯 効果
- ✅ Release-Pleaseがラベル作成可能に
- ✅ Release PRの自動作成が完全動作

この修正により、Release-Pleaseワークフローが正常に完了します。