### PR TITLE
chore: ignore jest coverage output, drop stale Prerequisites section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+coverage/
 *.log
 *.zip
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@ This is an **unofficial** Chrome extension not affiliated with PokerChase. Use a
 
 ## Quick Start
 
-### Prerequisites
-
-- Node.js 16+
-- Google Chrome
-
 ### Installation
 
 #### Option 1: From Release (Recommended)


### PR DESCRIPTION
## 概要

ワークツリー整理で見つかった小掃除 2 点。

- **`.gitignore` に `coverage/` を追加**: Jest のカバレッジ出力（`npm test -- --coverage` の生成物）が untracked として git status に出続けていたため
- **README の Prerequisites 節を削除**: 「Node.js 16+」は jest@30（Node 18.14+ 要求）の時点で不正確（#121 レビューでも指摘）。Node が必要なのは From Source ビルド時のみで、Chrome 拡張に Chrome が必要なのは自明なため、下限バージョンを追いかけるのではなく節ごと削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)