### PR TITLE
fix(api): stop spawning untracked WebSocket reconnects from the page hook

### DIFF
--- a/src/web_accessible_resource.ts
+++ b/src/web_accessible_resource.ts
@@ -12,15 +12,6 @@ const OriginalWebSocket = window.WebSocket
 function createWebSocket(...args: ConstructorParameters<typeof WebSocket>): WebSocket {
   const instance: WebSocket = new OriginalWebSocket(...args)
 
-  const connectionUrl = args[0]
-  const connectionProtocols = args.length > 1 ? args[1] : undefined
-
-  let wasConnected = false
-
-  instance.addEventListener('open', () => {
-    wasConnected = true
-  })
-
   instance.addEventListener('message', ({ data }) => {
     if (data instanceof ArrayBuffer) {
       try {
@@ -44,14 +35,8 @@ function createWebSocket(...args: ConstructorParameters<typeof WebSocket>): WebS
     }
   })
 
-  instance.addEventListener('close', (event) => {
-    if (wasConnected && !event.wasClean) {
-      // 予期せず接続が閉じられた、再接続を試しています...
-      setTimeout(() => {
-        new WebSocket(connectionUrl, connectionProtocols)
-      }, 500)
-    }
-  })
+  // 再接続はゲームクライアント自身に任せる。
+  // 拡張側で new WebSocket() しても参照を保持できず、ゲームが関知しない接続が増えるだけのため行わない。
 
   return instance
 }


### PR DESCRIPTION
## 問題

`web_accessible_resource.ts` の WebSocket フックは、unclean close を検知すると `new WebSocket(url)` を実行していましたが、生成したソケットへの**参照をどこにも保持していません**。ゲームクライアントは旧ソケットの参照しか持たないため、この「再接続」がゲームの通信復旧に寄与することはなく、ゲームが関知しない接続をサーバーに増やすだけでした(フック自身を再帰的に通るため傍受は重複しうる)。

## 修正

close リスナーと `wasConnected` 追跡を削除し、フックの責務を「メッセージ傍受と転送」のみに限定しました。再接続はゲームクライアント自身の責務です。

## 検証

- `npm run typecheck` ✅(挙動削除のみ、テスト対象コードパスなし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)