### PR TITLE
docs: document STL/FTS definitions incl. standard-conformant heads-up inclusion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -461,6 +461,8 @@ These definitions were validated by hand-tracing 22 hands from the integration t
 - **WWSF**: Flops seen → won. Preflop ALL_IN excluded.
 - **AF**: `(BET+RAISE) / CALL` — CHECK and FOLD excluded from both numerator and denominator.
 - **AFq**: `(BET+RAISE) / (BET+RAISE+CALL+FOLD)` — CHECK excluded from denominator.
+- **Steal (STL)**: First-in raise from CO/BTN/SB when folded to (mechanical PT4/HM3 definition). **Heads-up hands are INCLUDED**: the HU button posts the SB and is labeled `SB` by `getPositionMap` (a steal position), so HU button opens count as steal attempts — this matches PT4/HM3/Poker Copilot, none of which carve out heads-up. Measured on real data: HU contributes 6.9% of all steal chances (~98% of HU hands generate one, since the SB first-in is always unopened). Do not "fix" this by excluding HU; it is the industry-standard behavior.
+- **FoldToSteal (FTS)**: Blind (SB/BB) folds when facing an identified steal raise (`phasePrevBetCount=2`). Heads-up BB defenses are likewise INCLUDED (5.1% of all FTS chances), per the same standard.
 
 See `docs/hand-analysis.md` for the full 22-hand audit trail.
 


### PR DESCRIPTION
## 背景

「HU の button open が STL に混入している」件について、主要トラッカーの標準を調査した結果:

- **PokerTracker 4**: ATS = 「CO/BTN/SB からの first-in raise」。スタッフ回答も「これらのポジションでのオープンレイズは全て」の機械的定義で、**HU の除外規定なし**(HU 分析には Position フィルタを使う運用)
- **Hold'em Manager 3**: 同一の機械的定義、HU 除外なし
- **Poker Copilot**: 「BTN または SB からの unopened raise」、HU 除外なし

つまり**業界標準は HU 込みの機械的定義**であり、本 HUD の現行実装(HU の button = SB ラベル → steal position)は既に標準準拠。**コード変更は不要**と結論。

## 変更(ドキュメントのみ)

CLAUDE.md の Confirmed Statistical Definitions に、#86 以来未記載だった **STL / FTS の定義項を追加**。HU 算入が標準であること・実測寄与(STL 機会の 6.9% / FTS 機会の 5.1%)・「HU を除外する『修正』を行わない」根拠を明文化し、将来の善意の改変を防ぐ。

Sources: [PT4 ATS 定義(フォーラム/公式)](https://www.pokertracker.com/forums/viewtopic.php&p=228930)、[Poker Copilot: Blind Stealing](https://pokercopilot.com/poker-statistics/blind-stealing)、[HM3 Steal%](https://forums.holdemmanager.com/hud-general/135211-steal.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)