### PR TITLE
fix(stats): derive positions from explicit blind/button seats to handle empty seats

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -535,6 +535,15 @@ test('ログから各プレイヤーのスタッツを計算できる', async ()
   ]))
   expect(rinStats && 'statResults' in rinStats ? rinStats.statResults : []).toEqual(expect.arrayContaining([
     expect.objectContaining({ id: 'steal', value: [5, 10], formatted: '50.0% (5/10)' }),
-    expect.objectContaining({ id: 'foldToSteal', value: [7, 8], formatted: '87.5% (7/8)' })
+    // foldToStealは[7,8]から[8,9]に変化した。event_timelineには複数のヘッズアップハンド
+    // （SeatUserIds: [2, 4, -1, -1], ButtonSeat === SmallBlindSeat === 1）が含まれており、
+    // 旧実装（BigBlindSeatを基準に座席配列を回転させる方式）はヘッズアップ時に
+    // 空席が回転後の配列のスロットを占有してインデックスをズラし、
+    // 実際はSB（ボタン）である凛（playerId 4）をCO(1)と誤ってラベル付けしていた。
+    // 修正後はGame.ButtonSeat/SmallBlindSeat/BigBlindSeatから直接ポジションを求めるため、
+    // ヘッズアップでは正しくSB(-1)と判定される（旧実装のHU挙動: ButtonSeat===SmallBlindSeat
+    // のプレイヤーはSB、という定義自体は踏襲している）。この結果、FTSの機会・成功数が
+    // 1件ずつ増加した。
+    expect.objectContaining({ id: 'foldToSteal', value: [8, 9], formatted: '88.9% (8/9)' })
   ]))
 })

--- a/src/entity-converter.test.ts
+++ b/src/entity-converter.test.ts
@@ -1563,6 +1563,181 @@ describe('EntityConverter', () => {
       const importPositionsByPlayer = new Map(importActions.map(a => [a.playerId, a.position]))
       expect(importPositionsByPlayer).toEqual(positionsByPlayer)
     })
+
+    /**
+     * 空席（SeatUserIds内の-1）を含むケースの整合性テスト。
+     *
+     * 背景: `rotateArrayFromIndex(seatUserIds, BigBlindSeat + 1).reverse()`で座席配列を
+     * 回転させ、その配列上のインデックスからポジションを逆算する方式（修正前の実装）は、
+     * 「全座席が連続して埋まっている」ことを暗黙に仮定していた。トーナメントのバスト等で
+     * 空席（-1）が生じると、その-1が回転後の配列内でスロットを占有し続けるため、実プレイヤーの
+     * インデックスがズレてポジションが誤って算出される。
+     *
+     * 具体例: SeatUserIds=[-1,-1,A,B,-1,C], Game={ButtonSeat:2, SmallBlindSeat:3, BigBlindSeat:5}
+     * では、A(seat2)が実際のBTN、B(seat3)が実際のSBだが、修正前の方式では
+     * Bをrotate後配列のインデックス2（=BTN）、Aをインデックス3（=CO）と誤ってラベル付けする。
+     * 修正後はGame.ButtonSeat/SmallBlindSeat/BigBlindSeatから直接算出するため、
+     * 空席の有無に関わらずA=BTN、B=SB、C=BBと正しく判定される。
+     *
+     * このテストは修正前のロジックに戻すと失敗する（`git stash`で確認済み）。
+     */
+    it('produces identical and correct action positions when SeatUserIds contains empty seats (-1)', async () => {
+      const A = 100, B = 200, C = 300
+      const events: ApiEvent[] = [
+        createEvent(ApiType.EVT_DEAL, {
+          timestamp: 30000,
+          SeatUserIds: [-1, -1, A, B, -1, C],
+          Game: {
+            CurrentBlindLv: 1,
+            NextBlindUnixSeconds: 30000000,
+            Ante: 0,
+            SmallBlind: 10,
+            BigBlind: 20,
+            ButtonSeat: 2,
+            SmallBlindSeat: 3,
+            BigBlindSeat: 5
+          },
+          Player: {
+            SeatIndex: 2,
+            BetStatus: 1,
+            HoleCards: [37, 51],
+            Chip: 1980,
+            BetChip: 0
+          },
+          Progress: {
+            Phase: 0,
+            NextActionSeat: 2,
+            NextActionTypes: [2, 3, 4, 5],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 40,
+            Pot: 30,
+            SidePot: []
+          },
+          OtherPlayers: [
+            { SeatIndex: 3, Status: 0, BetStatus: 1, Chip: 1990, BetChip: 10 },
+            { SeatIndex: 5, Status: 0, BetStatus: 1, Chip: 1980, BetChip: 20 }
+          ]
+        }),
+        // BTN(seat2, playerA)がレイズ
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 30001,
+          SeatIndex: 2,
+          ActionType: ActionType.RAISE,
+          Chip: 1920,
+          BetChip: 60,
+          Progress: {
+            Phase: 0,
+            NextActionSeat: 3,
+            NextActionTypes: [2, 3, 4, 5],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 100,
+            Pot: 90,
+            SidePot: []
+          }
+        }),
+        // SB(seat3, playerB)がコール
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 30002,
+          SeatIndex: 3,
+          ActionType: ActionType.CALL,
+          Chip: 1940,
+          BetChip: 60,
+          Progress: {
+            Phase: 0,
+            NextActionSeat: 5,
+            NextActionTypes: [2, 3, 4, 5],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 100,
+            Pot: 150,
+            SidePot: []
+          }
+        }),
+        // BB(seat5, playerC)がフォールド
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 30003,
+          SeatIndex: 5,
+          ActionType: ActionType.FOLD,
+          Chip: 1980,
+          BetChip: 0,
+          Progress: {
+            Phase: 0,
+            NextActionSeat: -1,
+            NextActionTypes: [],
+            NextExtraLimitSeconds: 0,
+            MinRaise: 0,
+            Pot: 150,
+            SidePot: []
+          }
+        }),
+        createEvent(ApiType.EVT_HAND_RESULTS, {
+          timestamp: 30004,
+          HandId: 999002,
+          CommunityCards: [],
+          Pot: 150,
+          SidePot: [],
+          ResultType: 0,
+          DefeatStatus: 0,
+          Results: [
+            {
+              UserId: A,
+              HoleCards: [37, 51],
+              RankType: 10, // NO_CALL
+              Hands: [],
+              HandRanking: 1,
+              Ranking: 1,
+              RewardChip: 150
+            }
+          ],
+          OtherPlayers: [
+            { SeatIndex: 3, Status: 0, BetStatus: -1, Chip: 1940, BetChip: 0 },
+            { SeatIndex: 5, Status: 0, BetStatus: -1, Chip: 1980, BetChip: 0 }
+          ]
+        }, { skipValidation: true })
+      ]
+
+      // --- ライブ記録パイプライン: WriteEntityStream経由 ---
+      const dbMock = new PokerChaseDB(indexedDB, IDBKeyRange)
+      const service = new PokerChaseService({ db: dbMock })
+      await service.ready
+      await new Promise<void>((resolve, reject) => {
+        service.handAggregateStream
+          .on('finish', () => resolve())
+          .on('error', (error: Error) => reject(error))
+        Readable.from(events).pipe(service.handAggregateStream)
+      })
+      await dbMock.open()
+      const liveActions = (await dbMock.actions
+        .where('handId').equals(999002)
+        .toArray())
+        .sort((a, b) => a.index - b.index)
+
+      // --- インポート/リビルドパイプライン: EntityConverter経由 ---
+      const importResult = converter.convertEventsToEntities(events)
+      const importActions = importResult.actions.slice().sort((a, b) => a.index - b.index)
+
+      expect(liveActions.length).toBeGreaterThan(0)
+      expect(importActions.length).toBe(liveActions.length)
+
+      const pickComparable = (action: Action) => ({
+        playerId: action.playerId,
+        phase: action.phase,
+        actionType: action.actionType,
+        position: action.position,
+        actionDetails: action.actionDetails
+      })
+
+      expect(importActions.map(pickComparable)).toEqual(liveActions.map(pickComparable))
+
+      // 空席があっても、明示的なButtonSeat/SmallBlindSeat/BigBlindSeatから
+      // 正しくポジションが割り当てられることを検証する
+      const positionsByPlayer = new Map(liveActions.map(a => [a.playerId, a.position]))
+      expect(positionsByPlayer.get(A)).toBe(Position.BTN)
+      expect(positionsByPlayer.get(B)).toBe(Position.SB)
+      expect(positionsByPlayer.get(C)).toBe(Position.BB)
+
+      const importPositionsByPlayer = new Map(importActions.map(a => [a.playerId, a.position]))
+      expect(importPositionsByPlayer).toEqual(positionsByPlayer)
+    })
   })
 
   /**

--- a/src/entity-converter.ts
+++ b/src/entity-converter.ts
@@ -27,7 +27,7 @@ import type {
 } from './types'
 
 import { defaultRegistry } from './stats'
-import { rotateArrayFromIndex } from './utils/array-utils'
+import { getPositionMap } from './utils/position-utils'
 
 /**
  * エンティティバンドル（一括保存用）
@@ -148,10 +148,10 @@ export class EntityConverter {
       statStates: {} // 各統計プラグインが自身のIDでネームスペース化した一時状態を保持
     }
 
-    // ポジション計算用のユーザーID配列（EVT_DEALで1ハンドにつき1度だけ設定される。
+    // プレイヤーID → ポジションのマップ（EVT_DEALで1ハンドにつき1度だけ設定される。
     // WriteEntityStream（ライブ記録パイプライン）と同一のロジックで算出し、
     // インポート/リビルド後もポジション値が一致するようにする）
-    let positionUserIds: number[] = []
+    let positionMap: Map<number, Position> = new Map()
 
     let progress: any = undefined
 
@@ -174,9 +174,9 @@ export class EntityConverter {
             results: []
           }
 
-          // ポジション計算用のユーザーID配列を算出（WriteEntityStreamと同一ロジック）。
-          // BigBlindSeatの次（=SB）から逆順に並べ、全フェーズ共通で使用する。
-          positionUserIds = rotateArrayFromIndex(event.SeatUserIds, event.Game.BigBlindSeat + 1).reverse()
+          // プレイヤーID → ポジションのマップを算出（WriteEntityStreamと同一ロジック）。
+          // Game.ButtonSeat/SmallBlindSeat/BigBlindSeatから直接導出し、全フェーズ共通で使用する。
+          positionMap = getPositionMap(event.SeatUserIds, event.Game)
 
           // プリフロップフェーズの作成（handIdは後で更新される）
           handState.phases.push({
@@ -211,8 +211,10 @@ export class EntityConverter {
           ).length
 
           // ポジション計算（WriteEntityStreamと同一ロジック。EVT_DEAL時点で確定した
-          // positionUserIdsを全フェーズで使い回すことで、ライブ記録と同じポジション値を得る）
-          const position: Position = positionUserIds.indexOf(playerId ?? 0) - 2
+          // positionMapを全フェーズで使い回すことで、ライブ記録と同じポジション値を得る）
+          // 座席に存在しないplayerId（不正なイベント等）の場合は、旧実装の
+          // `indexOf()`が-1を返す挙動（結果的にposition=-3）を踏襲する
+          const position: Position = positionMap.get(playerId ?? 0) ?? -3 as Position
 
           // 統計モジュールを使用してActionDetailを検出
           const detectionContext: ActionDetailContext = {

--- a/src/streams/write-entity-stream.ts
+++ b/src/streams/write-entity-stream.ts
@@ -6,7 +6,8 @@ import {
   ApiType,
   BetStatusType,
   PhaseType,
-  isShowdownParticipant
+  isShowdownParticipant,
+  Position
 } from '../types'
 import type {
   ApiHandEvent,
@@ -15,7 +16,7 @@ import type {
 } from '../types'
 import type { ActionDetailContext } from '../types/stats'
 import { ErrorHandler } from '../utils/error-handler'
-import { rotateArrayFromIndex } from '../utils/array-utils'
+import { getPositionMap } from '../utils/position-utils'
 import { defaultRegistry } from '../stats'
 import type { ErrorContext } from '../types/errors'
 
@@ -68,7 +69,7 @@ export class WriteEntityStream extends Transform {
     }
   }
   private toHandState = (events: ApiHandEvent[]): HandState => {
-    const positionUserIds = []
+    let positionMap: Map<number, Position> = new Map()
     const handState: HandState = {
       hand: {
         session: {
@@ -93,7 +94,7 @@ export class WriteEntityStream extends Transform {
       switch (event.ApiTypeId) {
         case ApiType.EVT_DEAL:
           handState.hand.seatUserIds = event.SeatUserIds
-          positionUserIds.push(...rotateArrayFromIndex(event.SeatUserIds, event.Game.BigBlindSeat + 1).reverse())
+          positionMap = getPositionMap(event.SeatUserIds, event.Game)
           handState.phases.push({
             phase: event.Progress.Phase,
             seatUserIds: event.SeatUserIds,
@@ -150,7 +151,9 @@ export class WriteEntityStream extends Transform {
           const phaseActions = handState.actions.filter(action => action.phase === phase)
           const phasePlayerActionIndex = phaseActions.filter(action => action.playerId === playerId).length
           const phasePrevBetCount = phaseActions.filter(action => [ActionType.BET, ActionType.RAISE].includes(action.actionType)).length + Number(phase === PhaseType.PREFLOP)
-          const position = positionUserIds.indexOf(playerId ?? 0) - 2
+          // 座席に存在しないplayerId（不正なイベント等）の場合は、旧実装の
+          // `indexOf()`が-1を返す挙動（結果的にposition=-3）を踏襲する
+          const position: Position = positionMap.get(playerId ?? 0) ?? -3 as Position
           // モジュールベース検出用のActionDetailContext
           const detectionContext: ActionDetailContext = {
             playerId: playerId ?? 0,

--- a/src/utils/position-utils.test.ts
+++ b/src/utils/position-utils.test.ts
@@ -1,0 +1,109 @@
+import { getPositionMap } from './position-utils'
+import { Position } from '../types/game'
+
+describe('getPositionMap', () => {
+  it('6人フルリング（空席なし）で全ポジションを正しく割り当てる', () => {
+    // seat: 0=SB, 1=BB, 2=UTG, 3=HJ, 4=CO, 5=BTN
+    const seatUserIds = [600, 601, 602, 603, 604, 605]
+    const game = { ButtonSeat: 5, SmallBlindSeat: 0, BigBlindSeat: 1 }
+
+    const positions = getPositionMap(seatUserIds, game)
+
+    expect(positions.get(600)).toBe(Position.SB)
+    expect(positions.get(601)).toBe(Position.BB)
+    expect(positions.get(602)).toBe(Position.UTG)
+    expect(positions.get(603)).toBe(Position.HJ)
+    expect(positions.get(604)).toBe(Position.CO)
+    expect(positions.get(605)).toBe(Position.BTN)
+    expect(positions.size).toBe(6)
+  })
+
+  it('4人卓（空席なし）ではBTNの次はCOのみに割り当てる', () => {
+    // seat: 0=UTG, 1=BTN, 2=SB, 3=BB
+    const seatUserIds = [10, 20, 30, 40]
+    const game = { ButtonSeat: 1, SmallBlindSeat: 2, BigBlindSeat: 3 }
+
+    const positions = getPositionMap(seatUserIds, game)
+
+    expect(positions.get(10)).toBe(Position.CO) // BTNの直前 = COラベル
+    expect(positions.get(20)).toBe(Position.BTN)
+    expect(positions.get(30)).toBe(Position.SB)
+    expect(positions.get(40)).toBe(Position.BB)
+    expect(positions.size).toBe(4)
+  })
+
+  it('ヘッズアップ（ButtonSeat === SmallBlindSeat）ではボタンのプレイヤーはSBになる', () => {
+    const seatUserIds = [111, 222]
+    const game = { ButtonSeat: 0, SmallBlindSeat: 0, BigBlindSeat: 1 }
+
+    const positions = getPositionMap(seatUserIds, game)
+
+    expect(positions.get(111)).toBe(Position.SB) // ボタン件SB
+    expect(positions.get(222)).toBe(Position.BB)
+    expect(positions.size).toBe(2)
+  })
+
+  /**
+   * バグ検証用ケース（issue記載の実データ由来の例）
+   * seats: [-1, -1, A, B, -1, C], Game = { ButtonSeat: 2, SmallBlindSeat: 3, BigBlindSeat: 5 }
+   *
+   * 旧実装（rotateArrayFromIndexで座席配列を回転してインデックスから逆算する方式）は、
+   * 空席（-1）が回転後の配列内でスロットを占有するため、実プレイヤーのインデックスが
+   * ズレてしまい、Bを実際のBTN(seat2)、Aを実際のSB(seat3)であるにもかかわらず
+   * Bを BTN(0)、Aを CO(1) と誤ってラベル付けしていた（本来はAがBTN、BがSB）。
+   * 新実装はGame.ButtonSeat/SmallBlindSeat/BigBlindSeatから直接算出するため、
+   * 空席の有無に関わらず正しいポジションが得られる。
+   */
+  it('空席（-1）を含む座席配列でもButtonSeat/SmallBlindSeat/BigBlindSeatから正しく算出する', () => {
+    const A = 100, B = 200, C = 300
+    const seatUserIds = [-1, -1, A, B, -1, C]
+    const game = { ButtonSeat: 2, SmallBlindSeat: 3, BigBlindSeat: 5 }
+
+    const positions = getPositionMap(seatUserIds, game)
+
+    expect(positions.get(A)).toBe(Position.BTN)
+    expect(positions.get(B)).toBe(Position.SB)
+    expect(positions.get(C)).toBe(Position.BB)
+    expect(positions.size).toBe(3)
+  })
+
+  it('空席を挟んだ短期テーブルでCO/HJを正しく割り当てる（着席5人）', () => {
+    // 6座席中、着席は5人。seat1が空席。
+    const P0 = 1, P2 = 3, P3 = 4, P4 = 5, P5 = 6
+    const seatUserIds = [P0, -1, P2, P3, P4, P5]
+    const game = { ButtonSeat: 4, SmallBlindSeat: 5, BigBlindSeat: 0 }
+
+    const positions = getPositionMap(seatUserIds, game)
+
+    expect(positions.get(P0)).toBe(Position.BB)
+    expect(positions.get(P5)).toBe(Position.SB)
+    expect(positions.get(P4)).toBe(Position.BTN)
+    // BBの次はseat1（空席、スキップ）→ seat2(P2), seat3(P3)の順で着席。
+    // BTN直前（最もBTNに近い）のP3がCO、その手前のP2がHJ。
+    // 着席5人のためUTGラベルは使われない。
+    expect(positions.get(P3)).toBe(Position.CO)
+    expect(positions.get(P2)).toBe(Position.HJ)
+    expect(positions.size).toBe(5)
+  })
+
+  it('着席人数が3人の場合はBB, SB, BTNのみに割り当てる', () => {
+    const seatUserIds = [1, 2, 3]
+    const game = { ButtonSeat: 0, SmallBlindSeat: 1, BigBlindSeat: 2 }
+
+    const positions = getPositionMap(seatUserIds, game)
+
+    expect(positions.get(1)).toBe(Position.BTN)
+    expect(positions.get(2)).toBe(Position.SB)
+    expect(positions.get(3)).toBe(Position.BB)
+    expect(positions.size).toBe(3)
+  })
+
+  it('空席のプレイヤーIDはマップに含まれない', () => {
+    const seatUserIds = [-1, 2, 3, -1, 5, 6]
+    const game = { ButtonSeat: 4, SmallBlindSeat: 5, BigBlindSeat: 1 }
+
+    const positions = getPositionMap(seatUserIds, game)
+
+    expect(positions.has(-1)).toBe(false)
+  })
+})

--- a/src/utils/position-utils.ts
+++ b/src/utils/position-utils.ts
@@ -1,0 +1,100 @@
+import { Position } from '../types/game'
+
+/**
+ * ポジション計算に必要なGameイベントのサブセット
+ */
+export interface PositionGameInfo {
+  ButtonSeat: number
+  SmallBlindSeat: number
+  BigBlindSeat: number
+}
+
+/**
+ * 着席プレイヤーIDからポジション（Position enum値）へのマップを構築する。
+ *
+ * 背景（バグ修正の経緯）:
+ * 旧実装は `rotateArrayFromIndex(seatUserIds, BigBlindSeat + 1).reverse()` で
+ * 座席配列を回転させ、その配列上のインデックスからポジションを逆算していた。
+ * この方式は「全座席が連続して埋まっている」ことを暗黙に仮定しており、
+ * トーナメントのバスト等で空席（SeatUserIds内の-1）が生じると、
+ * 空席が回転後の配列内でスロットを占有し続けるため、実プレイヤーの
+ * インデックスがズレてポジションが誤って算出されていた。
+ * 実データ（393,830イベント、うちEVT_DEAL 31,916件）を検証したところ、
+ * 58.10%のハンドで空席が存在し、この方式ではハンド全体の29%でBTNの
+ * ラベル付けが誤っていた。
+ *
+ * 新実装は回転を使わず、Game.ButtonSeat / SmallBlindSeat / BigBlindSeat という
+ * 明示的なフィールドから直接ポジションを求める:
+ * - BigBlindSeatの占有者 → BB
+ * - SmallBlindSeatの占有者 → SB（ヘッズアップ時はButtonSeat === SmallBlindSeatとなり、
+ *   このプレイヤーはSBのまま。これは旧実装のHU挙動と一致する）
+ * - ButtonSeatの占有者 → BTN（ヘッズアップ時は上記のSB判定が優先されるため、ここには来ない）
+ * - 残りの着席プレイヤー: BBの次の座席からBTNまで時計回りに辿った順（＝アクション順）を求め、
+ *   その順序を反転して「BTNに近い方から」CO, HJ, UTGの順にラベル付けする。
+ *   人数が少ない場合は近い方のラベルのみ使われる（例: 4人卓ならBB, SB, BTN, COの4種）。
+ *
+ * 実データ検証結果（31,916件のEVT_DEAL全件に対して）:
+ * - ButtonSeat/SmallBlindSeat/BigBlindSeatは全件で存在し、常に着席済み座席（-1でない）を指していた
+ *   （範囲外・空席参照は0件）
+ * - ButtonSeat === SmallBlindSeat（ヘッズアップ）は2,794件（8.75%）
+ * - デッドブラインドや欠落ブラインド座席のケースは検出されなかった
+ * 上記により、本関数は「ButtonSeat/SmallBlindSeat/BigBlindSeatは必ず着席済み座席を指す」
+ * ことを前提として実装している。
+ *
+ * @param seatUserIds 座席インデックス順のプレイヤーID配列（空席は-1）
+ * @param game ButtonSeat/SmallBlindSeat/BigBlindSeatを含むGame情報
+ * @returns プレイヤーID → Positionのマップ（空席・存在しないプレイヤーIDは含まれない）
+ */
+export function getPositionMap(seatUserIds: number[], game: PositionGameInfo): Map<number, Position> {
+  const positions = new Map<number, Position>()
+  const seatCount = seatUserIds.length
+  const { ButtonSeat, SmallBlindSeat, BigBlindSeat } = game
+
+  const seatOccupant = (seat: number): number | undefined => {
+    const playerId = seatUserIds[((seat % seatCount) + seatCount) % seatCount]
+    return playerId !== undefined && playerId !== -1 ? playerId : undefined
+  }
+
+  const isHeadsUp = ButtonSeat === SmallBlindSeat
+
+  const bbPlayerId = seatOccupant(BigBlindSeat)
+  if (bbPlayerId !== undefined) {
+    positions.set(bbPlayerId, Position.BB)
+  }
+
+  const sbPlayerId = seatOccupant(SmallBlindSeat)
+  if (sbPlayerId !== undefined) {
+    positions.set(sbPlayerId, Position.SB)
+  }
+
+  if (!isHeadsUp) {
+    const btnPlayerId = seatOccupant(ButtonSeat)
+    if (btnPlayerId !== undefined) {
+      positions.set(btnPlayerId, Position.BTN)
+    }
+  }
+
+  // BBの次の座席からButtonSeatの手前まで、時計回りに着席プレイヤーを収集する
+  // （＝プリフロップのアクション順で、UTGが先頭・BTN直前が末尾になる）
+  const earlyToLate: number[] = []
+  for (let offset = 1; offset < seatCount; offset++) {
+    const seat = (BigBlindSeat + offset) % seatCount
+    if (seat === ButtonSeat) break
+    const playerId = seatOccupant(seat)
+    if (playerId !== undefined) {
+      earlyToLate.push(playerId)
+    }
+  }
+
+  // BTNに近い方から順にCO, HJ, UTG, ...をラベル付けする
+  const lateToEarlyLabels = [Position.CO, Position.HJ, Position.UTG]
+  const lateToEarly = earlyToLate.slice().reverse()
+  lateToEarly.forEach((playerId, index) => {
+    const label = lateToEarlyLabels[index]
+    if (label !== undefined) {
+      positions.set(playerId, label)
+    }
+  })
+
+  return positions
+}


### PR DESCRIPTION
## 問題(実データ検証・独立オラクル照合で発見)

両経路の position 算出 `rotateArrayFromIndex(seatUserIds, BigBlindSeat + 1).reverse()` + `indexOf - 2` は**全席連続着席を暗黙に仮定**しており、空席(-1)が回転後の配列でスロットを占有するため、実プレイヤーの位置がズレます。

実データ(EVT_DEAL 31,916 件)での実測:
- 58.1% のハンドに空席が存在
- **29% のハンドで実際の BTN プレイヤーを誤ラベル**(検証例: 真の SB が BTN 扱い → STEAL を誤付与)
- STL / FTS はこのバグで崩壊(独立オラクルとの一致率 ~15%)。position 非依存の統計は無傷

## 修正

- `src/utils/position-utils.ts` の `getPositionMap()` を新設: `Game.ButtonSeat` / `SmallBlindSeat` / `BigBlindSeat` から直接導出(BB→BTN 間の着席者を時計回りに歩行し、BTN 側から CO/HJ/UTG)。ヘッズアップ(ButtonSeat==SmallBlindSeat、実データ 8.75%)は旧挙動どおり SB ラベルを維持
- 事前検証: blind/button seat フィールドは **31,916 件全件で存在し、常に着席済み座席を指す**ことを確認済み(前提として実装)
- 両経路(WriteEntityStream / EntityConverter)を同ヘルパーに置換

## テスト

- ヘルパー単体テスト 7 件(6-max フル / 空席あり / 4-max / HU / 5人卓)
- EC↔WES パリティテストに**空席ありシナリオを追加**(修正前 main で fail することを確認済み)
- 期待値変更は `app.test.ts` の FTS 1件のみ([7,8]→[8,9]: HU ハンドで SB/BTN プレイヤーが CO と誤ラベルされていた旧バグの是正。インラインで根拠コメント付き)

## 検証

- `npm run typecheck` ✅ / `npm run test` — 374/374(42 suites)✅

**注**: 過去データの position / STL / FTS の是正にはデータ再構築(rebuild)が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)