### PR TITLE
fix(stats): gate showdown phase on revealing RankTypes, not result count

### DIFF
--- a/src/entity-converter.test.ts
+++ b/src/entity-converter.test.ts
@@ -7,6 +7,7 @@ import {
   ActionDetail,
   Position,
   BetStatusType,
+  RankType,
   apiEventSchemas
 } from '../src/types'
 import type { ApiEvent, Session } from '../src/types'
@@ -1561,6 +1562,209 @@ describe('EntityConverter', () => {
 
       const importPositionsByPlayer = new Map(importActions.map(a => [a.playerId, a.position]))
       expect(importPositionsByPlayer).toEqual(positionsByPlayer)
+    })
+  })
+
+  /**
+   * SHOWDOWNフェーズ生成のRankTypeゲーティング
+   *
+   * バグ: 修正前は`Results.length > 1`のみでSHOWDOWNフェーズを生成していたため、
+   * 「無競争勝利（NO_CALL）＋フォールド後の自発公開（FOLD_OPEN）」のような、実際には
+   * カードを比較していない2件の結果でも誤ってSHOWDOWNフェーズが作られていた
+   * （実データ393,830件中、複数結果ハンド12,329件のうち692件＝5.6%で発生）。
+   * これによりWTSD/W$SDの分母が水増しされる。
+   * CLAUDE.mdのConfirmed Statistical Definitionsに従い、ショーダウン参加者は
+   * 「実役（RankType 0-9）またはSHOWDOWN_MUCK（11）」のみとし、NO_CALL（10）と
+   * FOLD_OPEN（12）は除外する。
+   */
+  describe('SHOWDOWN phase gating by RankType', () => {
+    // 2人テーブルでプリフロップにオールインし、そのままハンド結果を迎える最小フィクスチャ。
+    // Resultsだけを差し替えて各RankTypeの組み合わせを検証する。
+    const buildHeadsUpAllInEvents = (results: ApiEvent<ApiType.EVT_HAND_RESULTS>['Results']): ApiEvent[] => [
+      createEvent(ApiType.EVT_DEAL, {
+        timestamp: 3000,
+        SeatUserIds: [300, 301, -1, -1, -1, -1],
+        Game: {
+          CurrentBlindLv: 1,
+          NextBlindUnixSeconds: 3000000,
+          Ante: 0,
+          SmallBlind: 50,
+          BigBlind: 100,
+          ButtonSeat: 0,
+          SmallBlindSeat: 0,
+          BigBlindSeat: 1
+        },
+        Progress: {
+          Phase: 0,
+          NextActionSeat: 0,
+          NextActionTypes: [ActionType.BET, ActionType.FOLD],
+          NextExtraLimitSeconds: 15,
+          MinRaise: 200,
+          Pot: 150,
+          SidePot: []
+        },
+        OtherPlayers: [
+          { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 1900, BetChip: 100 }
+        ]
+      }),
+      createEvent(ApiType.EVT_ACTION, {
+        timestamp: 3001,
+        SeatIndex: 0,
+        ActionType: ActionType.ALL_IN,
+        Chip: 0,
+        BetChip: 2000,
+        Progress: {
+          Phase: 0,
+          NextActionSeat: 1,
+          NextActionTypes: [ActionType.BET],
+          NextExtraLimitSeconds: 15,
+          MinRaise: 4000,
+          Pot: 2150,
+          SidePot: []
+        }
+      }),
+      createEvent(ApiType.EVT_HAND_RESULTS, {
+        timestamp: 3002,
+        HandId: 34567,
+        CommunityCards: [1, 21, 44, 2, 15],
+        Pot: 2150,
+        SidePot: [],
+        ResultType: 0,
+        DefeatStatus: 0,
+        Results: results,
+        OtherPlayers: [
+          { SeatIndex: 1, Status: 0, BetStatus: -1, Chip: 1900, BetChip: 0 }
+        ]
+      }, { skipValidation: true })
+    ]
+
+    it('does NOT create a SHOWDOWN phase for NO_CALL + FOLD_OPEN (uncontested win, no cards compared)', () => {
+      // 実例（hand 295913653）: 相手がフォールドしたため無競争勝利（NO_CALL）。
+      // フォールドしたプレイヤーは自発的にカードを公開した（FOLD_OPEN）だけで、
+      // ショーダウンは発生していない。
+      const events = buildHeadsUpAllInEvents([
+        {
+          UserId: 300,
+          HoleCards: [],
+          RankType: RankType.NO_CALL,
+          Hands: [],
+          HandRanking: 1,
+          Ranking: 1,
+          RewardChip: 2150
+        },
+        {
+          UserId: 301,
+          HoleCards: [48, 13],
+          RankType: RankType.FOLD_OPEN,
+          Hands: [],
+          HandRanking: -1,
+          Ranking: -1,
+          RewardChip: 0
+        }
+      ])
+
+      // インポート/リビルドパイプライン: EntityConverter経由
+      // （ライブ記録パイプライン=WriteEntityStreamでの同等テストは次のitを参照）
+      const importResult = converter.convertEventsToEntities(events)
+      expect(importResult.phases.find(p => p.phase === PhaseType.SHOWDOWN)).toBeUndefined()
+    })
+
+    it('does NOT create a SHOWDOWN phase for NO_CALL + FOLD_OPEN via the live WriteEntityStream pipeline either', async () => {
+      const events = buildHeadsUpAllInEvents([
+        {
+          UserId: 300,
+          HoleCards: [],
+          RankType: RankType.NO_CALL,
+          Hands: [],
+          HandRanking: 1,
+          Ranking: 1,
+          RewardChip: 2150
+        },
+        {
+          UserId: 301,
+          HoleCards: [48, 13],
+          RankType: RankType.FOLD_OPEN,
+          Hands: [],
+          HandRanking: -1,
+          Ranking: -1,
+          RewardChip: 0
+        }
+      ])
+
+      const dbMock = new PokerChaseDB(indexedDB, IDBKeyRange)
+      const service = new PokerChaseService({ db: dbMock })
+      await service.ready
+      await new Promise<void>((resolve, reject) => {
+        service.handAggregateStream
+          .on('finish', () => resolve())
+          .on('error', (error: Error) => reject(error))
+        Readable.from(events).pipe(service.handAggregateStream)
+      })
+      await dbMock.open()
+      const livePhases = await dbMock.phases
+        .where('handId').equals(34567)
+        .toArray()
+
+      expect(livePhases.find(p => p.phase === PhaseType.SHOWDOWN)).toBeUndefined()
+    })
+
+    it('creates a SHOWDOWN phase for a real rank vs SHOWDOWN_MUCK (loser mucked, but showdown occurred)', () => {
+      // ショーダウンが発生し、敗者がマックした（SHOWDOWN_MUCK）ケース。CLAUDE.mdの定義通り、
+      // SHOWDOWN_MUCKはショーダウンとしてカウントする。
+      const events = buildHeadsUpAllInEvents([
+        {
+          UserId: 300,
+          HoleCards: [37, 51],
+          RankType: RankType.ONE_PAIR,
+          Hands: [1, 21, 44, 37, 51],
+          HandRanking: 1,
+          Ranking: 1,
+          RewardChip: 2150
+        },
+        {
+          UserId: 301,
+          HoleCards: [],
+          RankType: RankType.SHOWDOWN_MUCK,
+          Hands: [],
+          HandRanking: -1,
+          Ranking: -1,
+          RewardChip: 0
+        }
+      ])
+
+      const importResult = converter.convertEventsToEntities(events)
+      const showdownPhase = importResult.phases.find(p => p.phase === PhaseType.SHOWDOWN)
+      expect(showdownPhase).toBeDefined()
+      expect(showdownPhase!.seatUserIds).toEqual([300, 301])
+    })
+
+    it('does NOT create a SHOWDOWN phase for a real rank vs NO_CALL (only one player actually revealed)', () => {
+      // RankType 0-9とNO_CALLの組み合わせは実データ上は稀だが、NO_CALLは常に「比較していない」
+      // ことを意味するため、もう片方が実役でもショーダウン参加者は1名のみとなり、
+      // SHOWDOWNフェーズは生成されないべき。
+      const events = buildHeadsUpAllInEvents([
+        {
+          UserId: 300,
+          HoleCards: [37, 51],
+          RankType: RankType.HIGH_CARD,
+          Hands: [1, 21, 44, 37, 51],
+          HandRanking: 1,
+          Ranking: 1,
+          RewardChip: 2150
+        },
+        {
+          UserId: 301,
+          HoleCards: [],
+          RankType: RankType.NO_CALL,
+          Hands: [],
+          HandRanking: -1,
+          Ranking: -1,
+          RewardChip: 0
+        }
+      ])
+
+      const importResult = converter.convertEventsToEntities(events)
+      expect(importResult.phases.find(p => p.phase === PhaseType.SHOWDOWN)).toBeUndefined()
     })
   })
 })

--- a/src/entity-converter.ts
+++ b/src/entity-converter.ts
@@ -11,7 +11,8 @@ import {
   ApiType,
   PhaseType,
   Position,
-  isApiEventType
+  isApiEventType,
+  isShowdownParticipant
 } from './types'
 
 import type {
@@ -285,15 +286,19 @@ export class EntityConverter {
             action.handId = event.HandId
           })
 
-          // ショーダウンフェーズの生成（複数のプレイヤーが結果に含まれる場合）
-          if (event.Results && event.Results.length > 1) {
-            const lastPhase = handState.phases.at(-1)
-            handState.phases.push({
-              handId: event.HandId,
-              phase: PhaseType.SHOWDOWN,
-              communityCards: [...(lastPhase?.communityCards || []), ...(event.CommunityCards || [])],
-              seatUserIds: event.Results.map(result => result.UserId)
-            })
+          // ショーダウンフェーズの生成（実際にカードを比較したプレイヤーが2名以上いる場合）
+          // NO_CALL（無競争勝利）やFOLD_OPEN（フォールド後の自発公開）はショーダウンではないため除外する
+          {
+            const showdownParticipants = (event.Results || []).filter(isShowdownParticipant)
+            if (showdownParticipants.length >= 2) {
+              const lastPhase = handState.phases.at(-1)
+              handState.phases.push({
+                handId: event.HandId,
+                phase: PhaseType.SHOWDOWN,
+                communityCards: [...(lastPhase?.communityCards || []), ...(event.CommunityCards || [])],
+                seatUserIds: showdownParticipants.map(result => result.UserId)
+              })
+            }
           }
 
           // ハンド結果の更新

--- a/src/streams/write-entity-stream.ts
+++ b/src/streams/write-entity-stream.ts
@@ -5,7 +5,8 @@ import {
   ActionType,
   ApiType,
   BetStatusType,
-  PhaseType
+  PhaseType,
+  isShowdownParticipant
 } from '../types'
 import type {
   ApiHandEvent,
@@ -186,34 +187,38 @@ export class WriteEntityStream extends Transform {
           progress = event.Progress
         }
           break
-        case ApiType.EVT_HAND_RESULTS:
-          if (event.Results.length > 1) {
+        case ApiType.EVT_HAND_RESULTS: {
+          // ショーダウンフェーズの生成（実際にカードを比較したプレイヤーが2名以上いる場合）
+          // NO_CALL（無競争勝利）やFOLD_OPEN（フォールド後の自発公開）はショーダウンではないため除外する
+          const showdownParticipants = event.Results.filter(isShowdownParticipant)
+          if (showdownParticipants.length >= 2) {
             handState.phases.push({
               phase: PhaseType.SHOWDOWN,
               communityCards: [...handState.phases.at(-1)!.communityCards, ...event.CommunityCards],
-              seatUserIds: event.Results.map(({ UserId }) => UserId),
+              seatUserIds: showdownParticipants.map(({ UserId }) => UserId),
             })
           }
           handState.hand.id = event.HandId
           handState.hand.winningPlayerIds = event.Results.filter(({ HandRanking }) => HandRanking === 1).map(({ UserId }) => UserId)
           handState.hand.approxTimestamp = event.timestamp
           handState.hand.results = event.Results
-          
+
           // Update actions with handId and add RIVER_CALL_WON for winning river calls
           handState.actions = handState.actions.map(action => {
             const updatedAction = { ...action, handId: event.HandId }
-            
+
             // Check if this is a river call by a winning player
-            if (action.actionDetails.includes(ActionDetail.RIVER_CALL) && 
+            if (action.actionDetails.includes(ActionDetail.RIVER_CALL) &&
                 handState.hand.winningPlayerIds.includes(action.playerId)) {
               updatedAction.actionDetails = [...action.actionDetails, ActionDetail.RIVER_CALL_WON]
             }
-            
+
             return updatedAction
           })
-          
+
           handState.phases = handState.phases.map(phase => ({ ...phase, handId: event.HandId }))
           break
+        }
       }
     }
     return handState

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -55,6 +55,21 @@ export enum RankType {
   FOLD_OPEN = 12
 }
 
+/**
+ * ショーダウン（カードの強制/自発的公開による勝敗比較）が実際に発生したことを示すRankTypeか判定する。
+ *
+ * - 0-9（実役）: ショーダウンで役を比較した結果
+ * - 11 (SHOWDOWN_MUCK): ショーダウンに参加したが敗北してマック（＝ショーダウンは発生した）
+ * - 10 (NO_CALL) / 12 (FOLD_OPEN): ショーダウンは発生していない（無競争勝利／フォールド後の自発公開）
+ *
+ * `EVT_HAND_RESULTS.Results`は`RankType`を持つオブジェクトの配列であり、SHOWDOWNフェーズ生成や
+ * WTSD/W$SD統計はこの述語で「ショーダウン参加者」を判定する必要がある（詳細はCLAUDE.mdの
+ * Confirmed Statistical Definitions参照）。
+ */
+export function isShowdownParticipant(result: { RankType: RankType }): boolean {
+  return result.RankType !== RankType.NO_CALL && result.RankType !== RankType.FOLD_OPEN
+}
+
 export enum Position {
   BB = -2,
   SB = -1,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,7 +37,8 @@ export {
   RankType,
   Position,
   ActionDetail,
-  BATTLE_TYPE_FILTERS
+  BATTLE_TYPE_FILTERS,
+  isShowdownParticipant
 } from './game'
 
 // Entity types


### PR DESCRIPTION
## 問題(実データ検証で発見)

SHOWDOWN フェーズの生成条件が `Results.length > 1` のみで、RankType を見ていませんでした。NO_CALL(無競争勝利)+ FOLD_OPEN(フォールド後の自発公開)のような「ショーダウン不成立」のハンドでもフェーズが生成され、WTSD / W$SD の分母を水増ししていました。実データでは multi-result ハンドの **5.6%(692/12,329)** が該当。CLAUDE.md 自身の定義(NO_CALL はショーダウンに数えない)とも矛盾していました。

## 修正

- `isShowdownParticipant`(RankType 0–9 の実役 + SHOWDOWN_MUCK(11) = 参加、NO_CALL(10) / FOLD_OPEN(12) = 不参加)を `types/game.ts` に定義
- 両経路(WriteEntityStream / EntityConverter)で「参加者 2 名以上」にゲーティングし、フェーズの `seatUserIds` も参加者のみで構築

## 検証

- 新規テスト 4 件(NO_CALL+FOLD_OPEN → フェーズなし、実役+MUCK → あり、実役+NO_CALL → なし、両経路)。修正を外すと 3 件が期待どおり fail することを確認済み
- 既存フィクスチャに RankType 10/12 複合ケースが皆無であることをスクリプトで確認(期待値変更ゼロ)
- `npm run typecheck` ✅ / `npm run test` — 366/366(41 suites)✅

**注**: 過去データへの反映にはデータ再構築(rebuild)が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)