### PR TITLE
refactor(build): extract runtime constants to decouple page/content bundles from service graph

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,5 +1,7 @@
 import { memo, useCallback, useEffect, useMemo, useState } from "react"
-import PokerChaseService, { ApiType, PlayerStats, isApiEventType } from "../app"
+import { POKER_CHASE_SERVICE_EVENT } from "../constants/runtime"
+import { ApiType, isApiEventType } from "../types"
+import type { PlayerStats } from "../types"
 import type { StatsData } from "../content_script"
 import { defaultStatDisplayConfigs } from "../stats"
 import type { StatDisplayConfig } from "../types"
@@ -59,13 +61,13 @@ const App = memo(() => {
 
   useEffect(() => {
     window.addEventListener(
-      PokerChaseService.POKER_CHASE_SERVICE_EVENT,
+      POKER_CHASE_SERVICE_EVENT,
       handleStatsMessage
     )
 
     return () => {
       window.removeEventListener(
-        PokerChaseService.POKER_CHASE_SERVICE_EVENT,
+        POKER_CHASE_SERVICE_EVENT,
         handleStatsMessage
       )
     }

--- a/src/components/Hud.tsx
+++ b/src/components/Hud.tsx
@@ -1,5 +1,5 @@
 import { CSSProperties, useState, useCallback, useMemo, memo } from 'react'
-import type { PlayerStats } from '../app'
+import type { PlayerStats } from '../types'
 import type { StatDisplayConfig } from '../types'
 import type { StatResult } from '../types/stats'
 import type { RealTimeStats } from '../realtime-stats/realtime-stats-service'

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -1,7 +1,7 @@
 import { getBucket } from '@extend-chrome/storage'
 import Divider from '@mui/material/Divider'
 import { ChangeEvent, useEffect, useRef, useState } from 'react'
-import { FilterOptions, GameTypeFilter } from '../app'
+import type { FilterOptions, GameTypeFilter } from '../types'
 import { defaultStatDisplayConfigs } from '../stats'
 import type { StatDisplayConfig } from '../types/filters'
 import type { UIConfig } from '../types/hand-log'

--- a/src/components/popup/GameTypeFilterSection.tsx
+++ b/src/components/popup/GameTypeFilterSection.tsx
@@ -4,7 +4,7 @@ import FormControl from '@mui/material/FormControl'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import FormGroup from '@mui/material/FormGroup'
 import Typography from '@mui/material/Typography'
-import type { GameTypeFilter } from '../../app'
+import type { GameTypeFilter } from '../../types'
 
 interface GameTypeFilterSectionProps {
   gameTypeFilter: GameTypeFilter

--- a/src/constants/runtime.ts
+++ b/src/constants/runtime.ts
@@ -1,0 +1,12 @@
+/**
+ * ランタイム定数: サービスクラス本体（Dexie/Streams/統計レジストリ等）に依存せず、
+ * background / content_script / web_accessible_resource のいずれからも安全にインポートできる。
+ *
+ * !!! poker-chase-service.ts 以外からはこのファイルを直接参照すること !!!
+ * (PokerChaseService の静的プロパティ経由でのインポートは依存グラフ全体をバンドルしてしまうため避ける)
+ */
+import { content_scripts } from '../../manifest.json'
+
+export const POKER_CHASE_SERVICE_EVENT = 'PokerChaseServiceEvent'
+export const POKER_CHASE_ORIGIN = new URL(content_scripts[0]!.matches[0]!).origin
+export const STORAGE_KEY = 'pokerChaseServiceState'

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -6,7 +6,9 @@
 import { createElement } from 'react'
 import { createRoot } from 'react-dom/client'
 import { web_accessible_resources } from '../manifest.json'
-import PokerChaseService, { ApiEvent, ApiType, PlayerStats } from './app'
+import { POKER_CHASE_SERVICE_EVENT, POKER_CHASE_ORIGIN } from './constants/runtime'
+import { ApiType } from './types'
+import type { ApiEvent, PlayerStats } from './types'
 import App from './components/App'
 import type { ChromeMessage } from './types/messages'
 import { MESSAGE_ACTIONS as EVENTS } from './types/messages'
@@ -28,13 +30,13 @@ export interface StatsData {
 
 declare global {
   interface WindowEventMap {
-    [PokerChaseService.POKER_CHASE_SERVICE_EVENT]: CustomEvent<StatsData>
+    [POKER_CHASE_SERVICE_EVENT]: CustomEvent<StatsData>
   }
 }
 
 const connectToBackgroundService = () => {
   try {
-    const port = chrome.runtime.connect({ name: PokerChaseService.POKER_CHASE_SERVICE_EVENT })
+    const port = chrome.runtime.connect({ name: POKER_CHASE_SERVICE_EVENT })
 
     // 接続成功時、ゲーム中ならキープアライブを開始
     if (isGameActive) {
@@ -44,7 +46,7 @@ const connectToBackgroundService = () => {
     port.onMessage.addListener((message: { stats: PlayerStats[], evtDeal?: ApiEvent<ApiType.EVT_DEAL>, realTimeStats?: AllPlayersRealTimeStats } | string) => {
       if (typeof message === 'object' && message !== null && 'stats' in message) {
         console.time('[content_script] Dispatching stats event')
-        window.dispatchEvent(new CustomEvent(PokerChaseService.POKER_CHASE_SERVICE_EVENT, { detail: message }))
+        window.dispatchEvent(new CustomEvent(POKER_CHASE_SERVICE_EVENT, { detail: message }))
         console.timeEnd('[content_script] Dispatching stats event')
         if (message.realTimeStats) {
           console.log('[content_script] Real-time stats received:', Object.keys(message.realTimeStats))
@@ -101,7 +103,7 @@ window.addEventListener('message', (event: MessageEvent<unknown>) => {
   if (
     // セキュリティチェック: ゲームのオリジンからのメッセージのみ受け付ける
     event.source !== window ||
-    event.origin !== PokerChaseService.POKER_CHASE_ORIGIN ||
+    event.origin !== POKER_CHASE_ORIGIN ||
     // PokerChase APIメッセージの型ガード: ApiTypeIdを持つことを確認
     !event.data ||
     typeof event.data !== 'object' ||
@@ -181,7 +183,7 @@ const messageHandlers: Record<string, (message: ChromeMessage) => void> = {
   },
   latestStats: (message) => {
     if ('stats' in message) {
-      window.dispatchEvent(new CustomEvent(PokerChaseService.POKER_CHASE_SERVICE_EVENT, {
+      window.dispatchEvent(new CustomEvent(POKER_CHASE_SERVICE_EVENT, {
         detail: { stats: message.stats }
       }))
     }

--- a/src/services/poker-chase-service.ts
+++ b/src/services/poker-chase-service.ts
@@ -1,4 +1,3 @@
-import { content_scripts } from '../../manifest.json'
 import { PokerChaseDB } from '../db/poker-chase-db'
 import { findLatestPlayerDealEvent } from '../utils/database-utils'
 import { AggregateEventsStream } from '../streams/aggregate-events-stream'
@@ -7,6 +6,11 @@ import { ReadEntityStream } from '../streams/read-entity-stream'
 import { HandLogStream } from '../streams/hand-log-stream'
 import { RealTimeStatsStream } from '../streams/realtime-stats-stream'
 import { setHandImprovementBatchMode } from '../realtime-stats'
+import {
+  POKER_CHASE_SERVICE_EVENT,
+  POKER_CHASE_ORIGIN,
+  STORAGE_KEY
+} from '../constants/runtime'
 import {
   ApiType,
   BATTLE_TYPE_FILTERS
@@ -50,9 +54,9 @@ class PokerChaseService {
   handLogConfig?: HandLogConfig = undefined // Hand log display configuration
   batchMode: boolean = false // Batch mode flag for bulk operations
 
-  static readonly POKER_CHASE_SERVICE_EVENT = 'PokerChaseServiceEvent'
-  static readonly POKER_CHASE_ORIGIN = new URL(content_scripts[0]!.matches[0]!).origin
-  static readonly STORAGE_KEY = 'pokerChaseServiceState'
+  static readonly POKER_CHASE_SERVICE_EVENT = POKER_CHASE_SERVICE_EVENT
+  static readonly POKER_CHASE_ORIGIN = POKER_CHASE_ORIGIN
+  static readonly STORAGE_KEY = STORAGE_KEY
 
   // Getter/Setter for automatic persistence
   get playerId(): number | undefined {

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -3,7 +3,7 @@
  * Uses discriminated union pattern for type safety
  */
 
-import { FilterOptions, PlayerStats } from '../app'
+import type { FilterOptions, PlayerStats } from './index'
 import { HandLogConfig, HandLogEvent, UIConfig } from './hand-log'
 import type { SyncState } from '../services/auto-sync-service'
 

--- a/src/web_accessible_resource.ts
+++ b/src/web_accessible_resource.ts
@@ -4,7 +4,7 @@
  * @see https://developer.mozilla.org/ja/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources
  */
 import { decode } from '@msgpack/msgpack'
-import PokerChaseService from './services/poker-chase-service'
+import { POKER_CHASE_ORIGIN } from './constants/runtime'
 /** !!! BACKGROUND、CONTENT_SCRIPTSからインポートしないこと !!! */
 
 const OriginalWebSocket = window.WebSocket
@@ -35,7 +35,7 @@ function createWebSocket(...args: ConstructorParameters<typeof WebSocket>): WebS
           window.postMessage({
             ...decoded,
             timestamp: Date.now()
-          }, PokerChaseService.POKER_CHASE_ORIGIN)
+          }, POKER_CHASE_ORIGIN)
         }
       } catch (error) {
         // デコードエラーは静かに無視（ログも最小限に）


### PR DESCRIPTION
## 問題

`web_accessible_resource.ts`(ページ注入)と `content_script.ts` / `App.tsx` が、`POKER_CHASE_ORIGIN` / `POKER_CHASE_SERVICE_EVENT` という**定数のためだけに** `PokerChaseService` 本体を import していました。サービスクラスはコンストラクタで全ストリーム・Dexie・統計レジストリを参照するため tree-shaking で除去できず、データ処理層の依存グラフ全体がページ注入・コンテンツスクリプト両バンドルに混入していました。

## 修正

- `src/constants/runtime.ts` を新設し、`POKER_CHASE_SERVICE_EVENT` / `POKER_CHASE_ORIGIN` / `STORAGE_KEY` を軽量モジュールとして提供
- `PokerChaseService` の静的プロパティは新定数から代入する形で維持(後方互換)
- `web_accessible_resource.ts` / `content_script.ts` / `App.tsx` からサービスの値 import を除去、型 import は `./types` 直参照に整理

## 効果(バンドルサイズ)

| バンドル | Before | After | 削減 |
|---|---|---|---|
| `dist/web_accessible_resource.js` | 420,399 B | 14,474 B | **−96.6%** |
| `dist/content_script.js` | 633,855 B | 362,583 B | **−42.8%** |

両バンドルに Dexie / 各 Stream クラスのコードが含まれないことを確認済み。

## 検証

- `npm run typecheck` ✅
- `npm run test` — 348/348 passed(39 suites)✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)