### PR TITLE
fix: harden position mapping, action attribution, and config merge per codex review

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -23,7 +23,7 @@ import { saveEntities, findLatestPlayerDealEvent } from './utils/database-utils'
 import type { AllPlayersRealTimeStats } from './realtime-stats/realtime-stats-service'
 import type { Options } from './components/Popup'
 import type { HandLogEvent } from './types/hand-log'
-import { defaultRegistry } from './stats'
+import { defaultRegistry, defaultStatDisplayConfigs, mergeStatDisplayConfigs } from './stats'
 import type { StatsRegistry } from './stats/registry'
 import type {
   ChromeMessage,
@@ -149,7 +149,14 @@ chrome.storage.sync.get('options', (result: Record<string, any>) => {
       ])]
       : undefined
     service.handLimitFilter = options.filterOptions.handLimit
-    service.statDisplayConfigs = options.filterOptions.statDisplayConfigs
+    // 保存済みのstatDisplayConfigsをデフォルトとマージしてから設定する。
+    // マージしないと、リリースで新しい統計（例: #86のSTL/FTS）が追加されても、
+    // ユーザーがポップアップを開いて再保存するまでHUDに一切表示されない
+    // （service-worker起動時にstorageの値をそのまま代入していたため）。
+    service.statDisplayConfigs = mergeStatDisplayConfigs(
+      options.filterOptions.statDisplayConfigs,
+      defaultStatDisplayConfigs
+    )
   } else {
     // デフォルトフィルターを設定（再計算をトリガーせずに）
     service.battleTypeFilter = undefined  // デフォルトではすべてのゲームタイプを表示

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -2,7 +2,7 @@ import { getBucket } from '@extend-chrome/storage'
 import Divider from '@mui/material/Divider'
 import { ChangeEvent, useEffect, useRef, useState } from 'react'
 import type { FilterOptions, GameTypeFilter } from '../types'
-import { defaultStatDisplayConfigs } from '../stats'
+import { defaultStatDisplayConfigs, mergeStatDisplayConfigs } from '../stats'
 import type { StatDisplayConfig } from '../types/filters'
 import type { UIConfig } from '../types/hand-log'
 import { DEFAULT_UI_CONFIG } from '../types/hand-log'
@@ -32,45 +32,6 @@ export interface Options {
 }
 
 const bucket = getBucket<Options>('options', 'sync')
-
-/**
- * Merge existing stat display configurations with new defaults
- * This ensures new statistics appear and obsolete ones are removed for existing users
- */
-function mergeStatDisplayConfigs(
-  existingConfigs: StatDisplayConfig[],
-  defaultConfigs: StatDisplayConfig[]
-): StatDisplayConfig[] {
-  const defaultMap = new Map(defaultConfigs.map(config => [config.id, config]))
-  const existingMap = new Map(existingConfigs.map(config => [config.id, config]))
-
-  // Start with default configs as the base (ensures proper order and removes obsolete stats)
-  const mergedConfigs = defaultConfigs.map(defaultConfig => {
-    const existingConfig = existingMap.get(defaultConfig.id)
-    if (existingConfig) {
-      // Preserve user settings (enabled/disabled state and order) but update defaults if needed
-      return {
-        ...defaultConfig,
-        enabled: existingConfig.enabled,
-        order: existingConfig.order
-      }
-    }
-    // New statistic - use default configuration
-    return defaultConfig
-  })
-
-  // Log removed statistics for debugging
-  const removedStats = existingConfigs
-    .filter(existing => !defaultMap.has(existing.id))
-    .map(stat => stat.id)
-
-  if (removedStats.length > 0) {
-    // Removed obsolete statistics
-  }
-
-  // Sort by order to maintain consistent display
-  return mergedConfigs.sort((a, b) => a.order - b.order)
-}
 
 const Popup = () => {
   const [options, setOptions] = useState<Options>({ sendUserData: true })

--- a/src/entity-converter.test.ts
+++ b/src/entity-converter.test.ts
@@ -42,6 +42,73 @@ function createEvent<T extends ApiType>(
   return result as ApiEvent<T>
 }
 
+/**
+ * ライブ記録パイプライン（WriteEntityStream）と同一の書き込みを行い、
+ * IndexedDBへの反映を待ってから読み取り結果を返すヘルパー。
+ *
+ * 背景（デフレーク）: `handAggregateStream`の'finish'イベントは、その書き込み側
+ * （Writable）の完了のみを保証する。実際のDexie書き込みはpipeで繋がった
+ * 下流のWriteEntityStreamの非同期`_transform`内で行われるため、
+ * 'finish'直後に`dbMock.<table>`を読むと、まだ書き込みが終わっていない
+ * （テーブルが空、または一部の行しか反映されていない）状態を読んでしまう
+ * レースコンディションがあった。
+ *
+ * このヘルパーはevents をpipeし、'finish'を待った後、`isReady`が真になるまで
+ * 対象テーブルを短い間隔でポーリングする。タイムアウト時は分かりやすいエラーで失敗する。
+ */
+async function pipeEventsAndWaitForReady<T>(
+  service: PokerChaseService,
+  read: () => Promise<T>,
+  isReady: (result: T) => boolean,
+  options: { timeoutMs?: number, intervalMs?: number, description?: string } = {}
+): Promise<T> {
+  const { timeoutMs = 5000, intervalMs = 50, description = 'expected rows' } = options
+
+  await new Promise<void>((resolve, reject) => {
+    service.handAggregateStream
+      .on('finish', () => resolve())
+      .on('error', (error: Error) => reject(error))
+  })
+
+  const startedAt = Date.now()
+  let lastResult = await read()
+  while (!isReady(lastResult)) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error(
+        `pipeEventsAndWaitForReady: timed out after ${timeoutMs}ms waiting for ${description}. ` +
+        `Last observed result: ${JSON.stringify(lastResult)}`
+      )
+    }
+    await new Promise(resolve => setTimeout(resolve, intervalMs))
+    lastResult = await read()
+  }
+  return lastResult
+}
+
+/**
+ * `pipeEventsAndWaitForReady`の薄いラッパー。EC↔WESパリティテストで最も多く使われる
+ * 「指定handIdのactions行がminCount件以上たまるまで待つ」パターンを簡潔に書ける。
+ */
+async function pipeEventsAndWaitForActions(
+  service: PokerChaseService,
+  dbMock: PokerChaseDB,
+  events: ApiEvent[],
+  { handId, minCount = 1 }: { handId: number, minCount?: number }
+): Promise<Action[]> {
+  Readable.from(events).pipe(service.handAggregateStream)
+  const actions = await pipeEventsAndWaitForReady(
+    service,
+    async () => {
+      await dbMock.open()
+      return (await dbMock.actions.where('handId').equals(handId).toArray())
+        .sort((a, b) => a.index - b.index)
+    },
+    result => result.length >= minCount,
+    { description: `dbMock.actions with handId=${handId} to have >= ${minCount} row(s)` }
+  )
+  return actions
+}
+
 describe('EntityConverter', () => {
   let converter: EntityConverter
   const mockSession: Session = {
@@ -1294,10 +1361,11 @@ describe('EntityConverter', () => {
 
       const result = converter.convertEventsToEntities(events)
 
-      // 無効なアクションは含まれるが、playerIdは0になる
+      // 座席解決不能（範囲外のSeatIndex）なアクションはスキップされる。
+      // ハンド自体は他の情報から正常に変換される（テーブル移動後の
+      // 座席未解決アクションと同じ扱い。実データでは0.09%のハンドで発生）。
       expect(result.hands).toHaveLength(1)
-      expect(result.actions).toHaveLength(1)
-      expect(result.actions[0]!.playerId).toBe(0)
+      expect(result.actions).toHaveLength(0)
     })
   })
 
@@ -1522,23 +1590,15 @@ describe('EntityConverter', () => {
       // restoreState()（コンストラクタ内でトリガーされる非同期処理）の完了を待たないと、
       // handAggregateStreamへの書き込みとレースしてIndexedDBの読み取りが空になることがある
       await service.ready
-      await new Promise<void>((resolve, reject) => {
-        service.handAggregateStream
-          .on('finish', () => resolve())
-          .on('error', (error: Error) => reject(error))
-        Readable.from(events).pipe(service.handAggregateStream)
-      })
-      // Dexie/fake-indexeddbはテスト実行順によって暗黙にクローズされることがあるため、
-      // 読み取り前に明示的にopenし直す（データ自体は書き込み済み）
-      await dbMock.open()
-      const liveActions = (await dbMock.actions
-        .where('handId').equals(999001)
-        .toArray())
-        .sort((a, b) => a.index - b.index)
 
       // --- インポート/リビルドパイプライン: EntityConverter経由 ---
       const importResult = converter.convertEventsToEntities(events)
       const importActions = importResult.actions.slice().sort((a, b) => a.index - b.index)
+
+      const liveActions = (await pipeEventsAndWaitForActions(service, dbMock, events, {
+        handId: 999001,
+        minCount: importActions.length
+      })).slice().sort((a, b) => a.index - b.index)
 
       expect(liveActions.length).toBeGreaterThan(0)
       expect(importActions.length).toBe(liveActions.length)
@@ -1699,21 +1759,15 @@ describe('EntityConverter', () => {
       const dbMock = new PokerChaseDB(indexedDB, IDBKeyRange)
       const service = new PokerChaseService({ db: dbMock })
       await service.ready
-      await new Promise<void>((resolve, reject) => {
-        service.handAggregateStream
-          .on('finish', () => resolve())
-          .on('error', (error: Error) => reject(error))
-        Readable.from(events).pipe(service.handAggregateStream)
-      })
-      await dbMock.open()
-      const liveActions = (await dbMock.actions
-        .where('handId').equals(999002)
-        .toArray())
-        .sort((a, b) => a.index - b.index)
 
       // --- インポート/リビルドパイプライン: EntityConverter経由 ---
       const importResult = converter.convertEventsToEntities(events)
       const importActions = importResult.actions.slice().sort((a, b) => a.index - b.index)
+
+      const liveActions = (await pipeEventsAndWaitForActions(service, dbMock, events, {
+        handId: 999002,
+        minCount: importActions.length
+      })).slice().sort((a, b) => a.index - b.index)
 
       expect(liveActions.length).toBeGreaterThan(0)
       expect(importActions.length).toBe(liveActions.length)
@@ -1737,6 +1791,161 @@ describe('EntityConverter', () => {
 
       const importPositionsByPlayer = new Map(importActions.map(a => [a.playerId, a.position]))
       expect(importPositionsByPlayer).toEqual(positionsByPlayer)
+    })
+
+    /**
+     * 座席解決不能なEVT_ACTIONのスキップ（EC↔WESパリティ）
+     *
+     * 背景: 途中着席（EVT_ENTRY_QUEUED）によるテーブル移動後、直前にバッファされた
+     * EVT_DEALのSeatUserIdsには新テーブルの座席が反映されていない状態のまま
+     * EVT_ACTIONが届くことがある。この場合`seatUserIds[event.SeatIndex]`は
+     * undefinedまたは-1（空席）を返す。
+     * 実データ検証: 完走した27ハンド / 68アクション（全ハンドの0.09%）でこの状況を確認。
+     * 修正前は`playerId ?? 0`でplayerId=0を捏造し、position=-3の実在しないアクションが
+     * actionsテーブルに混入していた。修正後は両パイプラインとも該当アクションを
+     * 丸ごとスキップし、ハンドの他のアクションは正常に処理を継続する。
+     */
+    it('skips an EVT_ACTION with an unresolvable SeatIndex in BOTH pipelines, leaving other actions intact', async () => {
+      const events: ApiEvent[] = [
+        createEvent(ApiType.EVT_DEAL, {
+          timestamp: 40000,
+          SeatUserIds: [400, 401, -1, -1],
+          Game: {
+            CurrentBlindLv: 1,
+            NextBlindUnixSeconds: 40000000,
+            Ante: 0,
+            SmallBlind: 10,
+            BigBlind: 20,
+            ButtonSeat: 0,
+            SmallBlindSeat: 0,
+            BigBlindSeat: 1
+          },
+          Progress: {
+            Phase: 0,
+            NextActionSeat: 0,
+            NextActionTypes: [ActionType.CALL, ActionType.FOLD],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 40,
+            Pot: 30,
+            SidePot: []
+          },
+          OtherPlayers: [
+            { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 1980, BetChip: 20 }
+          ]
+        }),
+        // BTN/SB(seat0, player400)がコール
+        // NextActionSeat: 3 は、次に届く（座席未解決の）アクションのSeatIndexと一致させておく。
+        // AggregateEventsStreamは`Progress.NextActionSeat !== event.SeatIndex`の場合に
+        // 順序不整合とみなしてバッファをクリアしてしまうため、このテストでは
+        // その整合性チェック自体はパスさせ、EVT_ACTIONハンドラ内のスキップ処理
+        // （本テストの対象）だけを検証する
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 40001,
+          SeatIndex: 0,
+          ActionType: ActionType.CALL,
+          Chip: 1980,
+          BetChip: 20,
+          Progress: {
+            Phase: 0,
+            NextActionSeat: 3,
+            NextActionTypes: [ActionType.CHECK, ActionType.BET],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 40,
+            Pot: 40,
+            SidePot: []
+          }
+        }),
+        // 途中着席によるテーブル移動後の座席未反映アクション（SeatIndex=3は空席=-1を指す）
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 40002,
+          SeatIndex: 3,
+          ActionType: ActionType.CALL,
+          BetChip: 20,
+          Chip: 0,
+          Progress: {
+            Phase: 0,
+            NextActionSeat: 1,
+            NextActionTypes: [ActionType.CHECK, ActionType.BET],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 40,
+            Pot: 40,
+            SidePot: []
+          }
+        }, { skipValidation: true }),
+        // BB(seat1, player401)がチェック
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 40003,
+          SeatIndex: 1,
+          ActionType: ActionType.CHECK,
+          Chip: 1980,
+          BetChip: 0,
+          Progress: {
+            Phase: 0,
+            NextActionSeat: -1,
+            NextActionTypes: [],
+            NextExtraLimitSeconds: 0,
+            MinRaise: 0,
+            Pot: 40,
+            SidePot: []
+          }
+        }),
+        createEvent(ApiType.EVT_HAND_RESULTS, {
+          timestamp: 40004,
+          HandId: 999020,
+          CommunityCards: [],
+          Pot: 40,
+          SidePot: [],
+          ResultType: 0,
+          DefeatStatus: 0,
+          Results: [
+            {
+              UserId: 400,
+              HoleCards: [],
+              RankType: RankType.NO_CALL,
+              Hands: [],
+              HandRanking: 1,
+              Ranking: 1,
+              RewardChip: 40
+            }
+          ],
+          OtherPlayers: [
+            { SeatIndex: 1, Status: 0, BetStatus: -1, Chip: 1980, BetChip: 0 }
+          ]
+        }, { skipValidation: true })
+      ]
+
+      // --- インポート/リビルドパイプライン: EntityConverter経由 ---
+      const importResult = converter.convertEventsToEntities(events)
+      expect(importResult.hands).toHaveLength(1)
+      // 座席解決不能なアクション（SeatIndex=3）はスキップされ、残り2件のみ含まれる
+      expect(importResult.actions).toHaveLength(2)
+      expect(importResult.actions.every(a => a.playerId === 400 || a.playerId === 401)).toBe(true)
+      expect(importResult.actions.some(a => a.actionType === ActionType.CALL && a.playerId === 400)).toBe(true)
+      expect(importResult.actions.some(a => a.actionType === ActionType.CHECK && a.playerId === 401)).toBe(true)
+
+      // --- ライブ記録パイプライン: WriteEntityStream経由 ---
+      const dbMock = new PokerChaseDB(indexedDB, IDBKeyRange)
+      const service = new PokerChaseService({ db: dbMock })
+      await service.ready
+      const liveActions = await pipeEventsAndWaitForActions(service, dbMock, events, {
+        handId: 999020,
+        minCount: importResult.actions.length
+      })
+
+      // 両パイプラインとも同じ2件のアクションのみ（不正なアクションは混入しない）
+      expect(liveActions).toHaveLength(2)
+      expect(liveActions.every(a => a.playerId === 400 || a.playerId === 401)).toBe(true)
+      expect(liveActions.some(a => a.position === -3 as Position)).toBe(false)
+
+      const pickComparable = (action: Action) => ({
+        playerId: action.playerId,
+        phase: action.phase,
+        actionType: action.actionType,
+        position: action.position,
+        actionDetails: action.actionDetails
+      })
+      expect(importResult.actions.slice().sort((a, b) => a.index - b.index).map(pickComparable))
+        .toEqual(liveActions.slice().sort((a, b) => a.index - b.index).map(pickComparable))
     })
   })
 
@@ -1949,19 +2158,21 @@ describe('EntityConverter', () => {
       const dbMock = new PokerChaseDB(indexedDB, IDBKeyRange)
       const service = new PokerChaseService({ db: dbMock })
       await service.ready
-      await new Promise<void>((resolve, reject) => {
-        service.handAggregateStream
-          .on('finish', () => resolve())
-          .on('error', (error: Error) => reject(error))
-        Readable.from(events).pipe(service.handAggregateStream)
-      })
-      await dbMock.open()
-      const livePhases = (await dbMock.phases.where('handId').equals(999010).toArray())
-        .sort((a, b) => a.phase - b.phase)
 
       // --- インポート/リビルドパイプライン: EntityConverter経由 ---
       const importResult = converter.convertEventsToEntities(events)
       const importPhases = importResult.phases.slice().sort((a, b) => a.phase - b.phase)
+
+      Readable.from(events).pipe(service.handAggregateStream)
+      const livePhases = (await pipeEventsAndWaitForReady(
+        service,
+        async () => {
+          await dbMock.open()
+          return (await dbMock.phases.where('handId').equals(999010).toArray())
+        },
+        result => result.length >= importPhases.length,
+        { description: `dbMock.phases with handId=999010 to have >= ${importPhases.length} row(s)` }
+      )).sort((a, b) => a.phase - b.phase)
 
       const pickComparablePhase = (phase: typeof livePhases[0]) => ({
         phase: phase.phase,
@@ -2092,18 +2303,21 @@ describe('EntityConverter', () => {
       const dbMock = new PokerChaseDB(indexedDB, IDBKeyRange)
       const service = new PokerChaseService({ db: dbMock })
       await service.ready
-      await new Promise<void>((resolve, reject) => {
-        service.handAggregateStream
-          .on('finish', () => resolve())
-          .on('error', (error: Error) => reject(error))
-        Readable.from(events).pipe(service.handAggregateStream)
-      })
-      await dbMock.open()
-      const liveHand = await dbMock.hands.get(269804225)
 
       // --- インポート/リビルドパイプライン: EntityConverter経由 ---
       const importResult = converter.convertEventsToEntities(events)
       const importHand = importResult.hands.find(h => h.id === 269804225)
+
+      Readable.from(events).pipe(service.handAggregateStream)
+      const liveHand = await pipeEventsAndWaitForReady(
+        service,
+        async () => {
+          await dbMock.open()
+          return dbMock.hands.get(269804225)
+        },
+        result => result !== undefined && result.winningPlayerIds.length >= (importHand?.winningPlayerIds.length ?? 0),
+        { description: 'dbMock.hands row 269804225 with winningPlayerIds populated' }
+      )
 
       // 修正前のWES（HandRanking===1）ではWINNER_SIDEを見逃していたが、
       // 修正後はRewardChip>0に統一されているため、両者ともサイドポット勝者を含む
@@ -2422,14 +2636,11 @@ describe('EntityConverter', () => {
       const dbMock = new PokerChaseDB(indexedDB, IDBKeyRange)
       const service = new PokerChaseService({ db: dbMock })
       await service.ready
-      await new Promise<void>((resolve, reject) => {
-        service.handAggregateStream
-          .on('finish', () => resolve())
-          .on('error', (error: Error) => reject(error))
-        Readable.from(events).pipe(service.handAggregateStream)
+      const liveHandActions = await pipeEventsAndWaitForActions(service, dbMock, events, {
+        handId: 271929009,
+        minCount: importResult.actions.filter(a => a.handId === 271929009).length
       })
-      await dbMock.open()
-      const liveRiverCallAction = (await dbMock.actions.where('handId').equals(271929009).toArray())
+      const liveRiverCallAction = liveHandActions
         .find(a => a.playerId === WINNER_CALLER && a.phase === PhaseType.RIVER && a.actionType === ActionType.CALL)
       expect(liveRiverCallAction).toBeDefined()
       expect(liveRiverCallAction!.actionDetails).toContain(ActionDetail.RIVER_CALL_WON)
@@ -2565,19 +2776,24 @@ describe('EntityConverter', () => {
         }
       ])
 
+      // インポート/リビルドパイプラインの結果を先に求め、ライブパイプラインが
+      // 書き込むべきフェーズ数（このハンドはSHOWDOWNなしのPREFLOPのみ）の基準にする
+      const importResult = converter.convertEventsToEntities(events)
+      const importPhasesForHand = importResult.phases.filter(p => p.handId === 34567)
+
       const dbMock = new PokerChaseDB(indexedDB, IDBKeyRange)
       const service = new PokerChaseService({ db: dbMock })
       await service.ready
-      await new Promise<void>((resolve, reject) => {
-        service.handAggregateStream
-          .on('finish', () => resolve())
-          .on('error', (error: Error) => reject(error))
-        Readable.from(events).pipe(service.handAggregateStream)
-      })
-      await dbMock.open()
-      const livePhases = await dbMock.phases
-        .where('handId').equals(34567)
-        .toArray()
+      Readable.from(events).pipe(service.handAggregateStream)
+      const livePhases = await pipeEventsAndWaitForReady(
+        service,
+        async () => {
+          await dbMock.open()
+          return dbMock.phases.where('handId').equals(34567).toArray()
+        },
+        result => result.length >= importPhasesForHand.length,
+        { description: `dbMock.phases with handId=34567 to have >= ${importPhasesForHand.length} row(s)` }
+      )
 
       expect(livePhases.find(p => p.phase === PhaseType.SHOWDOWN)).toBeUndefined()
     })

--- a/src/entity-converter.ts
+++ b/src/entity-converter.ts
@@ -200,6 +200,20 @@ export class EntityConverter {
           // ALL_INアクションの正規化
           const actionType = this.normalizeAllInAction(event, progress, actionDetails)
           const playerId = handState.hand.seatUserIds[event.SeatIndex]
+
+          // 途中着席（EVT_ENTRY_QUEUED）によるテーブル移動後、直前にバッファされた
+          // EVT_DEALのSeatUserIdsには新テーブルの座席が反映されておらず、
+          // event.SeatIndexが解決できない（undefined）か空席（-1）を指すことがある。
+          // 実データ検証: 完走した27ハンド / 68アクション（全ハンドの0.09%）でこの状況を確認。
+          // 従来はplayerId ?? 0でplayerId=0を捏造し、position=-3のアクションが
+          // actionsテーブルに混入していた。検出コンテキストも意味を持たないため、
+          // このアクション自体を丸ごとスキップする（ハンドの他のアクションは通常通り処理を続ける）。
+          // progressは次のアクションのALL_IN正規化で参照されるため、スキップする場合でも更新する。
+          if (playerId === undefined || playerId === -1) {
+            progress = event.Progress
+            break
+          }
+
           const phase = handState.phases.at(-1)!.phase
           const phaseActions = handState.actions.filter(action => action.phase === phase)
           const phasePrevBetCount = phaseActions.filter(action =>
@@ -213,13 +227,11 @@ export class EntityConverter {
 
           // ポジション計算（WriteEntityStreamと同一ロジック。EVT_DEAL時点で確定した
           // positionMapを全フェーズで使い回すことで、ライブ記録と同じポジション値を得る）
-          // 座席に存在しないplayerId（不正なイベント等）の場合は、旧実装の
-          // `indexOf()`が-1を返す挙動（結果的にposition=-3）を踏襲する
-          const position: Position = positionMap.get(playerId ?? 0) ?? -3 as Position
+          const position: Position = positionMap.get(playerId) ?? -3 as Position
 
           // 統計モジュールを使用してActionDetailを検出
           const detectionContext: ActionDetailContext = {
-            playerId: playerId ?? 0,
+            playerId,
             actionType,
             phase,
             phasePlayerActionIndex,
@@ -244,7 +256,7 @@ export class EntityConverter {
           handState.actions.push({
             handId: 0, // EVT_HAND_RESULTSで更新される
             index: handState.actions.length,
-            playerId: playerId ?? 0,
+            playerId,
             phase,
             actionType,
             bet: event.BetChip,

--- a/src/services/poker-chase-service.ts
+++ b/src/services/poker-chase-service.ts
@@ -6,6 +6,7 @@ import { ReadEntityStream } from '../streams/read-entity-stream'
 import { HandLogStream } from '../streams/hand-log-stream'
 import { RealTimeStatsStream } from '../streams/realtime-stats-stream'
 import { setHandImprovementBatchMode } from '../realtime-stats'
+import { defaultStatDisplayConfigs, mergeStatDisplayConfigs } from '../stats'
 import {
   POKER_CHASE_SERVICE_EVENT,
   POKER_CHASE_ORIGIN,
@@ -306,7 +307,13 @@ class PokerChaseService {
     this.handLimitFilter = filterOptions.handLimit
 
     // Set stat display configuration
-    this.statDisplayConfigs = filterOptions.statDisplayConfigs
+    // 保存済みのstatDisplayConfigsをデフォルトとマージしてから設定する（background.tsの
+    // 起動時ロードと同じ理由。呼び出し元のfilterOptionsが、マージ処理を経ていない
+    // 古いstorage値や外部由来のメッセージであっても、新しい統計が欠落しないようにする）
+    this.statDisplayConfigs = mergeStatDisplayConfigs(
+      filterOptions.statDisplayConfigs,
+      defaultStatDisplayConfigs
+    )
 
     // Trigger recalculation using the dedicated method
     await this.statsOutputStream.recalculateStats()

--- a/src/stats/index.test.ts
+++ b/src/stats/index.test.ts
@@ -1,0 +1,81 @@
+import { mergeStatDisplayConfigs } from './index'
+import type { StatDisplayConfig } from '../types/filters'
+
+/**
+ * mergeStatDisplayConfigsのユニットテスト
+ *
+ * 背景: このヘルパーはPopup.tsx（ポップアップUI）とbackground.ts
+ * （service-worker起動時のオプション復元、setBattleTypeFilter経由の
+ * フィルター更新）の両方から呼ばれる。保存済みの統計表示設定に
+ * リリース後追加された新しい統計（例: #86のSTL/FTS）が欠けていても、
+ * デフォルト設定とマージすることでHUDから新統計が漏れないようにする。
+ */
+describe('mergeStatDisplayConfigs', () => {
+  const defaults: StatDisplayConfig[] = [
+    { id: 'hands', enabled: true, order: 0 },
+    { id: 'vpip', enabled: true, order: 1 },
+    { id: 'pfr', enabled: true, order: 2 },
+    { id: 'steal', enabled: true, order: 3 },      // 新規追加された統計を想定
+    { id: 'foldToSteal', enabled: true, order: 4 } // 新規追加された統計を想定
+  ]
+
+  it('保存済み設定に存在しない新しいIDはデフォルト設定のまま末尾側に追加される', () => {
+    // 保存済み設定はsteal/foldToStealが追加される前のバージョン
+    const saved: StatDisplayConfig[] = [
+      { id: 'hands', enabled: true, order: 0 },
+      { id: 'vpip', enabled: false, order: 2 }, // ユーザーが無効化＆並び替え済み
+      { id: 'pfr', enabled: true, order: 1 }
+    ]
+
+    const merged = mergeStatDisplayConfigs(saved, defaults)
+
+    // 新規統計（steal, foldToSteal）がデフォルト設定のまま含まれる
+    const steal = merged.find(c => c.id === 'steal')
+    const foldToSteal = merged.find(c => c.id === 'foldToSteal')
+    expect(steal).toEqual({ id: 'steal', enabled: true, order: 3 })
+    expect(foldToSteal).toEqual({ id: 'foldToSteal', enabled: true, order: 4 })
+
+    // 既存統計はユーザー設定（enabled/order）を維持する
+    expect(merged.find(c => c.id === 'vpip')).toEqual({ id: 'vpip', enabled: false, order: 2 })
+    expect(merged.find(c => c.id === 'pfr')).toEqual({ id: 'pfr', enabled: true, order: 1 })
+
+    // 全項目が含まれ、廃止された項目は存在しない
+    expect(merged.map(c => c.id).sort()).toEqual(defaults.map(c => c.id).sort())
+
+    // orderでソートされている
+    expect(merged.map(c => c.order)).toEqual([...merged.map(c => c.order)].sort((a, b) => a - b))
+  })
+
+  it('保存済み設定が空配列の場合はデフォルト設定がそのまま返る', () => {
+    const merged = mergeStatDisplayConfigs([], defaults)
+    expect(merged).toEqual(defaults.slice().sort((a, b) => a.order - b.order))
+  })
+
+  it('保存済み設定がundefinedの場合はデフォルト設定がそのまま返る（service-worker起動時の初回など）', () => {
+    const merged = mergeStatDisplayConfigs(undefined, defaults)
+    expect(merged).toEqual(defaults.slice().sort((a, b) => a.order - b.order))
+  })
+
+  it('デフォルトに存在しない廃止済みの統計IDは結果から除外される', () => {
+    const saved: StatDisplayConfig[] = [
+      { id: 'hands', enabled: true, order: 0 },
+      { id: 'vpip', enabled: true, order: 1 },
+      { id: 'pfr', enabled: true, order: 2 },
+      { id: 'steal', enabled: true, order: 3 },
+      { id: 'foldToSteal', enabled: true, order: 4 },
+      { id: 'obsoleteStat', enabled: true, order: 5 } // もう存在しない統計
+    ]
+
+    const merged = mergeStatDisplayConfigs(saved, defaults)
+
+    expect(merged.find(c => c.id === 'obsoleteStat')).toBeUndefined()
+    expect(merged).toHaveLength(defaults.length)
+  })
+
+  it('全項目が保存済みの場合はenabled/orderがそのまま保持される（冪等性）', () => {
+    const saved: StatDisplayConfig[] = defaults.map(c => ({ ...c, enabled: false }))
+    const merged = mergeStatDisplayConfigs(saved, defaults)
+    expect(merged.every(c => c.enabled === false)).toBe(true)
+    expect(merged).toHaveLength(defaults.length)
+  })
+})

--- a/src/stats/index.ts
+++ b/src/stats/index.ts
@@ -10,6 +10,7 @@
  */
 
 import type { StatDefinition } from '../types/stats'
+import type { StatDisplayConfig } from '../types/filters'
 import { defaultRegistry } from './registry'
 
 // Import all core statistics automatically
@@ -70,6 +71,49 @@ export const defaultStatDisplayConfigs = orderedCoreStats.map(({ stat }) => ({
   enabled: true,
   order: stat.order!
 }))
+
+/**
+ * 保存済みのstatDisplayConfigsをデフォルト構成とマージする。
+ *
+ * 背景: ユーザーが以前保存した設定（storageの`filterOptions.statDisplayConfigs`）は、
+ * リリース後に新しい統計項目が追加されても自動的には増えない。
+ * このマージ処理を通さずにそのまま使うと、STL/FTS等（#86）のような
+ * 新規統計がHUDに一切表示されなくなる（ポップアップを開いて再保存するまで）。
+ *
+ * マージ結果はデフォルト構成をベース（順序・新規項目を保証）にしつつ、
+ * 既存項目についてはユーザーが設定したenabled/orderを保持する:
+ * - デフォルトに存在し、保存済み設定にもある項目 → ユーザーのenabled/orderを維持
+ * - デフォルトに存在するが、保存済み設定にない項目（新規統計） → デフォルト設定のまま追加
+ * - 保存済み設定にあるがデフォルトに存在しない項目（廃止された統計） → 除外
+ *
+ * @param existingConfigs 保存済みのstatDisplayConfigs（undefined/空配列可）
+ * @param defaultConfigs デフォルトのstatDisplayConfigs
+ * @returns マージ後のstatDisplayConfigs（orderでソート済み）
+ */
+export function mergeStatDisplayConfigs(
+  existingConfigs: StatDisplayConfig[] | undefined,
+  defaultConfigs: StatDisplayConfig[]
+): StatDisplayConfig[] {
+  const existingMap = new Map((existingConfigs || []).map(config => [config.id, config]))
+
+  // デフォルト構成をベースにする（順序を保証し、廃止された統計を自動的に除外する）
+  const mergedConfigs = defaultConfigs.map(defaultConfig => {
+    const existingConfig = existingMap.get(defaultConfig.id)
+    if (existingConfig) {
+      // ユーザー設定（enabled/order）を維持しつつ、その他のデフォルト値を反映
+      return {
+        ...defaultConfig,
+        enabled: existingConfig.enabled,
+        order: existingConfig.order
+      }
+    }
+    // 新規統計 - デフォルト設定をそのまま使用
+    return defaultConfig
+  })
+
+  // orderでソートして表示順を安定させる
+  return mergedConfigs.sort((a, b) => a.order - b.order)
+}
 
 // Export registry and utilities
 export { defaultRegistry } from './registry'

--- a/src/streams/write-entity-stream.ts
+++ b/src/streams/write-entity-stream.ts
@@ -147,16 +147,27 @@ export class WriteEntityStream extends Transform {
             }
           })(event)
           const playerId = handState.hand.seatUserIds[event.SeatIndex]
+
+          // 途中着席（EVT_ENTRY_QUEUED）によるテーブル移動後、直前にバッファされた
+          // EVT_DEALのSeatUserIdsには新テーブルの座席が反映されておらず、
+          // event.SeatIndexが解決できない（undefined）か空席（-1）を指すことがある。
+          // 実データ検証: 完走した27ハンド / 68アクション（全ハンドの0.09%）でこの状況を確認。
+          // 従来はplayerId ?? 0でplayerId=0を捏造し、position=-3のアクションが
+          // actionsテーブルに混入していた。検出コンテキストも意味を持たないため、
+          // このアクション自体を丸ごとスキップする（ハンドの他のアクションは通常通り処理を続ける）。
+          if (playerId === undefined || playerId === -1) {
+            progress = event.Progress
+            break
+          }
+
           const phase = handState.phases.at(-1)!.phase
           const phaseActions = handState.actions.filter(action => action.phase === phase)
           const phasePlayerActionIndex = phaseActions.filter(action => action.playerId === playerId).length
           const phasePrevBetCount = phaseActions.filter(action => [ActionType.BET, ActionType.RAISE].includes(action.actionType)).length + Number(phase === PhaseType.PREFLOP)
-          // 座席に存在しないplayerId（不正なイベント等）の場合は、旧実装の
-          // `indexOf()`が-1を返す挙動（結果的にposition=-3）を踏襲する
-          const position: Position = positionMap.get(playerId ?? 0) ?? -3 as Position
+          const position: Position = positionMap.get(playerId) ?? -3 as Position
           // モジュールベース検出用のActionDetailContext
           const detectionContext: ActionDetailContext = {
-            playerId: playerId ?? 0,
+            playerId,
             actionType,
             phase,
             phasePlayerActionIndex,
@@ -177,7 +188,7 @@ export class WriteEntityStream extends Transform {
             }
           }
           handState.actions.push({
-            playerId: playerId ?? 0,
+            playerId,
             phase,
             index: handState.actions.length,
             actionType,

--- a/src/utils/position-utils.test.ts
+++ b/src/utils/position-utils.test.ts
@@ -106,4 +106,47 @@ describe('getPositionMap', () => {
 
     expect(positions.has(-1)).toBe(false)
   })
+
+  /**
+   * 防御的テスト: ButtonSeat === BigBlindSeat（≠ SmallBlindSeat）。
+   * 実データ31,916件のEVT_DEAL全件では0件観測（未観測の組み合わせ）だが、
+   * entity-converter.test.ts（ButtonSeat:1, SmallBlindSeat:0, BigBlindSeat:1）や
+   * hand-log-processor.test.ts（ButtonSeat:3, SmallBlindSeat:5, BigBlindSeat:3）の
+   * 合成フィクスチャに存在するため、誤動作しないことを保証する。
+   *
+   * 旧実装では、この組み合わせだと (a) BB占有者のラベルがBTNで上書きされ、
+   * (b) 時計回り走査の停止条件 `seat === ButtonSeat` が
+   * 開始座席（BigBlindSeat+1）と噛み合わず発火しないため全周してしまい、
+   * SB占有者のラベルまでCO/HJ/UTGで上書きされ得た。
+   */
+  it('ButtonSeat === BigBlindSeat（防御的・実データ未観測）ではBBラベルを優先しBTNは付与しない', () => {
+    // hand-log-processor.test.ts の実フィクスチャに準拠した座席配置
+    const seatUserIds = [-1, -1, -1, 561384657, -1, 898959592]
+    const game = { ButtonSeat: 3, SmallBlindSeat: 5, BigBlindSeat: 3 }
+
+    const positions = getPositionMap(seatUserIds, game)
+
+    expect(positions.get(561384657)).toBe(Position.BB) // BTN===BBの座席はBB優先、BTNは付与されない
+    expect(positions.get(898959592)).toBe(Position.SB) // 誤って上書きされない
+    expect(positions.size).toBe(2)
+  })
+
+  it('ButtonSeat === BigBlindSeat（防御的・実データ未観測）で他の着席プレイヤーはCO/HJ/UTGを正しく受け取る', () => {
+    // entity-converter.test.ts の実フィクスチャに準拠した座席配置（6人フルリング相当）
+    const seatUserIds = [10, 20, 30, 40, 50, 60]
+    const game = { ButtonSeat: 1, SmallBlindSeat: 0, BigBlindSeat: 1 }
+
+    const positions = getPositionMap(seatUserIds, game)
+
+    expect(positions.get(20)).toBe(Position.BB) // ButtonSeat===BigBlindSeat: BB優先、BTN付与なし
+    expect(positions.get(10)).toBe(Position.SB)
+    // BBの次（seat2）からBBの手前（seat0はSBなので除外済み）までを時計回りに収集:
+    // seat2, seat3, seat4, seat5 → 反転してBTNに近い方から CO, HJ, UTG
+    expect(positions.get(60)).toBe(Position.CO)
+    expect(positions.get(50)).toBe(Position.HJ)
+    expect(positions.get(40)).toBe(Position.UTG)
+    // 4番目（seat2=30）はUTGの手前で、ラベルが尽きているため付与されない
+    expect(positions.has(30)).toBe(false)
+    expect(positions.size).toBe(5)
+  })
 })

--- a/src/utils/position-utils.ts
+++ b/src/utils/position-utils.ts
@@ -28,18 +28,24 @@ export interface PositionGameInfo {
  * - BigBlindSeatの占有者 → BB
  * - SmallBlindSeatの占有者 → SB（ヘッズアップ時はButtonSeat === SmallBlindSeatとなり、
  *   このプレイヤーはSBのまま。これは旧実装のHU挙動と一致する）
- * - ButtonSeatの占有者 → BTN（ヘッズアップ時は上記のSB判定が優先されるため、ここには来ない）
- * - 残りの着席プレイヤー: BBの次の座席からBTNまで時計回りに辿った順（＝アクション順）を求め、
- *   その順序を反転して「BTNに近い方から」CO, HJ, UTGの順にラベル付けする。
+ * - ButtonSeatの占有者 → BTN（ヘッズアップ時は上記のSB判定が優先されるため、ここには来ない。
+ *   同様にButtonSeat === BigBlindSeatの場合もBB判定が優先され、BTNは付与されない）
+ * - 残りの着席プレイヤー: Button/SmallBlind/BigBlindの各座席を除き、BBの次の座席から
+ *   時計回りに辿った順（＝アクション順）を求め、その順序を反転して「BTNに近い方から」
+ *   CO, HJ, UTGの順にラベル付けする。
  *   人数が少ない場合は近い方のラベルのみ使われる（例: 4人卓ならBB, SB, BTN, COの4種）。
  *
  * 実データ検証結果（31,916件のEVT_DEAL全件に対して）:
  * - ButtonSeat/SmallBlindSeat/BigBlindSeatは全件で存在し、常に着席済み座席（-1でない）を指していた
  *   （範囲外・空席参照は0件）
  * - ButtonSeat === SmallBlindSeat（ヘッズアップ）は2,794件（8.75%）
+ * - ButtonSeat === BigBlindSeat（SmallBlindSeatと異なる）は0件（未観測）
  * - デッドブラインドや欠落ブラインド座席のケースは検出されなかった
  * 上記により、本関数は「ButtonSeat/SmallBlindSeat/BigBlindSeatは必ず着席済み座席を指す」
- * ことを前提として実装している。
+ * ことを前提として実装している。ButtonSeat === BigBlindSeat（≠ SmallBlindSeat）は
+ * 実データでは未観測だが、テストフィクスチャ（entity-converter.test.ts /
+ * hand-log-processor.test.ts）に存在するため、誤動作しないよう防御的に扱っている
+ * （BBラベルを優先し、時計回り収集はButton/SmallBlind/BigBlindの各座席をスキップする）。
  *
  * @param seatUserIds 座席インデックス順のプレイヤーID配列（空席は-1）
  * @param game ButtonSeat/SmallBlindSeat/BigBlindSeatを含むGame情報
@@ -57,6 +63,9 @@ export function getPositionMap(seatUserIds: number[], game: PositionGameInfo): M
 
   const isHeadsUp = ButtonSeat === SmallBlindSeat
 
+  // ブラインドのラベルを先に確定させる。BB/SBは一次情報（ButtonSeat/SmallBlindSeat/
+  // BigBlindSeatから直接決まる）なので、後段の時計回り収集がこれらの座席を
+  // 再ラベル付けしないよう、先に「特別座席」の集合として扱う。
   const bbPlayerId = seatOccupant(BigBlindSeat)
   if (bbPlayerId !== undefined) {
     positions.set(bbPlayerId, Position.BB)
@@ -67,19 +76,29 @@ export function getPositionMap(seatUserIds: number[], game: PositionGameInfo): M
     positions.set(sbPlayerId, Position.SB)
   }
 
-  if (!isHeadsUp) {
+  // BTNはSmallBlindSeat・BigBlindSeatのいずれとも異なる場合のみ付与する。
+  // ButtonSeat === SmallBlindSeat はヘッズアップの正常系（SBラベルを優先、旧実装と同じ）。
+  // ButtonSeat === BigBlindSeat は実データ31,916件のEVT_DEALでは0件観測（純粋に防御的）だが、
+  // テストフィクスチャ（entity-converter.test.ts, hand-log-processor.test.ts）に存在するため
+  // 対応する：この場合はBBラベルを優先し、BTNは付与しない（BBと同一座席のため）。
+  if (!isHeadsUp && ButtonSeat !== BigBlindSeat) {
     const btnPlayerId = seatOccupant(ButtonSeat)
     if (btnPlayerId !== undefined) {
       positions.set(btnPlayerId, Position.BTN)
     }
   }
 
-  // BBの次の座席からButtonSeatの手前まで、時計回りに着席プレイヤーを収集する
-  // （＝プリフロップのアクション順で、UTGが先頭・BTN直前が末尾になる）
+  // Button/SmallBlind/BigBlindの各座席（重複する場合は実質1〜2座席）を「特別座席」として
+  // 除外し、それ以外の着席プレイヤーをBigBlindSeatの次から時計回りに収集する。
+  // 従来は「seat === ButtonSeat」で走査を止めていたが、ButtonSeat === BigBlindSeatの
+  // ケースでは開始座席（BigBlindSeat+1）と停止座席（ButtonSeat）が噛み合わず全周してしまい、
+  // SB等の座席を誤って上書きし得た。特別座席の集合でスキップする方式なら、
+  // どの組み合わせでも安全（該当座席をスキップし、それ以外を1周だけ収集する）。
+  const specialSeats = new Set<number>([ButtonSeat, SmallBlindSeat, BigBlindSeat])
   const earlyToLate: number[] = []
   for (let offset = 1; offset < seatCount; offset++) {
     const seat = (BigBlindSeat + offset) % seatCount
-    if (seat === ButtonSeat) break
+    if (specialSeats.has(seat)) continue
     const playerId = seatOccupant(seat)
     if (playerId !== undefined) {
       earlyToLate.push(playerId)


### PR DESCRIPTION
## 概要

codex-connector が過去 PR(#86/#93/#95/#96)に残したレビュー指摘のうち、未解消と確認した4件を修正します。各指摘は実データ(393,830 イベント)で裏取り済みです。

## 修正内容

**1. `getPositionMap` の防御的再構成**(#95 指摘)
`ButtonSeat === BigBlindSeat` の場合に BB ラベルが BTN に上書きされ、歩行ループが全周する問題。実データでは **0/31,916 件**の純粋に理論的なケース(引用元のフィクスチャは合成データ)ですが、ブラインドラベル優先 + `specialSeats` スキップ方式に再構成して耐性を持たせました。**既存7テストはバイト単位で不変**(実挙動への影響なし)。

**2. 解決不能な SeatIndex のアクションをスキップ**(#96 指摘、#93 の position=-3 指摘も根本解消)
テーブル移動後のアクションが旧 `SeatUserIds` で解決できない場合(実測: 完走ハンド 27 件 / 68 アクション、0.09%)、従来は `playerId ?? 0` で幽霊行を生成していました。両経路でスキップに変更し、パリティテストで両経路同一を担保。
*調査付録*: `EVT_PLAYER_SEAT_ASSIGNED`(313)の最新マッピングで **99.9%(768/769)が正しく帰属可能**と実証済み — スキップではなく回復する改善を将来課題として記録。

**3. `statDisplayConfigs` のデフォルトマージを background に移設**(#86 指摘)
`mergeStatDisplayConfigs` を `src/stats/index.ts` に共有化し、SW 起動時ロードと `setBattleTypeFilter` の両代入箇所でマージ。**popup を一度も開かなくても新統計(STL/FTS 等)が HUD に反映**されます。単体テスト5件追加。

**4. EC↔WES パリティテストの deflake**(#93 指摘)
'finish' 待ち → 即読み取りのレースを、ポーリングヘルパー(50ms 間隔 / 5s タイムアウト)に置換。指摘の3箇所だけでなく **#97 で増えた同型を含む6箇所すべて**を修正。全スイート2回 + 対象スイート3回の再実行でフレークなし。

## 検証

- `npm run typecheck` ✅ / `npm run test` — **398/398(45 suites)** ✅(2回実行で安定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)