### PR TITLE
feat(hud): prompt users to rebuild data after stat-logic updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,7 @@ data storage (Dexie.js), normalized entities, Firestore strategy, and v3 index o
 12. **Operation Exclusivity**: Only one long-running operation (export/import/rebuild) at a time, enforced in background.ts via `currentOperationState`
 13. **Optimistic UI + Server Guard**: Popup sets state immediately on click (responsive UX), background validates and rejects if busy (correctness)
 14. **Cache-First Rendering**: Frequently needed state (Firebase auth) cached in `chrome.storage.local` for instant popup rendering
+15. **Rebuild Advisory Versioning**: Bump `REBUILD_ADVISORY_VERSION` (`src/constants/database.ts`) whenever a change alters write-time entity derivation for already-recorded data, so existing users get prompted (badge/notification/popup banner via `src/background/rebuild-advisory.ts`) to run データ再構築 after updating
 
 ### Data Flow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,6 +252,8 @@ To backfill existing hands so your new statistic reflects historical data too, r
 
 Without this step, your statistic will look like it's stuck at 0 (or empty) for any session recorded before the change, even though the logic itself is correct.
 
+**Prompting existing users to rebuild:** the steps above only help users who know to look for the rebuild button. If your change alters write-time derivation for data that's *already* recorded (not just new stats going forward — e.g. changing `detectActionDetails`, position/seat derivation, or showdown phase detection so previously recorded hands would now compute differently), bump `REBUILD_ADVISORY_VERSION` in `src/constants/database.ts`. This triggers a one-time advisory (badge + notification + popup banner, see `src/background/rebuild-advisory.ts`) prompting existing users to rebuild after they update the extension. Don't bump it for changes that only affect newly recorded data (e.g. adding a brand-new stat with no backward-looking derivation change).
+
 ### Verifying Against Real Data (`verify-stats`)
 
 Unit tests cover individual stats in isolation, but they can't catch a bug that only shows up when many hands' worth of state accumulates (off-by-one phase membership, position derivation on tables with empty seats, etc.). `npm run verify-stats` closes that gap by cross-checking the live pipeline against an independently re-implemented "oracle":

--- a/src/background.ts
+++ b/src/background.ts
@@ -16,6 +16,7 @@ import { content_scripts } from '../manifest.json'
 import { registerStreamSubscriptions } from './background/ports'
 import { registerEventIngestion } from './background/event-ingestion'
 import { registerMessageRouter } from './background/message-router'
+import { checkOnUpdate } from './background/rebuild-advisory'
 /** !!! CONTENT_SCRIPTS、WEB_ACCESSIBLE_RESOURCESからインポートしないこと !!! */
 
 // Get game URL pattern from manifest
@@ -55,6 +56,14 @@ service.ready.then(async () => {
 /** 拡張更新時の処理 */
 chrome.runtime.onInstalled.addListener(async details => {
   console.log(`[onInstalled] Extension ${details.reason}: previousVersion=${details.previousVersion}`)
+
+  if (details.reason === 'update') {
+    try {
+      await checkOnUpdate(db)
+    } catch (error) {
+      console.error('[onInstalled] Rebuild advisory check failed:', error)
+    }
+  }
 })
 
 /** 拡張起動時: フィルター設定を復元（統計の再計算はしない） */

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -19,6 +19,7 @@ import type {
   RebuildProgressMessage
 } from '../types/messages'
 import { setOperationState } from './operation-state'
+import { resolveAdvisory } from './rebuild-advisory'
 
 const IMPORT_CHUNK_SIZE = DATABASE_CONSTANTS.IMPORT_CHUNK_SIZE
 
@@ -546,6 +547,9 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
       // データベースを完全に削除
       await db.delete()
 
+      // データが無くなったので再構築アドバイザリも解消する（reloadより前に行う）
+      await resolveAdvisory()
+
       // データベースの新しいインスタンスを確保するために拡張機能をリロード
       chrome.runtime.reload()
     } catch (error) {
@@ -601,6 +605,8 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
 
       if (totalCount === 0) {
         console.log('[rebuildAllData] No events to process')
+        // 対象イベントが無い＝再構築の必要が無いため、保留中のアドバイザリも解消する
+        await resolveAdvisory()
         setOperationState({ type: 'idle' })
         chrome.runtime.sendMessage<RebuildProgressMessage>({
           action: 'rebuildProgress',
@@ -703,6 +709,9 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
             service.statsOutputStream.write(service.latestEvtDeal.SeatUserIds)
           }
         }
+
+        // 再構築が完了したので、保留中の再構築アドバイザリがあれば解消する
+        await resolveAdvisory()
 
         setOperationState({ type: 'idle' })
         chrome.runtime.sendMessage<RebuildProgressMessage>({

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -11,6 +11,7 @@ import { firebaseAuthService } from '../services/firebase-auth-service'
 import { autoSyncService } from '../services/auto-sync-service'
 import { getOperationState, isOperationIdle } from './operation-state'
 import { getLastKnownStats, setLastKnownStats } from './ports'
+import { resolveAdvisory } from './rebuild-advisory'
 import {
   createImportExportHandlers,
   getCurrentImportSession,
@@ -299,6 +300,15 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
     } else if (request.action === 'getOperationState') {
       console.log('[getOperationState]', JSON.stringify(getOperationState()))
       sendResponse({ success: true, operationState: getOperationState() })
+      return true
+    } else if (request.action === 'acknowledgeRebuildAdvisory') {
+      // Popupのバナー「閉じる」によるアドバイザリの手動解消
+      resolveAdvisory()
+        .then(() => sendResponse({ success: true }))
+        .catch(error => {
+          console.error('[acknowledgeRebuildAdvisory] Error:', error)
+          sendResponse({ success: false, error: error.message })
+        })
       return true
     }
     return false

--- a/src/background/rebuild-advisory.test.ts
+++ b/src/background/rebuild-advisory.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for the rebuild advisory (src/background/rebuild-advisory.ts)
+ */
+import {
+  checkOnUpdate,
+  resolveAdvisory,
+  getRebuildAdvisoryState,
+  REBUILD_ADVISORY_STORAGE_KEY,
+} from './rebuild-advisory'
+import { REBUILD_ADVISORY_VERSION } from '../constants/database'
+import type { PokerChaseDB } from '../db/poker-chase-db'
+
+describe('rebuild-advisory', () => {
+  let mockDb: jest.Mocked<PokerChaseDB>
+
+  beforeEach(async () => {
+    // Clear chrome.storage.local between tests
+    await chrome.storage.local.set({ [REBUILD_ADVISORY_STORAGE_KEY]: undefined })
+    jest.clearAllMocks()
+
+    mockDb = {
+      apiEvents: {
+        count: jest.fn()
+      }
+    } as any
+  })
+
+  describe('checkOnUpdate', () => {
+    it('sets pendingVersion and notifies when data exists and version is unacknowledged', async () => {
+      ;(mockDb.apiEvents.count as jest.Mock).mockResolvedValue(42)
+
+      await checkOnUpdate(mockDb)
+
+      const state = await getRebuildAdvisoryState()
+      expect(state.pendingVersion).toBe(REBUILD_ADVISORY_VERSION)
+      expect(chrome.action.setBadgeText).toHaveBeenCalledWith({ text: '!' })
+      expect(chrome.action.setBadgeBackgroundColor).toHaveBeenCalled()
+      expect(chrome.notifications.create).toHaveBeenCalledTimes(1)
+      const [notification] = (chrome.notifications.create as jest.Mock).mock.calls[0]
+      expect(notification.type).toBe('basic')
+      expect(notification.title).toEqual(expect.any(String))
+      expect(notification.message).toEqual(expect.any(String))
+    })
+
+    it('silently acknowledges when there is no existing data (nothing to rebuild)', async () => {
+      ;(mockDb.apiEvents.count as jest.Mock).mockResolvedValue(0)
+
+      await checkOnUpdate(mockDb)
+
+      const state = await getRebuildAdvisoryState()
+      expect(state.pendingVersion).toBeUndefined()
+      expect(state.acknowledgedVersion).toBe(REBUILD_ADVISORY_VERSION)
+      expect(chrome.notifications.create).not.toHaveBeenCalled()
+      expect(chrome.action.setBadgeText).not.toHaveBeenCalled()
+    })
+
+    it('does not notify again when already acknowledged at the current version', async () => {
+      await chrome.storage.local.set({
+        [REBUILD_ADVISORY_STORAGE_KEY]: { acknowledgedVersion: REBUILD_ADVISORY_VERSION }
+      })
+      ;(mockDb.apiEvents.count as jest.Mock).mockResolvedValue(100)
+
+      await checkOnUpdate(mockDb)
+
+      expect(chrome.notifications.create).not.toHaveBeenCalled()
+      expect(chrome.action.setBadgeText).not.toHaveBeenCalled()
+      // apiEvents.count should not even need to be consulted once acknowledged,
+      // but if it is, state must remain unchanged either way
+      const state = await getRebuildAdvisoryState()
+      expect(state.pendingVersion).toBeUndefined()
+    })
+
+    it('does not double count when acknowledgedVersion is higher than current (future-proofing)', async () => {
+      await chrome.storage.local.set({
+        [REBUILD_ADVISORY_STORAGE_KEY]: { acknowledgedVersion: REBUILD_ADVISORY_VERSION + 1 }
+      })
+      ;(mockDb.apiEvents.count as jest.Mock).mockResolvedValue(100)
+
+      await checkOnUpdate(mockDb)
+
+      expect(chrome.notifications.create).not.toHaveBeenCalled()
+      expect(chrome.action.setBadgeText).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('resolveAdvisory', () => {
+    it('clears pendingVersion, sets acknowledgedVersion, and clears the badge', async () => {
+      await chrome.storage.local.set({
+        [REBUILD_ADVISORY_STORAGE_KEY]: { pendingVersion: REBUILD_ADVISORY_VERSION }
+      })
+
+      await resolveAdvisory()
+
+      const state = await getRebuildAdvisoryState()
+      expect(state.pendingVersion).toBeUndefined()
+      expect(state.acknowledgedVersion).toBe(REBUILD_ADVISORY_VERSION)
+      expect(chrome.action.setBadgeText).toHaveBeenCalledWith({ text: '' })
+    })
+  })
+
+  describe('API availability guards', () => {
+    it('does not throw when chrome.notifications is unavailable', async () => {
+      const original = (chrome as any).notifications
+      delete (chrome as any).notifications
+      ;(mockDb.apiEvents.count as jest.Mock).mockResolvedValue(10)
+
+      await expect(checkOnUpdate(mockDb)).resolves.not.toThrow()
+
+      ;(chrome as any).notifications = original
+    })
+
+    it('does not throw when chrome.action is unavailable', async () => {
+      const original = (chrome as any).action
+      delete (chrome as any).action
+      ;(mockDb.apiEvents.count as jest.Mock).mockResolvedValue(10)
+
+      await expect(checkOnUpdate(mockDb)).resolves.not.toThrow()
+      await expect(resolveAdvisory()).resolves.not.toThrow()
+
+      ;(chrome as any).action = original
+    })
+  })
+})

--- a/src/background/rebuild-advisory.ts
+++ b/src/background/rebuild-advisory.ts
@@ -1,0 +1,113 @@
+/** !!! CONTENT_SCRIPTS、WEB_ACCESSIBLE_RESOURCESからインポートしないこと !!! */
+/**
+ * データ再構築アドバイザリ。
+ *
+ * `REBUILD_ADVISORY_VERSION`（`src/constants/database.ts`）がバンプされた状態で
+ * 拡張機能が更新されたとき、既存データを持つユーザーに対して一度だけ
+ * 「データ再構築」の実行を促す。状態は`chrome.storage.local`の`rebuildAdvisory`
+ * キーに永続化し、拡張機能アイコンのバッジと通知、およびPopup内バナーで
+ * ユーザーに知らせる。
+ */
+import type { PokerChaseDB } from '../db/poker-chase-db'
+import { REBUILD_ADVISORY_VERSION } from '../constants/database'
+
+export const REBUILD_ADVISORY_STORAGE_KEY = 'rebuildAdvisory'
+
+export interface RebuildAdvisoryState {
+  /** ユーザーへの提示待ちのバージョン。未設定ならアドバイザリなし */
+  pendingVersion?: number
+  /** ユーザーが最後に解消（rebuild実行 or 閉じる）したバージョン */
+  acknowledgedVersion?: number
+}
+
+const BADGE_TEXT = '!'
+const BADGE_BACKGROUND_COLOR = '#d70022'
+
+/** `chrome.storage.local`から現在のアドバイザリ状態を取得する */
+export const getRebuildAdvisoryState = async (): Promise<RebuildAdvisoryState> => {
+  const result = await chrome.storage.local.get(REBUILD_ADVISORY_STORAGE_KEY)
+  return (result?.[REBUILD_ADVISORY_STORAGE_KEY] as RebuildAdvisoryState | undefined) ?? {}
+}
+
+const setRebuildAdvisoryState = async (state: RebuildAdvisoryState): Promise<void> => {
+  await chrome.storage.local.set({ [REBUILD_ADVISORY_STORAGE_KEY]: state })
+}
+
+/** バッジ表示（API未対応環境ではno-op） */
+const setBadge = (): void => {
+  if (!chrome.action?.setBadgeText) return
+  try {
+    chrome.action.setBadgeText({ text: BADGE_TEXT })
+    chrome.action.setBadgeBackgroundColor?.({ color: BADGE_BACKGROUND_COLOR })
+  } catch (error) {
+    console.warn('[rebuild-advisory] Failed to set badge:', error)
+  }
+}
+
+/** バッジ解除（API未対応環境ではno-op） */
+const clearBadge = (): void => {
+  if (!chrome.action?.setBadgeText) return
+  try {
+    chrome.action.setBadgeText({ text: '' })
+  } catch (error) {
+    console.warn('[rebuild-advisory] Failed to clear badge:', error)
+  }
+}
+
+/** ユーザーへの通知（API未対応環境ではno-op） */
+const notifyUser = (): void => {
+  if (!chrome.notifications?.create) return
+  try {
+    chrome.notifications.create({
+      type: 'basic',
+      iconUrl: chrome.runtime.getURL('icons/icon_128px.png'),
+      title: '統計ロジックが更新されました',
+      message: '拡張機能の更新により統計ロジックが改善されました。ポップアップから「データ再構築」を実行して、既存データに正しい統計を反映してください。'
+    })
+  } catch (error) {
+    console.warn('[rebuild-advisory] Failed to create notification:', error)
+  }
+}
+
+/**
+ * `chrome.runtime.onInstalled`（`details.reason === 'update'`）から呼び出す。
+ *
+ * `REBUILD_ADVISORY_VERSION`が既に確認済みバージョンより新しく、かつ既存の
+ * `apiEvents`が存在する場合、アドバイザリを保留状態にしてバッジ・通知を出す。
+ * データが存在しない場合は再構築の必要がないため、確認済みとして静かに記録する。
+ */
+export const checkOnUpdate = async (db: PokerChaseDB): Promise<void> => {
+  const state = await getRebuildAdvisoryState()
+  const acknowledgedVersion = state.acknowledgedVersion ?? 0
+
+  if (REBUILD_ADVISORY_VERSION <= acknowledgedVersion) {
+    // 既にこのバージョンまで確認済み（二重通知の防止）
+    return
+  }
+
+  const eventCount = await db.apiEvents.count()
+
+  if (eventCount === 0) {
+    // 再構築対象のデータが存在しない場合は通知不要
+    await setRebuildAdvisoryState({ ...state, acknowledgedVersion: REBUILD_ADVISORY_VERSION, pendingVersion: undefined })
+    return
+  }
+
+  await setRebuildAdvisoryState({ ...state, pendingVersion: REBUILD_ADVISORY_VERSION })
+  setBadge()
+  notifyUser()
+}
+
+/**
+ * アドバイザリを解消する。
+ *
+ * 呼び出し元:
+ * - `rebuildAllData`成功時（再構築が完了したので不要になった）
+ * - `deleteAllData`（全データ削除で再構築対象が無くなった。`chrome.runtime.reload()`
+ *   より前に呼ぶこと）
+ * - Popupでのバナー「閉じる」（`acknowledgeRebuildAdvisory`メッセージ経由）
+ */
+export const resolveAdvisory = async (): Promise<void> => {
+  await setRebuildAdvisoryState({ acknowledgedVersion: REBUILD_ADVISORY_VERSION, pendingVersion: undefined })
+  clearBadge()
+}

--- a/src/components/Popup.test.tsx
+++ b/src/components/Popup.test.tsx
@@ -49,6 +49,10 @@ global.chrome = {
       get: jest.fn((_key: string, cb: (result: Record<string, unknown>) => void) => cb({})),
       set: jest.fn(),
     },
+    onChanged: {
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    },
   },
 } as any
 

--- a/src/components/popup/ImportExportSection.test.tsx
+++ b/src/components/popup/ImportExportSection.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ImportExportSection } from './ImportExportSection'
+import { REBUILD_ADVISORY_STORAGE_KEY } from '../../background/rebuild-advisory'
+
+const noop = () => {}
+
+const defaultProps = {
+  importStatus: '',
+  importProgress: 0,
+  importProcessed: 0,
+  importTotal: 0,
+  importDuplicates: 0,
+  importSuccess: 0,
+  importStartTime: 0,
+  fileInputRef: { current: null },
+  setImportStatus: noop,
+  setImportProgress: noop,
+  setImportProcessed: noop,
+  setImportTotal: noop,
+  setImportDuplicates: noop,
+  setImportSuccess: noop,
+  setImportStartTime: noop,
+}
+
+describe('ImportExportSection - rebuild advisory banner', () => {
+  let storageChangeListeners: Array<(changes: Record<string, any>, areaName: string) => void>
+  let storageLocalData: Record<string, any>
+  let mockSendMessage: jest.Mock
+
+  beforeEach(() => {
+    storageChangeListeners = []
+    storageLocalData = {}
+    mockSendMessage = jest.fn()
+
+    global.chrome = {
+      ...global.chrome,
+      runtime: {
+        ...global.chrome.runtime,
+        sendMessage: mockSendMessage,
+        onMessage: {
+          addListener: jest.fn(),
+          removeListener: jest.fn(),
+        },
+      },
+      storage: {
+        ...global.chrome.storage,
+        local: {
+          get: jest.fn((_keys: any, callback: any) => {
+            callback({ [REBUILD_ADVISORY_STORAGE_KEY]: storageLocalData[REBUILD_ADVISORY_STORAGE_KEY] })
+          }),
+          set: jest.fn(),
+        },
+        onChanged: {
+          addListener: jest.fn((listener: any) => {
+            storageChangeListeners.push(listener)
+          }),
+          removeListener: jest.fn((listener: any) => {
+            const idx = storageChangeListeners.indexOf(listener)
+            if (idx !== -1) storageChangeListeners.splice(idx, 1)
+          }),
+        },
+      },
+      tabs: {
+        query: jest.fn(),
+      },
+    } as any
+  })
+
+  const emitStorageChange = (newValue: any) => {
+    storageChangeListeners.forEach(listener =>
+      listener({ [REBUILD_ADVISORY_STORAGE_KEY]: { newValue } }, 'local')
+    )
+  }
+
+  it('does not render the banner when there is no pending advisory', async () => {
+    storageLocalData[REBUILD_ADVISORY_STORAGE_KEY] = undefined
+
+    render(<ImportExportSection {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(chrome.storage.local.get).toHaveBeenCalled()
+    })
+
+    expect(screen.queryByText(/データ再構築」を実行してください/)).not.toBeInTheDocument()
+  })
+
+  it('renders the banner when pendingVersion is set on mount', async () => {
+    storageLocalData[REBUILD_ADVISORY_STORAGE_KEY] = { pendingVersion: 1 }
+
+    render(<ImportExportSection {...defaultProps} />)
+
+    expect(await screen.findByText(/データ再構築」を実行してください/)).toBeInTheDocument()
+  })
+
+  it('sends the acknowledge message and hides the banner on dismiss', async () => {
+    storageLocalData[REBUILD_ADVISORY_STORAGE_KEY] = { pendingVersion: 1 }
+
+    render(<ImportExportSection {...defaultProps} />)
+
+    await screen.findByText(/データ再構築」を実行してください/)
+
+    const closeButton = screen.getByRole('button', { name: '閉じる' })
+    await userEvent.click(closeButton)
+
+    expect(mockSendMessage).toHaveBeenCalledWith({ action: 'acknowledgeRebuildAdvisory' })
+    expect(screen.queryByText(/データ再構築」を実行してください/)).not.toBeInTheDocument()
+  })
+
+  it('hides the banner reactively when storage.onChanged reports resolution', async () => {
+    storageLocalData[REBUILD_ADVISORY_STORAGE_KEY] = { pendingVersion: 1 }
+
+    render(<ImportExportSection {...defaultProps} />)
+
+    await screen.findByText(/データ再構築」を実行してください/)
+
+    // Simulate resolveAdvisory() writing storage while the popup is open
+    emitStorageChange({ acknowledgedVersion: 1 })
+
+    await waitFor(() => {
+      expect(screen.queryByText(/データ再構築」を実行してください/)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/popup/ImportExportSection.tsx
+++ b/src/components/popup/ImportExportSection.tsx
@@ -1,3 +1,4 @@
+import Alert from '@mui/material/Alert'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import CircularProgress from '@mui/material/CircularProgress'
@@ -6,6 +7,7 @@ import Typography from '@mui/material/Typography'
 import React, { useCallback, useEffect, useState } from 'react'
 import { FileDownload, FileUpload } from '@mui/icons-material'
 import type {
+  AcknowledgeRebuildAdvisoryMessage,
   ExportDataMessage,
   ExportProgressMessage,
   ImportDataChunkMessage,
@@ -14,6 +16,7 @@ import type {
   RebuildProgressMessage,
 } from '../../types/messages'
 import { isExportProgressMessage, isRebuildProgressMessage } from '../../types/messages'
+import { REBUILD_ADVISORY_STORAGE_KEY, type RebuildAdvisoryState } from '../../background/rebuild-advisory'
 
 interface ImportExportSectionProps {
   importStatus: string
@@ -63,6 +66,7 @@ export const ImportExportSection = ({
   const [rebuildState, setRebuildState] = useState<RebuildState>('idle')
   const [rebuildProgress, setRebuildProgress] = useState(0)
   const [operationStatus, setOperationStatus] = useState('')
+  const [rebuildAdvisoryPending, setRebuildAdvisoryPending] = useState(false)
 
   const isImporting = importProgress > 0 && importProgress < 100
   const isAnyOperationInProgress = isImporting || exportState !== 'idle' || rebuildState !== 'idle'
@@ -156,6 +160,38 @@ export const ImportExportSection = ({
     return () => {
       chrome.runtime.onMessage.removeListener(handleMessage)
     }
+  }, [])
+
+  // データ再構築アドバイザリ: マウント時に一度読み込み、以後はstorage変更を購読する
+  // （rebuildAllData完了時のresolveAdvisory()によるstorage書き込みでバナーが自動的に消える）
+  useEffect(() => {
+    chrome.storage.local.get(REBUILD_ADVISORY_STORAGE_KEY, (result: Record<string, any>) => {
+      if (chrome.runtime.lastError) return
+      const state = result?.[REBUILD_ADVISORY_STORAGE_KEY] as RebuildAdvisoryState | undefined
+      setRebuildAdvisoryPending(!!state?.pendingVersion)
+    })
+
+    const handleStorageChange = (
+      changes: { [key: string]: chrome.storage.StorageChange },
+      areaName: string
+    ) => {
+      if (areaName !== 'local' || !changes[REBUILD_ADVISORY_STORAGE_KEY]) return
+      const newState = changes[REBUILD_ADVISORY_STORAGE_KEY].newValue as RebuildAdvisoryState | undefined
+      setRebuildAdvisoryPending(!!newState?.pendingVersion)
+    }
+
+    chrome.storage.onChanged.addListener(handleStorageChange)
+    return () => {
+      chrome.storage.onChanged.removeListener(handleStorageChange)
+    }
+  }, [])
+
+  const handleDismissRebuildAdvisory = useCallback(() => {
+    // 楽観的に即座に消す（background側の書き込みでも二重に消えるが問題ない）
+    setRebuildAdvisoryPending(false)
+    chrome.runtime.sendMessage<AcknowledgeRebuildAdvisoryMessage>({
+      action: 'acknowledgeRebuildAdvisory'
+    })
   }, [])
 
   const handleExportClick = useCallback((format: 'json' | 'pokerstars') => {
@@ -435,6 +471,18 @@ export const ImportExportSection = ({
             {operationStatus || 'データ再構築中...'}
           </Typography>
         </Box>
+      )}
+
+      {/* データ再構築アドバイザリ: 統計ロジック更新後、既存ユーザーに再構築を促すバナー */}
+      {rebuildAdvisoryPending && (
+        <Alert
+          severity="warning"
+          onClose={handleDismissRebuildAdvisory}
+          closeText="閉じる"
+          sx={{ marginTop: 1, marginBottom: 1 }}
+        >
+          拡張機能の更新により統計ロジックが改善されました。既存データに正しい統計を反映するには「データ再構築」を実行してください。
+        </Alert>
       )}
 
       <Button

--- a/src/constants/database.ts
+++ b/src/constants/database.ts
@@ -49,3 +49,18 @@ export type BatchSize = 10 | 100 | 300 | 500
 // Database operation modes
 export type DbTransactionMode = 'r' | 'rw'
 export type DbOperationType = 'import' | 'export' | 'sync' | 'rebuild'
+
+/**
+ * データ再構築アドバイザリのバージョン。
+ *
+ * `detectActionDetails`（ActionDetailフラグ）、ポジション算出、ショーダウン
+ * フェーズ判定など、書き込み時に確定させるエンティティ導出ロジックを変更し、
+ * 既存に記録済みのハンドを再評価すると異なる結果になる場合はこの値をインクリ
+ * メントすること（例: #94–#97, #100–#101 の修正 = version 1）。
+ *
+ * インクリメントすると、拡張機能の更新後に既存ユーザーへ一度だけ
+ * 「データ再構築」の実行を促すアドバイソリーが表示される
+ * （`src/background/rebuild-advisory.ts`参照）。単なるUI変更やバグ修正でも
+ * 書き込み時の導出結果に影響しないものはバンプ不要。
+ */
+export const REBUILD_ADVISORY_VERSION = 1

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -13,6 +13,17 @@ const chromeStorageMockData = {
   local: {} as Record<string, any>,
 }
 
+// chrome.storage.onChanged listeners (fired by the local/sync `set` mocks below)
+const storageChangeListeners: Array<(changes: Record<string, { oldValue?: any, newValue?: any }>, areaName: string) => void> = []
+
+const fireStorageChange = (areaName: 'sync' | 'local', items: Record<string, any>) => {
+  const changes: Record<string, { oldValue?: any, newValue?: any }> = {}
+  for (const key of Object.keys(items)) {
+    changes[key] = { oldValue: chromeStorageMockData[areaName][key], newValue: items[key] }
+  }
+  storageChangeListeners.forEach(listener => listener(changes, areaName))
+}
+
 global.chrome = {
   runtime: {
     sendMessage: jest.fn(),
@@ -20,6 +31,8 @@ global.chrome = {
       addListener: jest.fn(),
       removeListener: jest.fn(),
     },
+    getURL: jest.fn((path: string) => `chrome-extension://mock-extension-id/${path}`),
+    reload: jest.fn(),
   },
   storage: {
     sync: {
@@ -38,6 +51,7 @@ global.chrome = {
         return Promise.resolve(result)
       }),
       set: jest.fn((items, callback?) => {
+        fireStorageChange('sync', items)
         Object.assign(chromeStorageMockData.sync, items)
         if (typeof callback === 'function') {
           callback()
@@ -62,12 +76,22 @@ global.chrome = {
         return Promise.resolve(result)
       }),
       set: jest.fn((items, callback?) => {
+        fireStorageChange('local', items)
         Object.assign(chromeStorageMockData.local, items)
         if (typeof callback === 'function') {
           callback()
           return undefined
         }
         return Promise.resolve()
+      }),
+    },
+    onChanged: {
+      addListener: jest.fn((listener: (changes: Record<string, any>, areaName: string) => void) => {
+        storageChangeListeners.push(listener)
+      }),
+      removeListener: jest.fn((listener: (changes: Record<string, any>, areaName: string) => void) => {
+        const index = storageChangeListeners.indexOf(listener)
+        if (index !== -1) storageChangeListeners.splice(index, 1)
       }),
     },
   },
@@ -81,6 +105,32 @@ global.chrome = {
   },
   identity: {
     getAuthToken: jest.fn(),
+  },
+  notifications: {
+    create: jest.fn((_idOrOptions?: any, _optionsOrCallback?: any, callback?: any) => {
+      const cb = typeof _optionsOrCallback === 'function' ? _optionsOrCallback : callback
+      if (typeof cb === 'function') {
+        cb('mock-notification-id')
+        return undefined
+      }
+      return Promise.resolve('mock-notification-id')
+    }),
+  },
+  action: {
+    setBadgeText: jest.fn((_details, callback?) => {
+      if (typeof callback === 'function') {
+        callback()
+        return undefined
+      }
+      return Promise.resolve()
+    }),
+    setBadgeBackgroundColor: jest.fn((_details, callback?) => {
+      if (typeof callback === 'function') {
+        callback()
+        return undefined
+      }
+      return Promise.resolve()
+    }),
   },
 } as any
 

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -49,6 +49,8 @@ export const MESSAGE_ACTIONS = {
   UPDATE_UI_CONFIG: 'updateUIConfig',
   // Operation state
   GET_OPERATION_STATE: 'getOperationState',
+  // Rebuild advisory
+  ACKNOWLEDGE_REBUILD_ADVISORY: 'acknowledgeRebuildAdvisory',
 } as const
 
 // Import/Export related messages
@@ -226,6 +228,11 @@ export interface GetOperationStateMessage {
   action: 'getOperationState'
 }
 
+// Rebuild advisory messages
+export interface AcknowledgeRebuildAdvisoryMessage {
+  action: 'acknowledgeRebuildAdvisory'
+}
+
 export interface FirebaseBackupProgressMessage {
   action: 'firebaseBackupProgress'
   progress: number
@@ -331,6 +338,7 @@ export type ChromeMessage =
   | ManualSyncUploadMessage
   | ManualSyncDownloadMessage
   | GetOperationStateMessage
+  | AcknowledgeRebuildAdvisoryMessage
 
 // Helper function for type guard implementation
 const isMessageWithAction = (msg: unknown, action: string): msg is { action: string } =>
@@ -414,3 +422,6 @@ export const isRebuildProgressMessage = (msg: unknown): msg is RebuildProgressMe
 
 export const isGetOperationStateMessage = (msg: unknown): msg is GetOperationStateMessage =>
   isMessageWithAction(msg, 'getOperationState')
+
+export const isAcknowledgeRebuildAdvisoryMessage = (msg: unknown): msg is AcknowledgeRebuildAdvisoryMessage =>
+  isMessageWithAction(msg, 'acknowledgeRebuildAdvisory')


### PR DESCRIPTION
## 背景

#94〜#97 / #100〜#101 で統計の書き込み時導出を修正しましたが、既存ユーザーの IndexedDB は**手動で「データ再構築」を実行するまで壊れた統計のまま**です。製品内に案内が存在しなかったため、更新検知型のアドバイザリを実装します。

## 仕組み

- `REBUILD_ADVISORY_VERSION`(現在 1)を導入。**書き込み時導出が変わる変更で bump する**運用を CONTRIBUTING / CLAUDE.md に明文化(純粋に新統計を追加しただけの場合は不要)
- 拡張 update 時(`onInstalled`)、`未ack かつ apiEvents > 0` なら: アクションバッジ「!」+ `chrome.notifications` 1回 + popup 内 MUI Alert バナー(再構築ボタン直上)
- **既存データがなければ何も出さず ack**(新規ユーザーへのノイズなし)
- 解除は3経路すべて `resolveAdvisory()` に集約: rebuild 成功(0件時の早期リターン含む)/ `deleteAllData`(reload 前)/ バナーの「閉じる」(型付きメッセージ `acknowledgeRebuildAdvisory` を追加)
- popup は `chrome.storage.onChanged` 購読でリアクティブ(表示中に rebuild が完了すれば自動で消える)
- `chrome.notifications` / `chrome.action` は存在ガード付き(テスト環境で無害)

## テスト

- advisory ライフサイクル 7 テスト(データ有無・二重通知防止・解除)+ バナー表示/dismiss の RTL テスト 4 件
- test-setup の chrome モックを notifications / action / storage.onChanged まで拡張(callback / Promise 両対応)

## 検証

- `npm run typecheck` ✅ / `npm run test` ×2回 — **433/433(50 suites)** ✅ / `npm run build` + postbuild zip ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)