### PR TITLE
fix(export): サイドポットのcollected行を入れ子資格ベースで正しい勝者に帰属

### DIFF
--- a/docs/pokerstars-export.md
+++ b/docs/pokerstars-export.md
@@ -139,6 +139,27 @@ PlayerA collected 450 from side pot-1
 PlayerA collected 200 from main pot
 ```
 
+### ポットごとの勝者の割り当て（分配ロジック）
+
+`EVT_HAND_RESULTS` はポット単位の内訳（どのポットを誰が獲得したか）を直接は提供しない
+（`Pot` / `SidePot[]` の金額列と、プレイヤーごとの `HandRanking` / `RewardChip` 合計のみ）。
+collected 行の帰属は以下の前提から復元する:
+
+- **参加資格は入れ子構造**: メインポット ⊇ side pot-1 ⊇ side pot-2 …（早くオールインした
+  プレイヤーほど浅いポットまでしか資格がない）
+- したがって各勝者が獲得するのは**メイン側から連続する区間**であり、最強ハンドが資格の
+  ある全ポットを総取りし、その資格が尽きた次のポットからはより弱い勝者に移る
+- 「potIdx+1 == HandRanking」のような 1:1 対応は**成立しない**（例: HandRanking=1 が
+  メイン+side1 を獲得し、side2 は HandRanking=2 が獲得するケース。実データ
+  Hand #296039758 で確認済み）
+
+実装（`buildCollectedEntries`）: 勝者（`RewardChip > 0`、NO_CALL 勝者は先頭扱い）を
+`HandRanking` 昇順に並べ、メインポットから順に、残 `RewardChip` を持つ最強グループへ
+ポットを割り当てて残額を消費していく貪欲法。同点スプリット時の端数（オッドチップ）は
+残額が最小のメンバーに寄せることで、後続ポットの資格判定（残額 > 0）が壊れないように
+している。検算の不変条件は `Pot + sum(SidePot) == sum(RewardChip)`（実データで 100% 成立、
+docs/api-events.md 参照）。
+
 ### Summary 行
 
 ```

--- a/src/utils/hand-log-processor.test.ts
+++ b/src/utils/hand-log-processor.test.ts
@@ -794,6 +794,91 @@ describe('複数サイドポット (2つ)', () => {
 })
 
 // ============================================================
+// Test 9.5: サイドポット帰属 (regression) — Hand #296039758
+// HandRanking=1 がメインポット+side pot-1 を総取りし、
+// HandRanking=2 が side pot-2 のみ獲得する実データハンド。
+// 旧実装は「potIdx+1 == HandRanking」で対応付けていたため、
+// side pot-1 を HandRanking=2 に誤帰属していた。
+// ============================================================
+describe('サイドポット帰属: HandRanking=1がメイン+side1を総取り (Hand #296039758)', () => {
+  const players = [
+    { userId: 1001, name: 'PlayerA' },
+    { userId: 1002, name: 'PlayerB' },
+    { userId: 1003, name: 'PlayerC' },
+    { userId: 561384657, name: 'sola' },
+    { userId: 1004, name: 'PlayerD' },
+  ]
+
+  // Hero (SB) はアンテオールイン (Chip=0, BetChip=0)、BB (PlayerD) は 560359 で
+  // オールイン、BTN (PlayerC) が 1000000 をコール。
+  // RewardChip: PlayerD = 1875830 = main 620448 + side1 1255382 (HandRanking=1),
+  //             PlayerC = 439641 = side2 のみ (HandRanking=2)。
+  const events: ApiEvent[] = [
+    {
+      ApiTypeId: ApiType.EVT_DEAL, timestamp: 1735318901395,
+      SeatUserIds: [1001, 1002, 1003, -1, 561384657, 1004],
+      Game: { CurrentBlindLv: 16, NextBlindUnixSeconds: -1, Ante: 200000, SmallBlind: 500000, BigBlind: 1000000, ButtonSeat: 2, SmallBlindSeat: 4, BigBlindSeat: 5 },
+      Player: { SeatIndex: 4, BetStatus: 3, Chip: 0, BetChip: 0, HoleCards: [24, 2] },
+      OtherPlayers: [
+        { SeatIndex: 0, Status: 0, BetStatus: 1, Chip: 516390, BetChip: 0 },
+        { SeatIndex: 1, Status: 0, BetStatus: 0, Chip: 972708, BetChip: 0 },
+        { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 2262310, BetChip: 0 },
+        { SeatIndex: 5, Status: 0, BetStatus: 3, Chip: 0, BetChip: 560359 },
+      ],
+      Progress: { Phase: 0, NextActionSeat: 0, NextActionTypes: [2, 5], NextExtraLimitSeconds: 1, MinRaise: 0, Pot: 620448, SidePot: [695023] }
+    } as unknown as ApiEvent,
+    { ApiTypeId: ApiType.EVT_ACTION, timestamp: 1735318912801, SeatIndex: 0, ActionType: 2, BetChip: 0, Chip: 516390, Progress: { Phase: 0, NextActionSeat: 2, NextActionTypes: [2, 3], NextExtraLimitSeconds: 6, MinRaise: 0, Pot: 620448, SidePot: [695023] } } as unknown as ApiEvent,
+    { ApiTypeId: ApiType.EVT_ACTION, timestamp: 1735318915388, SeatIndex: 2, ActionType: 3, BetChip: 1000000, Chip: 1262310, Progress: { Phase: 3, NextActionSeat: -2, NextActionTypes: [], NextExtraLimitSeconds: 0, MinRaise: 0, Pot: 620448, SidePot: [1255382, 439641] } } as unknown as ApiEvent,
+    {
+      ApiTypeId: ApiType.EVT_HAND_RESULTS, timestamp: 1735318916405, HandId: 296039758,
+      CommunityCards: [21, 51, 29, 7, 23], Pot: 620448, SidePot: [1255382, 439641],
+      ResultType: 0, DefeatStatus: 1, HandLog: '',
+      Results: [
+        { UserId: 1004, HoleCards: [28, 40], RankType: 7, Hands: [29, 28, 23, 21, 51], HandRanking: 1, Ranking: -2, RewardChip: 1875830 },
+        { UserId: 1003, HoleCards: [45, 43], RankType: 8, Hands: [23, 21, 51, 45, 43], HandRanking: 2, Ranking: -2, RewardChip: 439641 },
+        { UserId: 561384657, HoleCards: [24, 2], RankType: 8, Hands: [23, 21, 51, 29, 24], HandRanking: -1, Ranking: 10, RewardChip: 0 },
+      ],
+      Player: { SeatIndex: 4, BetStatus: -1, Chip: 0, BetChip: 0 },
+      OtherPlayers: [
+        { SeatIndex: 0, Status: 0, BetStatus: -1, Chip: 516390, BetChip: 0 },
+        { SeatIndex: 1, Status: 0, BetStatus: -1, Chip: 972708, BetChip: 0 },
+        { SeatIndex: 2, Status: 0, BetStatus: -1, Chip: 1701951, BetChip: 0 },
+        { SeatIndex: 5, Status: 0, BetStatus: -1, Chip: 1875830, BetChip: 0 },
+      ]
+    } as unknown as ApiEvent,
+  ]
+
+  test('ポット整合: Pot + sum(SidePot) == sum(RewardChip)', () => {
+    const resultEvent = events.find(e => (e as any).ApiTypeId === ApiType.EVT_HAND_RESULTS) as any
+    const totalPot = resultEvent.Pot + resultEvent.SidePot.reduce((s: number, p: number) => s + p, 0)
+    const totalReward = resultEvent.Results.reduce((s: number, r: any) => s + r.RewardChip, 0)
+    expect(totalPot).toBe(totalReward)
+  })
+
+  test('HandRanking=1がmain+side1、HandRanking=2がside2のみ獲得', () => {
+    const session = createSession(players, { battleType: BattleType.SIT_AND_GO })
+    const processor = new HandLogProcessor(createContext(session))
+    const lines = getLines(processor, events)
+
+    const collectedLines = lines.filter(l => l.includes('collected'))
+    expect(collectedLines).toEqual([
+      'PlayerC collected 439641 from side pot-2',
+      'PlayerD collected 1255382 from side pot-1',
+      'PlayerD collected 620448 from main pot',
+    ])
+  })
+
+  test('Summary行のポット内訳が正しい', () => {
+    const session = createSession(players, { battleType: BattleType.SIT_AND_GO })
+    const processor = new HandLogProcessor(createContext(session))
+    const lines = getLines(processor, events)
+
+    const totalPotLine = lines.find(l => l.includes('Total pot'))
+    expect(totalPotLine).toBe('Total pot 2315471 Main pot 620448. Side pot-1 1255382. Side pot-2 439641. | Rake 0')
+  })
+})
+
+// ============================================================
 // Test 10: サイドポットなし (regression)
 // ============================================================
 describe('サイドポットなし (regression)', () => {

--- a/src/utils/hand-log-processor.ts
+++ b/src/utils/hand-log-processor.ts
@@ -560,56 +560,51 @@ export class HandLogProcessor {
     }
 
     // RewardChipベースのポット割当アルゴリズム:
-    // HandRankingだけでは不十分（メインポット勝者がサイドポット対象外の場合がある）
-    // 各プレイヤーの残RewardChipを追跡し、ポットごとに正しい勝者を判定
-    const remainingReward = new Map<number, number>()
-    for (const r of event.Results) {
-      if (r.RewardChip > 0) {
-        remainingReward.set(r.UserId, (remainingReward.get(r.UserId) || 0) + r.RewardChip)
-      }
-    }
+    // ポットの参加資格は入れ子構造（メイン ⊇ side1 ⊇ side2 …）なので、
+    // 最強ハンドは資格のある全ポット（メインから連続する区間）を総取りし、
+    // 以降のポットはより弱い勝者へ順に移る。「potIdx+1 == HandRanking」の
+    // 対応付けは成立しない（例: HandRanking=1がメイン+side1を獲得し、
+    // HandRanking=2がside2のみ獲得するケース）。
+    // HandRanking順に勝者を並べ、メインポットから順に残RewardChipを
+    // 消費しながら割り当てることでこの構造を復元する。
+    const winners = event.Results
+      .filter(r => r.RewardChip > 0)
+      .map(r => ({
+        userId: r.UserId,
+        // NO_CALL勝者（HandRanking=-1）は単独勝者: 先頭に来るよう0扱い
+        handRanking: r.HandRanking > 0 ? r.HandRanking : 0,
+        remaining: r.RewardChip
+      }))
+      .sort((a, b) => a.handRanking - b.handRanking)
 
     const potWinners: Map<number, { userIds: number[], amount: number }> = new Map()
-    
+
     for (let potIdx = 0; potIdx < potAmounts.length; potIdx++) {
       const potAmount = potAmounts[potIdx]!
       if (potAmount <= 0) continue
 
-      const targetRanking = potIdx + 1
-      const rankWinners = event.Results.filter(r => r.HandRanking === targetRanking)
-      
-      let winnerIds: number[]
-      
-      if (rankWinners.length > 0) {
-        // HandRankingが一致するプレイヤーがいる場合
-        winnerIds = rankWinners.map(w => w.UserId)
-      } else {
-        // HandRankingが一致しない場合: 残RewardChipが最も大きいプレイヤーが勝者
-        // （メインポット勝者がサイドポット対象外のケースに対応）
-        let maxRemaining = 0
-        let maxUserIds: number[] = []
-        for (const [userId, rem] of remainingReward) {
-          if (rem > maxRemaining) {
-            maxRemaining = rem
-            maxUserIds = [userId]
-          } else if (rem === maxRemaining && rem > 0) {
-            maxUserIds.push(userId)
-          }
-        }
-        winnerIds = maxUserIds
-      }
-      
-      if (winnerIds.length > 0) {
-        const perPlayer = Math.floor(potAmount / winnerIds.length)
-        potWinners.set(potIdx, {
-          userIds: winnerIds,
-          amount: potAmount
-        })
-        // 割当済み分をremainingRewardから差し引き
-        for (const uid of winnerIds) {
-          const current = remainingReward.get(uid) || 0
-          remainingReward.set(uid, current - perPlayer)
-        }
+      // 残RewardChipを持つ最強HandRankingグループが現在のポットの勝者（同点はスプリット）
+      const active = winners.filter(w => w.remaining > 0)
+      if (active.length === 0) break
+      const bestRanking = active[0]!.handRanking
+      const group = active.filter(w => w.handRanking === bestRanking)
+
+      potWinners.set(potIdx, {
+        userIds: group.map(w => w.userId),
+        amount: potAmount
+      })
+
+      // 割当分を残RewardChipから消費。端数（オッドチップ）は残額が最小の
+      // メンバーに寄せる: オッドチップを受け取って退場するメンバーを
+      // ちょうど0にし、後続ポットの勝者判定を狂わせないため
+      const perPlayer = Math.floor(potAmount / group.length)
+      for (const w of group) w.remaining -= perPlayer
+      let leftover = potAmount - perPlayer * group.length
+      while (leftover > 0) {
+        const candidates = group.filter(w => w.remaining > 0)
+        if (candidates.length === 0) break
+        candidates.reduce((min, w) => w.remaining < min.remaining ? w : min).remaining -= 1
+        leftover -= 1
       }
     }
 


### PR DESCRIPTION
## 概要

PokerStars形式ハンドログの `collected ... from side pot` 行が、複数ポットハンドで誤った勝者に帰属されていた問題を修正します。

## 問題

`buildCollectedEntries` は「potIdx+1 == HandRanking」(メインポット→HandRanking=1、side pot-1→HandRanking=2 …)という対応付けでポット勝者を決めていました。実際にはポット参加資格は入れ子構造(メイン ⊇ side1 ⊇ side2)であり、最強ハンドは資格のある全ポットをメインから連続区間で総取りし、以降のポットはより弱い勝者に移ります。

実データのハンド #296039758 (`pokerchase_raw_data_2026-07-04T18-31-12-252Z.ndjson`) では:

| ポット | 額 | 実際の勝者 (RewardChip) | 旧実装の出力 |
|---|---|---|---|
| main | 620,448 | HandRanking=1 | HandRanking=1 ✅ |
| side pot-1 | 1,255,382 | HandRanking=1 (計 1,875,830) | **HandRanking=2 ❌** |
| side pot-2 | 439,641 | HandRanking=2 | **HandRanking=1 ❌** |

## 修正内容

- 勝者 (RewardChip>0) を HandRanking 順に並べ、メインポットから順に各勝者の残 RewardChip を消費しながら割り当てる貪欲法に置き換え。入れ子資格構造では後のポットほど弱い勝者に移るため、この走査で正しい帰属が復元されます。
- スプリット時の端数(オッドチップ)は残額が最小の正のメンバーに寄せ、そのポットで退場するメンバーをちょうど 0 にして後続ポットの勝者判定を狂わせないようにしています。
- uncalled bet 控除、表示順(side pot → main pot)、スプリット表示は従来どおり。

## 回帰テスト

ハンド #296039758 の実イベント列(UserId のみ匿名化、チップ額・ポット額は実値)で `describe('サイドポット帰属: HandRanking=1がメイン+side1を総取り (Hand #296039758)')` を追加。修正前コードでは報告どおりの誤帰属で失敗することを確認済みです。

## 検証

- `npm run test`: 486/486 通過(新規 3 テスト含む)
- `npm run typecheck`: クリーン
- `npm run verify-stats`(393,830イベント実データ): 全 16 統計 623/623 プレイヤー 100% 一致 — 統計パイプラインは無影響(ハンドログ文言のみの変更)
- 実データ全数スイープ(サイドポット付き 2,568 ハンド): 「プレイヤー毎 collected 合計 + uncalled 返却 == RewardChip」の不一致が 50 → 3 に減少、新規不一致(回帰)ゼロ

## レビュー時の注意

残る 3 ハンド(#300994365 / #420026617 / #517982965)の不一致は修正前から存在する別問題で、ショウダウン経路の uncalled bet 検出ヒューリスティックが複数レベルのオールインに直面したレイズで uncalled 額を過大算出するものです(別タスクとして追跡中)。本PRのスコープ外です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)