### PR TITLE
chore: strict mode無効化 + rebaseWhen緩和

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
     ":automergePatch"
   ],
   "labels": ["dependencies"],
-  "rebaseWhen": "behind-base-branch",
+  "rebaseWhen": "conflicted",
   "automerge": true,
   "automergeType": "pr",
   "platformAutomerge": true,


### PR DESCRIPTION
## 変更内容

### ブランチ保護（GitHub API経由で適用済み）
- `strict: true` → `false`
- CI必須（`test` チェック）は維持

### renovate.json
- `rebaseWhen: "behind-base-branch"` → `"conflicted"`

## 背景

`strict: true` は「PRマージ前にmainと最新同期を要求」する設定。1人開発のリポジトリではコストが大きい：

- **リベース連鎖**: 1つマージ → 残りPR全部out-of-date → リベース → CI再実行 → 次マージ → 繰り返し
- **無駄なCI**: Renovateが複数PR出すと、マージのたびに残り全部のCIが再実行される
- **修正の上書き**: Renovateブランチへの手動pushが自動リベースで消される（今回実際に発生）

`strict: false` でもCI必須は維持されるため、テスト通過しないとマージできない安全性は変わらない。

`rebaseWhen` も `"conflicted"`（コンフリクト時のみリベース）に緩和し、不要なリベースを抑制。