### PR TITLE
fix(hud): restore session seeding for imports, persist merged HUD configs, dedupe advisory notifications

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -17,6 +17,8 @@ import { registerStreamSubscriptions } from './background/ports'
 import { registerEventIngestion } from './background/event-ingestion'
 import { registerMessageRouter } from './background/message-router'
 import { checkOnUpdate } from './background/rebuild-advisory'
+import { needsConfigPersist } from './background/hud-config-sync'
+import type { Options } from './components/Popup'
 /** !!! CONTENT_SCRIPTS、WEB_ACCESSIBLE_RESOURCESからインポートしないこと !!! */
 
 // Get game URL pattern from manifest
@@ -85,10 +87,29 @@ chrome.storage.sync.get('options', (result: Record<string, any>) => {
     // マージしないと、リリースで新しい統計（例: #86のSTL/FTS）が追加されても、
     // ユーザーがポップアップを開いて再保存するまでHUDに一切表示されない
     // （service-worker起動時にstorageの値をそのまま代入していたため）。
-    service.statDisplayConfigs = mergeStatDisplayConfigs(
-      options.filterOptions.statDisplayConfigs,
+    const savedStatDisplayConfigs = options.filterOptions.statDisplayConfigs
+    const mergedStatDisplayConfigs = mergeStatDisplayConfigs(
+      savedStatDisplayConfigs,
       defaultStatDisplayConfigs
     )
+    service.statDisplayConfigs = mergedStatDisplayConfigs
+
+    // HUD（src/components/App.tsx）はservice worker経由ではなく、
+    // chrome.storage.syncの`options.filterOptions.statDisplayConfigs`を直接読む。
+    // Popupを一度も開かないユーザーだと、上記のマージ結果がインメモリの
+    // service.statDisplayConfigsにしか反映されず、HUDには古い設定のまま
+    // 表示され続けてしまう（#100）。差分がある場合のみ、マージ結果をstorageへ
+    // 書き戻す（冪等: 差分が無くなれば以降の起動では書き込まれない）。
+    if (needsConfigPersist(savedStatDisplayConfigs, mergedStatDisplayConfigs)) {
+      const updatedOptions: Options = {
+        ...options,
+        filterOptions: {
+          ...options.filterOptions,
+          statDisplayConfigs: mergedStatDisplayConfigs
+        }
+      }
+      chrome.storage.sync.set({ options: updatedOptions })
+    }
   } else {
     // デフォルトフィルターを設定（再計算をトリガーせずに）
     service.battleTypeFilter = undefined  // デフォルトではすべてのゲームタイプを表示

--- a/src/background/hud-config-sync.test.ts
+++ b/src/background/hud-config-sync.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for the HUD stat display config persistence decision logic
+ * (src/background/hud-config-sync.ts, #100 review)
+ */
+import { needsConfigPersist } from './hud-config-sync'
+import type { StatDisplayConfig } from '../types/filters'
+
+const config = (id: string, order: number, enabled = true): StatDisplayConfig => ({ id, enabled, order })
+
+describe('needsConfigPersist', () => {
+  it('returns false when saved and merged have the same id set (no new/removed stats)', () => {
+    const saved = [config('vpip', 0), config('pfr', 1)]
+    const merged = [config('vpip', 0, false), config('pfr', 1)] // enabled/order differ, that's fine
+
+    expect(needsConfigPersist(saved, merged)).toBe(false)
+  })
+
+  it('returns true when merged has more entries than saved (new stat added, e.g. #86 STL/FTS)', () => {
+    const saved = [config('vpip', 0), config('pfr', 1)]
+    const merged = [config('vpip', 0), config('pfr', 1), config('stl', 2)]
+
+    expect(needsConfigPersist(saved, merged)).toBe(true)
+  })
+
+  it('returns true when merged has fewer entries than saved (stat removed/deprecated)', () => {
+    const saved = [config('vpip', 0), config('pfr', 1), config('deprecated', 2)]
+    const merged = [config('vpip', 0), config('pfr', 1)]
+
+    expect(needsConfigPersist(saved, merged)).toBe(true)
+  })
+
+  it('returns true when the id sets differ even at the same length (swap)', () => {
+    const saved = [config('vpip', 0), config('pfr', 1)]
+    const merged = [config('vpip', 0), config('af', 1)]
+
+    expect(needsConfigPersist(saved, merged)).toBe(true)
+  })
+
+  it('returns true when saved is undefined and merged is non-empty (first-time persist)', () => {
+    expect(needsConfigPersist(undefined, [config('vpip', 0)])).toBe(true)
+  })
+
+  it('returns false when saved is undefined and merged is empty', () => {
+    expect(needsConfigPersist(undefined, [])).toBe(false)
+  })
+
+  it('returns true when saved is an empty array and merged is non-empty', () => {
+    expect(needsConfigPersist([], [config('vpip', 0)])).toBe(true)
+  })
+
+  it('is idempotent: once persisted, a second comparison with the merged result as "saved" returns false', () => {
+    const saved = [config('vpip', 0), config('pfr', 1)]
+    const merged = [config('vpip', 0), config('pfr', 1), config('stl', 2)]
+
+    expect(needsConfigPersist(saved, merged)).toBe(true)
+    // Simulate the write having happened - the next startup compares merged against itself
+    expect(needsConfigPersist(merged, merged)).toBe(false)
+  })
+})

--- a/src/background/hud-config-sync.ts
+++ b/src/background/hud-config-sync.ts
@@ -1,0 +1,55 @@
+/** !!! CONTENT_SCRIPTS、WEB_ACCESSIBLE_RESOURCESからインポートしないこと !!! */
+/**
+ * HUD統計表示設定（statDisplayConfigs）の起動時永続化。
+ *
+ * 背景（#100レビュー）: service worker起動時、保存済みのstatDisplayConfigsは
+ * デフォルトとマージしてから`service.statDisplayConfigs`（インメモリ）に設定される
+ * （新しい統計がリリースで追加されてもHUDに表示されるようにするため）。
+ * しかしHUD自体（`src/components/App.tsx`）はservice workerの状態を経由せず、
+ * `chrome.storage.sync`の`options.filterOptions.statDisplayConfigs`を直接読む。
+ * そのため、ユーザーがPopupを一度も開かずにマージが必要な状態（新統計追加後の
+ * 最初の起動など）だと、HUDはstorageに保存された古い設定のまま表示され続ける。
+ *
+ * 対処として、起動時にマージ済みの設定をstorageへ書き戻す。ただし毎起動で書き込むと
+ * 無駄なstorageイベントやsync競合を招くため、実際に差分がある場合のみ書き込む
+ * （`needsConfigPersist`で判定）。
+ */
+import type { StatDisplayConfig } from '../types/filters'
+
+/**
+ * 保存済みのstatDisplayConfigsとマージ後の内容を比較し、storageへの書き戻しが
+ * 必要かどうかを判定する（安価な比較: 件数とid集合のみを見る）。
+ *
+ * - 保存済みが存在しない/空の場合は、初回保存として書き戻しが必要と判定する。
+ * - 件数が異なる場合（新規統計の追加・廃止統計の除去）は書き戻しが必要。
+ * - 件数が同じでもid集合が異なる場合（入れ替わり）は書き戻しが必要。
+ * - それ以外（同一のid集合）は、enabled/orderがユーザー操作で変わっているだけなので
+ *   書き戻し不要（ユーザー設定を勝手に上書きしない）。
+ */
+export const needsConfigPersist = (
+  saved: StatDisplayConfig[] | undefined,
+  merged: StatDisplayConfig[]
+): boolean => {
+  if (!saved || saved.length === 0) {
+    return merged.length > 0
+  }
+
+  if (saved.length !== merged.length) {
+    return true
+  }
+
+  const savedIds = new Set(saved.map(config => config.id))
+  const mergedIds = new Set(merged.map(config => config.id))
+
+  if (savedIds.size !== mergedIds.size) {
+    return true
+  }
+
+  for (const id of mergedIds) {
+    if (!savedIds.has(id)) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/src/background/rebuild-advisory.test.ts
+++ b/src/background/rebuild-advisory.test.ts
@@ -81,6 +81,27 @@ describe('rebuild-advisory', () => {
       expect(chrome.notifications.create).not.toHaveBeenCalled()
       expect(chrome.action.setBadgeText).not.toHaveBeenCalled()
     })
+
+    it('re-asserts the badge but does not re-notify on a second update while the advisory is still pending (#105)', async () => {
+      ;(mockDb.apiEvents.count as jest.Mock).mockResolvedValue(42)
+
+      // 1回目の拡張機能更新: 通常どおりpendingVersionをセットし、バッジと通知を出す
+      await checkOnUpdate(mockDb)
+      expect(chrome.notifications.create).toHaveBeenCalledTimes(1)
+      expect(chrome.action.setBadgeText).toHaveBeenCalledTimes(1)
+
+      jest.clearAllMocks()
+
+      // 2回目の拡張機能更新: ユーザーはリビルド/解消せず、pendingVersionは同じバージョンのまま。
+      // 通知は再送されるべきではないが、バッジは再アサートされてよい（ブラウザ再起動対策）。
+      await checkOnUpdate(mockDb)
+
+      expect(chrome.notifications.create).not.toHaveBeenCalled()
+      expect(chrome.action.setBadgeText).toHaveBeenCalledWith({ text: '!' })
+
+      const state = await getRebuildAdvisoryState()
+      expect(state.pendingVersion).toBe(REBUILD_ADVISORY_VERSION)
+    })
   })
 
   describe('resolveAdvisory', () => {

--- a/src/background/rebuild-advisory.ts
+++ b/src/background/rebuild-advisory.ts
@@ -85,6 +85,15 @@ export const checkOnUpdate = async (db: PokerChaseDB): Promise<void> => {
     return
   }
 
+  if (state.pendingVersion === REBUILD_ADVISORY_VERSION) {
+    // 既に本バージョンのアドバイザリを提示済み（ユーザーがリビルド/解消せずに
+    // 再度拡張機能を更新した状態）。通知を再送すると更新の度に通知が積み重なって
+    // しまうため、バッジ（ブラウザ再起動後も見えるように再アサートしておく）だけ
+    // 更新し、通知の再送と冗長なストレージ書き込みはスキップする。
+    setBadge()
+    return
+  }
+
   const eventCount = await db.apiEvents.count()
 
   if (eventCount === 0) {

--- a/src/entity-converter.test.ts
+++ b/src/entity-converter.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../src/types'
 import type { ApiEvent, Session } from '../src/types'
 import PokerChaseService, { PokerChaseDB } from '../src/app'
+import { SessionState } from '../src/services/poker-chase-service'
 import type { Action } from '../src/types'
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
 
@@ -1362,6 +1363,121 @@ describe('EntityConverter', () => {
       // 座席未解決アクションと同じ扱い。実データでは0.09%のハンドで発生）。
       expect(result.hands).toHaveLength(1)
       expect(result.actions).toHaveLength(0)
+    })
+  })
+
+  /**
+   * 回帰テスト（#104由来のリグレッション）
+   *
+   * 背景: `service.session`は#104以降、`id`/`battleType`/`name`がprototype上の
+   * getterであるSessionStateクラスのインスタンス。EntityConverter内部で
+   * `{ ...this.session, players: new Map(...) }`のようにオブジェクトスプレッドで
+   * コピーすると、getterはコピーされず（privateな`_id`/`_battleType`/`_name`の方が
+   * コピーされてしまい、それらは`Session`インターフェース上には存在しないため）、
+   * `currentSession.id`等が`undefined`になってしまう。
+   *
+   * インポート系のパイプライン（インクリメンタルインポート等）はイベントウィンドウの
+   * 先頭にEVT_ENTRY_QUEUEDが含まれない場合があり、その場合はEntityConverter内で
+   * セッションIDが復元されないため、上記のスプレッドのバグがそのまま
+   * `hand.session.id`/`battleType`の欠落として表面化する。
+   */
+  describe('SessionState seeding (regression, #104)', () => {
+    it('carries over session id/battleType/name from a real SessionState instance even without a leading EVT_ENTRY_QUEUED', () => {
+      // 実際のSessionStateインスタンスを構築し、setter経由でフィールドを設定する
+      // （#104で導入されたクラス。id/battleType/nameはprototypeのgetterで公開される）
+      const realSession = new SessionState(() => { })
+      realSession.setId('real-session-456')
+      realSession.setBattleType(BattleType.SIT_AND_GO)
+      realSession.setName('Real Session')
+
+      // EVT_ENTRY_QUEUEDを含まないイベントウィンドウ（インクリメンタルインポートを模した状況）
+      const events: ApiEvent[] = [
+        createEvent(ApiType.EVT_DEAL, {
+          timestamp: 1000,
+          SeatUserIds: [100, 101, 102, 103, 104, 105],
+          Game: {
+            CurrentBlindLv: 1,
+            NextBlindUnixSeconds: 1000000,
+            Ante: 0,
+            SmallBlind: 10,
+            BigBlind: 20,
+            ButtonSeat: 5,
+            SmallBlindSeat: 0,
+            BigBlindSeat: 1
+          },
+          Player: {
+            SeatIndex: 2,
+            BetStatus: 1,
+            HoleCards: [37, 51],
+            Chip: 1980,
+            BetChip: 0
+          },
+          Progress: {
+            Phase: 0,
+            NextActionSeat: 2,
+            NextActionTypes: [2, 3, 4, 5],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 40,
+            Pot: 30,
+            SidePot: []
+          },
+          OtherPlayers: [
+            { SeatIndex: 0, Status: 0, BetStatus: 1, Chip: 1990, BetChip: 10 },
+            { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 1980, BetChip: 20 },
+            { SeatIndex: 3, Status: 0, BetStatus: 1, Chip: 2000, BetChip: 0 },
+            { SeatIndex: 4, Status: 0, BetStatus: 1, Chip: 2000, BetChip: 0 },
+            { SeatIndex: 5, Status: 0, BetStatus: 1, Chip: 2000, BetChip: 0 }
+          ]
+        }),
+        createEvent(ApiType.EVT_HAND_RESULTS, {
+          timestamp: 1005,
+          HandId: 22345,
+          CommunityCards: [],
+          Pot: 30,
+          SidePot: [],
+          ResultType: 0,
+          DefeatStatus: 0,
+          Results: [
+            {
+              UserId: 102,
+              HoleCards: [37, 51],
+              RankType: 8,
+              Hands: [1, 21, 44, 37, 51],
+              HandRanking: 1,
+              Ranking: 1,
+              RewardChip: 30
+            }
+          ],
+          OtherPlayers: [
+            { SeatIndex: 0, Status: 0, BetStatus: -1, Chip: 1990, BetChip: 0 },
+            { SeatIndex: 1, Status: 0, BetStatus: -1, Chip: 1980, BetChip: 0 },
+            { SeatIndex: 3, Status: 0, BetStatus: -1, Chip: 2000, BetChip: 0 },
+            { SeatIndex: 4, Status: 0, BetStatus: -1, Chip: 2000, BetChip: 0 },
+            { SeatIndex: 5, Status: 0, BetStatus: -1, Chip: 2000, BetChip: 0 }
+          ]
+        }, { skipValidation: true })
+      ]
+
+      // 事前条件: `Session`インターフェースに対するオブジェクトスプレッドではgetterが
+      // 引き継がれないことを確認する（このバグの直接的な実証）
+      const naiveSpread = { ...(realSession as unknown as Record<string, unknown>) }
+      expect(naiveSpread.id).toBeUndefined()
+      expect(naiveSpread.battleType).toBeUndefined()
+      expect(naiveSpread.name).toBeUndefined()
+      // 一方、getter経由では正しい値が読める
+      expect(realSession.id).toBe('real-session-456')
+
+      const converterWithRealSession = new EntityConverter(realSession)
+      const result = converterWithRealSession.convertEventsToEntities(events)
+
+      expect(result.hands).toHaveLength(1)
+      expect(result.hands[0]).toMatchObject({
+        session: {
+          id: 'real-session-456',
+          battleType: BattleType.SIT_AND_GO,
+          name: 'Real Session'
+        }
+      })
     })
   })
 

--- a/src/entity-converter.ts
+++ b/src/entity-converter.ts
@@ -62,9 +62,16 @@ export class EntityConverter {
 
     let currentHandEvents: ApiHandEvent[] = []
     // セッション情報をローカルに保持（インポートデータから抽出）
+    // NOTE: this.session は SessionState クラスのインスタンスの場合があり、
+    // id/battleType/name は prototype 上の getter のため、オブジェクトスプレッドでは
+    // コピーされない（private な _id/_battleType/_name のみコピーされ、値が undefined になる）。
+    // そのため各フィールドを明示的に読み出す。
     let currentSession = {
-      ...this.session,
-      players: new Map(this.session.players) // Mapを正しくコピー
+      id: this.session.id,
+      battleType: this.session.battleType,
+      name: this.session.name,
+      players: new Map(this.session.players), // Mapを正しくコピー（可変Mapとして扱う）
+      reset: () => { } // ローカルな作業コピーではreset()は使用されない
     }
 
     for (const event of events) {


### PR DESCRIPTION
## 背景

マージ済み PR に付いた codex レビューのうち、検証の結果**正当と確定した3件**を修正します(検証過程は各スレッドへの返信に記載)。

## 修正

**1. SessionState spread による session 情報消失(#104 レビュー指摘 — 退行)**
`EntityConverter` の `{...this.session}` は、#104 で session がクラスインスタンス化された際に **prototype getter がコピーされず** `id/battleType/name` が undefined になる退行を起こしていました(実証済み)。イベント窓の先頭に `EVT_ENTRY_QUEUED` が無い incremental import で、ハンドの session 情報(ゲームタイプフィルタの根拠)が欠落します。明示的なアクセサ読み出しに置換し、実 `SessionState` を使った回帰テストを追加(修正前 fail 確認済み)。他に spread 箇所が無いことも grep で確認。

**2. HUD の統計列が popup を開くまで更新されない(#100 レビュー指摘)**
マージ済み config をメモリ上の service にしか反映していませんでしたが、HUD(App.tsx)は `chrome.storage.sync` の平坦な `options` キーを直読みします。差分がある場合のみ startup で書き戻すよう修正(`needsConfigPersist` 純関数 + 8 テスト)。
*調査での発見*: Popup の `bucket.set`(@extend-chrome/storage)は**接頭辞付きサブキーに書き込み、他の全コードが読む平坦キーとは分断されている**ことを実測で確認。実際に消費される平坦シェイプ(message-router が書く形)へミラーしました。bucket 側の分断は別課題として要調査。

**3. アドバイザリ通知の再発火(#105 レビュー指摘)**
pending のまま次の拡張更新が来ると同一バージョンの通知が再発火していました。`pendingVersion` が現行と一致する場合はバッジ再表示のみ行い、通知・storage 書込みをスキップ(修正前 fail のテスト付き)。

## 検証

- `npm run typecheck` ✅ / `npm run test` ×2 — **446/446(51 suites)** ✅ / `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)