### PR TITLE
fix(stats): terminate position walk at the button to exclude dead-button seats

### DIFF
--- a/src/utils/position-utils.test.ts
+++ b/src/utils/position-utils.test.ts
@@ -149,4 +149,41 @@ describe('getPositionMap', () => {
     expect(positions.has(30)).toBe(false)
     expect(positions.size).toBe(5)
   })
+
+  // dead button等でボタンより後ろ（BTN〜BBの間）に配られたプレイヤーが座るケース。
+  // 実データ31,916件中213件で観測された実在のジオメトリ。
+  // このプレイヤーはボタンの直前に行動する席ではないため、COラベルを与えてはいけない
+  // （与えると本来のCOのラベルがずれ、STL/FTSの実測値がオラクルと乖離する回帰が発生した）。
+  it('BTNとブラインドの間に座る配られたプレイヤーにはポジションラベルを与えない（実データ観測ジオメトリ）', () => {
+    // 実データ観測例: 6人フル、Button=3, SB=5, BB=0 → seat4がBTNとSBの間
+    const seatUserIds = [100, 200, 300, 400, 500, 600]
+    const game = { ButtonSeat: 3, SmallBlindSeat: 5, BigBlindSeat: 0 }
+
+    const positions = getPositionMap(seatUserIds, game)
+
+    expect(positions.get(100)).toBe(Position.BB)
+    expect(positions.get(600)).toBe(Position.SB)
+    expect(positions.get(400)).toBe(Position.BTN)
+    // BB+1（seat1）からボタン（seat3）の手前まで: seat1, seat2 → 反転して CO=seat2, HJ=seat1
+    expect(positions.get(300)).toBe(Position.CO)
+    expect(positions.get(200)).toBe(Position.HJ)
+    // seat4（BTNとSBの間）はラベルなし = ポジション統計の対象外
+    expect(positions.has(500)).toBe(false)
+    expect(positions.size).toBe(5)
+  })
+
+  it('SBとBBの間に座る配られたプレイヤーにもラベルを与えない（実データ観測ジオメトリ）', () => {
+    // 実データ観測例: [-1,-1,A,B,X,C]、Button=2, SB=3, BB=5 → seat4がSBとBBの間
+    const seatUserIds = [-1, -1, 21, 22, 23, 24]
+    const game = { ButtonSeat: 2, SmallBlindSeat: 3, BigBlindSeat: 5 }
+
+    const positions = getPositionMap(seatUserIds, game)
+
+    expect(positions.get(24)).toBe(Position.BB)
+    expect(positions.get(22)).toBe(Position.SB)
+    expect(positions.get(21)).toBe(Position.BTN)
+    // BB+1（seat0）から: seat0=-1, seat1=-1, seat2=ButtonSeatで打ち切り → 収集なし
+    expect(positions.has(23)).toBe(false)
+    expect(positions.size).toBe(3)
+  })
 })

--- a/src/utils/position-utils.ts
+++ b/src/utils/position-utils.ts
@@ -98,6 +98,14 @@ export function getPositionMap(seatUserIds: number[], game: PositionGameInfo): M
   const earlyToLate: number[] = []
   for (let offset = 1; offset < seatCount; offset++) {
     const seat = (BigBlindSeat + offset) % seatCount
+    // 通常ジオメトリではボタン座席で走査を打ち切る。ボタンより後ろ（BTN〜BBの間）に
+    // 配られたプレイヤーが座るケース（dead button等。実データ31,916件中213件で観測）では、
+    // その席はボタンの直前に行動する席ではないため、CO/HJ/UTGのラベル対象に含めない
+    // （旧実装と同一の挙動。ここを「スキップして続行」にするとBTN後方の席が
+    // reverse後の先頭に来てCOラベルを横取りし、実プレイヤーのSTL/FTSがズレる）。
+    // ButtonSeat === BigBlindSeat の防御ケースのみ打ち切りが機能しないため、
+    // specialSeatsスキップで1周収集する。
+    if (seat === ButtonSeat && ButtonSeat !== BigBlindSeat) break
     if (specialSeats.has(seat)) continue
     const playerId = seatOccupant(seat)
     if (playerId !== undefined) {
@@ -106,11 +114,12 @@ export function getPositionMap(seatUserIds: number[], game: PositionGameInfo): M
   }
 
   // BTNに近い方から順にCO, HJ, UTG, ...をラベル付けする
+  // （既にBB/SB/BTNのラベルを持つプレイヤーは上書きしない）
   const lateToEarlyLabels = [Position.CO, Position.HJ, Position.UTG]
   const lateToEarly = earlyToLate.slice().reverse()
   lateToEarly.forEach((playerId, index) => {
     const label = lateToEarlyLabels[index]
-    if (label !== undefined) {
+    if (label !== undefined && !positions.has(playerId)) {
       positions.set(playerId, label)
     }
   })


### PR DESCRIPTION
## 回帰の検出(#98 ハーネスの初仕事)

#100 マージ後の main に対する `npm run verify-stats` 最終ゲートが **FAIL**(steal 96.15% / foldToSteal 97.60%、#100 以前は 100%)。

## 原因

#100 の `getPositionMap` 再構成が、歩行を「ボタン座席で打ち切り」から「全周 + 特別席スキップ」に変更した結果、**ボタンより後ろ(BTN〜BB 間)に配られたプレイヤー**(dead button 等のジオメトリ、実データ 31,916 ディール中 213 件 = 0.67%)が収集対象に入り、reverse 後の先頭に来て **CO ラベルを横取り**していました。CO は「ボタンの直前に行動する席」であり、ボタン後方の席ではありません。#100 の単体テストは既存7件がバイト単位不変でしたが、このジオメトリのテストが存在せずすり抜けました。

## 修正

- 通常ジオメトリでは**ボタン座席で走査を打ち切る旧セマンティクスを復元**(新旧アルゴリズムの全 31,916 ディール照合で差分 213 → 0 を確認)
- `ButtonSeat === BigBlindSeat` の防御ケース(実データ 0 件)に限り全周スキップ方式を維持し、既存ラベルの**上書き禁止ガード**を追加
- 実データ観測ジオメトリ2種(BTN〜SB 間 / SB〜BB 間の interloper)の回帰テストを追加

## 検証

- `npm run typecheck` ✅ / `npm run test` — 400/400(45 suites)✅
- **`npm run verify-stats`(実データ 393,830 イベント)— PASS、全統計 ≥99% 回復** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)