### PR TITLE
[codex] Remove Firebase remote auth script loaders

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PokerChase HUD",
-  "version": "4.2.0",
+  "version": "4.2.2",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiHjGBgceHTEGoM/G2SKZNjiHQEPjOqZFGVyoEccpcFzWFM8w/qaVOcW2OZNDMW+97H9OzF/il1Rh4Og2E2R2Uq9eylAfO3XQyOpeY3d/wRqPXOHJroilEu4An8VDcjXcR0Mv31i/iYVz7/nx6F+qO4uDf/qGQtAzK7O8n8rh+ZHO8wzEOwcbPMJ6nwId4eQHVyfGsgKx6Z0+c7KPNnPJxvDNwE6B8YxQ0Yp89nDgAo2Ss4mRl81FR6pGv9xilvTmorge6Ks0H7yVQd3Gd5UyYy2wSdqR+b/B8Q2jVrGp0C2rWrTKggl+lWDijeCQUiImRJASmxVVL9Dz1Q01eqTkyQIDAQAB",
   "permissions": [
     "storage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokerchase-hud",
-  "version": "4.2.0",
+  "version": "4.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pokerchase-hud",
-      "version": "4.2.0",
+      "version": "4.2.2",
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pokerchase-hud",
-  "version": "4.2.0",
+  "version": "4.2.2",
   "scripts": {
     "build": "tsx esbuild.config.ts",
     "postbuild": "zip -r extension.zip dist/ icons/ manifest.json",

--- a/src/services/firebase-auth-service.ts
+++ b/src/services/firebase-auth-service.ts
@@ -1,117 +1,199 @@
 /**
- * Firebase Authentication Service for Chrome Extension
- * Uses chrome.identity API for Google Sign-In
+ * Firebase Authentication Service for Chrome Extension.
+ *
+ * Uses chrome.identity for Google OAuth and Firebase Auth REST endpoints for
+ * Firebase ID tokens. Keeping the Firebase Auth SDK out of the extension
+ * bundle avoids MV3 remote-code scanner matches for gapi/reCAPTCHA loaders.
  */
 
-import { 
-  GoogleAuthProvider, 
-  User, 
-  signInWithCredential,
-  signOut as firebaseSignOut,
-  onAuthStateChanged
-} from 'firebase/auth'
-import { auth } from './firebase-config'
+import { firebaseConfig } from './firebase-config'
+
+export interface AuthUser {
+  uid: string
+  email: string | null
+  displayName: string | null
+  photoURL: string | null
+  getIdToken: (forceRefresh?: boolean) => Promise<string>
+}
+
+interface StoredAuthState {
+  uid: string
+  email: string | null
+  displayName: string | null
+  photoURL: string | null
+  idToken: string
+  refreshToken: string
+  expiresAt: number
+}
+
+interface FirebaseSignInResponse {
+  idToken: string
+  refreshToken: string
+  expiresIn: string
+  localId: string
+  email?: string
+  displayName?: string
+  photoUrl?: string
+}
+
+interface FirebaseRefreshResponse {
+  id_token: string
+  refresh_token: string
+  expires_in: string
+  user_id: string
+}
 
 export class FirebaseAuthService {
-  private currentUser: User | null = null
-  private authStateListeners: ((user: User | null) => void)[] = []
+  private static readonly STORAGE_KEY = 'firebaseRestAuthState'
+  private currentState: StoredAuthState | null = null
+  private authStateListeners: ((user: AuthUser | null) => void)[] = []
+  private restorePromise: Promise<void>
 
   constructor() {
-    // Listen to auth state changes
-    onAuthStateChanged(auth, (user) => {
-      this.currentUser = user
-      this.notifyAuthStateListeners(user)
-    })
+    this.restorePromise = this.restoreAuthState()
+  }
+
+  async ready(): Promise<void> {
+    await this.restorePromise
   }
 
   /**
-   * Sign in with Google using chrome.identity API
+   * Sign in with Google using chrome.identity API.
    */
-  async signInWithGoogle(): Promise<User> {
-    return new Promise((resolve, reject) => {
-      // Get OAuth2 token using chrome.identity
-      chrome.identity.getAuthToken({ interactive: true }, async (result) => {
-        const token = typeof result === 'string' ? result : result?.token
-        if (chrome.runtime.lastError || !token) {
-          console.error('[FirebaseAuth] Chrome identity error:', chrome.runtime.lastError)
-          reject(new Error(chrome.runtime.lastError?.message || 'Failed to get auth token'))
-          return
-        }
+  async signInWithGoogle(): Promise<AuthUser> {
+    const token = await this.getChromeAuthToken(true)
+    console.log('[FirebaseAuth] Got Chrome auth token')
 
-        console.log('[FirebaseAuth] Got Chrome auth token')
-
-        try {
-          // Get user info from Google API
-          const response = await fetch('https://www.googleapis.com/oauth2/v1/userinfo?alt=json', {
-            headers: { Authorization: `Bearer ${token}` }
+    try {
+      const response = await fetch(
+        `https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=${firebaseConfig.apiKey}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            postBody: `access_token=${encodeURIComponent(token)}&providerId=google.com`,
+            requestUri: `https://${chrome.runtime.id}.chromiumapp.org/`,
+            returnIdpCredential: false,
+            returnSecureToken: true
           })
-          const userInfo = await response.json()
-          console.log('[FirebaseAuth] User info:', userInfo)
-
-          // Create credential from the token
-          const credential = GoogleAuthProvider.credential(null, token)
-          
-          // Sign in to Firebase
-          const result = await signInWithCredential(auth, credential)
-          console.log('[FirebaseAuth] Firebase sign in successful:', result.user.email)
-          resolve(result.user)
-        } catch (error) {
-          console.error('[FirebaseAuth] Firebase sign in error:', error)
-          reject(error)
         }
-      })
-    })
+      )
+
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(`Firebase sign-in failed: ${response.status} ${errorText}`)
+      }
+
+      const result = await response.json() as FirebaseSignInResponse
+      this.currentState = {
+        uid: result.localId,
+        email: result.email ?? null,
+        displayName: result.displayName ?? null,
+        photoURL: result.photoUrl ?? null,
+        idToken: result.idToken,
+        refreshToken: result.refreshToken,
+        expiresAt: Date.now() + Number(result.expiresIn) * 1000
+      }
+      await this.persistAuthState()
+      this.notifyAuthStateListeners(this.getCurrentUser())
+      console.log('[FirebaseAuth] Firebase sign in successful:', this.currentState.email)
+      return this.getCurrentUser()!
+    } catch (error) {
+      console.error('[FirebaseAuth] Firebase sign in error:', error)
+      throw error
+    }
   }
 
   /**
-   * Sign out from Firebase and revoke Chrome identity token
+   * Sign out from Firebase and revoke Chrome identity token.
    */
   async signOut(): Promise<void> {
-    // Sign out from Firebase
-    await firebaseSignOut(auth)
-    
-    // Revoke the Chrome identity token
-    return new Promise((resolve, reject) => {
-      chrome.identity.getAuthToken({ interactive: false }, (result) => {
-        const token = typeof result === 'string' ? result : result?.token
-        if (token) {
-          chrome.identity.removeCachedAuthToken({ token }, () => {
-            // Revoke the token on Google's servers
-            fetch(`https://accounts.google.com/o/oauth2/revoke?token=${token}`)
-              .then(() => resolve())
-              .catch(reject)
-          })
-        } else {
-          resolve()
-        }
+    const previousToken = await this.getChromeAuthToken(false).catch(() => null)
+    this.currentState = null
+    await chrome.storage.local.remove(FirebaseAuthService.STORAGE_KEY)
+    this.notifyAuthStateListeners(null)
+
+    if (previousToken) {
+      await new Promise<void>((resolve) => {
+        chrome.identity.removeCachedAuthToken({ token: previousToken }, () => resolve())
       })
-    })
+      await fetch(`https://accounts.google.com/o/oauth2/revoke?token=${previousToken}`).catch(() => {})
+    }
   }
 
   /**
-   * Get the current user
+   * Get the current user.
    */
-  getCurrentUser(): User | null {
-    return this.currentUser
+  getCurrentUser(): AuthUser | null {
+    if (!this.currentState) {
+      return null
+    }
+
+    return {
+      uid: this.currentState.uid,
+      email: this.currentState.email,
+      displayName: this.currentState.displayName,
+      photoURL: this.currentState.photoURL,
+      getIdToken: (forceRefresh = false) => this.getIdToken(forceRefresh)
+    }
   }
 
   /**
-   * Check if user is signed in
+   * Get a valid Firebase ID token for REST API requests.
+   */
+  async getIdToken(forceRefresh = false): Promise<string> {
+    await this.ready()
+    if (!this.currentState) {
+      throw new Error('User not authenticated')
+    }
+
+    if (!forceRefresh && this.currentState.expiresAt - Date.now() > 5 * 60 * 1000) {
+      return this.currentState.idToken
+    }
+
+    const response = await fetch(
+      `https://securetoken.googleapis.com/v1/token?key=${firebaseConfig.apiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'refresh_token',
+          refresh_token: this.currentState.refreshToken
+        }).toString()
+      }
+    )
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      throw new Error(`Firebase token refresh failed: ${response.status} ${errorText}`)
+    }
+
+    const result = await response.json() as FirebaseRefreshResponse
+    this.currentState = {
+      ...this.currentState,
+      uid: result.user_id,
+      idToken: result.id_token,
+      refreshToken: result.refresh_token,
+      expiresAt: Date.now() + Number(result.expires_in) * 1000
+    }
+    await this.persistAuthState()
+    return this.currentState.idToken
+  }
+
+  /**
+   * Check if user is signed in.
    */
   isSignedIn(): boolean {
-    return this.currentUser !== null
+    return this.currentState !== null
   }
 
   /**
-   * Add auth state listener
+   * Add auth state listener.
    */
-  onAuthStateChange(callback: (user: User | null) => void): () => void {
+  onAuthStateChange(callback: (user: AuthUser | null) => void): () => void {
     this.authStateListeners.push(callback)
-    
-    // Call immediately with current state
-    callback(this.currentUser)
-    
-    // Return unsubscribe function
+    this.ready().then(() => callback(this.getCurrentUser())).catch(() => callback(null))
+
     return () => {
       const index = this.authStateListeners.indexOf(callback)
       if (index > -1) {
@@ -121,28 +203,50 @@ export class FirebaseAuthService {
   }
 
   /**
-   * Notify all auth state listeners
-   */
-  private notifyAuthStateListeners(user: User | null): void {
-    this.authStateListeners.forEach(listener => listener(user))
-  }
-
-  /**
-   * Get user display info
+   * Get user display info.
    */
   getUserInfo(): { email: string | null, displayName: string | null, photoURL: string | null, uid: string } | null {
-    if (!this.currentUser) {
+    const user = this.getCurrentUser()
+    if (!user) {
       return null
     }
 
     return {
-      email: this.currentUser.email,
-      displayName: this.currentUser.displayName,
-      photoURL: this.currentUser.photoURL,
-      uid: this.currentUser.uid
+      email: user.email,
+      displayName: user.displayName,
+      photoURL: user.photoURL,
+      uid: user.uid
     }
+  }
+
+  private async getChromeAuthToken(interactive: boolean): Promise<string> {
+    return await new Promise((resolve, reject) => {
+      chrome.identity.getAuthToken({ interactive }, (result) => {
+        const token = typeof result === 'string' ? result : result?.token
+        if (chrome.runtime.lastError || !token) {
+          reject(new Error(chrome.runtime.lastError?.message || 'Failed to get auth token'))
+          return
+        }
+        resolve(token)
+      })
+    })
+  }
+
+  private async restoreAuthState(): Promise<void> {
+    const stored = await chrome.storage.local.get(FirebaseAuthService.STORAGE_KEY) as Record<string, StoredAuthState | undefined>
+    this.currentState = stored[FirebaseAuthService.STORAGE_KEY] ?? null
+    this.notifyAuthStateListeners(this.getCurrentUser())
+  }
+
+  private async persistAuthState(): Promise<void> {
+    if (this.currentState) {
+      await chrome.storage.local.set({ [FirebaseAuthService.STORAGE_KEY]: this.currentState })
+    }
+  }
+
+  private notifyAuthStateListeners(user: AuthUser | null): void {
+    this.authStateListeners.forEach(listener => listener(user))
   }
 }
 
-// Export singleton instance
 export const firebaseAuthService = new FirebaseAuthService()

--- a/src/services/firebase-config.ts
+++ b/src/services/firebase-config.ts
@@ -1,18 +1,8 @@
 /**
- * Firebase configuration for PokerChase HUD
- *
- * Note: Replace these values with your actual Firebase project configuration
- * You can find these values in the Firebase Console:
- * Project Settings > General > Your apps > Web app
+ * Firebase project configuration for REST API access.
  */
 
-import { initializeApp } from 'firebase/app'
-import { getAuth } from 'firebase/auth'
-import { getStorage } from 'firebase/storage'
-import { getFirestore } from 'firebase/firestore'
-
-// Firebase configuration object
-const firebaseConfig = {
+export const firebaseConfig = {
   apiKey: "AIzaSyDflMV4xVPhKxsN_k0daWFOsCLn3CEtDAs",
   authDomain: "pokerchase-hud.firebaseapp.com",
   projectId: "pokerchase-hud",
@@ -21,13 +11,4 @@ const firebaseConfig = {
   appId: "1:412594878670:web:9b6f891e7b7493dba5b89f"
 }
 
-// Initialize Firebase
-const app = initializeApp(firebaseConfig)
-
-// Initialize Firebase services
-export const auth = getAuth(app)
-export const storage = getStorage(app)
-export const firestore = getFirestore(app)
-
-// Export the app instance
-export default app
+export default firebaseConfig

--- a/src/services/firestore-backup-service.ts
+++ b/src/services/firestore-backup-service.ts
@@ -1,20 +1,11 @@
 /**
- * Firestore Backup Service
- * Handles backup and restore operations using Firestore
- * Works in Service Worker environment (no XMLHttpRequest issues)
+ * Firestore Backup Service.
+ *
+ * Uses the Firestore REST API directly so the MV3 bundle does not include
+ * Firebase SDK code that Chrome Web Store can classify as remote-code loaders.
  */
 
-import { 
-  collection,
-  doc,
-  getDocs,
-  writeBatch,
-  query,
-  orderBy,
-  setDoc,
-  limit
-} from 'firebase/firestore'
-import { firestore } from './firebase-config'
+import { firebaseConfig } from './firebase-config'
 import { firebaseAuthService } from './firebase-auth-service'
 import type { ApiEvent } from '../types'
 import { DATABASE_CONSTANTS } from '../constants/database'
@@ -25,148 +16,50 @@ export interface BackupSummary {
   lastSyncTime: Date
 }
 
+type FirestoreValue =
+  | { nullValue: null }
+  | { booleanValue: boolean }
+  | { integerValue: string }
+  | { doubleValue: number }
+  | { stringValue: string }
+  | { arrayValue: { values?: FirestoreValue[] } }
+  | { mapValue: { fields?: Record<string, FirestoreValue> } }
+
+interface FirestoreDocument {
+  name: string
+  fields?: Record<string, FirestoreValue>
+}
+
+interface RunQueryResult {
+  document?: FirestoreDocument
+}
+
 export class FirestoreBackupService {
   private readonly USERS_COLLECTION = 'users'
   private readonly EVENTS_COLLECTION = 'apiEvents'
   private readonly BATCH_SIZE = DATABASE_CONSTANTS.FIRESTORE_BATCH_SIZE
   private readonly BATCH_DELAY_MS = DATABASE_CONSTANTS.FIRESTORE_BATCH_DELAY_MS
   private readonly DELETE_BATCH_SIZE = DATABASE_CONSTANTS.FIRESTORE_DELETE_BATCH
+  private readonly baseUrl = `https://firestore.googleapis.com/v1/projects/${firebaseConfig.projectId}/databases/(default)/documents`
 
   /**
-   * Get current user document reference
-   */
-  private getUserRef() {
-    const user = firebaseAuthService.getCurrentUser()
-    if (!user) {
-      throw new Error('User not authenticated')
-    }
-    return doc(firestore, this.USERS_COLLECTION, user.uid)
-  }
-
-  /**
-   * Sync local events to cloud (upload events newer than cloud's latest timestamp)
+   * Sync local events to cloud (upload events newer than cloud's latest timestamp).
    */
   async syncToCloud(
-    apiEvents: ApiEvent[], 
+    apiEvents: ApiEvent[],
     onProgress?: (progress: { current: number, total: number }) => void
   ): Promise<BackupSummary> {
-    const user = firebaseAuthService.getCurrentUser()
-    if (!user) {
-      throw new Error('User not authenticated')
-    }
-
-    const userRef = this.getUserRef()
-    const eventsCollection = collection(userRef, this.EVENTS_COLLECTION)
-    
-    try {
-      let processed = 0
-      let synced = 0
-
-      console.log(`[Firestore] Starting sync of ${apiEvents.length} events...`)
-
-      // Get the latest timestamp from cloud
-      const cloudMaxTimestamp = await this.getCloudMaxTimestamp()
-      console.log(`[Firestore] Cloud max timestamp: ${cloudMaxTimestamp || 'none'}`)
-
-      // Filter events newer than cloud's latest timestamp
-      const newEvents = cloudMaxTimestamp 
-        ? apiEvents.filter(event => (event.timestamp || 0) > cloudMaxTimestamp)
-        : apiEvents
-
-      console.log(`[Firestore] ${newEvents.length} new events to sync (after timestamp ${cloudMaxTimestamp || 0})`)
-
-      // Process only new events in batches
-      const PARALLEL_BATCHES = DATABASE_CONSTANTS.FIRESTORE_PARALLEL_BATCHES
-      for (let i = 0; i < newEvents.length; i += this.BATCH_SIZE * PARALLEL_BATCHES) {
-        const batchPromises = []
-        
-        // Create multiple batches to process in parallel
-        for (let j = 0; j < PARALLEL_BATCHES && i + j * this.BATCH_SIZE < newEvents.length; j++) {
-          const startIndex = i + j * this.BATCH_SIZE
-          const chunk = newEvents.slice(startIndex, startIndex + this.BATCH_SIZE)
-          if (chunk.length === 0) break
-
-          const batchPromise = this.writeBatch(eventsCollection, chunk)
-          batchPromises.push(batchPromise)
-          synced += chunk.length
-        }
-
-        // Wait for all parallel batches to complete
-        await Promise.all(batchPromises)
-        
-        processed = Math.min(i + this.BATCH_SIZE * PARALLEL_BATCHES, newEvents.length)
-
-        if (onProgress) {
-          // Show progress based on total events, not just new ones
-          const totalProcessed = apiEvents.length - newEvents.length + processed
-          onProgress({ current: totalProcessed, total: apiEvents.length })
-        }
-
-        // Only add delay if we have more batches to process
-        if (processed < newEvents.length) {
-          await new Promise(resolve => setTimeout(resolve, this.BATCH_DELAY_MS))
-        }
-      }
-
-      // Update last sync timestamp if we synced any events
-      if (synced > 0) {
-        const maxTimestamp = Math.max(...newEvents.map(e => e.timestamp || 0))
-        await this.updateLastSyncTimestamp(maxTimestamp)
-      }
-
-      return {
-        totalEvents: apiEvents.length,
-        syncedEvents: synced,
-        lastSyncTime: new Date()
-      }
-    } catch (error) {
-      console.error('Failed to sync to cloud:', error)
-      throw new Error(`Cloud sync failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
-    }
+    const cloudMaxTimestamp = await this.getCloudMaxTimestamp()
+    return await this.syncToCloudBatch(apiEvents, cloudMaxTimestamp, onProgress)
   }
 
   /**
-   * Write a batch of events with retry logic
-   */
-  private async writeBatch(eventsCollection: any, events: ApiEvent[]): Promise<void> {
-    const batch = writeBatch(firestore)
-    
-    events.forEach(event => {
-      const eventId = `${event.timestamp}_${event.ApiTypeId}`
-      const eventDoc = doc(eventsCollection, eventId)
-      batch.set(eventDoc, event)
-    })
-
-    // Retry logic for rate limit errors
-    let retries = 3
-    while (retries > 0) {
-      try {
-        await batch.commit()
-        return
-      } catch (error: any) {
-        if (error?.code === 'resource-exhausted' && retries > 1) {
-          console.warn(`[Firestore] Rate limit hit, retrying in ${this.BATCH_DELAY_MS}ms...`)
-          await new Promise(resolve => setTimeout(resolve, this.BATCH_DELAY_MS))
-          retries--
-        } else {
-          throw error
-        }
-      }
-    }
-  }
-
-  /**
-   * Get cloud backup status
+   * Get cloud backup status.
    */
   async getCloudStatus(): Promise<{ eventCount: number }> {
     try {
-      const userRef = this.getUserRef()
-      const eventsCollection = collection(userRef, this.EVENTS_COLLECTION)
-      const snapshot = await getDocs(eventsCollection)
-      
-      return {
-        eventCount: snapshot.size
-      }
+      const events = await this.queryEvents('asc')
+      return { eventCount: events.length }
     } catch (error) {
       console.error('Failed to get cloud status:', error)
       return { eventCount: 0 }
@@ -174,42 +67,23 @@ export class FirestoreBackupService {
   }
 
   /**
-   * Sync cloud events to local (cloud as source of truth)
+   * Sync cloud events to local (cloud as source of truth).
    */
   async syncFromCloud(
     onProgress?: (progress: { current: number, total: number }) => void
   ): Promise<ApiEvent[]> {
     try {
-      const userRef = this.getUserRef()
-      const eventsCollection = collection(userRef, this.EVENTS_COLLECTION)
-      
-      // Get all events from cloud (cloud is the source of truth)
-      const q = query(
-        eventsCollection,
-        orderBy('timestamp', 'asc')
-      )
-      
-      const snapshot = await getDocs(q)
-      console.log(`[Firestore] Found ${snapshot.size} events in cloud`)
-      
-      const newEvents: ApiEvent[] = []
-      let processed = 0
-      const total = snapshot.size
-
-      snapshot.docs.forEach(doc => {
-        const event = doc.data() as ApiEvent
-        newEvents.push(event)
-        
-        processed++
-        if (onProgress && processed % 100 === 0) {
-          onProgress({ current: processed, total })
-        }
-      })
+      const newEvents = await this.queryEvents('asc')
+      const total = newEvents.length
+      console.log(`[Firestore] Found ${total} events in cloud`)
 
       if (onProgress) {
+        for (let processed = 100; processed < total; processed += 100) {
+          onProgress({ current: processed, total })
+        }
         onProgress({ current: total, total })
       }
-      
+
       return newEvents
     } catch (error) {
       console.error('Failed to sync from cloud:', error)
@@ -217,34 +91,14 @@ export class FirestoreBackupService {
     }
   }
 
-
   /**
-   * Get the latest timestamp from cloud events
+   * Get the latest timestamp from cloud events.
    */
   async getCloudMaxTimestamp(): Promise<number | null> {
     try {
-      const userRef = this.getUserRef()
-      const eventsCollection = collection(userRef, this.EVENTS_COLLECTION)
-      
-      // Query for the latest event by timestamp
-      const q = query(
-        eventsCollection,
-        orderBy('timestamp', 'desc'),
-        limit(1)
-      )
-      
-      const snapshot = await getDocs(q)
-      if (!snapshot.empty && snapshot.docs.length > 0) {
-        const firstDoc = snapshot.docs[0]
-        if (firstDoc) {
-          const latestEvent = firstDoc.data() as ApiEvent
-          if (latestEvent && typeof latestEvent.timestamp === 'number') {
-            return latestEvent.timestamp
-          }
-        }
-      }
-      
-      return null
+      const events = await this.queryEvents('desc', 1)
+      const latestEvent = events[0]
+      return typeof latestEvent?.timestamp === 'number' ? latestEvent.timestamp : null
     } catch (error) {
       console.error('Failed to get cloud max timestamp:', error)
       return null
@@ -252,65 +106,41 @@ export class FirestoreBackupService {
   }
 
   /**
-   * Update last sync timestamp in user metadata
-   */
-  private async updateLastSyncTimestamp(timestamp: number): Promise<void> {
-    try {
-      await setDoc(this.getUserRef(), {
-        lastSyncTimestamp: timestamp,
-        lastSyncTime: new Date().toISOString()
-      }, { merge: true })
-    } catch (error) {
-      console.error('Failed to update last sync timestamp:', error)
-    }
-  }
-
-  /**
-   * Sync a batch of events to cloud with pre-fetched cloud max timestamp
+   * Sync a batch of events to cloud with pre-fetched cloud max timestamp.
    */
   async syncToCloudBatch(
     apiEvents: ApiEvent[],
     cloudMaxTimestamp: number | null,
     onProgress?: (progress: { current: number, total: number }) => void
   ): Promise<BackupSummary> {
-    const user = firebaseAuthService.getCurrentUser()
-    if (!user) {
-      throw new Error('User not authenticated')
-    }
+    const user = await this.requireUser()
 
-    const userRef = this.getUserRef()
-    const eventsCollection = collection(userRef, this.EVENTS_COLLECTION)
-    
     try {
       let processed = 0
       let synced = 0
 
       console.log(`[Firestore] Processing batch of ${apiEvents.length} events...`)
 
-      // Filter events newer than cloud's latest timestamp
-      const newEvents = cloudMaxTimestamp 
+      const newEvents = cloudMaxTimestamp
         ? apiEvents.filter(event => (event.timestamp || 0) > cloudMaxTimestamp)
         : apiEvents
 
       console.log(`[Firestore] ${newEvents.length} new events in this batch`)
 
-      // Process new events in batches
       const PARALLEL_BATCHES = DATABASE_CONSTANTS.FIRESTORE_PARALLEL_BATCHES
       for (let i = 0; i < newEvents.length; i += this.BATCH_SIZE * PARALLEL_BATCHES) {
         const batchPromises = []
-        
+
         for (let j = 0; j < PARALLEL_BATCHES && i + j * this.BATCH_SIZE < newEvents.length; j++) {
           const startIndex = i + j * this.BATCH_SIZE
           const chunk = newEvents.slice(startIndex, startIndex + this.BATCH_SIZE)
           if (chunk.length === 0) break
 
-          const batchPromise = this.writeBatch(eventsCollection, chunk)
-          batchPromises.push(batchPromise)
+          batchPromises.push(this.writeBatch(user.uid, chunk))
           synced += chunk.length
         }
 
         await Promise.all(batchPromises)
-        
         processed = Math.min(i + this.BATCH_SIZE * PARALLEL_BATCHES, newEvents.length)
 
         if (onProgress) {
@@ -322,10 +152,9 @@ export class FirestoreBackupService {
         }
       }
 
-      // Update last sync timestamp if we synced any events
       if (synced > 0) {
         const maxTimestamp = Math.max(...newEvents.map(e => e.timestamp || 0))
-        await this.updateLastSyncTimestamp(maxTimestamp)
+        await this.updateLastSyncTimestamp(user.uid, maxTimestamp)
       }
 
       return {
@@ -340,48 +169,34 @@ export class FirestoreBackupService {
   }
 
   /**
-   * Delete all cloud events and user metadata
+   * Delete all cloud events and user metadata.
    */
   async deleteAllCloudEvents(): Promise<void> {
     try {
-      const userRef = this.getUserRef()
-      const eventsCollection = collection(userRef, this.EVENTS_COLLECTION)
-      
+      const user = await this.requireUser()
       console.log('[Firestore] Starting optimized delete...')
-      
-      // Delete events in chunks - simple and efficient
+
       let totalDeleted = 0
-      
+
       while (true) {
-        // Get next chunk
-        const q = query(eventsCollection, limit(this.DELETE_BATCH_SIZE))
-        const snapshot = await getDocs(q)
-        
-        if (snapshot.empty) break
-        
-        // Create and commit batch immediately
-        const batch = writeBatch(firestore)
-        snapshot.docs.forEach(doc => batch.delete(doc.ref))
-        await batch.commit()
-        
-        totalDeleted += snapshot.size
-        
-        // Log progress every 10,000 documents
-        if (Math.floor(totalDeleted / 10000) > Math.floor((totalDeleted - snapshot.size) / 10000)) {
+        const docs = await this.queryEventDocuments(user.uid, 'asc', this.DELETE_BATCH_SIZE)
+        if (docs.length === 0) break
+
+        await this.batchWrite(docs.map(doc => ({ delete: doc.name })))
+        totalDeleted += docs.length
+
+        if (Math.floor(totalDeleted / 10000) > Math.floor((totalDeleted - docs.length) / 10000)) {
           console.log(`[Firestore] Deleted ${totalDeleted} events...`)
         }
       }
-      
-      // Clear user metadata
-      try {
-        await setDoc(userRef, {
-          lastSyncTimestamp: null,
-          lastSyncTime: null
-        }, { merge: true })
-      } catch (error) {
+
+      await this.setUserMetadata(user.uid, {
+        lastSyncTimestamp: null,
+        lastSyncTime: null
+      }).catch(error => {
         console.warn('[Firestore] Failed to clear user metadata:', error)
-      }
-      
+      })
+
       console.log(`[Firestore] Fast delete completed. Total deleted: ${totalDeleted} events`)
     } catch (error) {
       console.error('Failed to delete cloud events:', error)
@@ -389,7 +204,157 @@ export class FirestoreBackupService {
     }
   }
 
+  private async writeBatch(uid: string, events: ApiEvent[]): Promise<void> {
+    const writes = events.map(event => {
+      const eventId = `${event.timestamp}_${event.ApiTypeId}`
+      return {
+        update: {
+          name: `${this.baseUrl}/${this.docPath(this.USERS_COLLECTION, uid, this.EVENTS_COLLECTION, eventId)}`,
+          fields: encodeFields(event as Record<string, unknown>)
+        }
+      }
+    })
+
+    let retries = 3
+    while (retries > 0) {
+      try {
+        await this.batchWrite(writes)
+        return
+      } catch (error: any) {
+        if ((error?.message || '').includes('RESOURCE_EXHAUSTED') && retries > 1) {
+          console.warn(`[Firestore] Rate limit hit, retrying in ${this.BATCH_DELAY_MS}ms...`)
+          await new Promise(resolve => setTimeout(resolve, this.BATCH_DELAY_MS))
+          retries--
+        } else {
+          throw error
+        }
+      }
+    }
+  }
+
+  private async updateLastSyncTimestamp(uid: string, timestamp: number): Promise<void> {
+    try {
+      await this.setUserMetadata(uid, {
+        lastSyncTimestamp: timestamp,
+        lastSyncTime: new Date().toISOString()
+      })
+    } catch (error) {
+      console.error('Failed to update last sync timestamp:', error)
+    }
+  }
+
+  private async setUserMetadata(uid: string, metadata: Record<string, unknown>): Promise<void> {
+    await this.request(`${this.baseUrl}/${this.docPath(this.USERS_COLLECTION, uid)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fields: encodeFields(metadata) })
+    })
+  }
+
+  private async queryEvents(direction: 'asc' | 'desc', maxResults?: number): Promise<ApiEvent[]> {
+    const user = await this.requireUser()
+    const docs = await this.queryEventDocuments(user.uid, direction, maxResults)
+    return docs.map(doc => decodeFields(doc.fields ?? {}) as ApiEvent)
+  }
+
+  private async queryEventDocuments(uid: string, direction: 'asc' | 'desc', maxResults?: number): Promise<FirestoreDocument[]> {
+    const results = await this.request(`${this.baseUrl}/${this.docPath(this.USERS_COLLECTION, uid)}:runQuery`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        structuredQuery: {
+          from: [{ collectionId: this.EVENTS_COLLECTION }],
+          orderBy: [{
+            field: { fieldPath: 'timestamp' },
+            direction: direction === 'asc' ? 'ASCENDING' : 'DESCENDING'
+          }],
+          ...(maxResults ? { limit: maxResults } : {})
+        }
+      })
+    }) as RunQueryResult[]
+
+    return results.map(result => result.document).filter((doc): doc is FirestoreDocument => !!doc)
+  }
+
+  private async batchWrite(writes: Array<Record<string, unknown>>): Promise<void> {
+    await this.request(`${this.baseUrl}:batchWrite`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ writes })
+    })
+  }
+
+  private async request(url: string, init: RequestInit): Promise<unknown> {
+    const token = await firebaseAuthService.getIdToken()
+    const response = await fetch(url, {
+      ...init,
+      headers: {
+        ...(init.headers || {}),
+        Authorization: `Bearer ${token}`
+      }
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      throw new Error(`Firestore REST request failed: ${response.status} ${errorText}`)
+    }
+
+    return await response.json()
+  }
+
+  private async requireUser() {
+    await firebaseAuthService.ready()
+    const user = firebaseAuthService.getCurrentUser()
+    if (!user) {
+      throw new Error('User not authenticated')
+    }
+    return user
+  }
+
+  private docPath(...segments: string[]): string {
+    return segments.map(segment => encodeURIComponent(segment)).join('/')
+  }
 }
 
-// Export singleton instance
+function encodeFields(input: Record<string, unknown>): Record<string, FirestoreValue> {
+  return Object.fromEntries(
+    Object.entries(input)
+      .filter(([, value]) => value !== undefined)
+      .map(([key, value]) => [key, encodeValue(value)])
+  )
+}
+
+function encodeValue(value: unknown): FirestoreValue {
+  if (value === null) return { nullValue: null }
+  if (typeof value === 'boolean') return { booleanValue: value }
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? { integerValue: String(value) } : { doubleValue: value }
+  }
+  if (typeof value === 'string') return { stringValue: value }
+  if (Array.isArray(value)) {
+    return { arrayValue: { values: value.map(encodeValue) } }
+  }
+  if (typeof value === 'object') {
+    return { mapValue: { fields: encodeFields(value as Record<string, unknown>) } }
+  }
+  return { stringValue: String(value) }
+}
+
+function decodeFields(fields: Record<string, FirestoreValue>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(fields).map(([key, value]) => [key, decodeValue(value)])
+  )
+}
+
+function decodeValue(value: FirestoreValue): unknown {
+  if ('nullValue' in value) return null
+  if ('booleanValue' in value) return value.booleanValue
+  if ('integerValue' in value) return Number(value.integerValue)
+  if ('doubleValue' in value) return value.doubleValue
+  if ('stringValue' in value) return value.stringValue
+  if ('arrayValue' in value) return (value.arrayValue.values ?? []).map(decodeValue)
+  if ('mapValue' in value) return decodeFields(value.mapValue.fields ?? {})
+  return null
+}
+
 export const firestoreBackupService = new FirestoreBackupService()


### PR DESCRIPTION
## Summary

This PR updates the Chrome extension release fix that was already uploaded to the Chrome Web Store as version 4.2.2.

- removes Firebase Web SDK auth/firestore bundling from the extension runtime path
- replaces Google sign-in with `chrome.identity` plus Firebase Identity Toolkit REST sign-in/refresh
- replaces Firestore cloud backup operations with Firestore REST API calls
- bumps the extension version to `4.2.2`

## Why

Chrome Web Store rejected the previous draft under the MV3 Blue Argon policy because the bundled Firebase Auth code still contained external Google API / reCAPTCHA script-loader markers. Even when those loaders are not actively used, their presence in the extension bundle can trigger the remote hosted code check.

## Validation

- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`
- scanned built `dist/*.js` for `gapiScript`, `recaptcha`, `https://apis.google.com/js/api.js`, and Google reCAPTCHA loader URLs

## Release note

Chrome Web Store draft `4.2.2` has already been uploaded and submitted for review. The dashboard showed the draft as `審査待ち` instead of immediately rejected.