### PR TITLE
docs(stats): fix contributor guide drift and make 4bet example type-accurate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -272,6 +272,8 @@ These are the flags defined in the ActionDetail enum (`src/types/game.ts`):
 - `$3BET` / `$3BET_CHANCE` - 3-betting (note the $ prefix)
 - `$3BET_FOLD` / `$3BET_FOLD_CHANCE` - Folding to 3-bet
 - `DONK_BET` / `DONK_BET_CHANCE` - Donk betting
+- `STEAL` / `STEAL_CHANCE` - Attempting to steal from late position (CO/BTN/SB)
+- `FOLD_TO_STEAL` / `FOLD_TO_STEAL_CHANCE` - Blinds folding to a steal raise
 - `RIVER_CALL` / `RIVER_CALL_WON` - Calling on the river / winning after a river call
 
 #### Adding New Flags

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,6 +224,20 @@ After unit tests pass:
 await db.actions.where('actionDetails').anyOf(['MY_OPPORTUNITY', 'MY_OCCURRENCE']).toArray()
 ```
 
+### Applying Your Statistic to Existing Data (Rebuild)
+
+`detectActionDetails` flags are only assigned at write time, when hands are recorded into the database (see `src/streams/write-entity-stream.ts` and `src/entity-converter.ts`). This means a new statistic will only show correct/non-zero values for hands played (or imported) **after** your code change — previously recorded hands were never evaluated against your new detection logic, so their `actionDetails` won't contain your new flags.
+
+To backfill existing hands so your new statistic reflects historical data too, rebuild is required:
+
+1. Load the updated extension (`npm run build` → reload in `chrome://extensions/`).
+2. Open the extension popup.
+3. Click the "データ再構築" button (rebuild button) in the Import/Export section.
+4. Confirm the dialog ("データを再構築しますか？この処理には時間がかかる場合があります。"). This re-runs `detectActionDetails` for every stat — including yours — against all previously imported `apiEvents`, regenerating `hands`/`phases`/`actions` from scratch.
+5. Wait for the "データ再構築完了" status message; progress is shown via a progress bar while rebuilding.
+
+Without this step, your statistic will look like it's stuck at 0 (or empty) for any session recorded before the change, even though the logic itself is correct.
+
 ### Debugging Tips
 
 1. **Add logging to your detection logic:**
@@ -237,7 +251,7 @@ await db.actions.where('actionDetails').anyOf(['MY_OPPORTUNITY', 'MY_OCCURRENCE'
 2. **Check if your statistic is registered:**
    ```javascript
    // In background console
-   service.statsRegistry.getAll().map(s => s.id)
+   statsRegistry.getAll().map(s => s.id)
    ```
 
 3. **Verify action details are saved:**
@@ -258,6 +272,7 @@ These are the flags defined in the ActionDetail enum (`src/types/game.ts`):
 - `$3BET` / `$3BET_CHANCE` - 3-betting (note the $ prefix)
 - `$3BET_FOLD` / `$3BET_FOLD_CHANCE` - Folding to 3-bet
 - `DONK_BET` / `DONK_BET_CHANCE` - Donk betting
+- `RIVER_CALL` / `RIVER_CALL_WON` - Calling on the river / winning after a river call
 
 #### Adding New Flags
 To add new ActionDetail flags for your statistic:

--- a/src/background.ts
+++ b/src/background.ts
@@ -23,6 +23,8 @@ import { saveEntities, findLatestPlayerDealEvent } from './utils/database-utils'
 import type { AllPlayersRealTimeStats } from './realtime-stats/realtime-stats-service'
 import type { Options } from './components/Popup'
 import type { HandLogEvent } from './types/hand-log'
+import { defaultRegistry } from './stats'
+import type { StatsRegistry } from './stats/registry'
 import type {
   ChromeMessage,
   ExportProgressMessage,
@@ -49,6 +51,7 @@ declare global {
   interface Window {
     db: PokerChaseDB
     service: PokerChaseService
+    statsRegistry: StatsRegistry
   }
 }
 
@@ -58,6 +61,7 @@ const db = new PokerChaseDB(self.indexedDB, self.IDBKeyRange)
 const service = new PokerChaseService({ db })
 self.db = db
 self.service = service
+self.statsRegistry = defaultRegistry
 
 // Wait for service initialization
 service.ready.then(async () => {

--- a/src/stats/core/example-4bet.ts.example
+++ b/src/stats/core/example-4bet.ts.example
@@ -1,73 +1,64 @@
 /**
  * Example: 4-Bet Statistic
- * 
+ *
  * This is an example implementation showing how to create a new statistic.
  * To use this:
- * 1. Remove the .example extension from the filename
- * 2. Add the export to src/stats/core/index.ts
- * 3. The statistic will automatically appear in the HUD
+ * 1. Add `$4BET_CHANCE = '4BET_CHANCE'` and `$4BET = '4BET'` to the `ActionDetail`
+ *    enum in `src/types/game.ts` (follow the existing `$3BET`-style naming
+ *    convention already used there).
+ * 2. Rename this file from `example-4bet.ts.example` to `4bet.ts`.
+ * 3. Add the export to `src/stats/core/index.ts`.
+ * 4. Add unit tests (required — see CONTRIBUTING.md's "Unit Tests (Required)"
+ *    section).
+ * 5. Rebuild existing data: new flags are only assigned to hands recorded
+ *    going forward, so existing (previously imported) hands need a rebuild
+ *    to show non-zero values for this statistic. See CONTRIBUTING.md's
+ *    "Applying Your Statistic to Existing Data (Rebuild)" section.
  */
 
 import type { StatDefinition, ActionDetailContext } from '../../types/stats'
-import { ActionType } from '../../types/game'
+import { ActionDetail, ActionType } from '../../types/game'
 import { formatPercentage } from '../utils'
 import { isFacing3Bet } from '../helpers'
-
-// Custom action detail flags for this statistic
-// In a real implementation, these would be added to the ActionDetail enum
-const FOUR_BET_OPPORTUNITY = '4BET_OPPORTUNITY'
-const FOUR_BET = '4BET'
 
 export const fourBetStat: StatDefinition = {
   id: '4bet',
   name: '4B',
   description: '4-bet percentage',
-  
+
   // Detect when a player has the opportunity to 4-bet and whether they do
-  detectActionDetails: (context: ActionDetailContext): string[] => {
-    const details: string[] = []
-    
+  detectActionDetails: (context: ActionDetailContext): ActionDetail[] => {
+    const details: ActionDetail[] = []
+
     // Player is facing a 3-bet (phasePrevBetCount === 3)
     if (isFacing3Bet(context)) {
-      details.push(FOUR_BET_OPPORTUNITY)
-      
+      details.push(ActionDetail.$4BET_CHANCE)
+
       // Check if player responds with a raise (4-bet)
       if (context.actionType === ActionType.RAISE) {
-        details.push(FOUR_BET)
+        details.push(ActionDetail.$4BET)
       }
     }
-    
+
     return details
   },
-  
+
   // Calculate the statistic from accumulated data
   calculate: ({ actions }) => {
     // Count opportunities (when facing 3-bet)
-    const opportunities = actions.filter(a => 
-      a.actionDetails.includes(FOUR_BET_OPPORTUNITY)
+    const opportunities = actions.filter(a =>
+      a.actionDetails.includes(ActionDetail.$4BET_CHANCE)
     ).length
-    
+
     // Count actual 4-bets
-    const fourBets = actions.filter(a => 
-      a.actionDetails.includes(FOUR_BET)
+    const fourBets = actions.filter(a =>
+      a.actionDetails.includes(ActionDetail.$4BET)
     ).length
-    
+
     // Return as [numerator, denominator] for percentage calculation
     return [fourBets, opportunities]
   },
-  
+
   // Use the standard percentage formatter
   format: formatPercentage  // Will display as "25.0% (1/4)"
 }
-
-/**
- * Alternative implementation using ActionPatterns helper:
- * 
- * import { ActionPatterns } from '../helpers'
- * 
- * detectActionDetails: ActionPatterns.createOpportunityPattern(
- *   '4BET',
- *   (context) => isFacing3Bet(context),
- *   (context) => context.actionType === ActionType.RAISE
- * )
- */


### PR DESCRIPTION
## 問題

外部 contributor が統計を追加する際に確実に踏む3つの罠を修正します。

1. **`example-4bet.ts.example` がそのままでは動かない**: 生文字列のフラグを返しており、`detectActionDetails` の戻り型 `ActionDetail[]` に違反し、さらに `actionDetails: z.array(z.enum(ActionDetail))` の Zod 検証でランタイムエラーになる
2. **新統計が過去データに反映されない件が CONTRIBUTING に未記載**: `detectActionDetails` フラグは書き込み時に付与されるため、追加後のハンドにしか効かず、rebuild 実行が必要
3. **デバッグ手順の腐敗**: `service.statsRegistry.getAll()` は存在しないプロパティ

## 修正

- example を `ActionDetail.$4BET` / `$4BET_CHANCE` ベースに書き換え(enum 追加 → リネーム → export → テスト → rebuild の正確な手順を冒頭に記載)。enum を仮追加して `tsc --noEmit` が通ることを検証済み
- CONTRIBUTING に「Applying Your Statistic to Existing Data (Rebuild)」節を追加(popup の「データ再構築」ボタンの実際のフローを参照)
- `background.ts` で `self.statsRegistry = defaultRegistry` を公開し、デバッグ手順を実際に動くコマンドに修正
- Existing Flags 一覧を enum と同期(`RIVER_CALL` / `RIVER_CALL_WON` 追記)

## 検証

- `npm run typecheck` ✅
- `npm run test` — 348/348 passed(39 suites)✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)