### PR TITLE
feat(tools): add independent stats verification harness (verify-stats)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ Chrome extension providing real-time poker statistics overlay and hand history t
   - `npm run postbuild` - Create extension.zip
   - `npm run validate-schema` - Validate API events in NDJSON files
   - `npm run schema-diff` - Detect API schema changes (additions/removals) in NDJSON files
+  - `npm run verify-stats -- <file.ndjson>` - Cross-check stats pipeline output against an independent oracle (regression check for entity-converter/write-entity-stream/stats changes; see CONTRIBUTING.md)
   - `npm run firebase:deploy` - Deploy Firestore rules and indexes
   - `npm run firebase:deploy:rules` - Deploy Firestore rules only
   - `npm run firebase:deploy:indexes` - Deploy Firestore indexes only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,6 +252,29 @@ To backfill existing hands so your new statistic reflects historical data too, r
 
 Without this step, your statistic will look like it's stuck at 0 (or empty) for any session recorded before the change, even though the logic itself is correct.
 
+### Verifying Against Real Data (`verify-stats`)
+
+Unit tests cover individual stats in isolation, but they can't catch a bug that only shows up when many hands' worth of state accumulates (off-by-one phase membership, position derivation on tables with empty seats, etc.). `npm run verify-stats` closes that gap by cross-checking the live pipeline against an independently re-implemented "oracle":
+
+- `src/tools/verify-stats/pipeline.ts` runs the real `EntityConverter` + `StatDefinition.calculate` over the given NDJSON (the same code path the extension itself uses on import/rebuild).
+- `src/tools/verify-stats/oracle.ts` recomputes the same stats **from scratch** directly off the raw events, importing only enums/types from `src/types` — it never imports `src/stats` or `src/entity-converter`, so a bug introduced in either can't "leak" into the oracle and silently agree with itself.
+- `src/tools/verify-stats/compare.ts` diffs the two, per player (players with ≥50 hands by default) and per stat, and reports a percentage agreement table.
+
+Run it whenever you change **`src/entity-converter.ts`, `src/streams/write-entity-stream.ts`, or anything in `src/stats/`**:
+
+```bash
+npm run verify-stats -- <path/to/export.ndjson>
+# optional flags:
+npm run verify-stats -- <file.ndjson> --min-hands=100 --threshold=99.5
+```
+
+The command exits non-zero if any stat's agreement drops below `--threshold` (default 99%). Two gaps are expected and do not indicate a bug:
+
+- **WTSD/WWSF ≈ 99.5–99.7%**: a handful of hands in real captures carry a duplicated FLOP `EVT_DEAL_ROUND` event (a dual-board/run-it-twice-shaped anomaly in the source data). The oracle only tracks one "who's still in at the flop" snapshot per hand, so it can't represent this; the live pipeline (which stores a `Phase` per `EVT_DEAL_ROUND`) handles it correctly. This shows up as an occasional denominator off-by-one for the affected player.
+- **CBet ≈ 99.8%**: at least one real capture contains a duplicated `EVT_ACTION` event for the same seat/street, inflating the oracle's c-bet-fold opportunity count by one for that hand.
+
+To obtain an NDJSON file to run this against: open the extension popup → Import/Export section → export your captured hand history (this is the same NDJSON format `validate-schema`/`schema-diff` consume).
+
 ### Debugging Tips
 
 1. **Add logging to your detection logic:**

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "typecheck": "tsc --noEmit",
     "validate-schema": "tsx src/tools/validate-schemas.ts",
     "schema-diff": "tsx src/tools/detect-schema-diff.ts",
+    "verify-stats": "tsx src/tools/verify-stats.ts",
     "ccusage": "npx ccusage@latest",
     "firebase:deploy": "firebase deploy --only firestore:rules,firestore:indexes",
     "firebase:deploy:rules": "firebase deploy --only firestore:rules",

--- a/src/tools/verify-stats.test.ts
+++ b/src/tools/verify-stats.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Smoke test for the verify-stats harness's plumbing: runs the real
+ * pipeline (EntityConverter + StatDefinition.calculate) and the
+ * independent oracle over a tiny inline three-player hand fixture (NOT the
+ * 140MB real capture -- that is exercised manually via
+ * `npm run verify-stats -- <file.ndjson>`) and checks that:
+ *  - both sides produce the same per-stat fractions for a hand-crafted hand
+ *    with a known preflop raise, a continuation bet + fold, and a showdown
+ *  - compareResults/formatReport correctly report a mismatch when one side's
+ *    stat is deliberately perturbed
+ *
+ * This exercises the same code path `npm run verify-stats` uses, just
+ * against a fixture small enough for CI instead of a real ndjson export.
+ */
+import { runPipeline } from './verify-stats/pipeline'
+import { runOracle } from './verify-stats/oracle'
+import { compareResults, formatReport } from './verify-stats/compare'
+import { ApiType, apiEventSchemas } from '../types/api'
+import { ActionType } from '../types/game'
+import type { ApiEvent } from '../types'
+
+// Mirrors the createEvent() helper in entity-converter.test.ts: parses through
+// the real zod schema so the fixture is a realistic, schema-valid event.
+function createEvent<T extends ApiType>(apiType: T, data: Omit<ApiEvent<T>, 'ApiTypeId'>): ApiEvent<T> {
+  const eventData = { ...data, ApiTypeId: apiType }
+  const schema = apiEventSchemas[apiType]
+  if (!schema) throw new Error(`No schema found for ApiType: ${apiType}`)
+  return schema.parse(eventData) as ApiEvent<T>
+}
+
+const PLAYER_A = 100 // BTN/raiser, c-bets flop
+const PLAYER_B = 101 // BB, calls preflop, folds to c-bet
+const PLAYER_C = 102 // SB, folds preflop
+
+function buildHandEvents(): ApiEvent[] {
+  return [
+    createEvent(ApiType.EVT_DEAL, {
+      timestamp: 1000,
+      // 4-seat table (schema minimum) with one empty seat, to also exercise
+      // empty-seat handling in position derivation.
+      SeatUserIds: [PLAYER_C, PLAYER_B, PLAYER_A, -1],
+      Game: {
+        CurrentBlindLv: 1,
+        NextBlindUnixSeconds: -1,
+        Ante: 0,
+        SmallBlind: 10,
+        BigBlind: 20,
+        ButtonSeat: 2,
+        SmallBlindSeat: 0,
+        BigBlindSeat: 1
+      },
+      Player: { SeatIndex: 2, BetStatus: 1, HoleCards: [0, 1], Chip: 980, BetChip: 0 },
+      Progress: {
+        Phase: 0,
+        NextActionSeat: 2,
+        NextActionTypes: [ActionType.FOLD, ActionType.CALL, ActionType.RAISE, ActionType.ALL_IN],
+        NextExtraLimitSeconds: 15,
+        MinRaise: 40,
+        Pot: 30,
+        SidePot: []
+      },
+      OtherPlayers: [
+        { SeatIndex: 0, Status: 0, BetStatus: 1, Chip: 990, BetChip: 10 },
+        { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 980, BetChip: 20 }
+      ]
+    }),
+    // BTN (PLAYER_A) raises preflop.
+    createEvent(ApiType.EVT_ACTION, {
+      timestamp: 1001,
+      SeatIndex: 2,
+      ActionType: ActionType.RAISE,
+      Chip: 920,
+      BetChip: 60,
+      Progress: {
+        Phase: 0,
+        NextActionSeat: 0,
+        NextActionTypes: [ActionType.FOLD, ActionType.CALL, ActionType.RAISE, ActionType.ALL_IN],
+        NextExtraLimitSeconds: 15,
+        MinRaise: 100,
+        Pot: 90,
+        SidePot: []
+      }
+    }),
+    // SB (PLAYER_C) folds.
+    createEvent(ApiType.EVT_ACTION, {
+      timestamp: 1002,
+      SeatIndex: 0,
+      ActionType: ActionType.FOLD,
+      Chip: 990,
+      BetChip: 10,
+      Progress: {
+        Phase: 0,
+        NextActionSeat: 1,
+        NextActionTypes: [ActionType.FOLD, ActionType.CALL, ActionType.RAISE, ActionType.ALL_IN],
+        NextExtraLimitSeconds: 15,
+        MinRaise: 100,
+        Pot: 90,
+        SidePot: []
+      }
+    }),
+    // BB (PLAYER_B) calls.
+    createEvent(ApiType.EVT_ACTION, {
+      timestamp: 1003,
+      SeatIndex: 1,
+      ActionType: ActionType.CALL,
+      Chip: 920,
+      BetChip: 60,
+      Progress: {
+        Phase: 0,
+        NextActionSeat: -1,
+        NextActionTypes: [],
+        NextExtraLimitSeconds: 0,
+        MinRaise: 0,
+        Pot: 150,
+        SidePot: []
+      }
+    }),
+    // Flop deal-round: PLAYER_C folded preflop so is not BET_ABLE here.
+    createEvent(ApiType.EVT_DEAL_ROUND, {
+      timestamp: 1004,
+      CommunityCards: [10, 20, 30],
+      Progress: {
+        Phase: 1,
+        NextActionSeat: 1,
+        NextActionTypes: [ActionType.CHECK, ActionType.BET, ActionType.ALL_IN],
+        NextExtraLimitSeconds: 15,
+        MinRaise: 0,
+        Pot: 150,
+        SidePot: []
+      },
+      Player: { SeatIndex: 2, BetStatus: 1, HoleCards: [0, 1], Chip: 920, BetChip: 0 },
+      OtherPlayers: [
+        { SeatIndex: 0, Status: 0, BetStatus: 2, Chip: 990, BetChip: 0 },
+        { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 920, BetChip: 0 }
+      ]
+    }),
+    // BB checks.
+    createEvent(ApiType.EVT_ACTION, {
+      timestamp: 1005,
+      SeatIndex: 1,
+      ActionType: ActionType.CHECK,
+      Chip: 920,
+      BetChip: 0,
+      Progress: {
+        Phase: 1,
+        NextActionSeat: 2,
+        NextActionTypes: [ActionType.CHECK, ActionType.BET, ActionType.ALL_IN],
+        NextExtraLimitSeconds: 15,
+        MinRaise: 0,
+        Pot: 150,
+        SidePot: []
+      }
+    }),
+    // BTN c-bets the flop.
+    createEvent(ApiType.EVT_ACTION, {
+      timestamp: 1006,
+      SeatIndex: 2,
+      ActionType: ActionType.BET,
+      Chip: 820,
+      BetChip: 100,
+      Progress: {
+        Phase: 1,
+        NextActionSeat: 1,
+        NextActionTypes: [ActionType.FOLD, ActionType.CALL, ActionType.RAISE, ActionType.ALL_IN],
+        NextExtraLimitSeconds: 15,
+        MinRaise: 200,
+        Pot: 250,
+        SidePot: []
+      }
+    }),
+    // BB folds to the c-bet.
+    createEvent(ApiType.EVT_ACTION, {
+      timestamp: 1007,
+      SeatIndex: 1,
+      ActionType: ActionType.FOLD,
+      Chip: 920,
+      BetChip: 0,
+      Progress: {
+        Phase: 1,
+        NextActionSeat: -2,
+        NextActionTypes: [],
+        NextExtraLimitSeconds: 0,
+        MinRaise: 0,
+        Pot: 250,
+        SidePot: []
+      }
+    }),
+    createEvent(ApiType.EVT_HAND_RESULTS, {
+      timestamp: 1008,
+      HandId: 999001,
+      CommunityCards: [10, 20, 30],
+      Pot: 250,
+      SidePot: [],
+      ResultType: 0,
+      DefeatStatus: 0,
+      Player: { SeatIndex: 2, BetStatus: -1, Chip: 1070, BetChip: 0 },
+      Results: [
+        { UserId: PLAYER_A, HoleCards: [], RankType: 10, Hands: [], HandRanking: -1, Ranking: -2, RewardChip: 250 }
+      ],
+      OtherPlayers: [
+        { SeatIndex: 0, Status: 0, BetStatus: -1, Chip: 990, BetChip: 0 },
+        { SeatIndex: 1, Status: 0, BetStatus: -1, Chip: 920, BetChip: 0 }
+      ]
+    })
+  ]
+}
+
+describe('verify-stats harness', () => {
+  it('pipeline and oracle agree on every stat for a hand-crafted hand', async () => {
+    const events = buildHandEvents()
+
+    const pipeline = await runPipeline(events)
+    const oracle = runOracle(events)
+
+    // Sanity: both sides saw the same three players.
+    expect([...pipeline.keys()].sort()).toEqual([PLAYER_A, PLAYER_B, PLAYER_C].sort())
+    expect([...oracle.keys()].sort()).toEqual([PLAYER_A, PLAYER_B, PLAYER_C].sort())
+
+    const report = compareResults(pipeline, oracle, /* minHands */ 1)
+    expect(report.eligiblePlayers).toBe(3)
+
+    const failing = report.stats.filter(s => s.total > 0 && s.mismatches.length > 0)
+    expect(failing).toEqual([])
+
+    // Spot-check a couple of concrete values so a broken fixture doesn't
+    // silently pass just because both sides are equally wrong.
+    expect(pipeline.get(PLAYER_A)?.stats['cbet']).toEqual([1, 1]) // c-bet executed, one chance
+    expect(oracle.get(PLAYER_A)?.stats.cbet).toEqual([1, 1])
+    expect(pipeline.get(PLAYER_B)?.stats['cbetFold']).toEqual([1, 1]) // folded to the c-bet
+    expect(oracle.get(PLAYER_B)?.stats.cbetFold).toEqual([1, 1])
+    // PLAYER_C folded preflop, never reached the flop.
+    expect(pipeline.get(PLAYER_C)?.stats['wtsd']).toEqual([0, 0])
+    expect(oracle.get(PLAYER_C)?.stats.wtsd).toEqual([0, 0])
+  })
+
+  it('formatReport surfaces a mismatch when one side disagrees', () => {
+    const pipeline = new Map([
+      [PLAYER_A, { playerId: PLAYER_A, hands: 60, stats: { vpip: [30, 60] } }],
+    ])
+    const oracle = new Map([
+      [PLAYER_A, { playerId: PLAYER_A, hands: 60, stats: { vpip: [29, 60] as [number, number] } }],
+    ])
+
+    const report = compareResults(pipeline as any, oracle as any, 50)
+    const vpip = report.stats.find(s => s.stat === 'vpip')!
+    expect(vpip.total).toBe(1)
+    expect(vpip.agree).toBe(0)
+    expect(vpip.pct).toBe(0)
+    expect(vpip.mismatches).toHaveLength(1)
+    expect(vpip.mismatches[0]).toMatchObject({ playerId: PLAYER_A, dNum: 1, dDen: 0 })
+
+    const rendered = formatReport(report)
+    expect(rendered).toContain('Mismatches for vpip')
+    expect(rendered).toContain(`player ${PLAYER_A}`)
+  })
+})

--- a/src/tools/verify-stats.ts
+++ b/src/tools/verify-stats.ts
@@ -1,0 +1,121 @@
+/**
+ * Stats Verification Harness
+ *
+ * Regression tool that checks the live stats pipeline (EntityConverter +
+ * StatDefinition.calculate, see pipeline.ts) against an independently
+ * re-implemented "oracle" (oracle.ts, no imports from src/stats or
+ * src/entity-converter) computed from the same raw NDJSON.
+ *
+ * Run this after any change to entity-converter.ts, write-entity-stream.ts,
+ * or src/stats/**: a real behavioral regression will show up as a drop in
+ * per-stat agreement, whereas a bug shared between the pipeline and this
+ * tool's own oracle would not -- which is why the oracle is kept independent
+ * (see oracle.ts's header comment).
+ *
+ * Usage:
+ *   npm run verify-stats -- <NDJSONファイルパス> [--min-hands=50] [--threshold=99]
+ *
+ * Exits non-zero if any stat's agreement (for players with >= min-hands
+ * hands) falls below --threshold percent.
+ *
+ * Known benign gaps (do not indicate a pipeline bug):
+ *  - WTSD/WWSF typically settle around 99.5-99.7% agreement, not 100%, on
+ *    large real captures. This repo's audit traced the residual mismatches
+ *    to 8 hands with a dual-board/run-it-twice-shaped anomaly in the raw
+ *    event stream that a single flat community-card oracle model cannot
+ *    represent; the live pipeline's phase-membership logic is correct.
+ *  - CBet can show a single-hand discrepancy caused by one duplicate
+ *    EVT_ACTION event recorded for the same seat/street in the source
+ *    capture (an artifact of the capture, not of either implementation).
+ * The default --threshold=99 is set below both pipeline stats' typical
+ * ceiling so these two known gaps do not fail CI, while still catching any
+ * new, larger divergence.
+ */
+import { existsSync, createReadStream } from 'fs'
+import { resolve } from 'path'
+import { createInterface } from 'readline'
+import { runPipeline } from './verify-stats/pipeline'
+import { runOracle } from './verify-stats/oracle'
+import { compareResults, formatReport } from './verify-stats/compare'
+import type { ApiEvent } from '../types'
+
+interface CliOptions {
+  filePath: string
+  minHands: number
+  threshold: number
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const positional: string[] = []
+  let minHands = 50
+  let threshold = 99
+
+  for (const arg of argv) {
+    if (arg.startsWith('--min-hands=')) {
+      minHands = Number(arg.slice('--min-hands='.length))
+    } else if (arg.startsWith('--threshold=')) {
+      threshold = Number(arg.slice('--threshold='.length))
+    } else {
+      positional.push(arg)
+    }
+  }
+
+  const filePath = positional[0]
+  if (!filePath) {
+    console.log('使用方法: npm run verify-stats -- <NDJSONファイルパス> [--min-hands=50] [--threshold=99]')
+    console.log('例: npm run verify-stats -- ./pokerchase_raw_data.ndjson')
+    process.exit(1)
+  }
+
+  return { filePath: resolve(process.cwd(), filePath), minHands, threshold }
+}
+
+async function readNdjson(filePath: string): Promise<ApiEvent[]> {
+  const events: ApiEvent[] = []
+  const rl = createInterface({ input: createReadStream(filePath), crlfDelay: Infinity })
+  for await (const line of rl) {
+    if (!line.trim()) continue
+    events.push(JSON.parse(line))
+  }
+  return events
+}
+
+async function main() {
+  const { filePath, minHands, threshold } = parseArgs(process.argv.slice(2))
+
+  if (!existsSync(filePath)) {
+    console.error(`エラー: ファイルが見つかりません: ${filePath}`)
+    process.exit(1)
+  }
+
+  console.log(`ファイル: ${filePath}`)
+  console.log('Reading NDJSON...')
+  const events = await readNdjson(filePath)
+  console.log(`Loaded ${events.length} events`)
+
+  console.log('Running pipeline (EntityConverter + StatDefinition.calculate)...')
+  const pipeline = await runPipeline(events)
+  console.log(`Pipeline: ${pipeline.size} distinct players`)
+
+  console.log('Running independent oracle...')
+  const oracle = runOracle(events)
+  console.log(`Oracle: ${oracle.size} distinct players`)
+
+  const report = compareResults(pipeline, oracle, minHands)
+  console.log('')
+  console.log(formatReport(report))
+
+  const failing = report.stats.filter(s => s.total > 0 && s.pct < threshold)
+  console.log('')
+  if (failing.length > 0) {
+    console.error(`FAIL: ${failing.length} stat(s) below ${threshold}% agreement threshold: ${failing.map(s => `${s.stat} (${s.pct.toFixed(2)}%)`).join(', ')}`)
+    process.exit(1)
+  }
+
+  console.log(`PASS: all stats >= ${threshold}% agreement (min-hands=${minHands}).`)
+}
+
+main().catch(e => {
+  console.error(e)
+  process.exit(1)
+})

--- a/src/tools/verify-stats/compare.ts
+++ b/src/tools/verify-stats/compare.ts
@@ -1,0 +1,108 @@
+/**
+ * verify-stats: comparison / agreement report.
+ *
+ * Compares pipeline-side stat fractions (pipeline.ts) against the
+ * independent oracle's fractions (oracle.ts) per player, per stat, and
+ * reports numerator/denominator agreement. Only players with at least
+ * `minHands` hands are counted, to avoid noise from tiny samples where a
+ * single off-by-one dominates the percentage.
+ */
+import type { PipelineResult } from './pipeline'
+import type { OracleFraction, OracleResult } from './oracle'
+
+/** Stats compared -- must exist as a [num, denom] tuple on both sides. */
+export const COMPARED_STATS = [
+  'vpip', 'pfr', '3bet', '3betfold', 'cbet', 'cbetFold', 'af', 'afq',
+  'wtsd', 'wsd', 'wwsf', 'steal', 'foldToSteal',
+] as const
+export type ComparedStat = typeof COMPARED_STATS[number]
+
+export interface Mismatch {
+  playerId: number
+  pipeline: OracleFraction
+  oracle: OracleFraction
+  dNum: number
+  dDen: number
+}
+
+export interface StatAgreement {
+  stat: ComparedStat
+  agree: number
+  total: number
+  /** agree/total as a percentage in [0, 100]; 100 when total is 0 (nothing to disagree on). */
+  pct: number
+  mismatches: Mismatch[]
+}
+
+export interface ComparisonReport {
+  eligiblePlayers: number
+  minHands: number
+  stats: StatAgreement[]
+}
+
+function isFraction(value: unknown): value is OracleFraction {
+  return Array.isArray(value) && value.length === 2 && typeof value[0] === 'number' && typeof value[1] === 'number'
+}
+
+/**
+ * Compare pipeline vs oracle results for players with >= minHands hands.
+ * Both maps are keyed by playerId; a player missing from either side for a
+ * given stat is simply skipped for that stat (not counted as a mismatch).
+ */
+export function compareResults(pipeline: PipelineResult, oracle: OracleResult, minHands = 50): ComparisonReport {
+  const eligiblePlayerIds = [...pipeline.values()]
+    .filter(p => p.hands >= minHands)
+    .map(p => p.playerId)
+
+  const stats: StatAgreement[] = COMPARED_STATS.map(stat => {
+    let agree = 0
+    let total = 0
+    const mismatches: Mismatch[] = []
+
+    for (const playerId of eligiblePlayerIds) {
+      const p = pipeline.get(playerId)?.stats[stat]
+      const o = oracle.get(playerId)?.stats[stat]
+      if (!isFraction(p) || !isFraction(o)) continue
+      total++
+      const [pn, pd] = p
+      const [on, od] = o
+      if (pn === on && pd === od) {
+        agree++
+      } else {
+        mismatches.push({ playerId, pipeline: p, oracle: o, dNum: pn - on, dDen: pd - od })
+      }
+    }
+
+    return {
+      stat,
+      agree,
+      total,
+      pct: total === 0 ? 100 : (100 * agree) / total,
+      mismatches,
+    }
+  })
+
+  return { eligiblePlayers: eligiblePlayerIds.length, minHands, stats }
+}
+
+/** Render a human-readable agreement table, one line per stat. */
+export function formatReport(report: ComparisonReport, sampleMismatches = 5): string {
+  const lines: string[] = []
+  lines.push(`Eligible players (>= ${report.minHands} hands): ${report.eligiblePlayers}`)
+  lines.push('')
+  lines.push('Stat          Agreement          Pct')
+  lines.push('----          ---------          ---')
+  for (const s of report.stats) {
+    const ratio = `${s.agree}/${s.total}`
+    lines.push(`${s.stat.padEnd(13)} ${ratio.padEnd(18)} ${s.pct.toFixed(2)}%`)
+  }
+  for (const s of report.stats) {
+    if (s.mismatches.length === 0) continue
+    lines.push('')
+    lines.push(`Mismatches for ${s.stat} (showing up to ${sampleMismatches} of ${s.mismatches.length}):`)
+    for (const m of s.mismatches.slice(0, sampleMismatches)) {
+      lines.push(`  player ${m.playerId}: pipeline=[${m.pipeline}] oracle=[${m.oracle}] (dNum=${m.dNum}, dDen=${m.dDen})`)
+    }
+  }
+  return lines.join('\n')
+}

--- a/src/tools/verify-stats/oracle.ts
+++ b/src/tools/verify-stats/oracle.ts
@@ -1,0 +1,453 @@
+/**
+ * verify-stats: independent oracle.
+ *
+ * Computes VPIP/PFR/3BET/3BETFOLD/CBET/CBETFOLD/AF/AFq/WTSD/WSD/WWSF/STEAL/
+ * FOLDTOSTEAL directly from raw NDJSON events, with NO imports from
+ * `src/stats` or `src/entity-converter`. Only wire-protocol enums are
+ * imported -- `ApiType` from `src/types/api` and `ActionType`/
+ * `BetStatusType`/`RankType` from `src/types/game` -- for readability;
+ * every detection rule below is written from
+ * scratch against the documented event semantics in CLAUDE.md /
+ * docs/hand-analysis.md, not against the pipeline's implementation.
+ *
+ * This independence is the whole point of the tool: if a bug is introduced
+ * in entity-converter.ts or a stats/core/*.ts module, this file has no way
+ * to inherit it, so a genuine behavioral divergence shows up as a disagreement
+ * in compare.ts instead of two buggy implementations silently agreeing with
+ * each other. Do not import pipeline/stats code into this file.
+ *
+ * Semantics deliberately kept in sync with the pipeline (verified against
+ * entity-converter.ts / src/stats/core during the 2026-07 real-data audit
+ * that produced this harness, PRs #93-#97):
+ *  (a) "saw flop" is derived from the FLOP EVT_DEAL_ROUND event's per-seat
+ *      BetStatus === BET_ABLE (Player + OtherPlayers), not from "did not
+ *      fold preflop" -- a player who went all-in preflop has BetStatus
+ *      ALL_IN, not BET_ABLE, so they are correctly excluded even though
+ *      they never "folded".
+ *  (b) Positions are derived purely from Game.ButtonSeat / SmallBlindSeat /
+ *      BigBlindSeat (never by rotating/inferring from seat order), which
+ *      handles empty seats (busted players) correctly.
+ *  (c) Showdown participation is gated on RankType: NO_CALL and FOLD_OPEN
+ *      are excluded, everything else (0-9 real ranks, SHOWDOWN_MUCK)
+ *      counts as a showdown.
+ *  (d) Winners are players with RewardChip > 0 in EVT_HAND_RESULTS.Results.
+ */
+import { ApiType } from '../../types/api'
+import { ActionType, BetStatusType, RankType } from '../../types/game'
+
+type ActionTypeNum = Exclude<ActionType, ActionType.ALL_IN>
+
+/** Minimal shapes for the raw NDJSON fields this oracle reads. No schema/type imports beyond the enums above. */
+interface RawSeatPlayer {
+  SeatIndex: number
+  BetStatus: BetStatusType
+}
+interface RawGame {
+  ButtonSeat: number
+  SmallBlindSeat: number
+  BigBlindSeat: number
+}
+interface RawDealEvent {
+  ApiTypeId: ApiType.EVT_DEAL
+  SeatUserIds: number[]
+  Game: RawGame
+  Progress: RawProgress
+}
+interface RawProgress {
+  NextActionTypes: number[]
+  Phase?: number
+}
+interface RawActionEvent {
+  ApiTypeId: ApiType.EVT_ACTION
+  SeatIndex: number
+  ActionType: ActionType
+  BetChip: number
+  Progress: RawProgress
+}
+interface RawDealRoundEvent {
+  ApiTypeId: ApiType.EVT_DEAL_ROUND
+  Player?: RawSeatPlayer
+  OtherPlayers: RawSeatPlayer[]
+  Progress: RawProgress & { Phase: number }
+}
+interface RawResultEntry {
+  UserId: number
+  RankType: RankType
+  RewardChip: number
+}
+interface RawHandResultsEvent {
+  ApiTypeId: ApiType.EVT_HAND_RESULTS
+  HandId: number
+  Results: RawResultEntry[]
+}
+type RawEvent = RawDealEvent | RawActionEvent | RawDealRoundEvent | RawHandResultsEvent | { ApiTypeId: number }
+
+/** Fraction-valued stat: [numerator, denominator]. */
+export type OracleFraction = [number, number]
+
+export interface OraclePlayerResult {
+  playerId: number
+  hands: number
+  stats: {
+    vpip: OracleFraction
+    pfr: OracleFraction
+    '3bet': OracleFraction
+    '3betfold': OracleFraction
+    cbet: OracleFraction
+    cbetFold: OracleFraction
+    af: OracleFraction
+    afq: OracleFraction
+    wtsd: OracleFraction
+    wsd: OracleFraction
+    wwsf: OracleFraction
+    steal: OracleFraction
+    foldToSteal: OracleFraction
+  }
+}
+
+export type OracleResult = Map<number, OraclePlayerResult>
+
+interface PlayerAcc {
+  hands: Set<number>
+  vpip: number
+  pfrHands: Set<number>
+  threeBetChance: number
+  threeBet: number
+  threeBetFoldChance: number
+  threeBetFold: number
+  cbetChance: number
+  cbet: number
+  cbetFoldChance: number
+  cbetFold: number
+  betRaise: number
+  call: number
+  fold: number
+  flopsSeen: Set<number>
+  showdownsReached: Set<number>
+  wonAtShowdownAllHands: Set<number>
+  showdownAllCount: Set<number>
+  wonAfterFlop: Set<number>
+  stealChance: number
+  steal: number
+  foldToStealChance: number
+  foldToSteal: number
+}
+
+function newAcc(): PlayerAcc {
+  return {
+    hands: new Set(), vpip: 0, pfrHands: new Set(),
+    threeBetChance: 0, threeBet: 0, threeBetFoldChance: 0, threeBetFold: 0,
+    cbetChance: 0, cbet: 0, cbetFoldChance: 0, cbetFold: 0,
+    betRaise: 0, call: 0, fold: 0,
+    flopsSeen: new Set(), showdownsReached: new Set(),
+    wonAtShowdownAllHands: new Set(), showdownAllCount: new Set(), wonAfterFlop: new Set(),
+    stealChance: 0, steal: 0, foldToStealChance: 0, foldToSteal: 0,
+  }
+}
+
+type PositionLabel = 'BB' | 'SB' | 'BTN' | 'CO' | 'HJ' | 'UTG' | 'OTHER'
+
+/**
+ * Derive seat -> position labels purely from ButtonSeat/SmallBlindSeat/BigBlindSeat
+ * (independent re-derivation of the same rule src/utils/position-utils.ts implements).
+ */
+function computePositions(seatUserIds: number[], buttonSeat: number, sbSeat: number, bbSeat: number): Map<number, PositionLabel> {
+  const n = seatUserIds.length
+  const activeSeats: number[] = []
+  for (let i = 0; i < n; i++) if (seatUserIds[i] !== -1) activeSeats.push(i)
+
+  const posMap = new Map<number, PositionLabel>()
+
+  if (activeSeats.length === 2) {
+    // Heads-up: BTN === SB seat, the other seat is BB.
+    for (const seat of activeSeats) {
+      const pid = seatUserIds[seat]!
+      posMap.set(pid, seat === bbSeat ? 'BB' : 'SB')
+    }
+    return posMap
+  }
+
+  const idxInActiveBtn = activeSeats.indexOf(buttonSeat)
+  const postBtnOrder: number[] = []
+  for (let k = 1; k <= activeSeats.length; k++) {
+    postBtnOrder.push(activeSeats[(idxInActiveBtn + k) % activeSeats.length]!)
+  }
+  // postBtnOrder ends with BTN itself; label from the back: BTN, CO, HJ, then UTG for the rest.
+  const labels: PositionLabel[] = new Array(postBtnOrder.length).fill('OTHER')
+  labels[labels.length - 1] = 'BTN'
+  if (labels.length - 2 >= 0) labels[labels.length - 2] = 'CO'
+  if (labels.length - 3 >= 0) labels[labels.length - 3] = 'HJ'
+  for (let i = 0; i < labels.length - 3; i++) labels[i] = 'UTG'
+
+  for (let i = 0; i < postBtnOrder.length; i++) {
+    const seat = postBtnOrder[i]!
+    let label = labels[i]!
+    if (seat === sbSeat) label = 'SB'
+    else if (seat === bbSeat) label = 'BB'
+    posMap.set(seatUserIds[seat]!, label)
+  }
+  return posMap
+}
+
+interface ActionRec {
+  playerId: number
+  actionType: ActionTypeNum
+}
+
+/** Map ALL_IN to the action it functionally represents, using NextActionTypes like the live pipeline does. */
+function normalizeAllIn(actionEvent: RawActionEvent, prevProgress: RawProgress | undefined): ActionTypeNum {
+  if (actionEvent.ActionType !== ActionType.ALL_IN) return actionEvent.ActionType as ActionTypeNum
+  const nextTypes: number[] = prevProgress?.NextActionTypes || []
+  if (nextTypes.includes(ActionType.BET)) return ActionType.BET
+  if (nextTypes.includes(ActionType.CALL)) return ActionType.RAISE
+  return ActionType.CALL
+}
+
+export interface RunOracleOptions {
+  /** Emit hand-by-hand trace lines to the given sink for the listed hand IDs (debugging aid). */
+  traceHandIds?: Set<number>
+  trace?: (line: string) => void
+}
+
+/**
+ * Process every complete hand (EVT_DEAL .. EVT_HAND_RESULTS) in `events` and
+ * return per-player fractions for every tracked stat.
+ */
+export function runOracle(events: unknown[], options: RunOracleOptions = {}): OracleResult {
+  const players = new Map<number, PlayerAcc>()
+  const acc = (pid: number): PlayerAcc => {
+    let a = players.get(pid)
+    if (!a) { a = newAcc(); players.set(pid, a) }
+    return a
+  }
+
+  const trace = options.trace ?? ((line: string) => console.error(line))
+  const traceHandIds = options.traceHandIds ?? new Set<number>()
+
+  let currentHand: RawEvent[] = []
+
+  function processHand(handEvents: RawEvent[]): void {
+    const dealEvt = handEvents.find((e): e is RawDealEvent => e.ApiTypeId === ApiType.EVT_DEAL)
+    const resultsEvt = handEvents.find((e): e is RawHandResultsEvent => e.ApiTypeId === ApiType.EVT_HAND_RESULTS)
+    // Incomplete hand (session boundary / dropped event) -- excluded, same as the
+    // pipeline's `handState.hand.id > 0` completeness check.
+    if (!dealEvt || !resultsEvt) return
+
+    const seatUserIds = dealEvt.SeatUserIds
+    const { ButtonSeat: buttonSeat, SmallBlindSeat: sbSeat, BigBlindSeat: bbSeat } = dealEvt.Game
+    const posMap = computePositions(seatUserIds, buttonSeat, sbSeat, bbSeat)
+    const handId = resultsEvt.HandId
+
+    for (const pid of seatUserIds) {
+      if (pid === -1) continue
+      acc(pid).hands.add(handId)
+    }
+
+    let phase = 0 // 0=preflop
+    let prevProgress: RawProgress | undefined = dealEvt.Progress
+    const preflopRaisers: number[] = []
+    let cBetter: number | undefined
+    let cBetExecuted = false
+    let cBetPhase: number | undefined
+    let stealRaiser: number | undefined
+    const preflopActionsSoFar: ActionRec[] = []
+    // Players confirmed to have reached the flop (BetStatus===BET_ABLE at the FLOP deal-round).
+    let flopActivePlayers: Set<number> | undefined
+
+    const phaseActionsMap = new Map<number, ActionRec[]>([[0, []]])
+    const perPlayerPhaseActionIdx = new Map<string, number>()
+    const traceLines: string[] = []
+
+    for (const event of handEvents) {
+      if (event.ApiTypeId === ApiType.EVT_ACTION) {
+        const actionEvt = event as RawActionEvent
+        const seatIndex = actionEvt.SeatIndex
+        const playerId = seatUserIds[seatIndex]!
+        const normType = normalizeAllIn(actionEvt, prevProgress)
+
+        const actionsInPhase = phaseActionsMap.get(phase) ?? []
+        const betRaiseSoFarInPhase = actionsInPhase.filter(a => a.actionType === ActionType.BET || a.actionType === ActionType.RAISE).length
+        const curPrevBetCount = betRaiseSoFarInPhase + (phase === 0 ? 1 : 0)
+
+        const key = `${phase}:${playerId}`
+        const phasePlayerActionIndex = perPlayerPhaseActionIdx.get(key) ?? 0
+        const rec: ActionRec = { playerId, actionType: normType }
+
+        // VPIP: preflop, player's first preflop action, CALL or RAISE.
+        if (phase === 0 && phasePlayerActionIndex === 0 && (normType === ActionType.CALL || normType === ActionType.RAISE)) {
+          acc(playerId).vpip++
+        }
+
+        // PFR: any preflop RAISE (unique hand count).
+        if (phase === 0 && normType === ActionType.RAISE) {
+          acc(playerId).pfrHands.add(handId)
+        }
+
+        // 3BET / 3BETFOLD: facing a 2-bet -> 3bet chance; facing a 3-bet -> 3betfold chance.
+        if (phase === 0 && curPrevBetCount === 2) {
+          acc(playerId).threeBetChance++
+          if (normType === ActionType.RAISE) acc(playerId).threeBet++
+        }
+        if (phase === 0 && curPrevBetCount === 3) {
+          acc(playerId).threeBetFoldChance++
+          if (normType === ActionType.FOLD) acc(playerId).threeBetFold++
+        }
+
+        // STEAL: preflop, no raise yet, late position (CO/BTN/SB), everyone before folded.
+        const posLabel = posMap.get(playerId)
+        if (phase === 0 && curPrevBetCount === 1 && (posLabel === 'CO' || posLabel === 'BTN' || posLabel === 'SB')) {
+          const allFoldedBefore = preflopActionsSoFar.every(a => a.actionType === ActionType.FOLD)
+          if (allFoldedBefore) {
+            acc(playerId).stealChance++
+            if (normType === ActionType.RAISE) {
+              acc(playerId).steal++
+              stealRaiser = playerId
+            }
+          }
+        }
+
+        // FOLD TO STEAL: blinds facing the identified steal raiser.
+        if (phase === 0 && curPrevBetCount === 2 && (posLabel === 'SB' || posLabel === 'BB') && stealRaiser !== undefined && stealRaiser !== playerId) {
+          acc(playerId).foldToStealChance++
+          if (normType === ActionType.FOLD) acc(playerId).foldToSteal++
+        }
+
+        // CBET / CBETFOLD.
+        if (phase !== 0 && cBetter !== undefined) {
+          if (curPrevBetCount === 0) {
+            if (cBetter === playerId) {
+              acc(playerId).cbetChance++
+              if (normType === ActionType.BET) {
+                acc(playerId).cbet++
+                cBetExecuted = true
+                cBetPhase = phase
+                cBetter = undefined
+              } else {
+                cBetter = undefined // missed opportunity
+              }
+            } else if (normType === ActionType.BET) {
+              cBetter = undefined // donk bet
+            }
+          }
+        }
+        if (phase !== 0 && cBetExecuted && cBetPhase === phase && curPrevBetCount === 1) {
+          acc(playerId).cbetFoldChance++
+          if (normType === ActionType.FOLD) acc(playerId).cbetFold++
+        }
+
+        // AF / AFq.
+        if (normType === ActionType.BET || normType === ActionType.RAISE) acc(playerId).betRaise++
+        if (normType === ActionType.CALL) acc(playerId).call++
+        if (normType === ActionType.FOLD) acc(playerId).fold++
+
+        if (phase === 0 && normType === ActionType.RAISE) preflopRaisers.push(playerId)
+
+        actionsInPhase.push(rec)
+        phaseActionsMap.set(phase, actionsInPhase)
+        perPlayerPhaseActionIdx.set(key, phasePlayerActionIndex + 1)
+        if (phase === 0) preflopActionsSoFar.push(rec)
+
+        prevProgress = actionEvt.Progress
+
+        if (traceHandIds.has(handId)) {
+          traceLines.push(`  seat${seatIndex}(P${playerId}) phase=${phase} raw=${actionEvt.ActionType} norm=${normType} prevBet=${curPrevBetCount} bet=${actionEvt.BetChip}`)
+        }
+      } else if (event.ApiTypeId === ApiType.EVT_DEAL_ROUND) {
+        const roundEvt = event as RawDealRoundEvent
+        const newPhase = roundEvt.Progress.Phase
+        phase = newPhase
+        if (!phaseActionsMap.has(phase)) phaseActionsMap.set(phase, [])
+        prevProgress = roundEvt.Progress
+
+        if (phase === 1) {
+          // Semantic-sync (a): "saw flop" = BetStatus===BET_ABLE for this seat at the
+          // FLOP deal-round, exactly mirroring entity-converter.ts's phase-membership
+          // filter. This correctly excludes preflop all-ins (BetStatus=ALL_IN) even
+          // though they never technically "folded".
+          const seatPlayers = roundEvt.Player ? [roundEvt.Player, ...roundEvt.OtherPlayers] : roundEvt.OtherPlayers
+          flopActivePlayers = new Set(
+            seatPlayers
+              .filter(p => p.BetStatus === BetStatusType.BET_ABLE)
+              .map(p => seatUserIds[p.SeatIndex]!)
+              .filter(pid => pid !== -1)
+          )
+          cBetter = preflopRaisers.length > 0 ? preflopRaisers[preflopRaisers.length - 1] : undefined
+        }
+        if (traceHandIds.has(handId)) {
+          traceLines.push(`[DEAL_ROUND phase=${phase}]`)
+        }
+      }
+    }
+
+    // Showdown / WTSD / WSD / WWSF determination from Results.
+    const results = resultsEvt.Results || []
+    // Semantic-sync (d): winners are players with RewardChip > 0.
+    const winners = new Set(results.filter(r => r.RewardChip > 0).map(r => r.UserId))
+
+    for (const r of results) {
+      const pid = r.UserId
+      // Semantic-sync (c): showdown participation is RankType-gated (NO_CALL and
+      // FOLD_OPEN excluded; SHOWDOWN_MUCK and all real ranks count).
+      const isShowdownParticipant = r.RankType !== RankType.NO_CALL && r.RankType !== RankType.FOLD_OPEN
+      if (isShowdownParticipant) {
+        acc(pid).showdownAllCount.add(handId) // WSD denominator: ALL showdowns incl preflop all-in.
+        if (winners.has(pid)) acc(pid).wonAtShowdownAllHands.add(handId)
+      }
+      if (flopActivePlayers?.has(pid) && isShowdownParticipant) {
+        acc(pid).showdownsReached.add(handId) // WTSD numerator (flop seen -> showdown).
+      }
+    }
+
+    if (traceHandIds.has(handId)) {
+      trace(`--- Hand ${handId} --- seats=${JSON.stringify(seatUserIds)} btn=${buttonSeat} sb=${sbSeat} bb=${bbSeat}`)
+      traceLines.forEach(trace)
+      trace(`Results: ${JSON.stringify(results)}`)
+    }
+
+    if (flopActivePlayers) {
+      for (const pid of flopActivePlayers) {
+        acc(pid).flopsSeen.add(handId)
+        if (winners.has(pid)) acc(pid).wonAfterFlop.add(handId)
+      }
+    }
+  }
+
+  for (const raw of events) {
+    const e = raw as RawEvent
+    if (e.ApiTypeId === ApiType.EVT_DEAL) {
+      if (currentHand.length > 0) processHand(currentHand)
+      currentHand = [e]
+    } else if (currentHand.length > 0) {
+      currentHand.push(e)
+      if (e.ApiTypeId === ApiType.EVT_HAND_RESULTS) {
+        processHand(currentHand)
+        currentHand = []
+      }
+    }
+  }
+  if (currentHand.length > 0) processHand(currentHand)
+
+  const result: OracleResult = new Map()
+  for (const [pid, a] of players.entries()) {
+    result.set(pid, {
+      playerId: pid,
+      hands: a.hands.size,
+      stats: {
+        vpip: [a.vpip, a.hands.size],
+        pfr: [a.pfrHands.size, a.hands.size],
+        '3bet': [a.threeBet, a.threeBetChance],
+        '3betfold': [a.threeBetFold, a.threeBetFoldChance],
+        cbet: [a.cbet, a.cbetChance],
+        cbetFold: [a.cbetFold, a.cbetFoldChance],
+        af: [a.betRaise, a.call],
+        afq: [a.betRaise, a.betRaise + a.call + a.fold],
+        wtsd: [a.showdownsReached.size, a.flopsSeen.size],
+        wsd: [a.wonAtShowdownAllHands.size, a.showdownAllCount.size],
+        wwsf: [a.wonAfterFlop.size, a.flopsSeen.size],
+        steal: [a.steal, a.stealChance],
+        foldToSteal: [a.foldToSteal, a.foldToStealChance],
+      }
+    })
+  }
+  return result
+}

--- a/src/tools/verify-stats/pipeline.ts
+++ b/src/tools/verify-stats/pipeline.ts
@@ -1,0 +1,127 @@
+/**
+ * verify-stats: pipeline-side computation.
+ *
+ * Converts raw NDJSON events through the repo's own `EntityConverter`
+ * (exactly as the import path does) and then replicates
+ * `ReadEntityStream.calcStats` in memory (no Dexie) to build a
+ * `StatCalculationContext` per player and run every registered
+ * `StatDefinition.calculate`.
+ *
+ * This is intentionally the *dependent* half of the verification harness —
+ * see oracle.ts for the independent re-implementation this is checked against.
+ */
+import { EntityConverter } from '../../entity-converter'
+import { defaultRegistry } from '../../stats'
+import { PhaseType } from '../../types/game'
+import type { Action, ApiEvent, Hand, Phase, Session } from '../../types'
+
+/** Per-player pipeline output: hand count plus every registered stat's raw value. */
+export interface PipelinePlayerResult {
+  playerId: number
+  hands: number
+  stats: Record<string, unknown>
+}
+
+export type PipelineResult = Map<number, PipelinePlayerResult>
+
+/**
+ * Run the real EntityConverter + StatDefinition.calculate over `events` and
+ * return per-player results for every player who appeared in at least one hand.
+ */
+export async function runPipeline(events: ApiEvent[]): Promise<PipelineResult> {
+  const session: Session = {
+    id: undefined,
+    battleType: undefined,
+    name: undefined,
+    players: new Map(),
+    reset: () => { /* no-op: standalone tool has no live session to reset */ }
+  }
+
+  const converter = new EntityConverter(session)
+  const bundle = converter.convertEventsToEntities(events)
+
+  // In-memory indices mirroring the Dexie tables/queries used by
+  // ReadEntityStream.calcStats (hands.where('seatUserIds').equals(playerId),
+  // actions.where({playerId}), phases.where('seatUserIds').equals(playerId)).
+  const handsById = new Map<number, Hand>()
+  for (const h of bundle.hands) handsById.set(h.id, h)
+
+  const handsByPlayer = new Map<number, Hand[]>()
+  for (const h of bundle.hands) {
+    for (const pid of h.seatUserIds) {
+      if (pid === -1 || pid == null) continue
+      let list = handsByPlayer.get(pid)
+      if (!list) { list = []; handsByPlayer.set(pid, list) }
+      list.push(h)
+    }
+  }
+
+  const actionsByPlayer = new Map<number, Action[]>()
+  for (const a of bundle.actions) {
+    let list = actionsByPlayer.get(a.playerId)
+    if (!list) { list = []; actionsByPlayer.set(a.playerId, list) }
+    list.push(a)
+  }
+
+  const phasesByPlayer = new Map<number, Phase[]>()
+  for (const p of bundle.phases) {
+    for (const pid of p.seatUserIds) {
+      if (pid === -1 || pid == null) continue
+      let list = phasesByPlayer.get(pid)
+      if (!list) { list = []; phasesByPlayer.set(pid, list) }
+      list.push(p)
+    }
+  }
+
+  const allPlayerIds = new Set<number>()
+  for (const h of bundle.hands) {
+    for (const pid of h.seatUserIds) {
+      if (pid !== -1 && pid != null) allPlayerIds.add(pid)
+    }
+  }
+
+  const result: PipelineResult = new Map()
+
+  for (const playerId of allPlayerIds) {
+    // Mirrors calcStats with no battleType/handLimit filters (we want ALL hands).
+    const allPlayerHands = handsByPlayer.get(playerId) || []
+    const relevantActions = actionsByPlayer.get(playerId) || []
+    const relevantPhases = phasesByPlayer.get(playerId) || []
+
+    const flopPhases = relevantPhases.filter(p => p.phase === PhaseType.FLOP)
+    const showdownPhases = relevantPhases.filter(p => p.phase === PhaseType.SHOWDOWN)
+    const phaseHandIds = [...new Set([...flopPhases, ...showdownPhases].map(p => p.handId!))]
+
+    let winningHands: Hand[] = []
+    if (phaseHandIds.length > 0) {
+      winningHands = phaseHandIds
+        .map(id => handsById.get(id))
+        .filter((h): h is Hand => !!h && h.winningPlayerIds.includes(playerId))
+    }
+    const winningHandIds = new Set(winningHands.map(h => h.id))
+
+    const statResults = await defaultRegistry.calculateWithConfig({
+      playerId,
+      actions: relevantActions,
+      phases: relevantPhases,
+      hands: allPlayerHands,
+      allPlayerActions: relevantActions,
+      allPlayerPhases: relevantPhases,
+      winningHandIds,
+      session
+    }, undefined)
+
+    const stats: Record<string, unknown> = {}
+    for (const sr of statResults) {
+      stats[sr.id] = sr.value
+    }
+
+    result.set(playerId, {
+      playerId,
+      hands: allPlayerHands.length,
+      stats
+    })
+  }
+
+  return result
+}


### PR DESCRIPTION
## 概要

実データ監査(6欠陥発見 → #93〜#97 で修正)で使用した「独立オラクル照合」を、恒久的な回帰検証ツール `npm run verify-stats -- <file.ndjson>` として移植します。

## 仕組み

- `oracle.ts`: 全統計を生イベントから**独立再実装**(`src/stats` / `entity-converter` を一切 import しない — この独立性がツールの価値であり、ヘッダーコメントで明記)
- `pipeline.ts`: 実際の EntityConverter + StatDefinition.calculate(ReadEntityStream と同一のコンテキスト構築)
- `compare.ts`: プレイヤー毎(≥50 ハンド)・統計毎に分子分母を突合、閾値(既定 99%)未満で非ゼロ終了

## 実データ(393,830 イベント / 624 プレイヤー)での結果

13 統計中 11 統計が **100.00%**、WTSD 99.68% / WWSF 99.52%(既知の良性ギャップ: 同一 HandId のデュアルボード特異ハンド 8 件。ツール内に文書化済み)→ **PASS**。実行時間 ~8 秒。

移植時の品質確認で、旧スクリプトに BetStatus 修正(監査時パッチ)が未反映だったことを検出し補完済み。ポート時に混入した自前バグ(WTSD 分子の per-player チェック漏れ)も一致率低下(87%)として自己検出 → 修正済みで、ツールの検出能力自体の実証にもなっています。

## 運用

entity-converter / write-entity-stream / stats モジュールに触る変更では本ツールの実行を推奨(CONTRIBUTING に手順を追記済み)。CI では 140MB 実データは使わず、小型フィクスチャによる smoke テストのみ実行します。

- `npm run typecheck` ✅ / `npm run test` — 381/381(44 suites)✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)