### PR TITLE
fix(tools): harden verify-stats against silent skips and add RCA comparison

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,13 +256,13 @@ Without this step, your statistic will look like it's stuck at 0 (or empty) for 
 
 ### Verifying Against Real Data (`verify-stats`)
 
-Unit tests cover individual stats in isolation, but they can't catch a bug that only shows up when many hands' worth of state accumulates (off-by-one phase membership, position derivation on tables with empty seats, etc.). `npm run verify-stats` closes that gap by cross-checking the live pipeline against an independently re-implemented "oracle":
+Unit tests cover individual stats in isolation, but they can't catch a bug that only shows up when many hands' worth of state accumulates (off-by-one phase membership, position derivation on tables with empty seats, etc.). `npm run verify-stats` closes that gap by cross-checking the **`EntityConverter` + stats** path against an independently re-implemented "oracle":
 
-- `src/tools/verify-stats/pipeline.ts` runs the real `EntityConverter` + `StatDefinition.calculate` over the given NDJSON (the same code path the extension itself uses on import/rebuild).
+- `src/tools/verify-stats/pipeline.ts` runs the real `EntityConverter` + `StatDefinition.calculate` over the given NDJSON. Note this is the import/rebuild path, **not** the live-capture path — it does not exercise `src/streams/write-entity-stream.ts`. The pipeline also mirrors Dexie's `phases` table `bulkPut` de-duplication (primary key `[handId+phase]`, last write wins) so duplicate street events collapse the same way the real import does before stats are computed.
 - `src/tools/verify-stats/oracle.ts` recomputes the same stats **from scratch** directly off the raw events, importing only enums/types from `src/types` — it never imports `src/stats` or `src/entity-converter`, so a bug introduced in either can't "leak" into the oracle and silently agree with itself.
-- `src/tools/verify-stats/compare.ts` diffs the two, per player (players with ≥50 hands by default) and per stat, and reports a percentage agreement table.
+- `src/tools/verify-stats/compare.ts` diffs the two, per player (union of players with ≥50 hands by default on either side — a player dropped or undercounted on one side is reported as a mismatch, not silently excluded) and per stat, and reports a percentage agreement table. A stat missing or malformed (non-fraction) on either side also counts as a mismatch, surfaced under a distinct `missing` counter, rather than being skipped.
 
-Run it whenever you change **`src/entity-converter.ts`, `src/streams/write-entity-stream.ts`, or anything in `src/stats/`**:
+Run it whenever you change **`src/entity-converter.ts` or anything in `src/stats/`**:
 
 ```bash
 npm run verify-stats -- <path/to/export.ndjson>
@@ -270,10 +270,13 @@ npm run verify-stats -- <path/to/export.ndjson>
 npm run verify-stats -- <file.ndjson> --min-hands=100 --threshold=99.5
 ```
 
-The command exits non-zero if any stat's agreement drops below `--threshold` (default 99%). Two gaps are expected and do not indicate a bug:
+The command exits non-zero if any stat's agreement drops below `--threshold` (default 99%). One gap is expected and does not indicate a bug:
 
-- **WTSD/WWSF ≈ 99.5–99.7%**: a handful of hands in real captures carry a duplicated FLOP `EVT_DEAL_ROUND` event (a dual-board/run-it-twice-shaped anomaly in the source data). The oracle only tracks one "who's still in at the flop" snapshot per hand, so it can't represent this; the live pipeline (which stores a `Phase` per `EVT_DEAL_ROUND`) handles it correctly. This shows up as an occasional denominator off-by-one for the affected player.
 - **CBet ≈ 99.8%**: at least one real capture contains a duplicated `EVT_ACTION` event for the same seat/street, inflating the oracle's c-bet-fold opportunity count by one for that hand.
+
+If you change **`src/streams/write-entity-stream.ts`** (the live-capture write path), `verify-stats` does **not** cover it — run both:
+1. The EntityConverter↔WriteEntityStream parity tests in `src/entity-converter.test.ts` (part of `npm run test`), which assert the two independent write paths produce equivalent entities for the same events.
+2. `npm run verify-stats` (above), to make sure your change didn't also alter `EntityConverter` or `src/stats/` behavior.
 
 To obtain an NDJSON file to run this against: open the extension popup → Import/Export section → export your captured hand history (this is the same NDJSON format `validate-schema`/`schema-diff` consume).
 

--- a/src/tools/verify-stats.test.ts
+++ b/src/tools/verify-stats.test.ts
@@ -8,6 +8,10 @@
  *    with a known preflop raise, a continuation bet + fold, and a showdown
  *  - compareResults/formatReport correctly report a mismatch when one side's
  *    stat is deliberately perturbed
+ *  - a missing/non-fraction stat on one side is counted as a mismatch (not
+ *    silently skipped), with a distinct `missing` counter
+ *  - eligibility is the union of both sides, so a player entirely absent
+ *    from one side still surfaces as a mismatch instead of vanishing
  *
  * This exercises the same code path `npm run verify-stats` uses, just
  * against a fixture small enough for CI instead of a real ndjson export.
@@ -252,5 +256,61 @@ describe('verify-stats harness', () => {
     const rendered = formatReport(report)
     expect(rendered).toContain('Mismatches for vpip')
     expect(rendered).toContain(`player ${PLAYER_A}`)
+  })
+
+  it('counts a missing/non-fraction stat as a mismatch, not a silent skip', () => {
+    // Pipeline-side vpip resolved to scalar 0 (mirrors StatsRegistry's catch
+    // handler reducing a thrown StatDefinition.calculate to `0`) while the
+    // oracle has a legitimate fraction. A `continue`-based skip would drop
+    // this player from `total` entirely and let the stat report 100%
+    // agreement despite the divergence; hardened compareResults must count
+    // it as a mismatch with `missing: true` and expose a distinct `missing`
+    // counter on the StatAgreement.
+    const pipeline = new Map([
+      [PLAYER_A, { playerId: PLAYER_A, hands: 60, stats: { vpip: 0 } }],
+    ])
+    const oracle = new Map([
+      [PLAYER_A, { playerId: PLAYER_A, hands: 60, stats: { vpip: [30, 60] as [number, number] } }],
+    ])
+
+    const report = compareResults(pipeline as any, oracle as any, 50)
+    const vpip = report.stats.find(s => s.stat === 'vpip')!
+    expect(vpip.total).toBe(1)
+    expect(vpip.agree).toBe(0)
+    expect(vpip.missing).toBe(1)
+    expect(vpip.pct).toBe(0)
+    expect(vpip.mismatches).toHaveLength(1)
+    expect(vpip.mismatches[0]).toMatchObject({ playerId: PLAYER_A, missing: true, pipeline: undefined, oracle: [30, 60] })
+
+    const rendered = formatReport(report)
+    expect(rendered).toContain('Mismatches for vpip')
+    expect(rendered).toContain('MISSING')
+  })
+
+  it('builds eligibility from the union of both sides, not the pipeline alone', () => {
+    // PLAYER_B only appears on the oracle side with >= minHands (e.g.
+    // EntityConverter dropped the player entirely, or undercounted their
+    // hands below the threshold). Using only pipeline-side eligibility would
+    // silently exclude PLAYER_B from every stat comparison; union-based
+    // eligibility must still surface this as a mismatch for every compared
+    // stat, with the pipeline side reported as absent.
+    const pipeline = new Map([
+      [PLAYER_A, { playerId: PLAYER_A, hands: 60, stats: { vpip: [30, 60] } }],
+      // PLAYER_B absent entirely from the pipeline side.
+    ])
+    const oracle = new Map([
+      [PLAYER_A, { playerId: PLAYER_A, hands: 60, stats: { vpip: [30, 60] as [number, number] } }],
+      [PLAYER_B, { playerId: PLAYER_B, hands: 55, stats: { vpip: [20, 55] as [number, number] } }],
+    ])
+
+    const report = compareResults(pipeline as any, oracle as any, 50)
+    expect(report.eligiblePlayers).toBe(2)
+
+    const vpip = report.stats.find(s => s.stat === 'vpip')!
+    expect(vpip.total).toBe(2)
+    expect(vpip.agree).toBe(1) // PLAYER_A agrees
+    expect(vpip.missing).toBe(1) // PLAYER_B missing on the pipeline side
+    const bMismatch = vpip.mismatches.find(m => m.playerId === PLAYER_B)
+    expect(bMismatch).toMatchObject({ missing: true, pipeline: undefined, oracle: [20, 55] })
   })
 })

--- a/src/tools/verify-stats/compare.ts
+++ b/src/tools/verify-stats/compare.ts
@@ -6,6 +6,17 @@
  * reports numerator/denominator agreement. Only players with at least
  * `minHands` hands are counted, to avoid noise from tiny samples where a
  * single off-by-one dominates the percentage.
+ *
+ * Eligibility is the UNION of both sides' eligible players (each side's own
+ * `hands >= minHands`), not just the pipeline's: if EntityConverter drops a
+ * player entirely, or undercounts their hand count below minHands, that
+ * player must still show up as a mismatch rather than silently vanishing
+ * from the comparison. Likewise, a stat that is missing or malformed
+ * (non-fraction, e.g. a thrown StatDefinition.calculate reduced to scalar 0
+ * by StatsRegistry's catch handler) on either side for an eligible player is
+ * counted as a MISMATCH, not skipped -- silently skipping would let a
+ * regression that makes a stat throw (and thus resolve to `0`, which can
+ * spuriously equal a legitimate `0/0`) hide behind a 100% agreement report.
  */
 import type { PipelineResult } from './pipeline'
 import type { OracleFraction, OracleResult } from './oracle'
@@ -13,16 +24,18 @@ import type { OracleFraction, OracleResult } from './oracle'
 /** Stats compared -- must exist as a [num, denom] tuple on both sides. */
 export const COMPARED_STATS = [
   'vpip', 'pfr', '3bet', '3betfold', 'cbet', 'cbetFold', 'af', 'afq',
-  'wtsd', 'wsd', 'wwsf', 'steal', 'foldToSteal',
+  'wtsd', 'wsd', 'wwsf', 'steal', 'foldToSteal', 'riverCallAccuracy',
 ] as const
 export type ComparedStat = typeof COMPARED_STATS[number]
 
 export interface Mismatch {
   playerId: number
-  pipeline: OracleFraction
-  oracle: OracleFraction
-  dNum: number
-  dDen: number
+  pipeline: OracleFraction | undefined
+  oracle: OracleFraction | undefined
+  dNum: number | undefined
+  dDen: number | undefined
+  /** True when this mismatch is due to one/both sides missing or non-fraction, not a value disagreement. */
+  missing: boolean
 }
 
 export interface StatAgreement {
@@ -31,6 +44,8 @@ export interface StatAgreement {
   total: number
   /** agree/total as a percentage in [0, 100]; 100 when total is 0 (nothing to disagree on). */
   pct: number
+  /** Count of mismatches caused by a missing/non-fraction stat on one or both sides (subset of mismatches.length). */
+  missing: number
   mismatches: Mismatch[]
 }
 
@@ -45,31 +60,52 @@ function isFraction(value: unknown): value is OracleFraction {
 }
 
 /**
- * Compare pipeline vs oracle results for players with >= minHands hands.
- * Both maps are keyed by playerId; a player missing from either side for a
- * given stat is simply skipped for that stat (not counted as a mismatch).
+ * Compare pipeline vs oracle results for players eligible (>= minHands hands)
+ * on EITHER side. A player present/eligible on only one side counts as a
+ * mismatch (missing=true) on every compared stat, since the other side has
+ * no fraction to compare against.
  */
 export function compareResults(pipeline: PipelineResult, oracle: OracleResult, minHands = 50): ComparisonReport {
-  const eligiblePlayerIds = [...pipeline.values()]
-    .filter(p => p.hands >= minHands)
-    .map(p => p.playerId)
+  const pipelineEligible = new Set(
+    [...pipeline.values()].filter(p => p.hands >= minHands).map(p => p.playerId)
+  )
+  const oracleEligible = new Set(
+    [...oracle.values()].filter(p => p.hands >= minHands).map(p => p.playerId)
+  )
+  const eligiblePlayerIds = new Set([...pipelineEligible, ...oracleEligible])
 
   const stats: StatAgreement[] = COMPARED_STATS.map(stat => {
     let agree = 0
     let total = 0
+    let missing = 0
     const mismatches: Mismatch[] = []
 
     for (const playerId of eligiblePlayerIds) {
       const p = pipeline.get(playerId)?.stats[stat]
       const o = oracle.get(playerId)?.stats[stat]
-      if (!isFraction(p) || !isFraction(o)) continue
+      const pOk = isFraction(p)
+      const oOk = isFraction(o)
       total++
+
+      if (!pOk || !oOk) {
+        missing++
+        mismatches.push({
+          playerId,
+          pipeline: pOk ? p : undefined,
+          oracle: oOk ? o : undefined,
+          dNum: undefined,
+          dDen: undefined,
+          missing: true,
+        })
+        continue
+      }
+
       const [pn, pd] = p
       const [on, od] = o
       if (pn === on && pd === od) {
         agree++
       } else {
-        mismatches.push({ playerId, pipeline: p, oracle: o, dNum: pn - on, dDen: pd - od })
+        mismatches.push({ playerId, pipeline: p, oracle: o, dNum: pn - on, dDen: pd - od, missing: false })
       }
     }
 
@@ -78,30 +114,35 @@ export function compareResults(pipeline: PipelineResult, oracle: OracleResult, m
       agree,
       total,
       pct: total === 0 ? 100 : (100 * agree) / total,
+      missing,
       mismatches,
     }
   })
 
-  return { eligiblePlayers: eligiblePlayerIds.length, minHands, stats }
+  return { eligiblePlayers: eligiblePlayerIds.size, minHands, stats }
 }
 
 /** Render a human-readable agreement table, one line per stat. */
 export function formatReport(report: ComparisonReport, sampleMismatches = 5): string {
   const lines: string[] = []
-  lines.push(`Eligible players (>= ${report.minHands} hands): ${report.eligiblePlayers}`)
+  lines.push(`Eligible players (>= ${report.minHands} hands, union of both sides): ${report.eligiblePlayers}`)
   lines.push('')
-  lines.push('Stat          Agreement          Pct')
-  lines.push('----          ---------          ---')
+  lines.push('Stat          Agreement          Pct       Missing')
+  lines.push('----          ---------          ---       -------')
   for (const s of report.stats) {
     const ratio = `${s.agree}/${s.total}`
-    lines.push(`${s.stat.padEnd(13)} ${ratio.padEnd(18)} ${s.pct.toFixed(2)}%`)
+    lines.push(`${s.stat.padEnd(13)} ${ratio.padEnd(18)} ${(s.pct.toFixed(2) + '%').padEnd(9)} ${s.missing}`)
   }
   for (const s of report.stats) {
     if (s.mismatches.length === 0) continue
     lines.push('')
-    lines.push(`Mismatches for ${s.stat} (showing up to ${sampleMismatches} of ${s.mismatches.length}):`)
+    lines.push(`Mismatches for ${s.stat} (showing up to ${sampleMismatches} of ${s.mismatches.length}, missing=${s.missing}):`)
     for (const m of s.mismatches.slice(0, sampleMismatches)) {
-      lines.push(`  player ${m.playerId}: pipeline=[${m.pipeline}] oracle=[${m.oracle}] (dNum=${m.dNum}, dDen=${m.dDen})`)
+      if (m.missing) {
+        lines.push(`  player ${m.playerId}: MISSING pipeline=${m.pipeline ? `[${m.pipeline}]` : 'absent'} oracle=${m.oracle ? `[${m.oracle}]` : 'absent'}`)
+      } else {
+        lines.push(`  player ${m.playerId}: pipeline=[${m.pipeline}] oracle=[${m.oracle}] (dNum=${m.dNum}, dDen=${m.dDen})`)
+      }
     }
   }
   return lines.join('\n')

--- a/src/tools/verify-stats/oracle.ts
+++ b/src/tools/verify-stats/oracle.ts
@@ -2,7 +2,7 @@
  * verify-stats: independent oracle.
  *
  * Computes VPIP/PFR/3BET/3BETFOLD/CBET/CBETFOLD/AF/AFq/WTSD/WSD/WWSF/STEAL/
- * FOLDTOSTEAL directly from raw NDJSON events, with NO imports from
+ * FOLDTOSTEAL/RCA directly from raw NDJSON events, with NO imports from
  * `src/stats` or `src/entity-converter`. Only wire-protocol enums are
  * imported -- `ApiType` from `src/types/api` and `ActionType`/
  * `BetStatusType`/`RankType` from `src/types/game` -- for readability;
@@ -31,9 +31,18 @@
  *      are excluded, everything else (0-9 real ranks, SHOWDOWN_MUCK)
  *      counts as a showdown.
  *  (d) Winners are players with RewardChip > 0 in EVT_HAND_RESULTS.Results.
+ *  (e) River Call Accuracy (RCA): numerator is river CALL actions by a player
+ *      in hands where that player ends up with RewardChip > 0; denominator is
+ *      all river CALL actions by that player -- mirroring
+ *      src/stats/core/river-call-accuracy.ts's RIVER_CALL/RIVER_CALL_WON
+ *      ActionDetail tagging (RIVER_CALL is set when a CALL action occurs on
+ *      the river; RIVER_CALL_WON is added post-hoc, in EVT_HAND_RESULTS, to
+ *      any RIVER_CALL action taken by a player who ends up with
+ *      RewardChip > 0 for that hand -- see entity-converter.ts /
+ *      write-entity-stream.ts).
  */
 import { ApiType } from '../../types/api'
-import { ActionType, BetStatusType, RankType } from '../../types/game'
+import { ActionType, BetStatusType, PhaseType, RankType } from '../../types/game'
 
 type ActionTypeNum = Exclude<ActionType, ActionType.ALL_IN>
 
@@ -102,6 +111,7 @@ export interface OraclePlayerResult {
     wwsf: OracleFraction
     steal: OracleFraction
     foldToSteal: OracleFraction
+    riverCallAccuracy: OracleFraction
   }
 }
 
@@ -131,6 +141,8 @@ interface PlayerAcc {
   steal: number
   foldToStealChance: number
   foldToSteal: number
+  riverCall: number
+  riverCallWon: number
 }
 
 function newAcc(): PlayerAcc {
@@ -142,6 +154,7 @@ function newAcc(): PlayerAcc {
     flopsSeen: new Set(), showdownsReached: new Set(),
     wonAtShowdownAllHands: new Set(), showdownAllCount: new Set(), wonAfterFlop: new Set(),
     stealChance: 0, steal: 0, foldToStealChance: 0, foldToSteal: 0,
+    riverCall: 0, riverCallWon: 0,
   }
 }
 
@@ -266,6 +279,10 @@ export function runOracle(events: unknown[], options: RunOracleOptions = {}): Or
     const preflopActionsSoFar: ActionRec[] = []
     // Players confirmed to have reached the flop (BetStatus===BET_ABLE at the FLOP deal-round).
     let flopActivePlayers: Set<number> | undefined
+    // Count of river CALL actions by player this hand (RIVER_CALL is tagged
+    // per-action in the product; RIVER_CALL_WON is resolved for ALL of a
+    // winning player's river-call actions once EVT_HAND_RESULTS is known).
+    const riverCallsThisHand = new Map<number, number>()
 
     const phaseActionsMap = new Map<number, ActionRec[]>([[0, []]])
     const perPlayerPhaseActionIdx = new Map<string, number>()
@@ -353,6 +370,13 @@ export function runOracle(events: unknown[], options: RunOracleOptions = {}): Or
         if (normType === ActionType.CALL) acc(playerId).call++
         if (normType === ActionType.FOLD) acc(playerId).fold++
 
+        // RCA: RIVER_CALL is tagged on every river CALL action (denominator);
+        // RIVER_CALL_WON is resolved below, once Results is known.
+        if (phase === PhaseType.RIVER && normType === ActionType.CALL) {
+          acc(playerId).riverCall++
+          riverCallsThisHand.set(playerId, (riverCallsThisHand.get(playerId) ?? 0) + 1)
+        }
+
         if (phase === 0 && normType === ActionType.RAISE) preflopRaisers.push(playerId)
 
         actionsInPhase.push(rec)
@@ -396,6 +420,12 @@ export function runOracle(events: unknown[], options: RunOracleOptions = {}): Or
     const results = resultsEvt.Results || []
     // Semantic-sync (d): winners are players with RewardChip > 0.
     const winners = new Set(results.filter(r => r.RewardChip > 0).map(r => r.UserId))
+
+    // Semantic-sync (e): RIVER_CALL_WON is added to every RIVER_CALL action
+    // taken by a player who ends up with RewardChip > 0 for this hand.
+    for (const [pid, count] of riverCallsThisHand) {
+      if (winners.has(pid)) acc(pid).riverCallWon += count
+    }
 
     for (const r of results) {
       const pid = r.UserId
@@ -459,6 +489,7 @@ export function runOracle(events: unknown[], options: RunOracleOptions = {}): Or
         wwsf: [a.wonAfterFlop.size, a.flopsSeen.size],
         steal: [a.steal, a.stealChance],
         foldToSteal: [a.foldToSteal, a.foldToStealChance],
+        riverCallAccuracy: [a.riverCallWon, a.riverCall],
       }
     })
   }

--- a/src/tools/verify-stats/pipeline.ts
+++ b/src/tools/verify-stats/pipeline.ts
@@ -63,8 +63,21 @@ export async function runPipeline(events: ApiEvent[]): Promise<PipelineResult> {
     list.push(a)
   }
 
-  const phasesByPlayer = new Map<number, Phase[]>()
+  // Mirror Dexie's `phases` table primary key `[handId+phase]`: the real import
+  // path writes phases via `bulkPut`, so multiple EntityConverter-emitted phase
+  // records for the same (handId, phase) collapse to ONE record (last write
+  // wins, by array order) before ReadEntityStream.calcStats ever sees them.
+  // Without this de-dup, the harness indexes every phase EntityConverter
+  // emits, which diverges from product behavior for hands with duplicate
+  // street events (e.g. the documented dual-board/run-it-twice-shaped hands).
+  const dedupedPhasesByKey = new Map<string, Phase>()
   for (const p of bundle.phases) {
+    dedupedPhasesByKey.set(`${p.handId}:${p.phase}`, p)
+  }
+  const dedupedPhases = [...dedupedPhasesByKey.values()]
+
+  const phasesByPlayer = new Map<number, Phase[]>()
+  for (const p of dedupedPhases) {
     for (const pid of p.seatUserIds) {
       if (pid === -1 || pid == null) continue
       let list = phasesByPlayer.get(pid)


### PR DESCRIPTION
## 背景

#98 に付いた codex レビュー5件を検証した結果、全て正当と判断して対応します。

## 修正

1. **Dexie の `[handId+phase]` 重複排除をハーネスに反映**(last-write-wins)— 製品の `bulkPut` 挙動とパイプライン側計算を一致させる
2. **欠損/非分数統計を mismatch 扱い**(従来は `continue` で `0/0 100%` PASS になり得た)+ `missing` カウンタをレポートに追加
3. **RCA を比較対象に追加**(オラクル側に独立実装)
4. **母集団を両側 union に変更** — EC がプレイヤーを丸ごと落とす退行を検出可能に
5. **CONTRIBUTING の適用範囲を是正** — verify-stats は EC+stats 経路のみ。write-entity-stream 変更は EC↔WES パリティテスト + verify-stats の両方を実行するよう明記

## 効果(実データ 624 プレイヤー)

| 統計 | 前 | 後 |
|---|---|---|
| WTSD | 99.84% | **100.00%**(重複排除反映が残差の真因だった) |
| WWSF | 99.68% | **100.00%** |
| RCA | 未比較 | **100.00%**(新規、裁定不要) |
| cbet | 99.84% | 99.84%(文書化済みの重複 EVT_ACTION キャプチャ起因、無関係) |

union 母集団はこのデータセットでは 624 で不変(オラクル側のみ適格なプレイヤー不在を確認済み)。

## 検証

- `npm run typecheck` ✅ / `npm run test` ×2 — **438/438(50 suites)** ✅(欠損統計 fail 化・union 母集団の新テスト 2 件)
- `npm run verify-stats` — PASS ×2(出力一致確認)✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)