### PR TITLE
fix(hud): subscribe to options storage changes so open tabs pick up new stat columns

### DIFF
--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -361,4 +361,59 @@ describe('App', () => {
     // Chrome messageリスナーが削除される
     expect(removeMessageListenerSpy).toHaveBeenCalled()
   })
+
+  /**
+   * codexレビュー指摘（#109）への対応: マウント時の一括get()は一度きりのため、
+   * background起動時のマージ書き戻しやPopupでの保存がその後に発生した場合、
+   * 開きっぱなしのゲームタブのHUDには反映されなかった。
+   * 平坦'options'キーのstorage.onChanged購読で反映されることを検証する。
+   */
+  it('storage.onChangedのoptions変更でstatDisplayConfigsがHUDへ反映される（開いているタブへの追随）', async () => {
+    const addListenerMock = chrome.storage.onChanged.addListener as jest.Mock
+    const removeListenerMock = chrome.storage.onChanged.removeListener as jest.Mock
+    addListenerMock.mockClear()
+    removeListenerMock.mockClear()
+
+    const { unmount } = render(<App />)
+
+    // HUDを表示させる（Hudモックは statDisplayConfigs の要素数を描画する）
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('PokerChaseServiceEvent', { detail: mockStatsData })
+      )
+    })
+    expect(screen.getByTestId('hud-0')).toHaveTextContent('Stats: 0')
+
+    // マウント時にoptions変更リスナーが登録されている
+    expect(addListenerMock).toHaveBeenCalledWith(expect.any(Function))
+    const listener = addListenerMock.mock.calls[0][0]
+
+    // sync領域のoptions変更 → HUDの統計列設定に反映される
+    await act(async () => {
+      listener(
+        {
+          options: {
+            newValue: {
+              filterOptions: {
+                statDisplayConfigs: [{ id: 'vpip', enabled: true, order: 0 }],
+              },
+            },
+          },
+        },
+        'sync'
+      )
+    })
+    expect(screen.getByTestId('hud-0')).toHaveTextContent('Stats: 1')
+
+    // 対象外の領域・キーは無視される（値が変わらずクラッシュもしない）
+    await act(async () => {
+      listener({ rebuildAdvisory: { newValue: {} } }, 'local')
+      listener({ uiConfig: { newValue: {} } }, 'sync')
+    })
+    expect(screen.getByTestId('hud-0')).toHaveTextContent('Stats: 1')
+
+    // アンマウント時に同一の関数で解除される
+    unmount()
+    expect(removeListenerMock).toHaveBeenCalledWith(listener)
+  })
 })

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useEffect, useMemo, useState } from "react"
 import { POKER_CHASE_SERVICE_EVENT } from "../constants/runtime"
 import { ApiType, isApiEventType } from "../types"
+import type { Options } from '../utils/options-storage'
 import type { PlayerStats } from "../types"
 import type { StatsData } from "../content_script"
 import { defaultStatDisplayConfigs } from "../stats"
@@ -198,6 +199,24 @@ const App = memo(() => {
       setConfigLoaded(true)
     })
 
+    // 平坦'options'キーの変更を購読する。マウント時の一括get()は一度きりのため、
+    // その後に発生する書き込み — background起動時のマージ書き戻し（新統計の追加、
+    // #100/#109）やPopupでの保存（#111で書き込み元はPopupに一本化）— を反映するには
+    // この購読が必要。これが無いと、拡張更新時に既に開いていたゲームタブのHUDには
+    // 新しい統計列が表示されないままになる（マウント時get()との起動レースも
+    // 同様に救済される）。
+    const handleOptionsStorageChange = (
+      changes: { [key: string]: chrome.storage.StorageChange },
+      areaName: string
+    ) => {
+      if (areaName !== 'sync') return
+      const nextOptions = changes['options']?.newValue as Options | undefined
+      if (nextOptions?.filterOptions?.statDisplayConfigs) {
+        setStatDisplayConfigs(nextOptions.filterOptions.statDisplayConfigs)
+      }
+    }
+    chrome.storage.onChanged?.addListener(handleOptionsStorageChange)
+
     // ポップアップからの設定更新をリッスン
     window.addEventListener(
       "updateHandLogConfig",
@@ -208,6 +227,7 @@ const App = memo(() => {
       handleUIConfigUpdate as EventListener
     )
     return () => {
+      chrome.storage.onChanged?.removeListener(handleOptionsStorageChange)
       window.removeEventListener(
         "updateHandLogConfig",
         handleConfigUpdate as EventListener


### PR DESCRIPTION
## 背景(codex レビュー指摘 #109 の最終残件)

App.tsx はマウント時に一度だけ `chrome.storage.sync.get` を行うため、その後の書き込み — background 起動時の統計設定マージ書き戻し(#100/#109)、Popup での保存 — が**開きっぱなしのゲームタブの HUD に反映されません**でした(拡張更新直後、新統計列が出ないまま)。

## 修正

平坦 `options` キーの `chrome.storage.onChanged` 購読を追加(sync 領域のみ、アンマウントで解除)。#111 で書き込み経路が平坦キーに一本化されたため、この1つの購読で**全ての書き手に追随**でき、マウント時 get() との起動レースも解消されます。

## テスト

Hud モックの描画(`Stats: <列数>`)を使い、**onChanged 発火 → HUD 表示への反映**まで検証(0列 → 1列)。対象外の領域/キーの無視、同一関数でのリスナー解除も確認。

- `npm run typecheck` ✅ / `npm run test` — **458/458(52 suites)** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)