### PR TITLE
feat(ui): エクスポート/リビルドの進捗表示・連打防止

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -25,11 +25,13 @@ import type { Options } from './components/Popup'
 import type { HandLogEvent } from './types/hand-log'
 import type {
   ChromeMessage,
+  ExportProgressMessage,
   HandLogEventMessage,
   ImportProgressMessage,
   ImportStatusMessage,
   LatestStatsMessage,
-  MessageResponse
+  MessageResponse,
+  RebuildProgressMessage
 } from './types/messages'
 import { firebaseAuthService } from './services/firebase-auth-service'
 import { autoSyncService } from './services/auto-sync-service'
@@ -80,6 +82,17 @@ interface ImportSession {
   fileName: string
 }
 let currentImportSession: ImportSession | null = null
+
+interface OperationState {
+  type: 'idle' | 'export' | 'import' | 'rebuild'
+  format?: 'json' | 'pokerstars'
+  progress?: number
+  processed?: number
+  total?: number
+  message?: string
+}
+
+let currentOperationState: OperationState = { type: 'idle' }
 
 let lastKnownStats: PlayerStats[] = []
 
@@ -359,6 +372,9 @@ chrome.runtime.onMessage.addListener((request: ChromeMessage, sender: chrome.run
         sendResponse({ success: false, error: error.message })
       })
     return true
+  } else if (request.action === 'getOperationState') {
+    sendResponse({ success: true, operationState: currentOperationState })
+    return true
   }
   return false
 })
@@ -378,6 +394,7 @@ const exportData = async (format: string) => {
  */
 const importData = async (jsonlData: string): Promise<{ successCount: number, totalLines: number, duplicateCount: number }> => {
   try {
+    currentOperationState = { type: 'import', progress: 0 }
     console.log('[importData] Starting optimized import process with direct entity generation')
     const startTime = performance.now()
 
@@ -495,6 +512,7 @@ const importData = async (jsonlData: string): Promise<{ successCount: number, to
 
       // Send progress update
       const progress = Math.round((processed / lines.length) * 100)
+      currentOperationState = { type: 'import', progress, processed, total: lines.length }
       chrome.runtime.sendMessage<ImportProgressMessage>({
         action: 'importProgress',
         progress: progress,
@@ -613,9 +631,11 @@ const importData = async (jsonlData: string): Promise<{ successCount: number, to
       }
     }
 
+    currentOperationState = { type: 'idle' }
     return { successCount, totalLines: lines.length, duplicateCount }
 
   } catch (error) {
+    currentOperationState = { type: 'idle' }
     console.error('Import error:', error)
     throw error
   }
@@ -623,6 +643,14 @@ const importData = async (jsonlData: string): Promise<{ successCount: number, to
 
 const exportJsonData = async (db: PokerChaseDB) => {
   try {
+    currentOperationState = { type: 'export', format: 'json', progress: 0 }
+    chrome.runtime.sendMessage<ExportProgressMessage>({
+      action: 'exportProgress',
+      state: 'started',
+      format: 'json',
+      message: 'NDJSONエクスポート開始...'
+    }).catch(() => {})
+
     const totalCount = await db.apiEvents.count()
     console.log(`[Export] Exporting ${totalCount} events...`)
     
@@ -647,6 +675,19 @@ const exportJsonData = async (db: PokerChaseDB) => {
       const lastEvent = chunk[chunk.length - 1]!
       lastKey = [lastEvent.timestamp, lastEvent.ApiTypeId]
       
+      const progress = Math.round((processedCount / totalCount) * 100)
+      const progressMessage = `エクスポート中... ${processedCount.toLocaleString()}/${totalCount.toLocaleString()} (${progress}%)`
+      currentOperationState = { type: 'export', format: 'json', progress, processed: processedCount, total: totalCount, message: progressMessage }
+      chrome.runtime.sendMessage<ExportProgressMessage>({
+        action: 'exportProgress',
+        state: 'processing',
+        format: 'json',
+        progress,
+        processed: processedCount,
+        total: totalCount,
+        message: progressMessage
+      }).catch(() => {})
+
       if (processedCount % 50000 === 0 || processedCount >= totalCount) {
         console.log(`[Export] Processed ${processedCount}/${totalCount} events`)
       }
@@ -663,19 +704,64 @@ const exportJsonData = async (db: PokerChaseDB) => {
     )
     
     console.log(`[Export] Export completed: ${processedCount} events (${(jsonlContent.length / 1024 / 1024).toFixed(1)}MB)`)
+    
+    currentOperationState = { type: 'idle' }
+    chrome.runtime.sendMessage<ExportProgressMessage>({
+      action: 'exportProgress',
+      state: 'completed',
+      format: 'json',
+      progress: 100,
+      processed: processedCount,
+      total: totalCount,
+      message: `NDJSONエクスポート完了: ${processedCount.toLocaleString()}件`
+    }).catch(() => {})
   } catch (error) {
     console.error('[Export] Export failed:', error)
+    currentOperationState = { type: 'idle' }
+    chrome.runtime.sendMessage<ExportProgressMessage>({
+      action: 'exportProgress',
+      state: 'error',
+      format: 'json',
+      message: `NDJSONエクスポート失敗: ${error}`
+    }).catch(() => {})
     throw error
   }
 }
 
 const exportPokerStarsData = async () => {
   try {
+    currentOperationState = { type: 'export', format: 'pokerstars', progress: 0 }
+    chrome.runtime.sendMessage<ExportProgressMessage>({
+      action: 'exportProgress',
+      state: 'started',
+      format: 'pokerstars',
+      message: 'PokerStarsエクスポート開始...'
+    }).catch(() => {})
+
     // Get the last session's hand history
-    const handHistory = await service.exportHandHistory()
+    const handHistory = await service.exportHandHistory(undefined, (processed, total) => {
+      const progress = Math.round((processed / total) * 100)
+      chrome.runtime.sendMessage<ExportProgressMessage>({
+        action: 'exportProgress',
+        state: 'processing',
+        format: 'pokerstars',
+        progress,
+        processed,
+        total,
+        message: `ハンドヒストリー変換中... ${processed.toLocaleString()}/${total.toLocaleString()} (${progress}%)`
+      }).catch(() => {})
+      currentOperationState = { type: 'export', format: 'pokerstars', progress, processed, total, message: `ハンドヒストリー変換中... ${processed}/${total} (${progress}%)` }
+    })
 
     if (!handHistory) {
       console.error('No hands found to export')
+      currentOperationState = { type: 'idle' }
+      chrome.runtime.sendMessage<ExportProgressMessage>({
+        action: 'exportProgress',
+        state: 'error',
+        format: 'pokerstars',
+        message: 'エクスポートするハンドが見つかりませんでした'
+      }).catch(() => {})
       // Show notification to user
       chrome.notifications.create({
         type: 'basic',
@@ -691,8 +777,23 @@ const exportPokerStarsData = async () => {
       'pokerchase_hand_history.txt',
       'text/plain'
     )
+
+    currentOperationState = { type: 'idle' }
+    chrome.runtime.sendMessage<ExportProgressMessage>({
+      action: 'exportProgress',
+      state: 'completed',
+      format: 'pokerstars',
+      message: 'PokerStarsハンドヒストリーエクスポート完了'
+    }).catch(() => {})
   } catch (error) {
     console.error('Error exporting PokerStars format:', error)
+    currentOperationState = { type: 'idle' }
+    chrome.runtime.sendMessage<ExportProgressMessage>({
+      action: 'exportProgress',
+      state: 'error',
+      format: 'pokerstars',
+      message: `PokerStarsエクスポート失敗: ${error}`
+    }).catch(() => {})
     // Show error notification
     chrome.notifications.create({
       type: 'basic',
@@ -934,6 +1035,13 @@ const rebuildAllData = async (): Promise<void> => {
     console.log('[rebuildAllData] Starting batch rebuild of all data...')
     const startTime = performance.now()
 
+    currentOperationState = { type: 'rebuild', progress: 0, message: 'データ再構築開始...' }
+    chrome.runtime.sendMessage<RebuildProgressMessage>({
+      action: 'rebuildProgress',
+      state: 'started',
+      message: 'データ再構築開始...'
+    }).catch(() => {})
+
     // Clear all entity tables first
     await db.transaction('rw', [db.hands, db.phases, db.actions, db.meta], async () => {
       await db.hands.clear()
@@ -942,12 +1050,27 @@ const rebuildAllData = async (): Promise<void> => {
       await db.meta.delete('lastProcessed')
     })
 
+    currentOperationState = { type: 'rebuild', progress: 10, message: 'テーブルクリア完了、イベント読み込み中...' }
+    chrome.runtime.sendMessage<RebuildProgressMessage>({
+      action: 'rebuildProgress',
+      state: 'processing',
+      progress: 10,
+      message: 'テーブルクリア完了、イベント読み込み中...'
+    }).catch(() => {})
+
     // Get total event count
     const totalCount = await db.apiEvents.count()
     console.log(`[rebuildAllData] Processing ${totalCount} events...`)
 
     if (totalCount === 0) {
       console.log('[rebuildAllData] No events to process')
+      currentOperationState = { type: 'idle' }
+      chrome.runtime.sendMessage<RebuildProgressMessage>({
+        action: 'rebuildProgress',
+        state: 'completed',
+        progress: 100,
+        message: '処理対象のイベントがありません'
+      }).catch(() => {})
       return
     }
 
@@ -976,7 +1099,24 @@ const rebuildAllData = async (): Promise<void> => {
       const allEvents = await db.apiEvents.orderBy('[timestamp+ApiTypeId]').toArray()
       console.log(`[rebuildAllData] Loaded ${allEvents.length} events, converting to entities...`)
       
+      currentOperationState = { type: 'rebuild', progress: 40, message: `${allEvents.length.toLocaleString()}件のイベントを変換中...` }
+      chrome.runtime.sendMessage<RebuildProgressMessage>({
+        action: 'rebuildProgress',
+        state: 'processing',
+        progress: 40,
+        message: `${allEvents.length.toLocaleString()}件のイベントを変換中...`
+      }).catch(() => {})
+
       const entities = converter.convertEventsToEntities(allEvents)
+      
+      currentOperationState = { type: 'rebuild', progress: 70, message: 'エンティティ保存中...' }
+      chrome.runtime.sendMessage<RebuildProgressMessage>({
+        action: 'rebuildProgress',
+        state: 'processing',
+        progress: 70,
+        message: 'エンティティ保存中...'
+      }).catch(() => {})
+
       const counts = await saveEntities(db, entities)
       totalHands += counts.hands
       totalPhases += counts.phases
@@ -1010,6 +1150,14 @@ const rebuildAllData = async (): Promise<void> => {
       const rebuildTime = ((performance.now() - startTime) / 1000).toFixed(2)
       console.log(`[rebuildAllData] Rebuild completed in ${rebuildTime}s`)
 
+      currentOperationState = { type: 'rebuild', progress: 90, message: '統計情報を再計算中...' }
+      chrome.runtime.sendMessage<RebuildProgressMessage>({
+        action: 'rebuildProgress',
+        state: 'processing',
+        progress: 90,
+        message: '統計情報を再計算中...'
+      }).catch(() => {})
+
       // Trigger stats recalculation once at the end
       if (service.latestEvtDeal && service.latestEvtDeal.SeatUserIds) {
         const playerIds = service.latestEvtDeal.SeatUserIds.filter(id => id !== -1)
@@ -1019,6 +1167,14 @@ const rebuildAllData = async (): Promise<void> => {
         }
       }
 
+      currentOperationState = { type: 'idle' }
+      chrome.runtime.sendMessage<RebuildProgressMessage>({
+        action: 'rebuildProgress',
+        state: 'completed',
+        progress: 100,
+        message: `データ再構築完了 (${rebuildTime}秒) - ハンド: ${totalHands.toLocaleString()}, フェーズ: ${totalPhases.toLocaleString()}, アクション: ${totalActions.toLocaleString()}`
+      }).catch(() => {})
+
     } finally {
       // Disable batch mode
       service.setBatchMode(false)
@@ -1026,6 +1182,12 @@ const rebuildAllData = async (): Promise<void> => {
 
   } catch (error) {
     console.error('[rebuildAllData] Error:', error)
+    currentOperationState = { type: 'idle' }
+    chrome.runtime.sendMessage<RebuildProgressMessage>({
+      action: 'rebuildProgress',
+      state: 'error',
+      message: `データ再構築失敗: ${error}`
+    }).catch(() => {})
     throw error
   }
 }

--- a/src/components/popup/ImportExportSection.tsx
+++ b/src/components/popup/ImportExportSection.tsx
@@ -1,15 +1,19 @@
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
+import CircularProgress from '@mui/material/CircularProgress'
 import LinearProgress from '@mui/material/LinearProgress'
 import Typography from '@mui/material/Typography'
-import React from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { FileDownload, FileUpload } from '@mui/icons-material'
 import type {
   ExportDataMessage,
+  ExportProgressMessage,
   ImportDataChunkMessage,
   ImportDataInitMessage,
   ImportDataProcessMessage,
+  RebuildProgressMessage,
 } from '../../types/messages'
+import { isExportProgressMessage, isRebuildProgressMessage } from '../../types/messages'
 
 interface ImportExportSectionProps {
   importStatus: string
@@ -31,6 +35,9 @@ interface ImportExportSectionProps {
 
 const FILE_CHUNK_SIZE = 5 * 1024 * 1024 // 5MB chunks for file import
 
+type ExportState = 'idle' | 'exporting'
+type RebuildState = 'idle' | 'rebuilding'
+
 export const ImportExportSection = ({
   importStatus,
   importProgress,
@@ -48,16 +55,116 @@ export const ImportExportSection = ({
   setImportSuccess,
   setImportStartTime,
 }: ImportExportSectionProps) => {
-  const handleExportClick = (format: string) => {
+  const [exportState, setExportState] = useState<ExportState>('idle')
+  const [exportFormat, setExportFormat] = useState<'json' | 'pokerstars' | null>(null)
+  const [exportProgress, setExportProgress] = useState(0)
+  const [exportProcessed, setExportProcessed] = useState(0)
+  const [exportTotal, setExportTotal] = useState(0)
+  const [rebuildState, setRebuildState] = useState<RebuildState>('idle')
+  const [rebuildProgress, setRebuildProgress] = useState(0)
+  const [operationStatus, setOperationStatus] = useState('')
+
+  const isImporting = importProgress > 0 && importProgress < 100
+  const isAnyOperationInProgress = isImporting || exportState !== 'idle' || rebuildState !== 'idle'
+
+  // Listen for export/rebuild progress messages and query state on mount
+  useEffect(() => {
+    // Query current operation state on mount (handles popup close/reopen)
+    chrome.runtime.sendMessage({ action: 'getOperationState' }, (response: any) => {
+      if (chrome.runtime.lastError) return // Extension context may be invalid
+      if (response?.operationState) {
+        const state = response.operationState
+        if (state.type === 'export') {
+          setExportState('exporting')
+          setExportFormat(state.format ?? null)
+          setExportProgress(state.progress ?? 0)
+          setExportProcessed(state.processed ?? 0)
+          setExportTotal(state.total ?? 0)
+          setOperationStatus(state.message ?? '')
+        } else if (state.type === 'rebuild') {
+          setRebuildState('rebuilding')
+          setRebuildProgress(state.progress ?? 0)
+          setOperationStatus(state.message ?? '')
+        }
+        // Import state is managed by parent Popup.tsx via importProgress messages
+      }
+    })
+
+    const handleMessage = (message: unknown) => {
+      if (isExportProgressMessage(message)) {
+        const msg = message as ExportProgressMessage
+        switch (msg.state) {
+          case 'started':
+            setExportState('exporting')
+            setExportFormat(msg.format ?? null)
+            setExportProgress(0)
+            setExportProcessed(0)
+            setExportTotal(0)
+            setOperationStatus(msg.message ?? '')
+            break
+          case 'processing':
+            setExportProgress(msg.progress ?? 0)
+            setExportProcessed(msg.processed ?? 0)
+            setExportTotal(msg.total ?? 0)
+            setOperationStatus(msg.message ?? '')
+            break
+          case 'completed':
+            setExportState('idle')
+            setExportFormat(null)
+            setExportProgress(0)
+            setOperationStatus(msg.message ?? 'エクスポート完了')
+            break
+          case 'error':
+            setExportState('idle')
+            setExportFormat(null)
+            setExportProgress(0)
+            setOperationStatus(msg.message ?? 'エクスポート失敗')
+            break
+        }
+      }
+
+      if (isRebuildProgressMessage(message)) {
+        const msg = message as RebuildProgressMessage
+        switch (msg.state) {
+          case 'started':
+            setRebuildState('rebuilding')
+            setRebuildProgress(0)
+            setOperationStatus(msg.message ?? '')
+            break
+          case 'processing':
+            setRebuildProgress(msg.progress ?? 0)
+            setOperationStatus(msg.message ?? '')
+            break
+          case 'completed':
+            setRebuildState('idle')
+            setRebuildProgress(0)
+            setOperationStatus(msg.message ?? 'データ再構築完了')
+            break
+          case 'error':
+            setRebuildState('idle')
+            setRebuildProgress(0)
+            setOperationStatus(msg.message ?? 'データ再構築失敗')
+            break
+        }
+      }
+    }
+
+    chrome.runtime.onMessage.addListener(handleMessage)
+    return () => {
+      chrome.runtime.onMessage.removeListener(handleMessage)
+    }
+  }, [])
+
+  const handleExportClick = useCallback((format: string) => {
     chrome.runtime.sendMessage<ExportDataMessage>({
       action: 'exportData',
       format: format as 'json' | 'pokerstars'
     })
-  }
+  }, [])
 
-  const handleImportClick = () => {
+  const handleImportClick = useCallback(() => {
     fileInputRef.current?.click()
-  }
+  }, [fileInputRef])
 
   const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0]
@@ -139,11 +246,15 @@ export const ImportExportSection = ({
     }
   }
 
-  const handleRebuildClick = () => {
+  const handleRebuildClick = useCallback(() => {
     if (window.confirm('データを再構築しますか？この処理には時間がかかる場合があります。')) {
       chrome.runtime.sendMessage({ action: 'rebuildData' })
     }
-  }
+  }, [])
+
+  // Determine status display
+  const displayStatus = operationStatus || importStatus
+  const isStatusError = displayStatus.includes('失敗') || displayStatus.includes('エラー')
 
   return (
     <>
@@ -151,17 +262,29 @@ export const ImportExportSection = ({
         variant="contained"
         fullWidth
         onClick={() => handleExportClick('pokerstars')}
-        startIcon={<FileDownload />}
+        startIcon={
+          exportState === 'exporting' && exportFormat === 'pokerstars'
+            ? <CircularProgress size={20} color="inherit" />
+            : <FileDownload />
+        }
+        disabled={isAnyOperationInProgress}
         sx={{ 
           marginBottom: '10px',
           backgroundColor: '#d70022',
           color: 'white',
           '&:hover': {
             backgroundColor: '#b8001c'
+          },
+          '&.Mui-disabled': {
+            backgroundColor: exportState === 'exporting' && exportFormat === 'pokerstars' ? '#d70022' : undefined,
+            color: exportState === 'exporting' && exportFormat === 'pokerstars' ? 'white' : undefined,
+            opacity: exportState === 'exporting' && exportFormat === 'pokerstars' ? 0.8 : undefined,
           }
         }}
       >
-        Export Hand History (PokerStars)
+        {exportState === 'exporting' && exportFormat === 'pokerstars'
+          ? 'Exporting...'
+          : 'Export Hand History (PokerStars)'}
       </Button>
 
       <Button
@@ -169,11 +292,42 @@ export const ImportExportSection = ({
         color="primary"
         fullWidth
         onClick={() => handleExportClick('json')}
-        startIcon={<FileDownload />}
-        style={{ marginBottom: '10px' }}
+        startIcon={
+          exportState === 'exporting' && exportFormat === 'json'
+            ? <CircularProgress size={20} color="inherit" />
+            : <FileDownload />
+        }
+        disabled={isAnyOperationInProgress}
+        sx={{
+          marginBottom: '10px',
+          '&.Mui-disabled': {
+            backgroundColor: exportState === 'exporting' && exportFormat === 'json' ? 'primary.main' : undefined,
+            color: exportState === 'exporting' && exportFormat === 'json' ? 'white' : undefined,
+            opacity: exportState === 'exporting' && exportFormat === 'json' ? 0.8 : undefined,
+          }
+        }}
       >
-        Export Raw Data (NDJSON)
+        {exportState === 'exporting' && exportFormat === 'json'
+          ? 'Exporting...'
+          : 'Export Raw Data (NDJSON)'}
       </Button>
+
+      {/* Export progress bar (both NDJSON and PokerStars) */}
+      {exportState === 'exporting' && exportProgress > 0 && (
+        <Box sx={{ marginBottom: '10px' }}>
+          <LinearProgress variant="determinate" value={exportProgress} />
+          <Typography
+            variant="body2"
+            color="textSecondary"
+            style={{ marginTop: '5px', textAlign: 'center' }}
+          >
+            {exportFormat === 'json'
+              ? `エクスポート中... ${exportProcessed.toLocaleString()}/${exportTotal.toLocaleString()} (${exportProgress}%)`
+              : `ハンドヒストリー変換中... ${exportProcessed.toLocaleString()}/${exportTotal.toLocaleString()} (${exportProgress}%)`
+            }
+          </Typography>
+        </Box>
+      )}
 
       <input
         type="file"
@@ -188,14 +342,25 @@ export const ImportExportSection = ({
         color="primary"
         fullWidth
         onClick={handleImportClick}
-        startIcon={<FileUpload />}
-        style={{ marginBottom: '10px' }}
-        disabled={importProgress > 0 && importProgress < 100}
+        startIcon={
+          isImporting
+            ? <CircularProgress size={20} color="inherit" />
+            : <FileUpload />
+        }
+        disabled={isAnyOperationInProgress}
+        sx={{
+          marginBottom: '10px',
+          '&.Mui-disabled': {
+            backgroundColor: isImporting ? 'primary.main' : undefined,
+            color: isImporting ? 'white' : undefined,
+            opacity: isImporting ? 0.8 : undefined,
+          }
+        }}
       >
-        {importProgress > 0 && importProgress < 100 ? 'Importing...' : 'Import Raw Data (NDJSON)'}
+        {isImporting ? 'Importing...' : 'Import Raw Data (NDJSON)'}
       </Button>
 
-      {importProgress > 0 && importProgress < 100 && (
+      {isImporting && (
         <Box sx={{ marginTop: 2 }}>
           <LinearProgress variant="determinate" value={importProgress} />
           <Typography
@@ -218,24 +383,43 @@ export const ImportExportSection = ({
         </Box>
       )}
 
-      {importStatus && (
+      {displayStatus && (
         <Typography
           variant="body2"
-          color={importStatus.includes('失敗') ? 'error' : 'success'}
+          color={isStatusError ? 'error' : 'success'}
           style={{ marginTop: '5px', textAlign: 'center' }}
         >
-          {importStatus}
+          {displayStatus}
         </Typography>
+      )}
+
+      {/* Rebuild progress bar */}
+      {rebuildState === 'rebuilding' && (
+        <Box sx={{ marginTop: 1, marginBottom: 1 }}>
+          <LinearProgress variant={rebuildProgress > 0 ? 'determinate' : 'indeterminate'} value={rebuildProgress} />
+          <Typography
+            variant="body2"
+            color="textSecondary"
+            style={{ marginTop: '5px', textAlign: 'center' }}
+          >
+            {operationStatus || 'データ再構築中...'}
+          </Typography>
+        </Box>
       )}
 
       <Button
         variant="outlined"
         fullWidth
         onClick={handleRebuildClick}
+        disabled={isAnyOperationInProgress}
+        startIcon={
+          rebuildState === 'rebuilding'
+            ? <CircularProgress size={20} />
+            : undefined
+        }
         style={{ marginTop: '10px' }}
-        disabled={importStatus === 'データ再構築中...'}
       >
-        データ再構築
+        {rebuildState === 'rebuilding' ? 'データ再構築中...' : 'データ再構築'}
       </Button>
 
       <Typography

--- a/src/services/poker-chase-service.ts
+++ b/src/services/poker-chase-service.ts
@@ -354,12 +354,15 @@ class PokerChaseService {
     }
   }
 
-  readonly exportHandHistory = async (handIds?: number[]): Promise<string> => {
+  readonly exportHandHistory = async (
+    handIds?: number[],
+    onProgress?: (processed: number, total: number) => void
+  ): Promise<string> => {
     const { HandLogExporter } = await import('../utils/hand-log-exporter')
 
     if (!handIds) {
       // Export all recent hands (no session filter)
-      return HandLogExporter.exportRecentHands(this.db)
+      return HandLogExporter.exportRecentHands(this.db, undefined, undefined, onProgress)
     }
 
     if (handIds.length === 0) {
@@ -367,7 +370,7 @@ class PokerChaseService {
       return ''
     }
 
-    return HandLogExporter.exportMultipleHands(this.db, handIds)
+    return HandLogExporter.exportMultipleHands(this.db, handIds, onProgress)
   }
   eventLogger = (event: any, level: 'debug' | 'info' | 'warn' | 'error' = 'info') => {
     const timestamp = event.timestamp

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -39,11 +39,16 @@ export const MESSAGE_ACTIONS = {
   // Data management
   DELETE_ALL_DATA: 'deleteAllData',
   REBUILD_DATA: 'rebuildData',
+  // Export/Rebuild progress
+  EXPORT_PROGRESS: 'exportProgress',
+  REBUILD_PROGRESS: 'rebuildProgress',
   // Hand log
   HAND_LOG_EVENT: 'handLogEvent',
   UPDATE_HAND_LOG_CONFIG: 'updateHandLogConfig',
   // UI
-  UPDATE_UI_CONFIG: 'updateUIConfig'
+  UPDATE_UI_CONFIG: 'updateUIConfig',
+  // Operation state
+  GET_OPERATION_STATE: 'getOperationState',
 } as const
 
 // Import/Export related messages
@@ -110,6 +115,23 @@ export interface DeleteAllDataMessage {
 
 export interface RebuildDataMessage {
   action: 'rebuildData'
+}
+
+export interface ExportProgressMessage {
+  action: 'exportProgress'
+  state: 'started' | 'processing' | 'completed' | 'error'
+  format?: 'json' | 'pokerstars'
+  progress?: number // 0-100
+  processed?: number
+  total?: number
+  message?: string
+}
+
+export interface RebuildProgressMessage {
+  action: 'rebuildProgress'
+  state: 'started' | 'processing' | 'completed' | 'error'
+  progress?: number // 0-100
+  message?: string
 }
 
 // Hand log messages
@@ -200,6 +222,10 @@ export interface ManualSyncDownloadMessage {
   action: 'manualSyncDownload'
 }
 
+export interface GetOperationStateMessage {
+  action: 'getOperationState'
+}
+
 export interface FirebaseBackupProgressMessage {
   action: 'firebaseBackupProgress'
   progress: number
@@ -256,7 +282,18 @@ export interface SyncInfoResponse extends SuccessResponse {
   }
 }
 
-export type MessageResponse = SuccessResponse | ErrorResponse | BackupListResponse | BackupDownloadResponse | AuthStatusResponse | SyncStateResponse | UnsyncedCountResponse | SyncInfoResponse
+export interface OperationStateResponse extends SuccessResponse {
+  operationState: {
+    type: 'idle' | 'export' | 'import' | 'rebuild'
+    format?: 'json' | 'pokerstars'
+    progress?: number
+    processed?: number
+    total?: number
+    message?: string
+  }
+}
+
+export type MessageResponse = SuccessResponse | ErrorResponse | BackupListResponse | BackupDownloadResponse | AuthStatusResponse | SyncStateResponse | UnsyncedCountResponse | SyncInfoResponse | OperationStateResponse
 
 // Union type of all possible messages
 export type ChromeMessage =
@@ -272,6 +309,8 @@ export type ChromeMessage =
   | LatestStatsMessage
   | DeleteAllDataMessage
   | RebuildDataMessage
+  | ExportProgressMessage
+  | RebuildProgressMessage
   | HandLogEventMessage
   | UpdateHandLogConfigMessage
   | UpdateUIConfigMessage
@@ -291,6 +330,7 @@ export type ChromeMessage =
   | SyncStateUpdateMessage
   | ManualSyncUploadMessage
   | ManualSyncDownloadMessage
+  | GetOperationStateMessage
 
 // Helper function for type guard implementation
 const isMessageWithAction = (msg: unknown, action: string): msg is { action: string } =>
@@ -365,3 +405,12 @@ export const isFirebaseBackupDeleteMessage = (msg: unknown): msg is FirebaseBack
 
 export const isFirebaseBackupProgressMessage = (msg: unknown): msg is FirebaseBackupProgressMessage =>
   isMessageWithAction(msg, 'firebaseBackupProgress')
+
+export const isExportProgressMessage = (msg: unknown): msg is ExportProgressMessage =>
+  isMessageWithAction(msg, 'exportProgress')
+
+export const isRebuildProgressMessage = (msg: unknown): msg is RebuildProgressMessage =>
+  isMessageWithAction(msg, 'rebuildProgress')
+
+export const isGetOperationStateMessage = (msg: unknown): msg is GetOperationStateMessage =>
+  isMessageWithAction(msg, 'getOperationState')

--- a/src/utils/hand-log-exporter.ts
+++ b/src/utils/hand-log-exporter.ts
@@ -174,7 +174,11 @@ export class HandLogExporter {
   /**
    * Export multiple hands as PokerStars format string
    */
-  static async exportMultipleHands(db: PokerChaseDB, handIds: number[]): Promise<string> {
+  static async exportMultipleHands(
+    db: PokerChaseDB,
+    handIds: number[],
+    onProgress?: (processed: number, total: number) => void
+  ): Promise<string> {
     const results: string[] = []
 
     // Exporting hands
@@ -191,6 +195,7 @@ export class HandLogExporter {
         console.error(`[HandLogExporter] Error exporting hand ${handId}:`, error)
         // Continue with next hand instead of failing completely
       }
+      onProgress?.(results.length, handIds.length)
     }
 
     if (results.length === 0) {
@@ -275,7 +280,12 @@ export class HandLogExporter {
   /**
    * Export recent hands from a session or database
    */
-  static async exportRecentHands(db: PokerChaseDB, sessionId?: string, limit?: number): Promise<string> {
+  static async exportRecentHands(
+    db: PokerChaseDB,
+    sessionId?: string,
+    limit?: number,
+    onProgress?: (processed: number, total: number) => void
+  ): Promise<string> {
     let hands: Hand[]
 
     if (sessionId) {
@@ -298,6 +308,6 @@ export class HandLogExporter {
     }
 
     const handIds = hands.map(h => h.id)
-    return this.exportMultipleHands(db, handIds)
+    return this.exportMultipleHands(db, handIds, onProgress)
   }
 }


### PR DESCRIPTION
## 概要
エクスポート/インポート/リビルド操作のユーザー体験を改善。

## 変更内容

### 進捗表示
- **NDJSON Export**: チャンク処理ごとにプログレスバー + % 表示
- **PokerStars Export**: ハンドごとにプログレスバー + % 表示（`HandLogExporter` に `onProgress` コールバック追加）
- **データ再構築**: 各段階（テーブルクリア→イベント読込→変換→保存→統計再計算）でプログレスバー + ステータス表示

### 連打防止
- いずれかの操作が実行中の場合、全4ボタンを `disabled` に
- アクティブなボタンには `CircularProgress` スピナーを表示

### ポップアップ close/reopen 対応
- `background.ts` にグローバル `currentOperationState` を追加し、処理状態を保持
- ポップアップ起動時に `getOperationState` メッセージで状態を問い合わせ、UI を即座に復元

## 変更ファイル
- `src/types/messages.ts` — `ExportProgressMessage`, `RebuildProgressMessage`, `GetOperationStateMessage` 型追加
- `src/background.ts` — 操作状態管理 + 各処理からの進捗通知
- `src/components/popup/ImportExportSection.tsx` — スピナー・プログレスバー・ボタン排他制御
- `src/services/poker-chase-service.ts` — `onProgress` コールバック透過
- `src/utils/hand-log-exporter.ts` — `onProgress` コールバック対応

## テスト
- typecheck ✅
- 38 suites / 332 tests 全パス ✅