### PR TITLE
fix(hud): unify options storage on the flat chrome.storage.sync key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
-        "@extend-chrome/storage": "^1.5.0",
         "@msgpack/msgpack": "^3.0.0-beta2",
         "@mui/icons-material": "^7.0.0",
         "@mui/material": "^7.0.0",
@@ -1321,16 +1320,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@extend-chrome/storage": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@extend-chrome/storage/-/storage-1.5.0.tgz",
-      "integrity": "sha512-JhoBZ1xIzu0/mauNR/MadUsfNsWP1lTmWR8RlVJvWStUifzNZdAxI2i8NFCkd4RfjyTn4FcDETik3SDlAfGQRA==",
-      "license": "MIT",
-      "dependencies": {
-        "chrome-promise": "^3.0.5",
-        "rxjs": "^6.5.5 || ^7.1.0"
       }
     },
     "node_modules/@firebase/ai": {
@@ -3890,12 +3879,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/chrome-promise": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/chrome-promise/-/chrome-promise-3.0.5.tgz",
-      "integrity": "sha512-ekIevrJOO5S6ezSzl5TdaLhlQkovY5nVaNSgA2XyhuNtlGniUvTbf7rzH95alh1OajArwoP2xVGYUJbpVLmZYA==",
-      "license": "MIT"
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
@@ -6555,15 +6538,6 @@
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
-    "@extend-chrome/storage": "^1.5.0",
     "@msgpack/msgpack": "^3.0.0-beta2",
     "@mui/icons-material": "^7.0.0",
     "@mui/material": "^7.0.0",

--- a/src/background.ts
+++ b/src/background.ts
@@ -18,7 +18,7 @@ import { registerEventIngestion } from './background/event-ingestion'
 import { registerMessageRouter } from './background/message-router'
 import { checkOnUpdate } from './background/rebuild-advisory'
 import { needsConfigPersist } from './background/hud-config-sync'
-import type { Options } from './components/Popup'
+import { loadOptions, saveOptions, type Options } from './utils/options-storage'
 /** !!! CONTENT_SCRIPTS、WEB_ACCESSIBLE_RESOURCESからインポートしないこと !!! */
 
 // Get game URL pattern from manifest
@@ -68,11 +68,11 @@ chrome.runtime.onInstalled.addListener(async details => {
   }
 })
 
-/** 拡張起動時: フィルター設定を復元（統計の再計算はしない） */
-chrome.storage.sync.get('options', (result: Record<string, any>) => {
-  const options = result.options || {}
-
-  if (options.filterOptions) {
+/** 拡張起動時: フィルター設定を復元（統計の再計算はしない）。
+ * loadOptionsは旧@extend-chrome/storage bucketキーからのマイグレーションも行う
+ * （Popupを開かないユーザーでもservice worker起動時に移行が完了する） */
+loadOptions().then((options) => {
+  if (options?.filterOptions) {
     service.battleTypeFilter = options.filterOptions.gameTypes.sng ||
       options.filterOptions.gameTypes.mtt ||
       options.filterOptions.gameTypes.ring
@@ -108,7 +108,7 @@ chrome.storage.sync.get('options', (result: Record<string, any>) => {
           statDisplayConfigs: mergedStatDisplayConfigs
         }
       }
-      chrome.storage.sync.set({ options: updatedOptions })
+      saveOptions(updatedOptions)
     }
   } else {
     // デフォルトフィルターを設定（再計算をトリガーせずに）

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -1,6 +1,5 @@
 /** !!! CONTENT_SCRIPTS、WEB_ACCESSIBLE_RESOURCESからインポートしないこと !!! */
 import PokerChaseService, { PokerChaseDB } from '../app'
-import type { Options } from '../components/Popup'
 import type {
   ChromeMessage,
   ImportStatusMessage,
@@ -149,11 +148,8 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
           sendResponse({ success: false, error: error.message })
         })
 
-      // ストレージに保存
-      const storageUpdate: Partial<Options> = {
-        filterOptions: request.filterOptions
-      }
-      chrome.storage.sync.set({ options: storageUpdate })
+      // 永続化はPopup側（saveOptions）が行う。ここで部分オブジェクトを
+      // 書き戻すとsendUserData等を落としたoptionsで上書きしてしまう
 
       // コンテンツスクリプトにメッセージを転送
       chrome.tabs.query({ url: gameUrlPattern }, tabs => {

--- a/src/components/Popup.test.tsx
+++ b/src/components/Popup.test.tsx
@@ -4,17 +4,6 @@ import Popup from './Popup'
 import { DEFAULT_UI_CONFIG } from '../types/hand-log'
 import { defaultStatDisplayConfigs } from '../stats'
 
-// Mock @extend-chrome/storage
-jest.mock('@extend-chrome/storage', () => {
-  const mockBucket = {
-    get: jest.fn(() => Promise.resolve(null)),
-    set: jest.fn(() => Promise.resolve()),
-  }
-  return {
-    getBucket: jest.fn(() => mockBucket),
-  }
-})
-
 // Mock chrome APIs
 const mockChromeRuntimeSendMessage = jest.fn()
 const mockChromeTabsQuery = jest.fn()
@@ -23,6 +12,7 @@ const mockChromeTabsUpdate = jest.fn()
 const mockChromeWindowsUpdate = jest.fn()
 const mockChromeStorageGet = jest.fn()
 const mockChromeStorageSet = jest.fn()
+const mockChromeStorageRemove = jest.fn()
 
 global.chrome = {
   runtime: {
@@ -44,6 +34,7 @@ global.chrome = {
     sync: {
       get: mockChromeStorageGet,
       set: mockChromeStorageSet,
+      remove: mockChromeStorageRemove,
     },
     local: {
       get: jest.fn((_key: string, cb: (result: Record<string, unknown>) => void) => cb({})),
@@ -66,13 +57,11 @@ jest.mock('../../manifest.json', () => ({
 }))
 
 describe('Popup', () => {
-  let mockBucket: any
+  // chrome.storage.syncのバッキングストア（フラットな`options`キーを含む）
+  let syncData: Record<string, any>
 
   // Helper to wait for all initial async operations
   const waitForAsyncOperations = async () => {
-    await waitFor(() => {
-      expect(mockBucket.get).toHaveBeenCalled()
-    })
     await waitFor(() => {
       expect(mockChromeStorageGet).toHaveBeenCalled()
     })
@@ -85,28 +74,37 @@ describe('Popup', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    
-    // Get the mocked bucket instance
-    const { getBucket } = require('@extend-chrome/storage')
-    mockBucket = getBucket()
-    
-    // Default mock implementations
-    mockBucket.get.mockResolvedValue({
-      sendUserData: true,
-      filterOptions: {
-        gameTypes: { sng: true, mtt: true, ring: true },
-        handLimit: 500,
-        statDisplayConfigs: defaultStatDisplayConfigs,
+
+    // Default mock implementations: Popupはフラットな`options`キーを読む
+    syncData = {
+      options: {
+        sendUserData: true,
+        filterOptions: {
+          gameTypes: { sng: true, mtt: true, ring: true },
+          handLimit: 500,
+          statDisplayConfigs: defaultStatDisplayConfigs,
+        },
       },
-    })
-    
-    mockChromeStorageGet.mockImplementation((_keys, callback) => {
+      uiConfig: DEFAULT_UI_CONFIG,
+    }
+
+    mockChromeStorageGet.mockImplementation((keys, callback) => {
       // Execute callback immediately - tests will use waitFor
-      callback({
-        uiConfig: DEFAULT_UI_CONFIG,
-      })
+      const keyList = Array.isArray(keys) ? keys : [keys]
+      callback(keyList.reduce((acc: Record<string, any>, key: string) => ({ ...acc, [key]: syncData[key] }), {}))
     })
-    
+
+    mockChromeStorageSet.mockImplementation((items, callback?) => {
+      Object.assign(syncData, items)
+      if (typeof callback === 'function') callback()
+    })
+
+    mockChromeStorageRemove.mockImplementation((keys, callback?) => {
+      const keyList = Array.isArray(keys) ? keys : [keys]
+      keyList.forEach((key: string) => { delete syncData[key] })
+      if (typeof callback === 'function') callback()
+    })
+
     mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
       // Execute callback immediately - tests will use waitFor
       if (message.action === 'firebaseAuthStatus') {
@@ -125,8 +123,11 @@ describe('Popup', () => {
 
     await waitForAsyncOperations()
 
-    expect(mockBucket.get).toHaveBeenCalled()
-    expect(mockChromeStorageGet).toHaveBeenCalled()
+    // フラットな`options`キーから読み込む
+    expect(mockChromeStorageGet).toHaveBeenCalledWith(
+      expect.arrayContaining(['options']),
+      expect.any(Function)
+    )
     expect(mockChromeRuntimeSendMessage).toHaveBeenCalledWith(
       { action: 'firebaseAuthStatus' },
       expect.any(Function)
@@ -164,6 +165,70 @@ describe('Popup', () => {
     // Check that at least one checkbox exists
     const checkboxes = screen.getAllByRole('checkbox')
     expect(checkboxes.length).toBeGreaterThan(0)
+  })
+
+  it('フィルター変更時はフラットなoptionsキーへ保存しメッセージを送る', async () => {
+    render(<Popup />)
+
+    await waitForAsyncOperations()
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'MTT' }))
+
+    // フラットキーへoptions全体（sendUserData含む）が書き込まれる
+    await waitFor(() => {
+      expect(syncData.options).toEqual(
+        expect.objectContaining({
+          sendUserData: true,
+          filterOptions: expect.objectContaining({
+            gameTypes: { sng: true, mtt: false, ring: true },
+          }),
+        })
+      )
+    })
+
+    expect(mockChromeRuntimeSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'updateBattleTypeFilter' })
+    )
+  })
+
+  it('旧@extend-chrome/storage bucketキーのみのユーザーはフラットキーへ移行される', async () => {
+    // フラットキーが無く、旧bucketキーのみ存在する状態
+    syncData = {
+      'extend-chrome/storage__options_keys': ['sendUserData', 'filterOptions'],
+      'extend-chrome/storage__options--sendUserData': false,
+      'extend-chrome/storage__options--filterOptions': {
+        gameTypes: { sng: false, mtt: true, ring: true },
+        handLimit: 200,
+        statDisplayConfigs: defaultStatDisplayConfigs,
+      },
+      uiConfig: DEFAULT_UI_CONFIG,
+    }
+
+    render(<Popup />)
+
+    await waitForAsyncOperations()
+
+    // フラットキーへ移行され、旧キーは削除される
+    await waitFor(() => {
+      expect(syncData.options).toEqual({
+        sendUserData: false,
+        filterOptions: {
+          gameTypes: { sng: false, mtt: true, ring: true },
+          handLimit: 200,
+          statDisplayConfigs: defaultStatDisplayConfigs,
+        },
+      })
+    })
+    expect(syncData['extend-chrome/storage__options_keys']).toBeUndefined()
+    expect(syncData['extend-chrome/storage__options--sendUserData']).toBeUndefined()
+    expect(syncData['extend-chrome/storage__options--filterOptions']).toBeUndefined()
+
+    // 移行した設定がUIに反映される（handLimit 200）
+    expect(screen.getByText('200')).toBeInTheDocument()
+    const mttCheckbox = screen.getByRole('checkbox', { name: 'MTT' }) as HTMLInputElement
+    expect(mttCheckbox.checked).toBe(true)
+    const sngCheckbox = screen.getByRole('checkbox', { name: 'Sit & Go' }) as HTMLInputElement
+    expect(sngCheckbox.checked).toBe(false)
   })
 
   it('ハンド数制限を表示・変更できる', async () => {

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -1,7 +1,7 @@
-import { getBucket } from '@extend-chrome/storage'
 import Divider from '@mui/material/Divider'
 import { ChangeEvent, useEffect, useRef, useState } from 'react'
 import type { FilterOptions, GameTypeFilter } from '../types'
+import { loadOptions, saveOptions, type Options } from '../utils/options-storage'
 import { defaultStatDisplayConfigs, mergeStatDisplayConfigs } from '../stats'
 import type { StatDisplayConfig } from '../types/filters'
 import type { UIConfig } from '../types/hand-log'
@@ -25,13 +25,7 @@ import { GameTypeFilterSection } from './popup/GameTypeFilterSection'
 import { HandLimitSection } from './popup/HandLimitSection'
 import { StatisticsConfigSection } from './popup/StatisticsConfigSection'
 
-export interface Options {
-  sendUserData: boolean;
-  gameTypeFilter?: GameTypeFilter; // New filter format
-  filterOptions?: FilterOptions; // Complete filter options
-}
-
-const bucket = getBucket<Options>('options', 'sync')
+export type { Options }
 
 const Popup = () => {
   const [options, setOptions] = useState<Options>({ sendUserData: true })
@@ -123,7 +117,7 @@ const Popup = () => {
     // Check and switch to game tab on popup open
     openGameTab()
     
-    bucket.get().then((savedOptions) => {
+    loadOptions().then((savedOptions) => {
       if (savedOptions) {
         setOptions(savedOptions)
         if (savedOptions.filterOptions) {
@@ -138,7 +132,7 @@ const Popup = () => {
 
           // Save merged configurations back to storage if new stats were added
           if (savedOptions.filterOptions.statDisplayConfigs && mergedConfigs.length > savedOptions.filterOptions.statDisplayConfigs.length) {
-            bucket.set({
+            saveOptions({
               ...savedOptions,
               filterOptions: {
                 ...savedOptions.filterOptions,
@@ -299,7 +293,8 @@ const Popup = () => {
   const saveAndBroadcastOptions = (filterOptions: FilterOptions) => {
     const newOptions = { ...options, filterOptions }
     setOptions(newOptions)
-    bucket.set(newOptions)
+    // 永続化はここが唯一の書き込み元（message-routerは書かない）
+    saveOptions(newOptions)
 
     chrome.runtime.sendMessage<UpdateBattleTypeFilterMessage>({
       action: 'updateBattleTypeFilter',

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -59,6 +59,15 @@ global.chrome = {
         }
         return Promise.resolve()
       }),
+      remove: jest.fn((keys, callback?) => {
+        const keyList = Array.isArray(keys) ? keys : [keys]
+        keyList.forEach((key: string) => { delete chromeStorageMockData.sync[key] })
+        if (typeof callback === 'function') {
+          callback()
+          return undefined
+        }
+        return Promise.resolve()
+      }),
     },
     local: {
       get: jest.fn((keys, callback?) => {
@@ -78,6 +87,15 @@ global.chrome = {
       set: jest.fn((items, callback?) => {
         fireStorageChange('local', items)
         Object.assign(chromeStorageMockData.local, items)
+        if (typeof callback === 'function') {
+          callback()
+          return undefined
+        }
+        return Promise.resolve()
+      }),
+      remove: jest.fn((keys, callback?) => {
+        const keyList = Array.isArray(keys) ? keys : [keys]
+        keyList.forEach((key: string) => { delete chromeStorageMockData.local[key] })
         if (typeof callback === 'function') {
           callback()
           return undefined

--- a/src/utils/options-storage.test.ts
+++ b/src/utils/options-storage.test.ts
@@ -1,0 +1,115 @@
+/**
+ * options-storage: フラット`options`キーの読み書きと、
+ * 旧@extend-chrome/storage bucketキーからのマイグレーションのテスト
+ */
+import { loadOptions, saveOptions, OPTIONS_STORAGE_KEY, type Options } from './options-storage'
+
+const LEGACY_KEYS_KEY = 'extend-chrome/storage__options_keys'
+const legacyKey = (field: string) => `extend-chrome/storage__options--${field}`
+
+const sampleFilterOptions = {
+  gameTypes: { sng: true, mtt: false, ring: true },
+  handLimit: 200,
+  statDisplayConfigs: [{ id: 'vpip', enabled: true, order: 1 }]
+}
+
+// test-setup.tsのchromeモックはモジュールスコープで状態を持つため、各テスト前に全キーを消す
+const clearSyncStorage = async () => {
+  const all = await chrome.storage.sync.get(null as any) as Record<string, any>
+  const keys = Object.keys(all)
+  if (keys.length > 0) {
+    await chrome.storage.sync.remove(keys)
+  }
+}
+
+describe('options-storage', () => {
+  beforeEach(async () => {
+    await clearSyncStorage()
+    jest.clearAllMocks()
+  })
+
+  it('saveOptionsはフラットなoptionsキーへ書き込む', async () => {
+    const options: Options = { sendUserData: true, filterOptions: sampleFilterOptions }
+    await saveOptions(options)
+
+    // Promise形式のget（test-setupモックは両形式対応）
+    const result = await chrome.storage.sync.get(OPTIONS_STORAGE_KEY) as Record<string, any>
+    expect(result[OPTIONS_STORAGE_KEY]).toEqual(options)
+  })
+
+  it('フラットキーのみ存在する場合はそのまま返す（マイグレーションなし）', async () => {
+    const options: Options = { sendUserData: false, filterOptions: sampleFilterOptions }
+    await chrome.storage.sync.set({ [OPTIONS_STORAGE_KEY]: options })
+
+    const loaded = await loadOptions()
+
+    expect(loaded).toEqual(options)
+    expect(chrome.storage.sync.remove).not.toHaveBeenCalled()
+  })
+
+  it('データが無い場合はundefinedを返す', async () => {
+    await expect(loadOptions()).resolves.toBeUndefined()
+  })
+
+  it('旧bucketキーのみ存在する場合はフラットキーへ移行し旧キーを削除する', async () => {
+    await chrome.storage.sync.set({
+      [LEGACY_KEYS_KEY]: ['sendUserData', 'filterOptions'],
+      [legacyKey('sendUserData')]: false,
+      [legacyKey('filterOptions')]: sampleFilterOptions
+    })
+
+    const loaded = await loadOptions()
+
+    expect(loaded).toEqual({ sendUserData: false, filterOptions: sampleFilterOptions })
+
+    // フラットキーへ書き込まれ、旧キーは消えている（コールバック形式のgetで確認）
+    const after = await new Promise<Record<string, any>>(resolve =>
+      chrome.storage.sync.get(
+        [OPTIONS_STORAGE_KEY, LEGACY_KEYS_KEY, legacyKey('sendUserData'), legacyKey('filterOptions')],
+        resolve
+      )
+    )
+    expect(after[OPTIONS_STORAGE_KEY]).toEqual({ sendUserData: false, filterOptions: sampleFilterOptions })
+    expect(after[LEGACY_KEYS_KEY]).toBeUndefined()
+    expect(after[legacyKey('sendUserData')]).toBeUndefined()
+    expect(after[legacyKey('filterOptions')]).toBeUndefined()
+  })
+
+  it('フラットと旧bucketが両方ある場合はフラット優先でマージし旧キーを削除する', async () => {
+    const flatFilterOptions = { ...sampleFilterOptions, handLimit: 500 }
+    const legacyFilterOptions = { ...sampleFilterOptions, handLimit: 20 }
+    await chrome.storage.sync.set({
+      // message-routerの旧・部分書き込み形（sendUserData欠落）を再現
+      [OPTIONS_STORAGE_KEY]: { filterOptions: flatFilterOptions },
+      [LEGACY_KEYS_KEY]: ['sendUserData', 'filterOptions'],
+      [legacyKey('sendUserData')]: false,
+      [legacyKey('filterOptions')]: legacyFilterOptions
+    })
+
+    const loaded = await loadOptions()
+
+    // filterOptionsはフラット側が勝ち、bucketにしか無いsendUserDataは拾われる
+    expect(loaded).toEqual({ sendUserData: false, filterOptions: flatFilterOptions })
+
+    const after = await chrome.storage.sync.get(null as any) as Record<string, any>
+    expect(after[OPTIONS_STORAGE_KEY]).toEqual({ sendUserData: false, filterOptions: flatFilterOptions })
+    expect(after[LEGACY_KEYS_KEY]).toBeUndefined()
+    expect(after[legacyKey('sendUserData')]).toBeUndefined()
+    expect(after[legacyKey('filterOptions')]).toBeUndefined()
+  })
+
+  it('2回目以降のloadOptionsはマイグレーションを再実行しない（冪等）', async () => {
+    await chrome.storage.sync.set({
+      [LEGACY_KEYS_KEY]: ['filterOptions'],
+      [legacyKey('filterOptions')]: sampleFilterOptions
+    })
+
+    const first = await loadOptions()
+    jest.clearAllMocks()
+    const second = await loadOptions()
+
+    expect(second).toEqual(first)
+    expect(chrome.storage.sync.set).not.toHaveBeenCalled()
+    expect(chrome.storage.sync.remove).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/options-storage.ts
+++ b/src/utils/options-storage.ts
@@ -1,0 +1,63 @@
+/**
+ * options（フィルター設定など）のchrome.storage.sync永続化。
+ *
+ * 全コンシューマー（Popup / HUD / service worker）がフラットな`options`キー
+ * 1箇所を読み書きする。かつてPopupだけが@extend-chrome/storageのbucket
+ * （プレフィックス付きサブキー extend-chrome/storage__options--<field>）を
+ * 使っており、フラットキーとの同期はupdateBattleTypeFilterメッセージの
+ * 副作用頼みだった。旧bucketキーにしかデータが残っていないユーザーのために、
+ * loadOptionsは読み取り時マイグレーションを行う。
+ */
+import type { FilterOptions, GameTypeFilter } from '../types'
+
+export interface Options {
+  sendUserData: boolean;
+  gameTypeFilter?: GameTypeFilter; // New filter format
+  filterOptions?: FilterOptions; // Complete filter options
+}
+
+export const OPTIONS_STORAGE_KEY = 'options'
+
+/** @extend-chrome/storage getBucket('options', 'sync') が実際に使っていたキー形式 */
+const LEGACY_BUCKET_PREFIX = 'extend-chrome/storage__options'
+const LEGACY_BUCKET_KEYS_KEY = `${LEGACY_BUCKET_PREFIX}_keys`
+const legacyFieldKey = (field: string) => `${LEGACY_BUCKET_PREFIX}--${field}`
+
+// コールバック形式で呼び出す（jestのchromeモックが両形式に対応しているが、
+// 既存コード（App.tsx / background.ts）と同じ形式に揃える）
+const syncGet = (keys: string[]): Promise<Record<string, any>> =>
+  new Promise(resolve => chrome.storage.sync.get(keys, resolve))
+
+const syncSet = (items: Record<string, any>): Promise<void> =>
+  new Promise(resolve => chrome.storage.sync.set(items, resolve))
+
+const syncRemove = (keys: string[]): Promise<void> =>
+  new Promise(resolve => chrome.storage.sync.remove(keys, resolve))
+
+export const saveOptions = (options: Options): Promise<void> =>
+  syncSet({ [OPTIONS_STORAGE_KEY]: options })
+
+/**
+ * フラットな`options`キーを読む。旧bucketキーが残っている場合は
+ * フラットキーへ統合し、旧キーを削除する（一度きりのマイグレーション）。
+ */
+export const loadOptions = async (): Promise<Options | undefined> => {
+  const result = await syncGet([OPTIONS_STORAGE_KEY, LEGACY_BUCKET_KEYS_KEY])
+  const flat = result[OPTIONS_STORAGE_KEY] as Options | undefined
+  const legacyFields = (result[LEGACY_BUCKET_KEYS_KEY] as string[] | undefined) ?? []
+  if (legacyFields.length === 0) return flat
+
+  // フラット側に既にあるフィールドはフラット側を優先する
+  // （HUD・service workerが実際に消費してきたのはフラット側の値）。
+  // sendUserDataのように旧bucketにしか無いフィールドはここで拾われる。
+  const legacyResult = await syncGet(legacyFields.map(legacyFieldKey))
+  const legacy: Record<string, any> = {}
+  for (const field of legacyFields) {
+    const value = legacyResult[legacyFieldKey(field)]
+    if (value !== undefined) legacy[field] = value
+  }
+  const merged = { ...legacy, ...flat } as Options
+  await saveOptions(merged)
+  await syncRemove([LEGACY_BUCKET_KEYS_KEY, ...legacyFields.map(legacyFieldKey)])
+  return merged
+}


### PR DESCRIPTION
## 背景

`Popup.tsx` だけが `@extend-chrome/storage` の `getBucket('options', 'sync')` を使っており、実データはプレフィックス付きサブキー（`extend-chrome/storage__options--<field>` ＋ インデックス `extend-chrome/storage__options_keys`）に保存されていた。一方、他の全コンシューマー — HUD（`App.tsx`）、service worker 起動時ロード（`background.ts`）、`updateBattleTypeFilter` ハンドラー（`message-router.ts`）— は平坦な `options` キーを読み書きしていた（#109 の調査で発覚）。

2つのコピーの同期は `updateBattleTypeFilter` メッセージの副作用（message-router が `{ filterOptions }` のみの `Partial<Options>` を平坦キーへ上書き — `sendUserData` は脱落）頼みで、background 起動時のマージ書き戻し（#100 対応）は平坦キーのみに反映され bucket 側には届かない、という分断状態だった。

## 変更内容

- **`src/utils/options-storage.ts`（新規）**: `Options` 型と `loadOptions()` / `saveOptions()` を集約。全コンシューマーが平坦 `options` キーに統一。
- **`Popup.tsx`**: bucket を全廃し新モジュール経由に。
- **`background.ts`**: 起動時ロードも `loadOptions()` 経由に（`any` だった箇所が型付きに）。
- **`message-router.ts`**: storage 書き込み副作用を削除。書き込み元は Popup に一本化（部分オブジェクトによる `sendUserData` 上書き消失も解消）。
- **`@extend-chrome/storage` を依存から削除**（Popup が唯一の利用箇所だった）。

## 旧 bucket キーからの移行

- **いつ走るか**: `loadOptions()` の読み取り時。呼び出し箇所は (1) service worker 起動時（`background.ts`）と (2) Popup を開いた時。**Popup を一度も開かないユーザーでも拡張の起動時点で移行が完了する。**
- **仕様**: `extend-chrome/storage__options_keys` が存在する場合、各サブキーを読み出して平坦キーへマージ。フィールドごとに平坦側優先（HUD・service worker が実際に消費してきた値を正とする）。`sendUserData` のように bucket にしか存在しないフィールドはここで救出される。マージ結果を平坦キーへ書き込んだ後、旧キーを全削除。
- **冪等性**: 旧キー削除後は `legacyFields.length === 0` で即 return するため、2回目以降の `loadOptions()` は読み取りのみ（書き込み・削除は発生しない）。テストで担保済み。

## 検証

- `npm run typecheck` クリーン
- `npm run test` を2回実行: **52 suites / 457 tests green ×2**
- `npm run build` ＋ zip 成功
- 新規テスト: `options-storage.test.ts`（bucket のみ→移行＋旧キー削除 / 平坦優先マージ / 冪等性 / callback・Promise 両形式）、`Popup.test.tsx`（バッキングストア方式に書き換え、平坦キー保存・移行の UI 反映を追加）、`test-setup.ts` に `storage.*.remove` モック追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)