### PR TITLE
fix(stats): reject hands whose results reference players outside the dealt lineup

### DIFF
--- a/src/entity-converter.test.ts
+++ b/src/entity-converter.test.ts
@@ -1943,6 +1943,301 @@ describe('EntityConverter', () => {
       expect(importResult.actions.slice().sort((a, b) => a.index - b.index).map(pickComparable))
         .toEqual(liveActions.slice().sort((a, b) => a.index - b.index).map(pickComparable))
     })
+
+    /**
+     * テーブル移動キメラハンドの棄却（EC↔WESパリティ）
+     *
+     * 背景: MTTでヒーローがハンド途中に別テーブルへ移動する（EVT_ENTRY_QUEUED）と、
+     * クライアントは移動先テーブルで進行中だったハンドの残り（EVT_ACTIONの末尾、
+     * および対応するEVT_HAND_RESULTS）を受信する。移動先のEVT_ACTION.SeatIndexが
+     * 偶然、旧テーブルの有効な席番号・NextActionSeatの遷移パターンと一致すると、
+     * #100のSeatIndex未解決ガードをすり抜けてハンドバッファが継続してしまい、
+     * 旧テーブルのEVT_DEAL（座席構成・ブラインド・ヒーローのホールカード）と
+     * 新テーブルのEVT_HAND_RESULTS（HandId・勝者・獲得チップ）が1つのハンドとして
+     * 混ざり合う「キメラハンド」が生成される。
+     *
+     * 実データ検証（393,830イベント、31,392完走ハンド）: この機序で71ハンド
+     * （0.23%）が汚染されており、うち25ハンドはSeatIndex未解決アクションを伴う
+     * （23ハンドはResults[]が新テーブルの座席構成と完全一致、2ハンドは新旧混在）。
+     * 残り46ハンドはSeatIndex未解決アクションを伴わない（席番号の偶然の一致）が、
+     * 全てEVT_ENTRY_QUEUED直後の最初の完走ハンドであり、同一機序による汚染と
+     * 断定できる。修正: EVT_HAND_RESULTS.Results[]のUserIdが1件でも配札時の
+     * seatUserIdsに存在しない場合、バッファ中のハンドを丸ごと棄却する
+     * （hasResultsOutsideDealtLineup、src/types/game.ts）。
+     */
+    it('rejects a table-move chimera hand (RESULTS references players outside the dealt lineup) in BOTH pipelines', async () => {
+      const tableAEvents: ApiEvent[] = [
+        // テーブルAでのDEAL（座席構成: 500, 501, 502, 503）
+        createEvent(ApiType.EVT_DEAL, {
+          timestamp: 50000,
+          SeatUserIds: [500, 501, 502, 503],
+          Game: {
+            CurrentBlindLv: 1,
+            NextBlindUnixSeconds: 50000000,
+            Ante: 0,
+            SmallBlind: 10,
+            BigBlind: 20,
+            ButtonSeat: 0,
+            SmallBlindSeat: 1,
+            BigBlindSeat: 2
+          },
+          Progress: {
+            Phase: 0,
+            NextActionSeat: 3,
+            NextActionTypes: [ActionType.CALL, ActionType.FOLD, ActionType.RAISE],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 40,
+            Pot: 30,
+            SidePot: []
+          },
+          OtherPlayers: [
+            { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 990, BetChip: 10 },
+            { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 980, BetChip: 20 },
+            { SeatIndex: 3, Status: 0, BetStatus: 1, Chip: 1000, BetChip: 0 }
+          ]
+        }),
+        // 移動前の正常なアクション（テーブルAの座席501=player501によるコール）
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 50001,
+          SeatIndex: 3,
+          ActionType: ActionType.CALL,
+          Chip: 980,
+          BetChip: 20,
+          Progress: {
+            Phase: 0,
+            NextActionSeat: 0,
+            NextActionTypes: [ActionType.CALL, ActionType.FOLD, ActionType.RAISE],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 40,
+            Pot: 50,
+            SidePot: []
+          }
+        }),
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 50002,
+          SeatIndex: 0,
+          ActionType: ActionType.CALL,
+          Chip: 980,
+          BetChip: 20,
+          Progress: {
+            Phase: 0,
+            NextActionSeat: 1,
+            NextActionTypes: [ActionType.CALL, ActionType.CHECK, ActionType.RAISE],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 40,
+            Pot: 70,
+            SidePot: []
+          }
+        }),
+        // ここでヒーローがEVT_ENTRY_QUEUEDにより別テーブルへ移動する（本テストの
+        // 対象コードはハンドイベントのみを見るため、AggregateEventsStream相当の
+        // 集約はテスト対象外。EC/WESどちらも「1ハンド分のイベント配列」を受け取る
+        // 前提のため、集約済みの配列をそのまま構築する）。
+        // 移動先テーブルの残りアクション。SeatIndex=1は偶然テーブルAの有効な
+        // 座席（player501）を指すため、#100のSeatIndex未解決ガードはすり抜ける。
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 50003,
+          SeatIndex: 1,
+          ActionType: ActionType.CHECK,
+          Chip: 5000,
+          BetChip: 0,
+          Progress: {
+            Phase: 0,
+            NextActionSeat: -1,
+            NextActionTypes: [],
+            NextExtraLimitSeconds: 0,
+            MinRaise: 0,
+            Pot: 70,
+            SidePot: []
+          }
+        }, { skipValidation: true }),
+        // 移動先テーブルのEVT_HAND_RESULTS。UserId 900/901はテーブルAのDEALの
+        // 座席構成（500, 501, 502, 503）に一切含まれない（ゼロオーバーラップの
+        // 実データ観測ケース、HandId 258419183と同型）。
+        createEvent(ApiType.EVT_HAND_RESULTS, {
+          timestamp: 50004,
+          HandId: 999030,
+          CommunityCards: [],
+          Pot: 700,
+          SidePot: [],
+          ResultType: 0,
+          DefeatStatus: 0,
+          Results: [
+            {
+              UserId: 900,
+              HoleCards: [],
+              RankType: RankType.NO_CALL,
+              Hands: [],
+              HandRanking: 1,
+              Ranking: 1,
+              RewardChip: 700
+            },
+            {
+              UserId: 901,
+              HoleCards: [],
+              RankType: RankType.NO_CALL,
+              Hands: [],
+              HandRanking: 2,
+              Ranking: -1,
+              RewardChip: 0
+            }
+          ],
+          OtherPlayers: [
+            { SeatIndex: 1, Status: 0, BetStatus: -1, Chip: 5700, BetChip: 0 }
+          ]
+        }, { skipValidation: true })
+      ]
+
+      // --- インポート/リビルドパイプライン: EntityConverter経由 ---
+      const importResult = converter.convertEventsToEntities(tableAEvents)
+      // キメラハンドは棄却され、hands/phases/actionsのいずれにも現れない
+      expect(importResult.hands).toHaveLength(0)
+      expect(importResult.hands.some(h => h.id === 999030)).toBe(false)
+
+      // --- ライブ記録パイプライン: WriteEntityStream経由 ---
+      const dbMock = new PokerChaseDB(indexedDB, IDBKeyRange)
+      const service = new PokerChaseService({ db: dbMock })
+      await service.ready
+      for (const event of tableAEvents) service.handAggregateStream.write(event)
+      await service.handAggregateStream.whenIdle()
+
+      const liveHand = await dbMock.hands.get(999030)
+      expect(liveHand).toBeUndefined()
+      const liveActions = await dbMock.actions.where('handId').equals(999030).toArray()
+      expect(liveActions).toHaveLength(0)
+      const livePhases = await dbMock.phases.where('handId').equals(999030).toArray()
+      expect(livePhases).toHaveLength(0)
+    })
+
+    /**
+     * 対照実験: 正常なRESULTS（配札時のseatUserIdsの部分集合）は引き続き受理される。
+     * キメラハンド棄却ガードが、通常のフォールド落ち（Results[]がseatUserIdsの
+     * 全員ではなく一部のみを含む、ごく一般的なケース）まで誤って棄却しないことを
+     * 確認する。
+     */
+    it('still accepts a normal hand whose RESULTS is a subset of the dealt lineup', async () => {
+      const events: ApiEvent[] = [
+        createEvent(ApiType.EVT_DEAL, {
+          timestamp: 51000,
+          SeatUserIds: [600, 601, 602, 603],
+          Game: {
+            CurrentBlindLv: 1,
+            NextBlindUnixSeconds: 51000000,
+            Ante: 0,
+            SmallBlind: 10,
+            BigBlind: 20,
+            ButtonSeat: 0,
+            SmallBlindSeat: 1,
+            BigBlindSeat: 2
+          },
+          Progress: {
+            Phase: 0,
+            NextActionSeat: 3,
+            NextActionTypes: [ActionType.CALL, ActionType.FOLD, ActionType.RAISE],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 40,
+            Pot: 30,
+            SidePot: []
+          },
+          OtherPlayers: [
+            { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 990, BetChip: 10 },
+            { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 980, BetChip: 20 },
+            { SeatIndex: 3, Status: 0, BetStatus: 1, Chip: 1000, BetChip: 0 }
+          ]
+        }),
+        // 3名がフォールドし、602(BB)だけがポットを獲得して終わる、ごく普通のハンド
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 51001,
+          SeatIndex: 3,
+          ActionType: ActionType.FOLD,
+          Chip: 1000,
+          BetChip: 0,
+          Progress: {
+            Phase: 0,
+            NextActionSeat: 0,
+            NextActionTypes: [ActionType.CALL, ActionType.FOLD, ActionType.RAISE],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 40,
+            Pot: 30,
+            SidePot: []
+          }
+        }),
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 51002,
+          SeatIndex: 0,
+          ActionType: ActionType.FOLD,
+          Chip: 1000,
+          BetChip: 0,
+          Progress: {
+            Phase: 0,
+            NextActionSeat: 1,
+            NextActionTypes: [ActionType.CALL, ActionType.FOLD, ActionType.RAISE],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 40,
+            Pot: 30,
+            SidePot: []
+          }
+        }),
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 51003,
+          SeatIndex: 1,
+          ActionType: ActionType.FOLD,
+          Chip: 990,
+          BetChip: 10,
+          Progress: {
+            Phase: 0,
+            NextActionSeat: -2,
+            NextActionTypes: [],
+            NextExtraLimitSeconds: 0,
+            MinRaise: 0,
+            Pot: 30,
+            SidePot: []
+          }
+        }),
+        createEvent(ApiType.EVT_HAND_RESULTS, {
+          timestamp: 51004,
+          HandId: 999031,
+          CommunityCards: [],
+          Pot: 30,
+          SidePot: [],
+          ResultType: 0,
+          DefeatStatus: 0,
+          Results: [
+            {
+              UserId: 602,
+              HoleCards: [],
+              RankType: RankType.NO_CALL,
+              Hands: [],
+              HandRanking: 1,
+              Ranking: 1,
+              RewardChip: 30
+            }
+          ],
+          OtherPlayers: [
+            { SeatIndex: 0, Status: 0, BetStatus: -1, Chip: 1000, BetChip: 0 },
+            { SeatIndex: 1, Status: 0, BetStatus: -1, Chip: 990, BetChip: 0 },
+            { SeatIndex: 3, Status: 0, BetStatus: -1, Chip: 1000, BetChip: 0 }
+          ]
+        }, { skipValidation: true })
+      ]
+
+      // --- インポート/リビルドパイプライン: EntityConverter経由 ---
+      const importResult = converter.convertEventsToEntities(events)
+      expect(importResult.hands).toHaveLength(1)
+      expect(importResult.hands[0]?.id).toBe(999031)
+      expect(importResult.hands[0]?.winningPlayerIds).toEqual([602])
+
+      // --- ライブ記録パイプライン: WriteEntityStream経由 ---
+      const dbMock = new PokerChaseDB(indexedDB, IDBKeyRange)
+      const service = new PokerChaseService({ db: dbMock })
+      await service.ready
+      for (const event of events) service.handAggregateStream.write(event)
+      await service.handAggregateStream.whenIdle()
+
+      const liveHand = await dbMock.hands.get(999031)
+      expect(liveHand).toBeDefined()
+      expect(liveHand?.winningPlayerIds).toEqual([602])
+    })
   })
 
   /**

--- a/src/entity-converter.ts
+++ b/src/entity-converter.ts
@@ -12,6 +12,7 @@ import {
   BetStatusType,
   PhaseType,
   Position,
+  hasResultsOutsideDealtLineup,
   isApiEventType,
   isShowdownParticipant
 } from './types'
@@ -299,6 +300,16 @@ export class EntityConverter {
         }
 
         case ApiType.EVT_HAND_RESULTS: {
+          // テーブル移動キメラハンドの棄却（詳細はhasResultsOutsideDealtLineupのdocコメント参照）。
+          // Results[]に配札時のseatUserIdsへ存在しないUserIdが1件でもあれば、このRESULTSは
+          // 移動先テーブルのものであり、バッファ中のハンド（移動元テーブルのDEAL）とは
+          // 対応しない。真の対応先RESULTSは二度と届かないため、ハンド全体を棄却する
+          // （handState.hand.idを0のままにし、末尾の有効性チェックでnullを返させる）。
+          if (hasResultsOutsideDealtLineup(handState.hand.seatUserIds || [], event.Results || [])) {
+            console.log(`[EntityConverter] Rejected chimera hand (HandId=${event.HandId}): EVT_HAND_RESULTS.Results references a player outside the dealt lineup (mid-hand table move)`)
+            break
+          }
+
           // HandIdを設定
           handState.hand.id = event.HandId
 

--- a/src/streams/write-entity-stream.ts
+++ b/src/streams/write-entity-stream.ts
@@ -6,6 +6,7 @@ import {
   ApiType,
   BetStatusType,
   PhaseType,
+  hasResultsOutsideDealtLineup,
   isShowdownParticipant,
   Position
 } from '../types'
@@ -42,7 +43,15 @@ export class WriteEntityStream extends SimpleTransform<ApiHandEvent[], number[]>
   }
   protected async transform(events: ApiHandEvent[]): Promise<void> {
     try {
-      const { hand, actions, phases } = this.toHandState(events)
+      const handState = this.toHandState(events)
+      if (handState === null) {
+        // キメラハンド（テーブル移動によるDEAL/RESULTS不整合）。DB書き込み・
+        // seatUserIdsのダウンストリーム配信ともにスキップする。
+        const handId = events.find(e => e.ApiTypeId === ApiType.EVT_HAND_RESULTS)?.HandId
+        console.log(`[WriteEntityStream] Rejected chimera hand (HandId=${handId}): EVT_HAND_RESULTS.Results references a player outside the dealt lineup (mid-hand table move)`)
+        return
+      }
+      const { hand, actions, phases } = handState
 
       await this.service.db.transaction('rw', [this.service.db.hands, this.service.db.phases, this.service.db.actions], async () => {
         return Promise.all([
@@ -64,7 +73,7 @@ export class WriteEntityStream extends SimpleTransform<ApiHandEvent[], number[]>
       }
     }
   }
-  private toHandState = (events: ApiHandEvent[]): HandState => {
+  private toHandState = (events: ApiHandEvent[]): HandState | null => {
     let positionMap: Map<number, Position> = new Map()
     const handState: HandState = {
       hand: {
@@ -198,6 +207,13 @@ export class WriteEntityStream extends SimpleTransform<ApiHandEvent[], number[]>
         }
           break
         case ApiType.EVT_HAND_RESULTS: {
+          // テーブル移動キメラハンドの棄却（詳細はhasResultsOutsideDealtLineupのdocコメント参照）。
+          // Results[]に配札時のseatUserIdsへ存在しないUserIdが1件でもあれば、このRESULTSは
+          // 移動先テーブルのものであり、バッファ中のハンド（移動元テーブルのDEAL）とは
+          // 対応しない。真の対応先RESULTSは二度と届かないため、ハンド全体を棄却する。
+          if (hasResultsOutsideDealtLineup(handState.hand.seatUserIds, event.Results)) {
+            return null
+          }
           // ショーダウンフェーズの生成（実際にカードを比較したプレイヤーが2名以上いる場合）
           // NO_CALL（無競争勝利）やFOLD_OPEN（フォールド後の自発公開）はショーダウンではないため除外する
           const showdownParticipants = event.Results.filter(isShowdownParticipant)

--- a/src/tools/verify-stats/oracle.ts
+++ b/src/tools/verify-stats/oracle.ts
@@ -233,6 +233,19 @@ export function runOracle(events: unknown[], options: RunOracleOptions = {}): Or
     // pipeline's `handState.hand.id > 0` completeness check.
     if (!dealEvt || !resultsEvt) return
 
+    // Table-move chimera hand rejection, kept in sync with
+    // hasResultsOutsideDealtLineup (src/types/game.ts) / entity-converter.ts /
+    // write-entity-stream.ts: if EVT_HAND_RESULTS.Results references a UserId
+    // absent from this hand's EVT_DEAL.SeatUserIds, the RESULTS belongs to the
+    // destination table reached via a mid-hand EVT_ENTRY_QUEUED move, not to the
+    // buffered DEAL. The oracle must drop the same hands the pipeline drops or
+    // verify-stats would report a spurious divergence.
+    {
+      const dealtUserIds = new Set(dealEvt.SeatUserIds.filter(id => id !== -1))
+      const hasForeignResult = resultsEvt.Results.some(({ UserId }) => !dealtUserIds.has(UserId))
+      if (hasForeignResult) return
+    }
+
     const seatUserIds = dealEvt.SeatUserIds
     const { ButtonSeat: buttonSeat, SmallBlindSeat: sbSeat, BigBlindSeat: bbSeat } = dealEvt.Game
     const posMap = computePositions(seatUserIds, buttonSeat, sbSeat, bbSeat)

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -70,6 +70,35 @@ export function isShowdownParticipant(result: { RankType: RankType }): boolean {
   return result.RankType !== RankType.NO_CALL && result.RankType !== RankType.FOLD_OPEN
 }
 
+/**
+ * MTTでヒーローがハンド途中に別テーブルへ移動した際に発生する「キメラハンド」を検出する。
+ *
+ * 発生機序: EVT_ENTRY_QUEUEDでテーブル移動が発生すると、クライアントは移動先テーブルで
+ * 進行中だったハンドの残り（EVT_ACTIONの末尾、およびそのEVT_HAND_RESULTS）を受信する。
+ * 移動先のEVT_ACTION.SeatIndexは旧テーブルのバッファ済みEVT_DEAL.SeatUserIdsに対しては
+ * 意味を持たないが、席番号が偶然旧テーブルの有効な席インデックス範囲・NextActionSeatの
+ * 遷移パターンと一致した場合、#100のSeatIndex未解決ガード（EC/WES双方のEVT_ACTIONケース）
+ * をすり抜けてハンドバッファが継続してしまう。結果、旧テーブルのEVT_DEAL（座席構成・
+ * ブラインド・ヒーローのホールカード）と新テーブルのEVT_HAND_RESULTS（HandId、勝者、
+ * 獲得チップ）が1つのハンドとして混ざり合う。
+ *
+ * 実データ検証（393,830イベント、31,392完走ハンド）: SeatIndex未解決アクションを含む
+ * 27ハンド中、25ハンドはこの述語がtrueになる（23ハンドはResults[]が新テーブルの
+ * 座席構成と完全一致、2ハンドは新旧混在）。残り2ハンドは旧テーブルのDEALと正しく
+ * 対応しており、この述語はfalseのまま（正当なハンドとして許容される）。
+ * また、SeatIndex未解決アクションが1件もない場合でも、席番号の偶然の一致により
+ * 同様のキメラが発生するケースが46ハンド追加で確認された（全てEVT_ENTRY_QUEUED
+ * 直後の最初の完走ハンドであり、テーブル移動由来と断定できる）。
+ *
+ * 判定: EVT_HAND_RESULTS.Results[]のUserIdが1件でもEVT_DEAL.SeatUserIds（着席者）に
+ * 含まれない場合、そのRESULTSは真の対応先（ヒーローが離脱した旧テーブル）からは
+ * 決して届かないため、バッファ中のハンドを丸ごと棄却するべきと判定する。
+ */
+export function hasResultsOutsideDealtLineup(seatUserIds: readonly number[], results: readonly { UserId: number }[]): boolean {
+  const dealtUserIds = new Set(seatUserIds.filter(id => id !== -1))
+  return results.some(({ UserId }) => !dealtUserIds.has(UserId))
+}
+
 export enum Position {
   BB = -2,
   SB = -1,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,7 +38,8 @@ export {
   Position,
   ActionDetail,
   BATTLE_TYPE_FILTERS,
-  isShowdownParticipant
+  isShowdownParticipant,
+  hasResultsOutsideDealtLineup
 } from './game'
 
 // Entity types


### PR DESCRIPTION
## 問題(実データ分析で発見した「キメラハンド」)

MTT でヒーローがハンド途中にテーブル移動すると、クライアントは**移動先テーブルで進行中だった別ハンドの末尾**(アクション + その EVT_HAND_RESULTS)を受信します。この RESULTS が旧テーブルのバッファ済みハンドに縫い付けられ、**旧テーブルの DEAL(座席・ブラインド・ホールカード)+ 新テーブルの RESULTS(HandId・勝者・獲得チップ)というキメラハンド**が entities に永続化されていました。

実データ全件(393,830 イベント)の状態機械再現による定量:

- **キメラは 71 ハンド(完走ハンドの 0.23%)** — 全件が「EVT_ENTRY_QUEUED 後の最初の完走ハンド」で、正常ハンドへの巻き添え **0 件**
- うち 25 件のみ #100 の座席未解決ガードに接触(23 完全異物 + 1 混在 + 正当 2 は非棄却)。**残り 46 件は座席番号が偶然一致し、既存のどのガードにも映らなかった**同一機構のキメラ

## 修正

- 共有述語 `hasResultsOutsideDealtLineup()`(発生機序と 71/25+2/46 の分類をコメントに文書化)
- WES: `toHandState` が null を返せるようにし、DB 書込み・下流 push を抑止 / EC: 既存の null 規約に接続。両経路とも棄却ログ出力
- **verify-stats オラクルにも同一ルールを同期**

## 効果(オラクル一致率、624 プレイヤー)

| 統計 | 前 | 後 |
|---|---|---|
| 3bet | 99.52% | **100.00%** |
| steal | 99.68% | **100.00%** |
| wtsd / wwsf | 99.68% / 99.52% | 99.84% / 99.68% |

退行ゼロ、verify-stats PASS。

## テスト

- EC↔WES パリティテストに「座席偶然一致型キメラ → 両経路とも非生成」+ 正常系コントロールを追加。修正前コードで `seatUserIds:[500..503]` に `winningPlayerIds:[900]` が融合する破損を実際に再現(fail-before 確認済み)
- `npm run typecheck` ✅ / `npm run test` ×2 — **435/435(50 suites)** ✅

`REBUILD_ADVISORY_VERSION` は据え置き(v1 未出荷を .release-please-manifest / git tag で確認 — 本修正は保留中の advisory v1 に同乗)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)