### PR TITLE
refactor(hud): replace implicit persistence triggers with an explicit session API

### DIFF
--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -285,14 +285,14 @@ class AutoSyncService {
               // セッション終了イベント: 次のセッションのためにリセット
               service.session.reset()
             } else if (isApiEventType(event, ApiType.EVT_ENTRY_QUEUED)) {
-              service.session.id = event.Id
-              service.session.battleType = event.BattleType
+              service.session.setId(event.Id)
+              service.session.setBattleType(event.BattleType)
             } else if (isApiEventType(event, ApiType.EVT_SESSION_DETAILS)) {
-              service.session.name = event.Name
+              service.session.setName(event.Name)
             } else if (isApiEventType(event, ApiType.EVT_PLAYER_SEAT_ASSIGNED)) {
               if (event.TableUsers) {
                 event.TableUsers.forEach(tableUser => {
-                  service.session.players.set(tableUser.UserId, {
+                  service.session.setPlayer(tableUser.UserId, {
                     name: tableUser.UserName,
                     rank: tableUser.Rank.RankId
                   })
@@ -300,7 +300,7 @@ class AutoSyncService {
               }
             } else if (isApiEventType(event, ApiType.EVT_PLAYER_JOIN)) {
               if (event.JoinUser) {
-                service.session.players.set(event.JoinUser.UserId, {
+                service.session.setPlayer(event.JoinUser.UserId, {
                   name: event.JoinUser.UserName,
                   rank: event.JoinUser.Rank.RankId
                 })

--- a/src/services/poker-chase-service.test.ts
+++ b/src/services/poker-chase-service.test.ts
@@ -1,0 +1,259 @@
+/**
+ * PokerChaseService - explicit session persistence tests
+ *
+ * Covers the refactor that replaced the implicit persistence triggers
+ * (hand-written getter/setter pairs + a monkey-patched `session.players.set`)
+ * with an explicit `SessionState` class. These tests pin down the observable
+ * behavior that must not regress:
+ *  - mutations schedule a single debounced `chrome.storage.local.set` call
+ *  - restoring from storage never re-triggers persistence
+ *  - the persisted shape is unchanged, so state written by the old
+ *    implementation still hydrates correctly
+ */
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { SessionState } from './poker-chase-service'
+import { ApiType } from '../types'
+import type { ApiEvent } from '../types'
+import { BattleType } from '../types/game'
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+
+const STORAGE_KEY = PokerChaseService.STORAGE_KEY
+
+const dealEvent: ApiEvent<ApiType.EVT_DEAL> = {
+  ApiTypeId: ApiType.EVT_DEAL,
+  SeatUserIds: [101, 102, 103],
+  Game: { CurrentBlindLv: 1, NextBlindUnixSeconds: 0, Ante: 0, SmallBlind: 100, BigBlind: 200, ButtonSeat: 0, SmallBlindSeat: 1, BigBlindSeat: 2 },
+  Player: { SeatIndex: 0, BetStatus: 1, HoleCards: [0, 1], Chip: 5000, BetChip: 0 },
+  OtherPlayers: [
+    { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 100, IsSafeLeave: false },
+    { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 200, IsSafeLeave: false },
+  ],
+  Progress: { Phase: 0, NextActionSeat: 0, NextActionTypes: [2, 3, 4, 5], NextExtraLimitSeconds: 1, MinRaise: 400, Pot: 300, SidePot: [] },
+  timestamp: 1000,
+}
+
+/** Clear the mocked chrome.storage.local state between tests */
+async function clearStorage() {
+  await chrome.storage.local.set({ [STORAGE_KEY]: undefined })
+  jest.clearAllMocks()
+}
+
+function newService() {
+  const db = new PokerChaseDB(indexedDB, IDBKeyRange)
+  return new PokerChaseService({ db })
+}
+
+describe('PokerChaseService - explicit session persistence', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(async () => {
+    jest.useRealTimers()
+    await clearStorage()
+  })
+
+  test('N回の連続ミューテーションが1回のstorage.set呼び出しにデバウンスされる', async () => {
+    const service = newService()
+    await service.ready
+
+    service.session.setId('session-1')
+    service.session.setBattleType(BattleType.SIT_AND_GO)
+    service.session.setName('Test Table')
+    service.session.setPlayer(1, { name: 'Alice', rank: 'gold' })
+    service.session.setPlayer(2, { name: 'Bob', rank: 'silver' })
+    service.playerId = 1
+    service.latestEvtDeal = dealEvent
+
+    // Debounce window (500ms) hasn't elapsed yet
+    expect(chrome.storage.local.set).not.toHaveBeenCalled()
+
+    jest.advanceTimersByTime(500)
+    // Allow the promise returned by chrome.storage.local.set to settle
+    await Promise.resolve()
+
+    expect(chrome.storage.local.set).toHaveBeenCalledTimes(1)
+    const [payload] = (chrome.storage.local.set as jest.Mock).mock.calls[0]
+    const state = payload[STORAGE_KEY]
+    expect(state.playerId).toBe(1)
+    expect(state.latestEvtDeal).toEqual(dealEvent)
+    expect(state.session.id).toBe('session-1')
+    expect(state.session.battleType).toBe(BattleType.SIT_AND_GO)
+    expect(state.session.name).toBe('Test Table')
+    expect(state.session.players).toEqual([
+      [1, { name: 'Alice', rank: 'gold' }],
+      [2, { name: 'Bob', rank: 'silver' }],
+    ])
+  })
+
+  test('restoreState()はストレージへの書き戻し（persist）をトリガーしない', async () => {
+    // Pre-seed storage as if a previous session had persisted state
+    await chrome.storage.local.set({
+      [STORAGE_KEY]: {
+        playerId: 42,
+        latestEvtDeal: dealEvent,
+        session: {
+          id: 'restored-session',
+          battleType: BattleType.TOURNAMENT,
+          name: 'Restored Table',
+          players: [[1, { name: 'Alice', rank: 'gold' }]],
+        },
+        lastUpdated: Date.now(),
+      },
+    })
+    jest.clearAllMocks()
+
+    const service = newService()
+    await service.ready
+
+    // Restoration applied the values...
+    expect(service.playerId).toBe(42)
+    expect(service.session.id).toBe('restored-session')
+    expect(service.session.battleType).toBe(BattleType.TOURNAMENT)
+    expect(service.session.name).toBe('Restored Table')
+    expect(service.session.players.get(1)).toEqual({ name: 'Alice', rank: 'gold' })
+
+    // ...but did NOT schedule/trigger any persistence
+    jest.advanceTimersByTime(1000)
+    await Promise.resolve()
+    expect(chrome.storage.local.set).not.toHaveBeenCalled()
+  })
+
+  test('reset()はpersistをトリガーし、セッションをクリアする', async () => {
+    const service = newService()
+    await service.ready
+
+    service.session.setId('session-1')
+    service.session.setPlayer(1, { name: 'Alice', rank: 'gold' })
+    jest.advanceTimersByTime(500)
+    await Promise.resolve()
+    expect(chrome.storage.local.set).toHaveBeenCalledTimes(1)
+
+    service.resetSession()
+    jest.advanceTimersByTime(500)
+    await Promise.resolve()
+
+    expect(chrome.storage.local.set).toHaveBeenCalledTimes(2)
+    const [payload] = (chrome.storage.local.set as jest.Mock).mock.calls[1]
+    const state = payload[STORAGE_KEY]
+    expect(state.session.id).toBeUndefined()
+    expect(state.session.battleType).toBeUndefined()
+    expect(state.session.name).toBeUndefined()
+    expect(state.session.players).toEqual([])
+
+    expect(service.session.id).toBeUndefined()
+    expect(service.session.players.size).toBe(0)
+  })
+
+  test('setPlayer()によるプレイヤー追加はpersistをトリガーする', async () => {
+    const service = newService()
+    await service.ready
+
+    service.session.setPlayer(7, { name: 'Carol', rank: 'diamond' })
+    jest.advanceTimersByTime(500)
+    await Promise.resolve()
+
+    expect(chrome.storage.local.set).toHaveBeenCalledTimes(1)
+    expect(service.session.players.get(7)).toEqual({ name: 'Carol', rank: 'diamond' })
+  })
+
+  test('players の読み取り（get/size/entries）は可能で、setPlayer()経由でのみ更新される', async () => {
+    const service = newService()
+    await service.ready
+
+    expect(service.session.players.size).toBe(0)
+    service.session.setPlayer(7, { name: 'Carol', rank: 'diamond' })
+    expect(service.session.players.size).toBe(1)
+    expect(service.session.players.get(7)).toEqual({ name: 'Carol', rank: 'diamond' })
+    expect(Array.from(service.session.players.entries())).toEqual([[7, { name: 'Carol', rank: 'diamond' }]])
+    // Note: `session.players.set(...)` is a *compile-time* error (ReadonlyMap) -
+    // enforced by `npm run typecheck`, not something we can assert at runtime
+    // without `any`-casting past the type system.
+  })
+
+  test('旧フォーマットで永続化されたstateが正しくhydrateされる（ストレージ形式の後方互換性）', async () => {
+    // This mirrors exactly what the OLD implementation (pre-refactor) wrote to
+    // chrome.storage.local: playerId, latestEvtDeal, session:{id,battleType,name,players:[[k,v]...]}, lastUpdated
+    const oldFormatState = {
+      playerId: 123,
+      latestEvtDeal: dealEvent,
+      session: {
+        id: 'legacy-session-456',
+        battleType: BattleType.RING_GAME,
+        name: 'Legacy Ring Table',
+        players: [
+          [101, { name: 'Player101', rank: 'legend' }],
+          [102, { name: 'Player102', rank: 'diamond' }],
+        ],
+      },
+      lastUpdated: 1700000000000,
+    }
+    await chrome.storage.local.set({ [STORAGE_KEY]: oldFormatState })
+    jest.clearAllMocks()
+
+    const service = newService()
+    await service.ready
+
+    expect(service.playerId).toBe(123)
+    expect(service.latestEvtDeal).toEqual(dealEvent)
+    expect(service.session.id).toBe('legacy-session-456')
+    expect(service.session.battleType).toBe(BattleType.RING_GAME)
+    expect(service.session.name).toBe('Legacy Ring Table')
+    expect(service.session.players.size).toBe(2)
+    expect(service.session.players.get(101)).toEqual({ name: 'Player101', rank: 'legend' })
+    expect(service.session.players.get(102)).toEqual({ name: 'Player102', rank: 'diamond' })
+
+    // And hydrating must not have scheduled a persist
+    jest.advanceTimersByTime(1000)
+    await Promise.resolve()
+    expect(chrome.storage.local.set).not.toHaveBeenCalled()
+  })
+})
+
+describe('SessionState (standalone unit tests)', () => {
+  test('明示的なセッターは全てnotifyChangeを一度だけ呼ぶ', () => {
+    const notifyChange = jest.fn()
+    const session = new SessionState(notifyChange)
+
+    session.setId('s1')
+    session.setBattleType(BattleType.SIT_AND_GO)
+    session.setName('Table')
+    session.setPlayer(1, { name: 'Alice', rank: 'gold' })
+    session.reset()
+
+    expect(notifyChange).toHaveBeenCalledTimes(5)
+  })
+
+  test('hydrate()はnotifyChangeを呼ばない', () => {
+    const notifyChange = jest.fn()
+    const session = new SessionState(notifyChange)
+
+    session.hydrate({
+      id: 's1',
+      battleType: BattleType.TOURNAMENT,
+      name: 'Table',
+      players: [[1, { name: 'Alice', rank: 'gold' }]],
+    })
+
+    expect(notifyChange).not.toHaveBeenCalled()
+    expect(session.id).toBe('s1')
+    expect(session.battleType).toBe(BattleType.TOURNAMENT)
+    expect(session.name).toBe('Table')
+    expect(session.players.get(1)).toEqual({ name: 'Alice', rank: 'gold' })
+  })
+
+  test('toJSON()は永続化形式（players配列化済み）を返す', () => {
+    const session = new SessionState(() => { })
+    session.setId('s1')
+    session.setBattleType(BattleType.SIT_AND_GO)
+    session.setName('Table')
+    session.setPlayer(1, { name: 'Alice', rank: 'gold' })
+
+    expect(session.toJSON()).toEqual({
+      id: 's1',
+      battleType: BattleType.SIT_AND_GO,
+      name: 'Table',
+      players: [[1, { name: 'Alice', rank: 'gold' }]],
+    })
+  })
+})

--- a/src/services/poker-chase-service.ts
+++ b/src/services/poker-chase-service.ts
@@ -18,11 +18,98 @@ import {
 } from '../types'
 import type {
   ApiEvent,
+  BattleType,
   FilterOptions,
   HandLogConfig,
   Session,
   StatDisplayConfig
 } from '../types'
+
+/** Serialized shape of a single session's player-info entry (persisted as an array tuple). */
+type SessionPlayerInfo = { name: string, rank: string }
+
+/**
+ * セッション状態を保持するクラス
+ *
+ * PokerChaseServiceが管理する「現在のセッション」を表す。全てのミューテーション
+ * （id/battleType/name/players/reset）は明示的なメソッドを経由し、それぞれが
+ * コンストラクタで渡された `notifyChange` を呼び出す一本道になっている。
+ * これにより「フィールドを追加したら誰かがpersistState()の呼び出しを
+ * 書き忘れる」という構造的な穴を型レベルで塞ぐ（`players`はReadonlyMapとして
+ * 公開され、`.set()`は型エラーになる）。
+ *
+ * リストア時は `hydrate()` を使う。これは同じフィールドを更新するが
+ * `notifyChange` を呼ばない（「復元してもストレージに書き戻さない」という
+ * 復元専用の経路）。
+ */
+export class SessionState implements Session {
+  private _id?: string
+  private _battleType?: BattleType
+  private _name?: string
+  private readonly _players = new Map<number, SessionPlayerInfo>()
+
+  constructor(private readonly notifyChange: () => void) { }
+
+  get id(): string | undefined { return this._id }
+  get battleType(): BattleType | undefined { return this._battleType }
+  get name(): string | undefined { return this._name }
+  /** 読み取り専用ビュー。ミューテーションは setPlayer()/reset() 経由のみ許可される */
+  get players(): ReadonlyMap<number, SessionPlayerInfo> { return this._players }
+
+  setId(value: string | undefined): void {
+    this._id = value
+    this.notifyChange()
+  }
+
+  setBattleType(value: BattleType | undefined): void {
+    this._battleType = value
+    this.notifyChange()
+  }
+
+  setName(value: string | undefined): void {
+    this._name = value
+    this.notifyChange()
+  }
+
+  setPlayer(userId: number, info: SessionPlayerInfo): void {
+    this._players.set(userId, info)
+    this.notifyChange()
+  }
+
+  reset(): void {
+    this._id = undefined
+    this._battleType = undefined
+    this._name = undefined
+    this._players.clear()
+    this.notifyChange()
+  }
+
+  /**
+   * ストレージから復元した値を、永続化をトリガーせずに適用する。
+   * restoreState() 専用。
+   */
+  hydrate(data: { id?: string, battleType?: BattleType, name?: string, players?: [number, SessionPlayerInfo][] }): void {
+    this._id = data.id
+    this._battleType = data.battleType
+    this._name = data.name
+    this._players.clear()
+    if (data.players && Array.isArray(data.players)) {
+      for (const [key, value] of data.players) {
+        this._players.set(key, value)
+      }
+    }
+  }
+
+  /** シリアライズ用（永続化状態の構築に使用） */
+  toJSON() {
+    return {
+      id: this._id,
+      battleType: this._battleType,
+      name: this._name,
+      players: Array.from(this._players.entries())
+    }
+  }
+}
 
 /**
  * PokerChase HUDのメインサービスクラス
@@ -40,7 +127,7 @@ import type {
 class PokerChaseService {
   private _playerId?: number
   private _latestEvtDeal?: ApiEvent<ApiType.EVT_DEAL>
-  private _sessionData: Session
+  private readonly _sessionData: SessionState
   private _isInitialized: boolean = false
   private _initializationError?: Error
   private _persistStateTimer?: ReturnType<typeof setTimeout>
@@ -59,7 +146,8 @@ class PokerChaseService {
   static readonly POKER_CHASE_ORIGIN = POKER_CHASE_ORIGIN
   static readonly STORAGE_KEY = STORAGE_KEY
 
-  // Getter/Setter for automatic persistence
+  // Getter/Setter for automatic persistence.
+  // どちらも同じ persistState()（500msデバウンス）を呼ぶ一本道。
   get playerId(): number | undefined {
     return this._playerId
   }
@@ -77,7 +165,14 @@ class PokerChaseService {
     this._latestEvtDeal = value
     this.persistState()
   }
-  get session(): Session {
+
+  /**
+   * 現在のセッション。ミューテーションは SessionState の明示的なメソッド
+   * （setId/setBattleType/setName/setPlayer/reset）を経由すること。
+   * players は ReadonlyMap として公開されるため `session.players.set(...)`
+   * は型エラーになる。
+   */
+  get session(): SessionState {
     return this._sessionData
   }
 
@@ -86,55 +181,9 @@ class PokerChaseService {
     return this._isInitialized && !this._initializationError
   }
 
-  private initializeSession(): Session {
-    const self = this
-    const session = {
-      _id: undefined as number | undefined,
-      _battleType: undefined as number | undefined,
-      _name: undefined as string | undefined,
-      players: new Map<number, { name: string, rank: string }>(),
-
-      get id() { return this._id },
-      set id(value: number | undefined) {
-        this._id = value
-        self.persistState()
-      },
-
-      get battleType() { return this._battleType },
-      set battleType(value: number | undefined) {
-        this._battleType = value
-        self.persistState()
-      },
-
-      get name() { return this._name },
-      set name(value: string | undefined) {
-        this._name = value
-        self.persistState()
-      },
-
-      reset: function () {
-        this.id = undefined
-        this.battleType = undefined
-        this.name = undefined
-        this.players.clear()
-        self.persistState()
-      }
-    }
-
-    // プレイヤー追加時も永続化
-    const originalSet = session.players.set.bind(session.players)
-    session.players.set = function (key: number, value: { name: string, rank: string }) {
-      const result = originalSet(key, value)
-      self.persistState()
-      return result
-    }
-
-    return session as Session
-  }
-
   /** Reset session and clear player data */
   readonly resetSession = () => {
-    this.session.reset()
+    this._sessionData.reset()
   }
 
   /** Persist current state to Chrome Storage with debouncing */
@@ -156,18 +205,10 @@ class PokerChaseService {
 
   /** Actual persistence logic */
   private actualPersistState = () => {
-    // Convert Map to array for serialization
-    const playersArray = Array.from(this._sessionData.players.entries())
-
     const state = {
       playerId: this._playerId,
       latestEvtDeal: this._latestEvtDeal,
-      session: {
-        id: this._sessionData.id,
-        battleType: this._sessionData.battleType,
-        name: this._sessionData.name,
-        players: playersArray
-      },
+      session: this._sessionData.toJSON(),
       lastUpdated: Date.now()
     }
 
@@ -225,20 +266,8 @@ class PokerChaseService {
         this._latestEvtDeal = state.latestEvtDeal
 
         if (state.session) {
-          // Direct assignment to avoid setter side effects during restoration
-          const sessionData = this._sessionData as any // Type assertion for private properties
-          sessionData._id = state.session.id
-          sessionData._battleType = state.session.battleType
-          sessionData._name = state.session.name
-
-          // Restore players Map from array
-          if (state.session.players && Array.isArray(state.session.players)) {
-            this._sessionData.players.clear()
-            state.session.players.forEach(([key, value]: [number, { name: string, rank: string }]) => {
-              // Use original Map.set to avoid persistence trigger
-              Map.prototype.set.call(this._sessionData.players, key, value)
-            })
-          }
+          // hydrate() applies the fields directly without calling notifyChange()
+          this._sessionData.hydrate(state.session)
         }
 
         console.log('[PokerChaseService] State restored successfully:', {
@@ -267,7 +296,7 @@ class PokerChaseService {
   readonly realTimeStatsStream: RealTimeStatsStream        // Real-time stats for hero only
   constructor({ db, playerId }: { db: PokerChaseDB, playerId?: number }) {
     this._playerId = playerId
-    this._sessionData = this.initializeSession()
+    this._sessionData = new SessionState(this.persistState)
     this.db = db
 
     // Initialize the ready promise

--- a/src/streams/aggregate-events-stream.ts
+++ b/src/streams/aggregate-events-stream.ts
@@ -47,18 +47,18 @@ export class AggregateEventsStream extends SimpleTransform<ApiEvent, ApiEvent[]>
           // 誤ってバッファがクリアされてしまう
           // （実データで933件中785件の不一致がこのケース、ハンド損失2.9%の主因）。
           this.service.resetSession()
-          this.service.session.id = event.Id
-          this.service.session.battleType = event.BattleType
+          this.service.session.setId(event.Id)
+          this.service.session.setBattleType(event.BattleType)
           this.progress = undefined
           break
         case ApiType.EVT_SESSION_DETAILS:
-          this.service.session.name = event.Name
+          this.service.session.setName(event.Name)
           break
         case ApiType.EVT_PLAYER_SEAT_ASSIGNED:
           // プレイヤー名とランクをセッションに保存
           if (event.TableUsers) {
             event.TableUsers.forEach(tableUser => {
-              this.service.session.players.set(tableUser.UserId, {
+              this.service.session.setPlayer(tableUser.UserId, {
                 name: tableUser.UserName,
                 rank: tableUser.Rank.RankId
               })
@@ -68,7 +68,7 @@ export class AggregateEventsStream extends SimpleTransform<ApiEvent, ApiEvent[]>
         case ApiType.EVT_PLAYER_JOIN:
           // 途中参加者のプレイヤー名とランクをセッションに保存
           if (event.JoinUser) {
-            this.service.session.players.set(event.JoinUser.UserId, {
+            this.service.session.setPlayer(event.JoinUser.UserId, {
               name: event.JoinUser.UserName,
               rank: event.JoinUser.Rank.RankId
             })

--- a/src/streams/hand-log-stream.test.ts
+++ b/src/streams/hand-log-stream.test.ts
@@ -696,12 +696,12 @@ test('ApiEventsからPokerStars形式のログを生成できる', async () => {
   const service = new PokerChaseService({ db: dbMock })
 
   const sessionEvent = event_timeline.find(e => e.ApiTypeId === ApiType.EVT_SESSION_DETAILS)!
-  service.session.name = sessionEvent.Name
-  service.session.battleType = BattleType.SIT_AND_GO
+  service.session.setName(sessionEvent.Name)
+  service.session.setBattleType(BattleType.SIT_AND_GO)
 
   const seatEvent = event_timeline.find(e => e.ApiTypeId === ApiType.EVT_PLAYER_SEAT_ASSIGNED)!
   seatEvent.TableUsers?.forEach(user => {
-    service.session.players.set(user.UserId, {
+    service.session.setPlayer(user.UserId, {
       name: user.UserName,
       rank: user.Rank.RankName
     })

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -23,43 +23,49 @@ global.chrome = {
   },
   storage: {
     sync: {
-      get: jest.fn((keys, callback) => {
+      get: jest.fn((keys, callback?) => {
+        const result = keys ?
+          (Array.isArray(keys) ?
+            keys.reduce((acc, key) => ({ ...acc, [key]: chromeStorageMockData.sync[key] }), {}) :
+            typeof keys === 'string' ? { [keys]: chromeStorageMockData.sync[keys] } :
+            chromeStorageMockData.sync) :
+          chromeStorageMockData.sync
         if (typeof callback === 'function') {
-          const result = keys ? 
-            (Array.isArray(keys) ? 
-              keys.reduce((acc, key) => ({ ...acc, [key]: chromeStorageMockData.sync[key] }), {}) :
-              typeof keys === 'string' ? { [keys]: chromeStorageMockData.sync[keys] } : 
-              chromeStorageMockData.sync) :
-            chromeStorageMockData.sync
           callback(result)
+          return undefined
         }
-        return Promise.resolve({})
+        // Promise-based call style (no callback): resolve with the actual looked-up data
+        return Promise.resolve(result)
       }),
-      set: jest.fn((items, callback) => {
+      set: jest.fn((items, callback?) => {
         Object.assign(chromeStorageMockData.sync, items)
         if (typeof callback === 'function') {
           callback()
+          return undefined
         }
         return Promise.resolve()
       }),
     },
     local: {
-      get: jest.fn((keys, callback) => {
+      get: jest.fn((keys, callback?) => {
+        const result = keys ?
+          (Array.isArray(keys) ?
+            keys.reduce((acc, key) => ({ ...acc, [key]: chromeStorageMockData.local[key] }), {}) :
+            typeof keys === 'string' ? { [keys]: chromeStorageMockData.local[keys] } :
+            chromeStorageMockData.local) :
+          chromeStorageMockData.local
         if (typeof callback === 'function') {
-          const result = keys ? 
-            (Array.isArray(keys) ? 
-              keys.reduce((acc, key) => ({ ...acc, [key]: chromeStorageMockData.local[key] }), {}) :
-              typeof keys === 'string' ? { [keys]: chromeStorageMockData.local[keys] } : 
-              chromeStorageMockData.local) :
-            chromeStorageMockData.local
           callback(result)
+          return undefined
         }
-        return Promise.resolve({})
+        // Promise-based call style (no callback): resolve with the actual looked-up data
+        return Promise.resolve(result)
       }),
-      set: jest.fn((items, callback) => {
+      set: jest.fn((items, callback?) => {
         Object.assign(chromeStorageMockData.local, items)
         if (typeof callback === 'function') {
           callback()
+          return undefined
         }
         return Promise.resolve()
       }),

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -55,11 +55,20 @@ export type Item = SessionResultsEvent['Items'][0]
 // ===============================
 
 // Session type - kept as interface for better type inference
+//
+// `players` is intentionally a ReadonlyMap: consumers must not call
+// `.set()`/`.delete()`/`.clear()` on it directly. PokerChaseService's own
+// session is backed by a class that only mutates players through an explicit
+// `setPlayer()` method (so persistence is triggered on every write, with no
+// way to bypass it). Standalone Session objects built elsewhere (e.g.
+// EntityConverter's local working copy, HandLogExporter's per-export
+// snapshot) are plain objects with a real Map underneath and are free to
+// build that Map however they like before handing it out as a Session.
 export interface Session {
   id?: string
   battleType?: BattleType
   name?: string
-  players: Map<number, { name: string, rank: string }>  // Session-based player information
+  players: ReadonlyMap<number, { name: string, rank: string }>  // Session-based player information
   reset: () => void
 }
 

--- a/src/utils/hand-log-exporter.ts
+++ b/src/utils/hand-log-exporter.ts
@@ -120,36 +120,39 @@ export class HandLogExporter {
     // Build or get global player names map
     const globalPlayerMap = await this.buildPlayerNamesMap(db)
 
-    // Create session with player names from global map
-    const session: Session = {
-      id: hand.session.id,
-      battleType: hand.session.battleType,
-      name: hand.session.name,
-      players: new Map(),
-      reset: function () {
-        this.id = undefined
-        this.battleType = undefined
-        this.name = undefined
-        this.players.clear()
-      }
-    }
-
-    // Populate session players from global map for this hand's players
+    // Populate session players from global map for this hand's players.
+    // Built as a plain, mutable Map first since Session.players is exposed
+    // as a ReadonlyMap once assigned below.
+    const players = new Map<number, { name: string, rank: string }>()
     hand.seatUserIds.forEach(userId => {
       if (userId !== -1) {
         const playerInfo = globalPlayerMap.get(userId)
         if (playerInfo) {
-          session.players.set(userId, playerInfo)
+          players.set(userId, playerInfo)
         } else {
           // Fallback for players not found in global map
           console.warn(`[HandLogExporter] Player ${userId} not found in global map`)
-          session.players.set(userId, {
+          players.set(userId, {
             name: `Player${userId}`,
             rank: 'Unknown'
           })
         }
       }
     })
+
+    // Create session with player names from global map
+    const session: Session = {
+      id: hand.session.id,
+      battleType: hand.session.battleType,
+      name: hand.session.name,
+      players,
+      reset: function () {
+        this.id = undefined
+        this.battleType = undefined
+        this.name = undefined
+        players.clear()
+      }
+    }
 
     // Session has players for hand
 
@@ -330,29 +333,32 @@ export class HandLogExporter {
     globalPlayerMap: Map<number, { name: string, rank: string }>,
     firstHandId?: number
   ): string {
-    const session: Session = {
-      id: hand.session.id,
-      battleType: hand.session.battleType,
-      name: hand.session.name,
-      players: new Map(),
-      reset: function () {
-        this.id = undefined
-        this.battleType = undefined
-        this.name = undefined
-        this.players.clear()
-      }
-    }
-
+    // Built as a plain, mutable Map first since Session.players is exposed
+    // as a ReadonlyMap once assigned below.
+    const players = new Map<number, { name: string, rank: string }>()
     hand.seatUserIds.forEach(userId => {
       if (userId !== -1) {
         const playerInfo = globalPlayerMap.get(userId)
         if (playerInfo) {
-          session.players.set(userId, playerInfo)
+          players.set(userId, playerInfo)
         } else {
-          session.players.set(userId, { name: `Player${userId}`, rank: 'Unknown' })
+          players.set(userId, { name: `Player${userId}`, rank: 'Unknown' })
         }
       }
     })
+
+    const session: Session = {
+      id: hand.session.id,
+      battleType: hand.session.battleType,
+      name: hand.session.name,
+      players,
+      reset: function () {
+        this.id = undefined
+        this.battleType = undefined
+        this.name = undefined
+        players.clear()
+      }
+    }
 
     const context: HandLogContext = {
       session,

--- a/src/utils/hand-log-processor.test.ts
+++ b/src/utils/hand-log-processor.test.ts
@@ -17,20 +17,21 @@ function createSession(
   players: Array<{ userId: number; name: string; rank?: string }>,
   opts?: { battleType?: number; name?: string; id?: string }
 ): Session {
+  const playersMap = new Map<number, { name: string, rank: string }>()
+  for (const p of players) {
+    playersMap.set(p.userId, { name: p.name, rank: p.rank ?? 'Unknown' })
+  }
   const session: Session = {
     id: opts?.id,
     battleType: opts?.battleType ?? BattleType.SIT_AND_GO,
     name: opts?.name ?? 'TestTournament',
-    players: new Map(),
+    players: playersMap,
     reset() {
       this.id = undefined
       this.battleType = undefined
       this.name = undefined
-      this.players.clear()
+      playersMap.clear()
     }
-  }
-  for (const p of players) {
-    session.players.set(p.userId, { name: p.name, rank: p.rank ?? 'Unknown' })
   }
   return session
 }


### PR DESCRIPTION
## 動機(アーキテクチャレビュー指摘 #6)

状態永続化が「手書き getter/setter + `session.players.set` のモンキーパッチ」という暗黙トリガーで実装されており、永続化対象プロパティの追加時に persist 漏れが構造的に起きやすく、restore 経路は `as any` によるプライベートフィールド操作と `Map.prototype.set.call` の回避策を必要としていました。

## 設計

`SessionState` クラスに集約(外部挙動は不変):

- 変更経路は `setId` / `setBattleType` / `setName` / `setPlayer` / `reset()` のみ。各々が単一の `notifyChange`(500ms デバウンスの `persistState`)を呼ぶ
- `players` は **`ReadonlyMap`** として公開 — 統制外の mutate は**コンパイルエラー**に。実際にこの型検査が、grep 調査で漏れていた `auto-sync-service.ts`(クラウド復元経路)の直接 mutate を検出しました(未修正ならランタイム TypeError になっていた箇所)
- `hydrate()` が restore 専用経路(persist 非発火)となり、`as any` / `Map.prototype.set.call` の回避策を全廃

## 互換性

**永続化フォーマットは完全不変**(STORAGE_KEY・シリアライズ構造とも)。旧形式フィクスチャを `chrome.storage.local` に事前投入し、persist 再発火なしで正しくハイドレートされることをテストで証明済み。

## 副次修正

`test-setup.ts` の chrome.storage モックが **Promise スタイル呼出しで常に `{}` を返す**バグを発見・修正(`restoreState()` の実呼出し形式。restore 系テストが silent no-op になるところでした)。

## 検証

- `npm run typecheck` ✅ / `npm run test` ×2回 — **417/417(47 suites)** ✅(旧形式ハイドレート・デバウンス合流・restore非persist等 9 テスト追加)
- **`npm run verify-stats`(実データ 393,830 イベント)— PASS** ✅
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)