### PR TITLE
fix(stats): derive import-path positions from BigBlindSeat to match live pipeline

### DIFF
--- a/src/entity-converter.test.ts
+++ b/src/entity-converter.test.ts
@@ -10,6 +10,10 @@ import {
   apiEventSchemas
 } from '../src/types'
 import type { ApiEvent, Session } from '../src/types'
+import PokerChaseService, { PokerChaseDB } from '../src/app'
+import type { Action } from '../src/types'
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import { Readable } from 'stream'
 
 // ヘルパー関数：型安全にイベントを作成
 function createEvent<T extends ApiType>(
@@ -1293,6 +1297,270 @@ describe('EntityConverter', () => {
       expect(result.hands).toHaveLength(1)
       expect(result.actions).toHaveLength(1)
       expect(result.actions[0]!.playerId).toBe(0)
+    })
+  })
+
+  /**
+   * ライブ記録パイプライン（WriteEntityStream）とインポート/リビルドパイプライン
+   * （EntityConverter）のポジション整合性テスト
+   *
+   * 背景: WriteEntityStreamはEVT_DEAL.Game.BigBlindSeatを基準にポジションを算出するが、
+   * 旧EntityConverter（getPositionUserIds）はBigBlindSeatを無視し、フルテーブルでは
+   * 常にseat0をSBとみなすヒューリスティックだった。既存フィクスチャは全てBigBlindSeat: 1
+   * （SBがseat0）だったため、このズレが表面化していなかった。
+   * BigBlindSeatが1以外（=SBがseat0以外）の同一イベント列を両パイプラインに通し、
+   * 生成されるActionが完全に一致することを確認する。
+   */
+  describe('position parity with WriteEntityStream', () => {
+    it('produces identical action positions to the live recording pipeline when BigBlindSeat !== 1', async () => {
+      // 4人テーブル。ButtonSeat=1, SmallBlindSeat=2, BigBlindSeat=3
+      // （SBがseat0ではないケース。ここが壊れていたヒューリスティックを踏み抜く）
+      const events: ApiEvent[] = [
+        createEvent(ApiType.EVT_DEAL, {
+          timestamp: 20000,
+          SeatUserIds: [10, 20, 30, 40],
+          Game: {
+            CurrentBlindLv: 1,
+            NextBlindUnixSeconds: 20000000,
+            Ante: 0,
+            SmallBlind: 10,
+            BigBlind: 20,
+            ButtonSeat: 1,
+            SmallBlindSeat: 2,
+            BigBlindSeat: 3
+          },
+          Player: {
+            SeatIndex: 0,
+            BetStatus: 1,
+            HoleCards: [37, 51],
+            Chip: 1980,
+            BetChip: 0
+          },
+          Progress: {
+            Phase: 0,
+            NextActionSeat: 0,
+            NextActionTypes: [2, 3, 4, 5],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 40,
+            Pot: 30,
+            SidePot: []
+          },
+          OtherPlayers: [
+            { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 2000, BetChip: 0 },
+            { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 1990, BetChip: 10 },
+            { SeatIndex: 3, Status: 0, BetStatus: 1, Chip: 1980, BetChip: 20 }
+          ]
+        }),
+        // UTG(seat0, player10)がレイズ
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 20001,
+          SeatIndex: 0,
+          ActionType: ActionType.RAISE,
+          Chip: 1920,
+          BetChip: 60,
+          Progress: {
+            Phase: 0,
+            NextActionSeat: 1,
+            NextActionTypes: [2, 3, 4, 5],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 100,
+            Pot: 90,
+            SidePot: []
+          }
+        }),
+        // BTN(seat1, player20)がフォールド
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 20002,
+          SeatIndex: 1,
+          ActionType: ActionType.FOLD,
+          Chip: 2000,
+          BetChip: 0,
+          Progress: {
+            Phase: 0,
+            NextActionSeat: 2,
+            NextActionTypes: [2, 3, 4, 5],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 100,
+            Pot: 90,
+            SidePot: []
+          }
+        }),
+        // SB(seat2, player30)がコール
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 20003,
+          SeatIndex: 2,
+          ActionType: ActionType.CALL,
+          Chip: 1940,
+          BetChip: 60,
+          Progress: {
+            Phase: 0,
+            NextActionSeat: 3,
+            NextActionTypes: [2, 3, 4, 5],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 100,
+            Pot: 150,
+            SidePot: []
+          }
+        }),
+        // BB(seat3, player40)がフォールド
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 20004,
+          SeatIndex: 3,
+          ActionType: ActionType.FOLD,
+          Chip: 1980,
+          BetChip: 0,
+          Progress: {
+            Phase: 0,
+            NextActionSeat: -1,
+            NextActionTypes: [],
+            NextExtraLimitSeconds: 0,
+            MinRaise: 0,
+            Pot: 150,
+            SidePot: []
+          }
+        }),
+        // フロップ
+        createEvent(ApiType.EVT_DEAL_ROUND, {
+          timestamp: 20005,
+          CommunityCards: [1, 21, 44],
+          Progress: {
+            Phase: 1,
+            NextActionSeat: 2,
+            NextActionTypes: [0, 1, 5],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 0,
+            Pot: 150,
+            SidePot: []
+          },
+          OtherPlayers: [
+            { SeatIndex: 0, Status: 0, BetStatus: 1, Chip: 1920, BetChip: 0 },
+            { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 1940, BetChip: 0 }
+          ]
+        }),
+        // SB(seat2, player30)がチェック
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 20006,
+          SeatIndex: 2,
+          ActionType: ActionType.CHECK,
+          Chip: 1940,
+          BetChip: 0,
+          Progress: {
+            Phase: 1,
+            NextActionSeat: 0,
+            NextActionTypes: [0, 1, 5],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 0,
+            Pot: 150,
+            SidePot: []
+          }
+        }),
+        // UTG(seat0, player10)がベット
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 20007,
+          SeatIndex: 0,
+          ActionType: ActionType.BET,
+          Chip: 1820,
+          BetChip: 100,
+          Progress: {
+            Phase: 1,
+            NextActionSeat: 2,
+            NextActionTypes: [2, 3, 4, 5],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 200,
+            Pot: 250,
+            SidePot: []
+          }
+        }),
+        // SB(seat2, player30)がフォールド
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 20008,
+          SeatIndex: 2,
+          ActionType: ActionType.FOLD,
+          Chip: 1940,
+          BetChip: 0,
+          Progress: {
+            Phase: 1,
+            NextActionSeat: -2,
+            NextActionTypes: [],
+            NextExtraLimitSeconds: 0,
+            MinRaise: 0,
+            Pot: 250,
+            SidePot: []
+          }
+        }),
+        createEvent(ApiType.EVT_HAND_RESULTS, {
+          timestamp: 20009,
+          HandId: 999001,
+          CommunityCards: [1, 21, 44],
+          Pot: 250,
+          SidePot: [],
+          ResultType: 0,
+          DefeatStatus: 0,
+          Results: [
+            {
+              UserId: 10,
+              HoleCards: [37, 51],
+              RankType: 10,
+              Hands: [],
+              HandRanking: 1,
+              Ranking: 1,
+              RewardChip: 250
+            }
+          ],
+          OtherPlayers: [
+            { SeatIndex: 1, Status: 0, BetStatus: -1, Chip: 2000, BetChip: 0 },
+            { SeatIndex: 2, Status: 0, BetStatus: -1, Chip: 1940, BetChip: 0 },
+            { SeatIndex: 3, Status: 0, BetStatus: -1, Chip: 1980, BetChip: 0 }
+          ]
+        })
+      ]
+
+      // --- ライブ記録パイプライン: WriteEntityStream経由 ---
+      const dbMock = new PokerChaseDB(indexedDB, IDBKeyRange)
+      const service = new PokerChaseService({ db: dbMock })
+      // restoreState()（コンストラクタ内でトリガーされる非同期処理）の完了を待たないと、
+      // handAggregateStreamへの書き込みとレースしてIndexedDBの読み取りが空になることがある
+      await service.ready
+      await new Promise<void>((resolve, reject) => {
+        service.handAggregateStream
+          .on('finish', () => resolve())
+          .on('error', (error: Error) => reject(error))
+        Readable.from(events).pipe(service.handAggregateStream)
+      })
+      // Dexie/fake-indexeddbはテスト実行順によって暗黙にクローズされることがあるため、
+      // 読み取り前に明示的にopenし直す（データ自体は書き込み済み）
+      await dbMock.open()
+      const liveActions = (await dbMock.actions
+        .where('handId').equals(999001)
+        .toArray())
+        .sort((a, b) => a.index - b.index)
+
+      // --- インポート/リビルドパイプライン: EntityConverter経由 ---
+      const importResult = converter.convertEventsToEntities(events)
+      const importActions = importResult.actions.slice().sort((a, b) => a.index - b.index)
+
+      expect(liveActions.length).toBeGreaterThan(0)
+      expect(importActions.length).toBe(liveActions.length)
+
+      const pickComparable = (action: Action) => ({
+        playerId: action.playerId,
+        phase: action.phase,
+        actionType: action.actionType,
+        position: action.position,
+        actionDetails: action.actionDetails
+      })
+
+      expect(importActions.map(pickComparable)).toEqual(liveActions.map(pickComparable))
+
+      // 具体的な期待値も明示しておく（BigBlindSeat=3 → SBはseat2=player30、BBはseat3=player40）
+      const positionsByPlayer = new Map(liveActions.map(a => [a.playerId, a.position]))
+      expect(positionsByPlayer.get(30)).toBe(Position.SB)
+      expect(positionsByPlayer.get(40)).toBe(Position.BB)
+      expect(positionsByPlayer.get(20)).toBe(Position.BTN)
+      expect(positionsByPlayer.get(10)).toBe(Position.CO) // 4人卓: BTNの次はCO
+
+      const importPositionsByPlayer = new Map(importActions.map(a => [a.playerId, a.position]))
+      expect(importPositionsByPlayer).toEqual(positionsByPlayer)
     })
   })
 })

--- a/src/entity-converter.ts
+++ b/src/entity-converter.ts
@@ -147,6 +147,11 @@ export class EntityConverter {
       cBetter: undefined // CB統計のために追加
     }
 
+    // ポジション計算用のユーザーID配列（EVT_DEALで1ハンドにつき1度だけ設定される。
+    // WriteEntityStream（ライブ記録パイプライン）と同一のロジックで算出し、
+    // インポート/リビルド後もポジション値が一致するようにする）
+    let positionUserIds: number[] = []
+
     let progress: any = undefined
 
     for (const event of events) {
@@ -167,6 +172,10 @@ export class EntityConverter {
             },
             results: []
           }
+
+          // ポジション計算用のユーザーID配列を算出（WriteEntityStreamと同一ロジック）。
+          // BigBlindSeatの次（=SB）から逆順に並べ、全フェーズ共通で使用する。
+          positionUserIds = rotateArrayFromIndex(event.SeatUserIds, event.Game.BigBlindSeat + 1).reverse()
 
           // プリフロップフェーズの作成（handIdは後で更新される）
           handState.phases.push({
@@ -200,25 +209,9 @@ export class EntityConverter {
             action.playerId === playerId
           ).length
 
-          // ポジション計算のためのユーザーID配列を作成
-          const positionUserIds = this.getPositionUserIds(handState.hand.seatUserIds, phase)
-
-          // ポジション計算
-          let position: Position
-          const playerIndex = positionUserIds.indexOf(playerId ?? 0)
-          if (playerIndex === 0) {
-            position = Position.SB // -1
-          } else if (playerIndex === 1) {
-            position = Position.BB // -2
-          } else if (playerIndex === 2) {
-            position = Position.UTG // 3
-          } else if (playerIndex === 3) {
-            position = Position.HJ // 2
-          } else if (playerIndex === 4) {
-            position = Position.CO // 1
-          } else {
-            position = Position.BTN // 0
-          }
+          // ポジション計算（WriteEntityStreamと同一ロジック。EVT_DEAL時点で確定した
+          // positionUserIdsを全フェーズで使い回すことで、ライブ記録と同じポジション値を得る）
+          const position: Position = positionUserIds.indexOf(playerId ?? 0) - 2
 
           // 統計モジュールを使用してActionDetailを検出
           const detectionContext: ActionDetailContext = {
@@ -362,43 +355,5 @@ export class EntityConverter {
       case 3: return PhaseType.RIVER
       default: return null
     }
-  }
-
-  /**
-   * ポジション計算用のユーザーID配列を取得
-   */
-  private getPositionUserIds(seatUserIds: number[], phase: PhaseType): number[] {
-    // プリフロップの場合はSB/BBから始まる順序
-    if (phase === PhaseType.PREFLOP) {
-      // SBの位置を見つける（BBの1つ前）
-      let sbIndex = -1
-      for (let i = 0; i < seatUserIds.length; i++) {
-        if (seatUserIds[i] !== -1 && seatUserIds[(i + 1) % seatUserIds.length] !== -1) {
-          sbIndex = i
-          break
-        }
-      }
-
-      if (sbIndex === -1) return seatUserIds // フォールバック
-
-      // SBから順に並べ替え
-      return rotateArrayFromIndex(seatUserIds, sbIndex)
-    }
-
-    // ポストフロップの場合はボタンの次から始まる順序
-    // 簡単のため、最後の有効なプレイヤーをボタンとする
-    let buttonIndex = -1
-    for (let i = seatUserIds.length - 1; i >= 0; i--) {
-      if (seatUserIds[i] !== -1) {
-        buttonIndex = i
-        break
-      }
-    }
-
-    if (buttonIndex === -1) return seatUserIds // フォールバック
-
-    // ボタンの次から順に並べ替え
-    const nextIndex = (buttonIndex + 1) % seatUserIds.length
-    return rotateArrayFromIndex(seatUserIds, nextIndex)
   }
 }


### PR DESCRIPTION
## 問題(#86 レビューで発見)

EntityConverter(インポート/リビルド経路)の `getPositionUserIds` は `EVT_DEAL.Game.BigBlindSeat` を使わず、以下のヒューリスティックで position を推定していました:

- プリフロップ: 「隣接2席が埋まっている最初の席 = SB」→ **満席のテーブルでは常に seat 0 を SB とみなす**
- ポストフロップ: 「最後の有効席 = BTN」+ プリフロップとは別の index→Position マッピング

ブラインドは毎ハンド回るため、SB が seat 0 にないハンド(=実データの大半)では誤った position が保存されます。既存テストのフィクスチャが全て `BigBlindSeat: 1`(SB = seat 0)だったため露見していませんでした。

これまで `Action.position` は保存されるだけで統計に使われていませんでしたが、#86 で STL/FTS 判定が position に依存するようになったため、**ライブ記録とインポート/リビルド後で統計値が食い違う**実害となりました(#86 に事前コメント済み)。

## 修正

- EVT_DEAL 時に `rotateArrayFromIndex(SeatUserIds, BigBlindSeat + 1).reverse()` を1ハンドにつき一度算出し、`indexOf(playerId) - 2` で全フェーズ共通に position を導出 — **WriteEntityStream(ライブ経路・監査済み)と完全同一ロジック**
- フェーズ依存のヒューリスティック `getPositionUserIds` を削除

## パリティテスト

`BigBlindSeat: 3`(SB ≠ seat 0)の4人ハンドを **同一イベント列で両経路**(WriteEntityStream 実パイプライン + EntityConverter)に通し、全アクションの `{playerId, phase, actionType, position, actionDetails}` の一致を検証。修正前の main では position 不一致に加えて **STEAL/FOLD_TO_STEAL フラグの食い違い**まで再現して fail することを確認済みです。

## 補足

- 既存テストの期待値変更はゼロ(唯一の position 検証テストは `BigBlindSeat: 1` でヒューリスティックと正解が偶然一致するケースのため)
- マージ後、過去データの position / STL / FTS を正すには**データ再構築(rebuild)の実行が必要**です

## 検証

- `npm run typecheck` ✅
- `npm run test` — 362/362 passed(41 suites、+1 パリティテスト)✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)