### PR TITLE
feat(ui): add local HUD visual mockup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules/
 dist/
+mockup-dist/
+output/playwright/
+.playwright-cli/
 coverage/
 *.log
 *.zip

--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ npm run build
 3. Enable "Developer mode"
 4. Click "Load unpacked" and select the project folder
 
+### UI visual mockup
+
+Run the HUD against deterministic mock data without loading the extension or
+opening PokerChase:
+
+```sh
+npm run mockup
+```
+
+Open `http://127.0.0.1:4173`. The control panel switches between representative
+table states, changes the HUD scale, toggles the hand log, and resets dragged
+HUD positions. The mockup renders the production `Hud` and `HandLog` components,
+so visual changes are shared with the extension rather than duplicated.
+
 ## Architecture
 
 ![Architecture Diagram](README.drawio.png)

--- a/mockup.config.ts
+++ b/mockup.config.ts
@@ -1,0 +1,43 @@
+import { build, context, type BuildOptions } from 'esbuild'
+import { copyFileSync, mkdirSync, rmSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const outputDirectory = resolve('mockup-dist')
+const shouldServe = process.argv.includes('--serve')
+
+rmSync(outputDirectory, { force: true, recursive: true })
+mkdirSync(outputDirectory, { recursive: true })
+copyFileSync('mockup/index.html', resolve(outputDirectory, 'index.html'))
+
+const options: BuildOptions = {
+  bundle: true,
+  define: {
+    'process.env.NODE_ENV': '"development"',
+  },
+  entryNames: '[name]',
+  entryPoints: {
+    mockup: 'src/mockup/index.tsx',
+    styles: 'src/mockup/styles.css',
+  },
+  format: 'iife',
+  legalComments: 'none',
+  logLevel: 'info',
+  outdir: outputDirectory,
+  platform: 'browser',
+  sourcemap: true,
+  target: ['chrome123'],
+}
+
+if (shouldServe) {
+  const buildContext = await context(options)
+  await buildContext.watch()
+  const server = await buildContext.serve({
+    host: '127.0.0.1',
+    port: 4173,
+    servedir: outputDirectory,
+  })
+  console.log(`HUD visual mockup: http://127.0.0.1:${server.port}`)
+} else {
+  await build(options)
+  console.log(`HUD visual mockup built in ${outputDirectory}`)
+}

--- a/mockup/index.html
+++ b/mockup/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#080b14" />
+    <title>PokerChase HUD - Visual Mockup</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div id="mockup-root"></div>
+    <script src="./mockup.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "5.0.0",
   "scripts": {
     "build": "tsx esbuild.config.ts",
+    "mockup": "tsx mockup.config.ts --serve",
+    "mockup:build": "tsx mockup.config.ts",
     "postbuild": "zip -r extension.zip dist/ icons/ manifest.json",
     "test": "jest",
     "typecheck": "tsc --noEmit",

--- a/src/mockup/index.tsx
+++ b/src/mockup/index.tsx
@@ -1,0 +1,216 @@
+import { useState } from 'react'
+import { createRoot } from 'react-dom/client'
+import HandLog from '../components/HandLog'
+import Hud from '../components/Hud'
+import type { StatDisplayConfig } from '../types'
+import { installChromeMock } from './mock-chrome'
+import {
+  MOCK_SCENARIOS,
+  type MockScenarioId,
+  type TableSeat,
+} from './mock-data'
+
+const chromeMock = installChromeMock()
+const STAT_DISPLAY_CONFIGS: StatDisplayConfig[] = []
+
+const CARD_COLORS: Record<string, string> = {
+  '♣': 'card--black',
+  '♦': 'card--red',
+  '♥': 'card--red',
+  '♠': 'card--black',
+}
+
+const cardClassName = (card: string): string => {
+  const suit = card.slice(-1)
+  return `playing-card ${CARD_COLORS[suit] ?? 'card--black'}`
+}
+
+const Seat = ({ index, seat }: { index: number; seat: TableSeat }) => (
+  <div className={`table-seat table-seat--${index}${seat.isHero ? ' table-seat--hero' : ''}`}>
+    <div className="seat-avatar" aria-hidden="true">
+      {seat.name === 'empty' ? '+' : seat.name.slice(0, 1).toUpperCase()}
+    </div>
+    <div className="seat-copy">
+      <span className="seat-name">{seat.name}</span>
+      <span className="seat-stack">{seat.stack}</span>
+    </div>
+    {seat.action && <span className="seat-action">{seat.action}</span>}
+  </div>
+)
+
+const Mockup = () => {
+  const [scenarioId, setScenarioId] = useState<MockScenarioId>('turn-decision')
+  const [scale, setScale] = useState(1)
+  const [showHandLog, setShowHandLog] = useState(true)
+  const [dimTable, setDimTable] = useState(false)
+  const [panelOpen, setPanelOpen] = useState(false)
+  const [hudRevision, setHudRevision] = useState(0)
+  const scenario = MOCK_SCENARIOS[scenarioId]
+
+  const resetHudPositions = () => {
+    chromeMock.clearHudPositions()
+    setHudRevision((revision) => revision + 1)
+  }
+
+  return (
+    <main className={`mockup${dimTable ? ' mockup--dimmed' : ''}`}>
+      <div className="ambient ambient--one" />
+      <div className="ambient ambient--two" />
+
+      <header className="game-bar">
+        <div>
+          <span className="game-bar__caption">VISUAL LAB</span>
+          <strong>{scenario.stakes}</strong>
+        </div>
+        <div className="game-bar__phase">
+          <span>{scenario.eyebrow}</span>
+          <strong>{scenario.phase}</strong>
+        </div>
+        <div className="game-bar__timer" aria-label="decision timer">
+          <span />
+          <span />
+          <span />
+          <span />
+          <span />
+          <span className="is-muted" />
+          <span className="is-muted" />
+          <span className="is-muted" />
+        </div>
+      </header>
+
+      <section className="table-stage" aria-label="Synthetic six-max poker table">
+        <div className="table-rail">
+          <div className="table-felt">
+            <div className="felt-mark">
+              <span>PC</span>
+              <small>HUD LAB</small>
+            </div>
+            <div className="board" aria-label={`Board: ${scenario.board.join(' ') || 'none'}`}>
+              {scenario.board.map((card) => (
+                <span className={cardClassName(card)} key={card}>{card}</span>
+              ))}
+              {scenario.board.length === 0 && <span className="board-empty">WAITING FOR HAND</span>}
+            </div>
+            <div className="pot-display">
+              <span>POT</span>
+              <strong>{scenario.pot}</strong>
+            </div>
+            {scenario.heroCards.length > 0 && (
+              <div className="hero-cards" aria-label={`Hero cards: ${scenario.heroCards.join(' ')}`}>
+                {scenario.heroCards.map((card) => (
+                  <span className={cardClassName(card)} key={card}>{card}</span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {scenario.seats.map((seat, index) => (
+          <Seat index={index} key={`${scenario.id}-${index}`} seat={seat} />
+        ))}
+      </section>
+
+      <button
+        aria-expanded={panelOpen}
+        className="control-trigger"
+        onClick={() => setPanelOpen((isOpen) => !isOpen)}
+        type="button"
+      >
+        <span aria-hidden="true">◎</span>
+        モック操作
+      </button>
+
+      {panelOpen && (
+        <aside className="control-panel" aria-label="Mockup controls">
+          <div className="control-panel__header">
+            <div>
+              <span>POKERCHASE HUD</span>
+              <h1>Visual mockup</h1>
+            </div>
+            <button aria-label="操作パネルを閉じる" onClick={() => setPanelOpen(false)} type="button">×</button>
+          </div>
+          <p>本番 HUD コンポーネントを固定データ上で確認します。</p>
+
+          <label className="control-field">
+            <span>表示状態</span>
+            <select
+              onChange={(event) => setScenarioId(event.target.value as MockScenarioId)}
+              value={scenarioId}
+            >
+              {Object.values(MOCK_SCENARIOS).map((option) => (
+                <option key={option.id} value={option.id}>{option.label}</option>
+              ))}
+            </select>
+          </label>
+
+          <label className="control-field">
+            <span>HUD 倍率 <output>{scale.toFixed(1)}×</output></span>
+            <input
+              max="1.4"
+              min="0.7"
+              onChange={(event) => setScale(Number(event.target.value))}
+              step="0.1"
+              type="range"
+              value={scale}
+            />
+          </label>
+
+          <label className="control-toggle">
+            <input
+              checked={showHandLog}
+              onChange={(event) => setShowHandLog(event.target.checked)}
+              type="checkbox"
+            />
+            <span>ハンドログを表示</span>
+          </label>
+
+          <label className="control-toggle">
+            <input
+              checked={dimTable}
+              onChange={(event) => setDimTable(event.target.checked)}
+              type="checkbox"
+            />
+            <span>背景を暗くして可読性を確認</span>
+          </label>
+
+          <button className="reset-button" onClick={resetHudPositions} type="button">
+            HUD のドラッグ位置をリセット
+          </button>
+          <small>HUD 上端のハンドルをドラッグできます。統計パネルはクリックでコピーします。</small>
+        </aside>
+      )}
+
+      <div className="mock-badge">
+        <span />
+        MOCK DATA · {scenario.label}
+      </div>
+
+      {scenario.stats.map((stat, index) => (
+        <Hud
+          actualSeatIndex={index}
+          key={`${scenario.id}-${hudRevision}-${index}`}
+          playerPotOdds={scenario.playerPotOdds[index]}
+          realTimeStats={index === 0 ? scenario.realTimeStats : undefined}
+          scale={scale}
+          stat={stat}
+          statDisplayConfigs={STAT_DISPLAY_CONFIGS}
+        />
+      ))}
+
+      {showHandLog && (
+        <HandLog
+          config={{ enabled: true, opacity: 0.76, position: 'bottom-right' }}
+          entries={scenario.handLogEntries}
+          key={`${scenario.id}-${hudRevision}-log`}
+          scale={scale}
+        />
+      )}
+    </main>
+  )
+}
+
+const root = document.getElementById('mockup-root')
+
+if (!root) throw new Error('Missing #mockup-root')
+
+createRoot(root).render(<Mockup />)

--- a/src/mockup/mock-chrome.ts
+++ b/src/mockup/mock-chrome.ts
@@ -1,0 +1,96 @@
+type StorageChangeListener = (
+  changes: Record<string, chrome.storage.StorageChange>,
+  areaName: string,
+) => void
+
+export interface MockChromeController {
+  clearHudPositions: () => void
+}
+
+const selectValues = (
+  values: Map<string, unknown>,
+  keys?: string | string[] | Record<string, unknown> | null,
+): Record<string, unknown> => {
+  if (keys == null) return Object.fromEntries(values)
+
+  if (typeof keys === 'string') {
+    return values.has(keys) ? { [keys]: values.get(keys) } : {}
+  }
+
+  if (Array.isArray(keys)) {
+    return Object.fromEntries(
+      keys.filter((key) => values.has(key)).map((key) => [key, values.get(key)]),
+    )
+  }
+
+  return Object.fromEntries(
+    Object.entries(keys).map(([key, fallback]) => [
+      key,
+      values.has(key) ? values.get(key) : fallback,
+    ]),
+  )
+}
+
+export const installChromeMock = (): MockChromeController => {
+  const values = new Map<string, unknown>()
+  const listeners = new Set<StorageChangeListener>()
+
+  const notify = (changes: Record<string, chrome.storage.StorageChange>) => {
+    listeners.forEach((listener) => listener(changes, 'sync'))
+  }
+
+  const syncStorage = {
+    get: (
+      keys: string | string[] | Record<string, unknown> | null,
+      callback: (items: Record<string, unknown>) => void,
+    ) => callback(selectValues(values, keys)),
+    set: (items: Record<string, unknown>, callback?: () => void) => {
+      const changes: Record<string, chrome.storage.StorageChange> = {}
+
+      Object.entries(items).forEach(([key, newValue]) => {
+        const oldValue = values.get(key)
+        values.set(key, newValue)
+        changes[key] = { oldValue, newValue }
+      })
+
+      notify(changes)
+      callback?.()
+    },
+  }
+
+  const existingChrome = typeof chrome === 'object' ? chrome : undefined
+  const chromeHost = existingChrome ?? {}
+
+  Object.defineProperty(chromeHost, 'storage', {
+    configurable: true,
+    value: {
+      onChanged: {
+        addListener: (listener: StorageChangeListener) => listeners.add(listener),
+        removeListener: (listener: StorageChangeListener) => listeners.delete(listener),
+      },
+      sync: syncStorage,
+    },
+  })
+
+  if (!existingChrome) {
+    Object.defineProperty(globalThis, 'chrome', {
+      configurable: true,
+      value: chromeHost,
+    })
+  }
+
+  return {
+    clearHudPositions: () => {
+      const changes: Record<string, chrome.storage.StorageChange> = {}
+
+      Array.from(values.keys())
+        .filter((key) => key.startsWith('hudPosition_'))
+        .forEach((key) => {
+          changes[key] = { oldValue: values.get(key), newValue: undefined }
+          values.delete(key)
+        })
+
+      notify(changes)
+    },
+  }
+}

--- a/src/mockup/mock-data.ts
+++ b/src/mockup/mock-data.ts
@@ -1,0 +1,270 @@
+import type { RealTimeStats } from '../realtime-stats/realtime-stats-service'
+import type { PlayerStats } from '../types'
+import { HandLogEntryType, type HandLogEntry } from '../types/hand-log'
+import type { StatResult } from '../types/stats'
+
+export type MockScenarioId = 'turn-decision' | 'new-table' | 'dense-history'
+
+interface PlayerPotOdds {
+  spr?: number
+  potOdds?: {
+    pot: number
+    call: number
+    percentage: number
+    ratio: string
+    isPlayerTurn: boolean
+  }
+}
+
+export interface TableSeat {
+  action?: string
+  isHero?: boolean
+  name: string
+  stack: string
+}
+
+export interface MockScenario {
+  board: string[]
+  eyebrow: string
+  handLogEntries: HandLogEntry[]
+  heroCards: string[]
+  id: MockScenarioId
+  label: string
+  phase: string
+  playerPotOdds: Array<PlayerPotOdds | undefined>
+  pot: string
+  realTimeStats?: RealTimeStats
+  seats: TableSeat[]
+  stakes: string
+  stats: PlayerStats[]
+}
+
+const result = (
+  id: string,
+  name: string,
+  value: StatResult['value'],
+  formatted?: string,
+): StatResult => ({ id, name, value, formatted })
+
+const player = (
+  playerId: number,
+  name: string,
+  hands: number,
+  values: Array<[string, string, number | [number, number], string?]>,
+): PlayerStats => ({
+  playerId,
+  statResults: [
+    result('playerName', 'Name', name),
+    result('hands', 'HAND', hands),
+    ...values.map(([id, label, value, formatted]) => result(id, label, value, formatted)),
+  ],
+})
+
+const standardStats = (
+  playerId: number,
+  name: string,
+  hands: number,
+  profile: 'balanced' | 'loose' | 'tight',
+): PlayerStats => {
+  const profiles: Record<
+    'balanced' | 'loose' | 'tight',
+    Array<[string, string, number | [number, number], string]>
+  > = {
+    balanced: [
+      ['vpip', 'VPIP', [52, 214], '24.3% (52/214)'],
+      ['pfr', 'PFR', [38, 214], '17.8% (38/214)'],
+      ['cbet', 'CB', [19, 31], '61.3% (19/31)'],
+      ['3bet', '3B', [11, 74], '14.9% (11/74)'],
+      ['af', 'AF', 2.4, '2.4'],
+      ['wtsd', 'WTSD', [17, 52], '32.7% (17/52)'],
+    ],
+    loose: [
+      ['vpip', 'VPIP', [88, 168], '52.4% (88/168)'],
+      ['pfr', 'PFR', [61, 168], '36.3% (61/168)'],
+      ['cbet', 'CB', [24, 30], '80.0% (24/30)'],
+      ['3bet', '3B', [17, 62], '27.4% (17/62)'],
+      ['af', 'AF', 4.8, '4.8'],
+      ['wtsd', 'WTSD', [31, 88], '35.2% (31/88)'],
+    ],
+    tight: [
+      ['vpip', 'VPIP', [24, 192], '12.5% (24/192)'],
+      ['pfr', 'PFR', [18, 192], '9.4% (18/192)'],
+      ['cbet', 'CB', [8, 17], '47.1% (8/17)'],
+      ['3bet', '3B', [4, 66], '6.1% (4/66)'],
+      ['af', 'AF', 1.3, '1.3'],
+      ['wtsd', 'WTSD', [5, 24], '20.8% (5/24)'],
+    ],
+  }
+
+  return player(playerId, name, hands, profiles[profile])
+}
+
+const logTimestamp = Date.UTC(2026, 6, 15, 11, 42, 0)
+
+const turnHandLogLines: Array<[string, string, HandLogEntryType]> = [
+  ['header', 'PokerChase Hand #840217 · Ring 25/50', HandLogEntryType.HEADER],
+  ['seat-1', 'Seat 1: sola (6,240 in chips)', HandLogEntryType.SEAT],
+  ['seat-2', 'Seat 2: river_rat (5,850 in chips)', HandLogEntryType.SEAT],
+  ['cards', 'Dealt to sola [A♠ J♠]', HandLogEntryType.CARDS],
+  ['preflop', 'sola: raises 100 to 150', HandLogEntryType.ACTION],
+  ['flop', '*** FLOP *** [J♦ 7♠ 2♣]', HandLogEntryType.STREET],
+  ['flop-action', 'river_rat: calls 220', HandLogEntryType.ACTION],
+  ['turn', '*** TURN *** [J♦ 7♠ 2♣] [9♠]', HandLogEntryType.STREET],
+  ['turn-action', 'river_rat: bets 640', HandLogEntryType.ACTION],
+]
+
+const turnHandLog: HandLogEntry[] = turnHandLogLines.map(([id, text, type], index) => ({
+  handId: 840217,
+  id,
+  text,
+  timestamp: logTimestamp + index * 9_000,
+  type,
+}))
+
+const realTimeStats: RealTimeStats = {
+  communityCards: [38, 20, 3, 28],
+  currentPhase: 'Turn',
+  handImprovement: result(
+    'handImprovement',
+    'Hand Improvement',
+    {
+      currentHand: { name: 'One Pair', rank: 2 },
+      improvements: [
+        { isComplete: false, isCurrent: false, name: 'Straight Flush', probability: 0, rank: 9 },
+        { isComplete: false, isCurrent: false, name: 'Four of a Kind', probability: 0, rank: 8 },
+        { isComplete: false, isCurrent: false, name: 'Full House', probability: 8.7, rank: 7 },
+        { isComplete: false, isCurrent: false, name: 'Flush', probability: 19.6, rank: 6 },
+        { isComplete: false, isCurrent: false, name: 'Straight', probability: 8.7, rank: 5 },
+        { isComplete: false, isCurrent: false, name: 'Three of a Kind', probability: 4.3, rank: 4 },
+        { isComplete: false, isCurrent: false, name: 'Two Pair', probability: 13.0, rank: 3 },
+        { isComplete: true, isCurrent: true, name: 'One Pair', probability: 100, rank: 2 },
+      ],
+    },
+    'Current: One Pair',
+  ),
+  holeCards: [48, 36],
+  potOdds: result(
+    'potOdds',
+    'Pot Odds',
+    { call: 640, isHeroTurn: true, percentage: 26.9, pot: 1740, ratio: '2.7:1' },
+    '26.9% (2.7:1)',
+  ),
+}
+
+const densePlayer = (
+  playerId: number,
+  name: string,
+  hands: number,
+): PlayerStats => player(playerId, name, hands, [
+  ['vpip', 'VPIP', [401, 987], '40.6% (401/987)'],
+  ['pfr', 'PFR', [298, 987], '30.2% (298/987)'],
+  ['cbet', 'CB', [126, 183], '68.9% (126/183)'],
+  ['cbetFold', 'CBF', [44, 112], '39.3% (44/112)'],
+  ['3bet', '3B', [73, 316], '23.1% (73/316)'],
+  ['3betfold', '3BF', [41, 86], '47.7% (41/86)'],
+  ['steal', 'STL', [96, 173], '55.5% (96/173)'],
+  ['foldToSteal', 'FTS', [51, 104], '49.0% (51/104)'],
+  ['af', 'AF', 3.7, '3.7'],
+  ['afq', 'AFq', [311, 684], '45.5% (311/684)'],
+  ['wtsd', 'WTSD', [98, 401], '24.4% (98/401)'],
+  ['wwsf', 'WWSF', [221, 401], '55.1% (221/401)'],
+  ['wsd', 'W$SD', [57, 98], '58.2% (57/98)'],
+  ['riverCallAccuracy', 'RCA', [19, 27], '70.4% (19/27)'],
+])
+
+export const MOCK_SCENARIOS: Record<MockScenarioId, MockScenario> = {
+  'turn-decision': {
+    board: ['J♦', '7♠', '2♣', '9♠'],
+    eyebrow: 'LIVE DECISION',
+    handLogEntries: turnHandLog,
+    heroCards: ['A♠', 'J♠'],
+    id: 'turn-decision',
+    label: 'ターンの判断',
+    phase: 'TURN',
+    playerPotOdds: [
+      { spr: 2.7, potOdds: { call: 640, isPlayerTurn: true, percentage: 26.9, pot: 1740, ratio: '2.7:1' } },
+      { spr: 3.1 },
+      { spr: 6.8 },
+      { spr: 4.4 },
+      { spr: 8.2 },
+      { spr: 5.9 },
+    ],
+    pot: '1,740',
+    realTimeStats,
+    seats: [
+      { action: 'TO CALL 640', isHero: true, name: 'sola', stack: '6,240' },
+      { action: 'FOLD', name: 'orbit_99', stack: '4,980' },
+      { name: 'north_star', stack: '9,410' },
+      { action: 'FOLD', name: 'kiwi_tea', stack: '5,220' },
+      { name: 'river_rat', stack: '5,850' },
+      { action: 'BET 640', name: 'maverick', stack: '7,190' },
+    ],
+    stakes: 'RING · 25 / 50',
+    stats: [
+      standardStats(1024, 'sola', 642, 'balanced'),
+      standardStats(2108, 'orbit_99', 214, 'tight'),
+      standardStats(3440, 'north_star', 168, 'loose'),
+      standardStats(4611, 'kiwi_tea', 192, 'tight'),
+      standardStats(5870, 'river_rat', 987, 'balanced'),
+      standardStats(6032, 'maverick', 301, 'loose'),
+    ],
+  },
+  'new-table': {
+    board: [],
+    eyebrow: 'EDGE STATES',
+    handLogEntries: [],
+    heroCards: [],
+    id: 'new-table',
+    label: '新しい卓・データなし',
+    phase: 'WAITING',
+    playerPotOdds: [],
+    pot: '—',
+    seats: [
+      { isHero: true, name: 'sola', stack: '5,000' },
+      { name: 'joining…', stack: '—' },
+      { name: 'empty', stack: '—' },
+      { name: 'new_player', stack: '5,000' },
+      { name: 'empty', stack: '—' },
+      { name: 'guest_802', stack: '5,000' },
+    ],
+    stakes: 'SIT & GO · 50 / 100',
+    stats: [
+      { playerId: 1024, statResults: [] },
+      { playerId: -1 },
+      { playerId: -1 },
+      { playerId: 8801, statResults: [] },
+      { playerId: -1 },
+      { playerId: 8802, statResults: [] },
+    ],
+  },
+  'dense-history': {
+    board: ['A♣', 'K♦', 'T♥', '4♣', '4♦'],
+    eyebrow: 'STRESS TEST',
+    handLogEntries: turnHandLog,
+    heroCards: ['Q♣', 'J♣'],
+    id: 'dense-history',
+    label: '長い名前・全統計',
+    phase: 'RIVER',
+    playerPotOdds: [
+      { spr: 0.4, potOdds: { call: 2380, isPlayerTurn: true, percentage: 38.5, pot: 3800, ratio: '1.6:1' } },
+    ],
+    pot: '3,800',
+    seats: [
+      { action: 'ALL-IN?', isHero: true, name: 'sola', stack: '2,380' },
+      { name: 'player_with_a_very_long_name', stack: '12,400' },
+      { name: 'three_bet_machine', stack: '8,775' },
+      { name: 'quiet-observer', stack: '1,020' },
+      { action: 'BET 2,380', name: 'river_pressure', stack: '14,950' },
+      { name: 'data_collector', stack: '6,660' },
+    ],
+    stakes: 'MTT · 200 / 400 / 50',
+    stats: [
+      densePlayer(1024, 'sola', 12_840),
+      densePlayer(7321, 'player_with_a_very_long_name', 987),
+      densePlayer(7322, 'three_bet_machine', 2_411),
+      densePlayer(7323, 'quiet-observer', 104),
+      densePlayer(7324, 'river_pressure', 8_320),
+      densePlayer(7325, 'data_collector', 43_208),
+    ],
+  },
+}

--- a/src/mockup/styles.css
+++ b/src/mockup/styles.css
@@ -1,0 +1,580 @@
+:root {
+  color: #f5f7ff;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#mockup-root {
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button,
+select,
+input[type="range"] {
+  cursor: pointer;
+}
+
+.mockup {
+  background:
+    radial-gradient(circle at 50% 48%, rgba(24, 55, 79, 0.58), transparent 36%),
+    linear-gradient(150deg, #090b16 0%, #11122a 46%, #090b18 100%);
+  height: 100%;
+  isolation: isolate;
+  overflow: hidden;
+  position: relative;
+  transition: filter 180ms ease;
+}
+
+.mockup::after {
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.018) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.018) 1px, transparent 1px);
+  background-size: 32px 32px;
+  content: "";
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+  z-index: 3;
+}
+
+.mockup--dimmed .table-stage,
+.mockup--dimmed .game-bar,
+.mockup--dimmed .ambient {
+  filter: brightness(0.48) saturate(0.7);
+}
+
+.ambient {
+  border-radius: 999px;
+  filter: blur(70px);
+  opacity: 0.34;
+  pointer-events: none;
+  position: absolute;
+  transition: filter 180ms ease;
+}
+
+.ambient--one {
+  background: #6c34d8;
+  height: 420px;
+  left: -130px;
+  top: 14%;
+  width: 420px;
+}
+
+.ambient--two {
+  background: #087f8c;
+  bottom: -160px;
+  height: 520px;
+  right: -80px;
+  width: 520px;
+}
+
+.game-bar {
+  align-items: center;
+  background: linear-gradient(90deg, rgba(10, 13, 28, 0.92), rgba(18, 23, 46, 0.74));
+  border-bottom: 1px solid rgba(179, 204, 255, 0.16);
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  height: 72px;
+  inset: 0 0 auto;
+  padding: 0 28px;
+  position: absolute;
+  transition: filter 180ms ease;
+  z-index: 5;
+}
+
+.game-bar > div:first-child {
+  display: grid;
+  gap: 3px;
+}
+
+.game-bar strong {
+  font-size: 15px;
+  letter-spacing: 0.08em;
+}
+
+.game-bar__caption,
+.game-bar__phase span {
+  color: #7f8aa8;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+}
+
+.game-bar__phase {
+  display: grid;
+  gap: 2px;
+  justify-items: center;
+}
+
+.game-bar__phase strong {
+  color: #75e5ff;
+  font-size: 21px;
+  letter-spacing: 0.14em;
+}
+
+.game-bar__timer {
+  display: flex;
+  gap: 5px;
+  justify-self: end;
+}
+
+.game-bar__timer span {
+  background: #55d7ad;
+  border-radius: 8px;
+  box-shadow: 0 0 12px rgba(85, 215, 173, 0.38);
+  height: 6px;
+  width: 22px;
+}
+
+.game-bar__timer .is-muted {
+  background: #33394f;
+  box-shadow: none;
+}
+
+.table-stage {
+  inset: 72px 0 0;
+  position: absolute;
+  transition: filter 180ms ease;
+  z-index: 2;
+}
+
+.table-rail {
+  background: linear-gradient(145deg, #262e4d, #090c1d 56%, #27324e);
+  border: 2px solid rgba(172, 197, 245, 0.2);
+  border-radius: 50%;
+  box-shadow:
+    0 34px 90px rgba(0, 0, 0, 0.64),
+    inset 0 0 0 14px rgba(6, 8, 18, 0.68),
+    inset 0 0 0 16px rgba(155, 192, 236, 0.12);
+  height: min(58vw, 590px);
+  left: 50%;
+  max-height: calc(100vh - 190px);
+  min-height: 390px;
+  position: absolute;
+  top: 49%;
+  transform: translate(-50%, -50%);
+  width: min(76vw, 1160px);
+}
+
+.table-felt {
+  background:
+    radial-gradient(circle at 50% 44%, rgba(46, 142, 133, 0.42), transparent 48%),
+    linear-gradient(155deg, #0d554f, #073d42 62%, #092b37);
+  border: 1px solid rgba(135, 241, 224, 0.2);
+  border-radius: 50%;
+  box-shadow: inset 0 0 75px rgba(0, 0, 0, 0.64);
+  inset: 22px;
+  overflow: hidden;
+  position: absolute;
+}
+
+.table-felt::after {
+  border: 1px solid rgba(148, 245, 229, 0.11);
+  border-radius: 50%;
+  content: "";
+  inset: 11%;
+  position: absolute;
+}
+
+.felt-mark {
+  align-items: center;
+  color: rgba(180, 255, 244, 0.14);
+  display: flex;
+  flex-direction: column;
+  left: 50%;
+  position: absolute;
+  top: 72%;
+  transform: translate(-50%, -50%);
+}
+
+.felt-mark span {
+  font-size: clamp(36px, 5vw, 76px);
+  font-weight: 900;
+  letter-spacing: -0.09em;
+  line-height: 0.8;
+}
+
+.felt-mark small {
+  font-size: 9px;
+  font-weight: 900;
+  letter-spacing: 0.34em;
+  margin-top: 12px;
+}
+
+.board {
+  display: flex;
+  gap: 8px;
+  left: 50%;
+  min-height: 74px;
+  position: absolute;
+  top: 40%;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+}
+
+.playing-card {
+  align-items: center;
+  background: linear-gradient(145deg, #fff, #dfe4ed);
+  border: 1px solid rgba(255, 255, 255, 0.8);
+  border-radius: 7px;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.32);
+  display: flex;
+  font-family: Georgia, serif;
+  font-size: 21px;
+  font-weight: 800;
+  height: 66px;
+  justify-content: center;
+  width: 47px;
+}
+
+.card--black {
+  color: #171b27;
+}
+
+.card--red {
+  color: #d4455c;
+}
+
+.board-empty {
+  align-self: center;
+  border: 1px solid rgba(178, 255, 243, 0.16);
+  border-radius: 999px;
+  color: rgba(194, 255, 246, 0.48);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  padding: 10px 18px;
+  white-space: nowrap;
+}
+
+.pot-display {
+  align-items: baseline;
+  background: rgba(2, 17, 23, 0.62);
+  border: 1px solid rgba(135, 241, 224, 0.18);
+  border-radius: 999px;
+  display: flex;
+  gap: 10px;
+  left: 50%;
+  padding: 6px 18px;
+  position: absolute;
+  top: 57%;
+  transform: translateX(-50%);
+}
+
+.pot-display span {
+  color: #72a9a2;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+}
+
+.pot-display strong {
+  color: #dcfff9;
+  font-size: 16px;
+  letter-spacing: 0.04em;
+}
+
+.hero-cards {
+  bottom: 5%;
+  display: flex;
+  gap: 5px;
+  left: 50%;
+  position: absolute;
+  transform: translateX(-50%);
+  z-index: 2;
+}
+
+.hero-cards .playing-card {
+  height: 72px;
+  transform: rotate(-3deg);
+  width: 50px;
+}
+
+.hero-cards .playing-card + .playing-card {
+  transform: rotate(3deg);
+}
+
+.table-seat {
+  align-items: center;
+  display: flex;
+  gap: 9px;
+  position: absolute;
+  transform: translate(-50%, -50%);
+  z-index: 4;
+}
+
+.table-seat--0 { left: 50%; top: 88%; }
+.table-seat--1 { left: 18%; top: 73%; }
+.table-seat--2 { left: 18%; top: 29%; }
+.table-seat--3 { left: 50%; top: 12%; }
+.table-seat--4 { left: 82%; top: 29%; }
+.table-seat--5 { left: 82%; top: 73%; }
+
+.seat-avatar {
+  align-items: center;
+  background: linear-gradient(145deg, #6f7797, #20263f);
+  border: 2px solid #8791b8;
+  border-radius: 50%;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.46);
+  color: #edf1ff;
+  display: flex;
+  font-size: 13px;
+  font-weight: 900;
+  height: 48px;
+  justify-content: center;
+  width: 48px;
+}
+
+.table-seat--hero .seat-avatar {
+  background: linear-gradient(145deg, #55d7ad, #14677b);
+  border-color: #b4fff1;
+  box-shadow: 0 0 24px rgba(85, 215, 173, 0.3);
+  color: #06181d;
+}
+
+.seat-copy {
+  background: linear-gradient(90deg, rgba(9, 12, 27, 0.94), rgba(20, 26, 51, 0.94));
+  border: 1px solid rgba(171, 190, 232, 0.24);
+  border-radius: 7px;
+  display: grid;
+  min-width: 128px;
+  padding: 6px 10px;
+}
+
+.seat-name {
+  color: #c5cbdf;
+  font-size: 10px;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.seat-stack {
+  color: #fff;
+  font-size: 15px;
+  font-weight: 800;
+}
+
+.seat-action {
+  background: #ece9ff;
+  border: 2px solid #8065dc;
+  border-radius: 5px;
+  color: #282044;
+  font-size: 9px;
+  font-weight: 900;
+  left: 54px;
+  letter-spacing: 0.05em;
+  padding: 3px 7px;
+  position: absolute;
+  top: -18px;
+  white-space: nowrap;
+}
+
+.control-trigger,
+.control-panel,
+.mock-badge {
+  position: fixed;
+  z-index: 11010;
+}
+
+.control-trigger {
+  align-items: center;
+  backdrop-filter: blur(16px);
+  background: rgba(12, 16, 33, 0.88);
+  border: 1px solid rgba(155, 181, 232, 0.3);
+  border-radius: 999px;
+  color: #eef2ff;
+  display: flex;
+  font-size: 11px;
+  font-weight: 700;
+  gap: 7px;
+  left: 16px;
+  padding: 8px 12px;
+  top: 88px;
+}
+
+.control-trigger span {
+  color: #64e7c1;
+  font-size: 16px;
+}
+
+.control-panel {
+  backdrop-filter: blur(24px);
+  background: rgba(9, 13, 28, 0.95);
+  border: 1px solid rgba(155, 181, 232, 0.24);
+  border-radius: 14px;
+  box-shadow: 0 22px 70px rgba(0, 0, 0, 0.5);
+  left: 16px;
+  padding: 18px;
+  top: 132px;
+  width: 300px;
+}
+
+.control-panel__header {
+  align-items: flex-start;
+  display: flex;
+  justify-content: space-between;
+}
+
+.control-panel__header span {
+  color: #68dcb9;
+  font-size: 8px;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+}
+
+.control-panel h1 {
+  font-size: 20px;
+  letter-spacing: -0.03em;
+  margin: 2px 0 0;
+}
+
+.control-panel__header button {
+  background: transparent;
+  border: 0;
+  color: #8991aa;
+  font-size: 22px;
+  line-height: 1;
+}
+
+.control-panel > p {
+  color: #8d95ac;
+  font-size: 11px;
+  line-height: 1.55;
+  margin: 13px 0 18px;
+}
+
+.control-field {
+  display: grid;
+  gap: 7px;
+  margin-top: 14px;
+}
+
+.control-field > span {
+  color: #c7cce0;
+  display: flex;
+  font-size: 10px;
+  font-weight: 700;
+  justify-content: space-between;
+}
+
+.control-field output {
+  color: #68dcb9;
+}
+
+.control-field select {
+  appearance: none;
+  background: #151b32;
+  border: 1px solid #303a5b;
+  border-radius: 8px;
+  color: #eef2ff;
+  font-size: 12px;
+  outline: none;
+  padding: 9px 10px;
+  width: 100%;
+}
+
+.control-field input[type="range"] {
+  accent-color: #5fdab6;
+  width: 100%;
+}
+
+.control-toggle {
+  align-items: center;
+  color: #bcc3d7;
+  display: flex;
+  font-size: 11px;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.control-toggle input {
+  accent-color: #5fdab6;
+}
+
+.reset-button {
+  background: linear-gradient(135deg, #2d3f63, #1d2947);
+  border: 1px solid #465b86;
+  border-radius: 8px;
+  color: #edf2ff;
+  font-size: 11px;
+  font-weight: 700;
+  margin-top: 18px;
+  padding: 10px 12px;
+  width: 100%;
+}
+
+.control-panel > small {
+  color: #69728d;
+  display: block;
+  font-size: 9px;
+  line-height: 1.5;
+  margin-top: 10px;
+}
+
+.mock-badge {
+  align-items: center;
+  backdrop-filter: blur(12px);
+  background: rgba(7, 10, 21, 0.76);
+  border: 1px solid rgba(142, 169, 216, 0.18);
+  border-radius: 999px;
+  bottom: 20px;
+  color: #77819e;
+  display: flex;
+  font-size: 8px;
+  font-weight: 900;
+  gap: 7px;
+  left: 50%;
+  letter-spacing: 0.13em;
+  padding: 7px 11px;
+  transform: translateX(-50%);
+}
+
+.mock-badge span {
+  background: #5edbb7;
+  border-radius: 50%;
+  box-shadow: 0 0 10px rgba(94, 219, 183, 0.74);
+  height: 5px;
+  width: 5px;
+}
+
+@media (max-width: 1050px), (max-height: 720px) {
+  .table-rail {
+    min-height: 330px;
+    width: 72vw;
+  }
+
+  .seat-avatar {
+    height: 38px;
+    width: 38px;
+  }
+
+  .seat-copy {
+    min-width: 104px;
+  }
+
+  .seat-name {
+    max-width: 110px;
+  }
+
+  .table-seat--1,
+  .table-seat--2 { left: 16%; }
+
+  .table-seat--4,
+  .table-seat--5 { left: 84%; }
+}


### PR DESCRIPTION
## Summary

- add a local esbuild-powered visual mockup for HUD development
- render the production `Hud` and `HandLog` components against deterministic synthetic table data
- provide turn-decision, empty-table, and dense-stat scenarios with controls for scale, hand-log visibility, background contrast, and dragged-position reset
- document the `npm run mockup` workflow

## Why

UI iteration currently requires loading the extension and opening a live PokerChase table. This mockup provides a repeatable browser surface for visual feedback while keeping the rendered HUD components identical to production.

## User impact

There is no runtime behavior change to the extension. Contributors can run `npm run mockup` and open `http://127.0.0.1:4173` to review UI changes locally.

## Validation

- `npm test -- --runInBand` — 55 suites, 500 tests passed
- `npm run typecheck`
- `npm run build`
- `npm run mockup:build`
- Playwright fresh-load visual check at 1440×900 — 0 console errors

## Head

`da2f8487a0173450ab535d547c00625a15bae5a3`