### PR TITLE
fix(sync): make Firestore cloud sync reliable

### DIFF
--- a/src/constants/database.ts
+++ b/src/constants/database.ts
@@ -18,6 +18,7 @@ export const DATABASE_CONSTANTS = {
   FIRESTORE_DELETE_BATCH: 500,   // Firestore delete batch size
   FIRESTORE_PARALLEL_BATCHES: 3, // Number of parallel Firestore batches
   FIRESTORE_BATCH_DELAY_MS: 500, // Delay between batch groups
+  FIRESTORE_DOWNLOAD_PAGE_SIZE: 1000, // Maximum documents per Firestore download response
   
   // Cache durations
   PLAYER_CACHE_DURATION_MS: 60000,     // 1 minute

--- a/src/entity-converter.test.ts
+++ b/src/entity-converter.test.ts
@@ -773,6 +773,33 @@ describe('EntityConverter', () => {
       expect(result.actions).toHaveLength(0)
     })
 
+    it('should preserve an unfinished hand across event chunks', () => {
+      const deal = createEvent(ApiType.EVT_DEAL, {
+        timestamp: 1000,
+        SeatUserIds: [100, 101],
+        Game: {
+          SmallBlind: 10,
+          BigBlind: 20,
+          ButtonSeat: 0,
+          SmallBlindSeat: 0,
+          BigBlindSeat: 1
+        },
+        Progress: { Phase: 0 }
+      } as any, { skipValidation: true })
+      const result = createEvent(ApiType.EVT_HAND_RESULTS, {
+        timestamp: 1001,
+        HandId: 12345,
+        CommunityCards: [],
+        Results: []
+      } as any, { skipValidation: true })
+
+      expect(converter.convertEventChunk([deal]).hands).toHaveLength(0)
+      expect(converter.convertEventChunk([result]).hands).toEqual([
+        expect.objectContaining({ id: 12345, seatUserIds: [100, 101] })
+      ])
+      expect(converter.flush().hands).toHaveLength(0)
+    })
+
     it('should extract session information from EVT_ENTRY_QUEUED and EVT_SESSION_DETAILS', () => {
       const events: ApiEvent[] = [
         // セッション開始

--- a/src/entity-converter.ts
+++ b/src/entity-converter.ts
@@ -40,54 +40,66 @@ export interface EntityBundle {
   actions: Action[]
 }
 
+type MutableSession = Omit<Session, 'players'> & {
+  players: Map<number, { name: string, rank: string }>
+}
+
 /**
  * APIイベントからエンティティを変換するコンバーター
  */
 export class EntityConverter {
-  private session: Session
+  private currentHandEvents: ApiHandEvent[] = []
+  private currentSession: MutableSession
 
   constructor(session: Session) {
-    this.session = session
+    // SessionState の id/battleType/name は prototype 上の getter のため、
+    // オブジェクトスプレッドではなく各フィールドを明示的に読み出す。
+    this.currentSession = {
+      id: session.id,
+      battleType: session.battleType,
+      name: session.name,
+      players: new Map(session.players),
+      reset: () => { }
+    }
   }
 
   /**
    * イベント配列をエンティティに変換（バッチ処理用）
    */
   convertEventsToEntities(events: ApiEvent[]): EntityBundle {
+    const entities = this.convertEventChunk(events)
+    const remaining = this.flush()
+
+    entities.hands.push(...remaining.hands)
+    entities.phases.push(...remaining.phases)
+    entities.actions.push(...remaining.actions)
+    return entities
+  }
+
+  /**
+   * イベントの一部分を変換する。未完了ハンドとセッション状態は次の呼び出しへ引き継ぐ。
+   */
+  convertEventChunk(events: ApiEvent[]): EntityBundle {
     const entities: EntityBundle = {
       hands: [],
       phases: [],
       actions: []
     }
 
-    let currentHandEvents: ApiHandEvent[] = []
-    // セッション情報をローカルに保持（インポートデータから抽出）
-    // NOTE: this.session は SessionState クラスのインスタンスの場合があり、
-    // id/battleType/name は prototype 上の getter のため、オブジェクトスプレッドでは
-    // コピーされない（private な _id/_battleType/_name のみコピーされ、値が undefined になる）。
-    // そのため各フィールドを明示的に読み出す。
-    let currentSession = {
-      id: this.session.id,
-      battleType: this.session.battleType,
-      name: this.session.name,
-      players: new Map(this.session.players), // Mapを正しくコピー（可変Mapとして扱う）
-      reset: () => { } // ローカルな作業コピーではreset()は使用されない
-    }
-
     for (const event of events) {
       // セッション開始イベントの処理
       if (isApiEventType(event, ApiType.EVT_ENTRY_QUEUED)) {
-        currentSession.id = event.Id
-        currentSession.battleType = event.BattleType
+        this.currentSession.id = event.Id
+        this.currentSession.battleType = event.BattleType
         // 新しいセッション開始時はプレイヤー情報をクリア
-        currentSession.players = new Map()
+        this.currentSession.players = new Map()
       } else if (isApiEventType(event, ApiType.EVT_SESSION_DETAILS)) {
-        currentSession.name = event.Name
+        this.currentSession.name = event.Name
       } else if (isApiEventType(event, ApiType.EVT_PLAYER_SEAT_ASSIGNED)) {
         // プレイヤー名とランクをセッションに保存
         if (event.TableUsers) {
           event.TableUsers.forEach(tableUser => {
-            currentSession.players.set(tableUser.UserId, {
+            this.currentSession.players.set(tableUser.UserId, {
               name: tableUser.UserName,
               rank: tableUser.Rank.RankId
             })
@@ -96,7 +108,7 @@ export class EntityConverter {
       } else if (isApiEventType(event, ApiType.EVT_PLAYER_JOIN)) {
         // 途中参加者のプレイヤー名とランクをセッションに保存
         if (event.JoinUser) {
-          currentSession.players.set(event.JoinUser.UserId, {
+          this.currentSession.players.set(event.JoinUser.UserId, {
             name: event.JoinUser.UserName,
             rank: event.JoinUser.Rank.RankId
           })
@@ -106,42 +118,38 @@ export class EntityConverter {
       // EVT_DEALでハンド開始
       if (event.ApiTypeId === ApiType.EVT_DEAL) {
         // 前のハンドが完了していない場合も処理
-        if (currentHandEvents.length > 0) {
-          const handEntities = this.convertHandEvents(currentHandEvents, currentSession)
-          if (handEntities) {
-            entities.hands.push(handEntities.hand)
-            entities.phases.push(...handEntities.phases)
-            entities.actions.push(...handEntities.actions)
-          }
-        }
-        currentHandEvents = [event as ApiHandEvent]
-      } else if (currentHandEvents.length > 0) {
-        currentHandEvents.push(event as ApiHandEvent)
+        this.appendCurrentHand(entities)
+        this.currentHandEvents = [event as ApiHandEvent]
+      } else if (this.currentHandEvents.length > 0) {
+        this.currentHandEvents.push(event as ApiHandEvent)
 
         // EVT_HAND_RESULTSでハンド終了
         if (event.ApiTypeId === ApiType.EVT_HAND_RESULTS) {
-          const handEntities = this.convertHandEvents(currentHandEvents, currentSession)
-          if (handEntities) {
-            entities.hands.push(handEntities.hand)
-            entities.phases.push(...handEntities.phases)
-            entities.actions.push(...handEntities.actions)
-          }
-          currentHandEvents = []
+          this.appendCurrentHand(entities)
         }
-      }
-    }
-
-    // 残りのハンドデータを処理
-    if (currentHandEvents.length > 0) {
-      const handEntities = this.convertHandEvents(currentHandEvents, currentSession)
-      if (handEntities) {
-        entities.hands.push(handEntities.hand)
-        entities.phases.push(...handEntities.phases)
-        entities.actions.push(...handEntities.actions)
       }
     }
 
     return entities
+  }
+
+  /** 残っている未完了ハンドを最終化する。 */
+  flush(): EntityBundle {
+    const entities: EntityBundle = { hands: [], phases: [], actions: [] }
+    this.appendCurrentHand(entities)
+    return entities
+  }
+
+  private appendCurrentHand(entities: EntityBundle): void {
+    if (this.currentHandEvents.length === 0) return
+
+    const handEntities = this.convertHandEvents(this.currentHandEvents, this.currentSession)
+    if (handEntities) {
+      entities.hands.push(handEntities.hand)
+      entities.phases.push(...handEntities.phases)
+      entities.actions.push(...handEntities.actions)
+    }
+    this.currentHandEvents = []
   }
 
   /**

--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -1,0 +1,70 @@
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import { PokerChaseDB } from '../db/poker-chase-db'
+import { ApiType, BattleType } from '../types'
+import type { ApiEvent } from '../types'
+import { AutoSyncService } from './auto-sync-service'
+import { firestoreBackupService } from './firestore-backup-service'
+
+describe('AutoSyncService cloud downloads', () => {
+  let db: PokerChaseDB
+
+  beforeEach(async () => {
+    const sendMessageMock = chrome.runtime.sendMessage as jest.Mock
+    sendMessageMock.mockResolvedValue(undefined)
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    db.close()
+    await db.delete()
+  })
+
+  test('persists each cloud page and resumes after the latest local timestamp', async () => {
+    const localEvent = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Code: 0,
+      BattleType: BattleType.SIT_AND_GO,
+      Id: 'stage-100',
+      IsRetire: false,
+      timestamp: 100
+    } as ApiEvent
+    const cloudEvent = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Code: 0,
+      BattleType: BattleType.SIT_AND_GO,
+      Id: 'stage-101',
+      IsRetire: false,
+      timestamp: 101
+    } as ApiEvent
+    await db.apiEvents.put(localEvent)
+
+    const syncSpy = jest.spyOn(firestoreBackupService, 'syncFromCloud')
+      .mockImplementation(async options => {
+        expect(options.afterEvent).toEqual({
+          timestamp: 100,
+          apiTypeId: ApiType.EVT_ENTRY_QUEUED
+        })
+        await options.onBatch([cloudEvent])
+        options.onProgress?.({ current: 1, total: 1 })
+        return 1
+      })
+
+    const service = new AutoSyncService(db)
+    await service.performSync('download')
+
+    expect(syncSpy).toHaveBeenCalledTimes(1)
+    expect(await db.apiEvents.count()).toBe(2)
+    expect(await db.apiEvents.get([101, ApiType.EVT_ENTRY_QUEUED])).toEqual(cloudEvent)
+    expect(service.getSyncState()).toMatchObject({
+      status: 'success',
+      localLastTimestamp: 101,
+      progress: { current: 1, total: 1, direction: 'download' }
+    })
+    expect((await db.meta.get('importStatus'))?.value).toMatchObject({
+      lastProcessedTimestamp: 101,
+      lastProcessedEventCount: 2
+    })
+  })
+})

--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -21,16 +21,8 @@ describe('AutoSyncService cloud downloads', () => {
     await db.delete()
   })
 
-  test('persists each cloud page and resumes after the latest local timestamp', async () => {
+  test('persists older cloud pages without deriving a cursor from local history', async () => {
     const localEvent = {
-      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
-      Code: 0,
-      BattleType: BattleType.SIT_AND_GO,
-      Id: 'stage-100',
-      IsRetire: false,
-      timestamp: 100
-    } as ApiEvent
-    const cloudEvent = {
       ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
       Code: 0,
       BattleType: BattleType.SIT_AND_GO,
@@ -38,14 +30,19 @@ describe('AutoSyncService cloud downloads', () => {
       IsRetire: false,
       timestamp: 101
     } as ApiEvent
+    const cloudEvent = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Code: 0,
+      BattleType: BattleType.SIT_AND_GO,
+      Id: 'stage-100',
+      IsRetire: false,
+      timestamp: 100
+    } as ApiEvent
     await db.apiEvents.put(localEvent)
 
     const syncSpy = jest.spyOn(firestoreBackupService, 'syncFromCloud')
       .mockImplementation(async options => {
-        expect(options.afterEvent).toEqual({
-          timestamp: 100,
-          apiTypeId: ApiType.EVT_ENTRY_QUEUED
-        })
+        expect(options).not.toHaveProperty('afterEvent')
         await options.onBatch([cloudEvent])
         options.onProgress?.({ current: 1, total: 1 })
         return 1
@@ -56,7 +53,7 @@ describe('AutoSyncService cloud downloads', () => {
 
     expect(syncSpy).toHaveBeenCalledTimes(1)
     expect(await db.apiEvents.count()).toBe(2)
-    expect(await db.apiEvents.get([101, ApiType.EVT_ENTRY_QUEUED])).toEqual(cloudEvent)
+    expect(await db.apiEvents.get([100, ApiType.EVT_ENTRY_QUEUED])).toEqual(cloudEvent)
     expect(service.getSyncState()).toMatchObject({
       status: 'success',
       localLastTimestamp: 101,

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -205,16 +205,12 @@ export class AutoSyncService {
    * Sync cloud events to local (cloud as source of truth)
    */
   private async syncFromCloud(): Promise<void> {
-    console.log('[AutoSync] Starting incremental download from cloud...')
+    console.log('[AutoSync] Starting complete download from cloud...')
 
-    const latestLocalEvent = await this.db.apiEvents.orderBy('[timestamp+ApiTypeId]').reverse().first()
     let downloadedEvents = 0
 
     try {
       await firestoreBackupService.syncFromCloud({
-        afterEvent: latestLocalEvent?.timestamp !== undefined
-          ? { timestamp: latestLocalEvent.timestamp, apiTypeId: latestLocalEvent.ApiTypeId }
-          : undefined,
         onBatch: async (events) => {
           await this.db.apiEvents.bulkPut(events)
           downloadedEvents += events.length
@@ -227,7 +223,7 @@ export class AutoSyncService {
       })
     } catch (error) {
       // A previous page may already be durable. Rebuild before surfacing the
-      // error so a retry that starts after that page cannot leave entities stale.
+      // error so partially downloaded raw events cannot leave entities stale.
       if (downloadedEvents > 0) await this.rebuildLocalEntities()
       throw error
     }

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -9,7 +9,7 @@ import { PokerChaseDB } from '../db/poker-chase-db'
 import { EntityConverter } from '../entity-converter'
 import { ApiType, isApiEventType } from '../types'
 import type { ApiEvent } from '../types'
-import { saveEntities } from '../utils/database-utils'
+import { processInChunks, saveEntities } from '../utils/database-utils'
 import { DATABASE_CONSTANTS } from '../constants/database'
 
 export type SyncStatus = 'idle' | 'syncing' | 'error' | 'success'
@@ -28,7 +28,7 @@ export interface SyncState {
   }
 }
 
-class AutoSyncService {
+export class AutoSyncService {
   private db: PokerChaseDB
   private syncState: SyncState = { status: 'idle' }
   private isSyncing = false
@@ -37,8 +37,8 @@ class AutoSyncService {
   private readonly SYNC_STORAGE_KEY = 'autoSyncLastTime'
   private readonly EVENTS_THRESHOLD = 100 // 100イベント溜まったら同期
 
-  constructor() {
-    this.db = new PokerChaseDB(self.indexedDB, self.IDBKeyRange)
+  constructor(db?: PokerChaseDB) {
+    this.db = db ?? new PokerChaseDB(self.indexedDB, self.IDBKeyRange)
   }
 
   /**
@@ -205,145 +205,147 @@ class AutoSyncService {
    * Sync cloud events to local (cloud as source of truth)
    */
   private async syncFromCloud(): Promise<void> {
-    console.log('[AutoSync] Starting download from cloud (cloud as source of truth)...')
+    console.log('[AutoSync] Starting incremental download from cloud...')
 
-    // Get all events from cloud
-    const cloudEvents = await firestoreBackupService.syncFromCloud((progress) => {
-      this.updateSyncState({
-        progress: { ...progress, direction: 'download' }
+    const latestLocalEvent = await this.db.apiEvents.orderBy('[timestamp+ApiTypeId]').reverse().first()
+    let downloadedEvents = 0
+
+    try {
+      await firestoreBackupService.syncFromCloud({
+        afterEvent: latestLocalEvent?.timestamp !== undefined
+          ? { timestamp: latestLocalEvent.timestamp, apiTypeId: latestLocalEvent.ApiTypeId }
+          : undefined,
+        onBatch: async (events) => {
+          await this.db.apiEvents.bulkPut(events)
+          downloadedEvents += events.length
+        },
+        onProgress: (progress) => {
+          this.updateSyncState({
+            progress: { ...progress, direction: 'download' }
+          })
+        }
       })
-    })
+    } catch (error) {
+      // A previous page may already be durable. Rebuild before surfacing the
+      // error so a retry that starts after that page cannot leave entities stale.
+      if (downloadedEvents > 0) await this.rebuildLocalEntities()
+      throw error
+    }
 
-    if (cloudEvents.length > 0) {
-      // Use bulkPut to update existing events and add new ones
-      await this.db.apiEvents.bulkPut(cloudEvents)
-      console.log(`[AutoSync] Downloaded and updated ${cloudEvents.length} events from cloud`)
-      
-      // データ再構築をトリガー
-      try {
-        console.log('[AutoSync] Triggering data rebuild after download...')
-        
-        // EntityConverterを使用してエンティティを生成
-        // セッション情報はイベントから自動的に抽出される
-        const defaultSession = { 
-          id: undefined, 
-          battleType: undefined, 
-          name: undefined, 
-          players: new Map(), 
-          reset: () => {} 
-        }
-        const converter = new EntityConverter(defaultSession)
-        const entities = converter.convertEventsToEntities(cloudEvents)
-        
-        // Save entities using common utility
-        await saveEntities(this.db, entities, {
-          onProgress: (counts) => {
-            console.log(`[AutoSync] Generated entities - Hands: ${counts.hands}, Phases: ${counts.phases}, Actions: ${counts.actions}`)
-          }
-        })
-        
-        // Update metadata separately
-        const lastTimestamp = cloudEvents.reduce((max, event) => {
-          const timestamp = event.timestamp || 0
-          return timestamp > max ? timestamp : max
-        }, 0)
-        
-        await this.db.meta.put({
-          id: 'importStatus',
-          value: {
-            lastProcessedTimestamp: lastTimestamp,
-            lastProcessedEventCount: cloudEvents.length,
-            lastImportDate: new Date().toISOString()
-          },
-          updatedAt: Date.now()
-        })
-        
-        console.log('[AutoSync] Data rebuild completed')
-        
-        // serviceの状態を復元
-        const service = (self as any).service
-        if (service) {
-          // セッション情報を復元（最新のセッションを特定するためEVT_SESSION_RESULTSも含める）
-          const sessionEvents = cloudEvents
-            .filter((e: ApiEvent) => 
-              e.ApiTypeId === ApiType.EVT_ENTRY_QUEUED || 
-              e.ApiTypeId === ApiType.EVT_SESSION_DETAILS ||
-              e.ApiTypeId === ApiType.EVT_PLAYER_SEAT_ASSIGNED ||
-              e.ApiTypeId === ApiType.EVT_PLAYER_JOIN ||
-              e.ApiTypeId === ApiType.EVT_SESSION_RESULTS
-            )
-            .sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0))
-          
-          // セッション情報をリセット
-          if (service.session) {
-            service.session.reset()
-          }
-          
-          // セッションイベントを順番に処理
-          for (const event of sessionEvents) {
-            if (event.ApiTypeId === ApiType.EVT_SESSION_RESULTS) {
-              // セッション終了イベント: 次のセッションのためにリセット
-              service.session.reset()
-            } else if (isApiEventType(event, ApiType.EVT_ENTRY_QUEUED)) {
-              service.session.setId(event.Id)
-              service.session.setBattleType(event.BattleType)
-            } else if (isApiEventType(event, ApiType.EVT_SESSION_DETAILS)) {
-              service.session.setName(event.Name)
-            } else if (isApiEventType(event, ApiType.EVT_PLAYER_SEAT_ASSIGNED)) {
-              if (event.TableUsers) {
-                event.TableUsers.forEach(tableUser => {
-                  service.session.setPlayer(tableUser.UserId, {
-                    name: tableUser.UserName,
-                    rank: tableUser.Rank.RankId
-                  })
-                })
-              }
-            } else if (isApiEventType(event, ApiType.EVT_PLAYER_JOIN)) {
-              if (event.JoinUser) {
-                service.session.setPlayer(event.JoinUser.UserId, {
-                  name: event.JoinUser.UserName,
-                  rank: event.JoinUser.Rank.RankId
-                })
-              }
-            }
-          }
-          
-          if (service.session.id) {
-            console.log(`[AutoSync] Restored session: ${service.session.id} - ${service.session.name || 'Unknown'}`)
-          }
-          
-          // 最新のEVT_DEALイベントを検索してhero情報を復元
-          const latestDealEvent = cloudEvents
-            .filter((e: ApiEvent) => isApiEventType(e, ApiType.EVT_DEAL))
-            .sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0))[0]
-          
-          if (latestDealEvent && isApiEventType(latestDealEvent, ApiType.EVT_DEAL)) {
-            console.log('[AutoSync] Restoring service state from latest EVT_DEAL event')
-            service.latestEvtDeal = latestDealEvent
-            
-            // playerIdを設定
-            if (latestDealEvent.Player && latestDealEvent.Player.SeatIndex >= 0 && latestDealEvent.SeatUserIds) {
-              const playerId = latestDealEvent.SeatUserIds[latestDealEvent.Player.SeatIndex]
-              if (playerId && playerId !== -1) {
-                service.playerId = playerId
-                console.log(`[AutoSync] Restored playerId: ${playerId}`)
-              }
-            }
-          }
-          
-          // 統計の再計算をトリガー（latestEvtDealがある場合）
-          if (service.latestEvtDeal && service.latestEvtDeal.SeatUserIds) {
-            const playerIds = service.latestEvtDeal.SeatUserIds.filter((id: number) => id !== -1)
-            if (playerIds.length > 0) {
-              console.log('[AutoSync] Triggering stats recalculation...')
-              service.statsOutputStream.write(playerIds)
-            }
-          }
-        }
-      } catch (error) {
-        console.error('[AutoSync] Data rebuild error:', error)
-        // エラーが発生しても同期自体は成功とする
+    if (downloadedEvents > 0) {
+      console.log(`[AutoSync] Downloaded and updated ${downloadedEvents} events from cloud`)
+      await this.rebuildLocalEntities()
+    }
+  }
+
+  /** Rebuild derived tables without loading the entire event history into memory. */
+  private async rebuildLocalEntities(): Promise<void> {
+    try {
+      console.log('[AutoSync] Triggering chunked data rebuild after download...')
+
+      const defaultSession = {
+        id: undefined,
+        battleType: undefined,
+        name: undefined,
+        players: new Map(),
+        reset: () => { }
       }
+      const converter = new EntityConverter(defaultSession)
+      const service = (self as any).service
+      const totalEventCount = await this.db.apiEvents.count()
+      let lastProcessedTimestamp = 0
+      let latestDealEvent: ApiEvent | undefined
+
+      if (service?.session) service.session.reset()
+
+      for await (const events of processInChunks(
+        this.db.apiEvents.orderBy('[timestamp+ApiTypeId]'),
+        DATABASE_CONSTANTS.SYNC_CHUNK_SIZE
+      )) {
+        const entities = converter.convertEventChunk(events)
+        await this.saveRebuiltEntities(entities)
+
+        for (const event of events) {
+          lastProcessedTimestamp = Math.max(lastProcessedTimestamp, event.timestamp || 0)
+          this.restoreSessionEvent(service, event)
+          if (isApiEventType(event, ApiType.EVT_DEAL)) latestDealEvent = event
+        }
+      }
+
+      await this.saveRebuiltEntities(converter.flush())
+      await this.db.meta.put({
+        id: 'importStatus',
+        value: {
+          lastProcessedTimestamp,
+          lastProcessedEventCount: totalEventCount,
+          lastImportDate: new Date().toISOString()
+        },
+        updatedAt: Date.now()
+      })
+
+      this.restoreLatestDeal(service, latestDealEvent)
+      console.log(`[AutoSync] Chunked data rebuild completed (${totalEventCount} events)`)
+    } catch (error) {
+      console.error('[AutoSync] Data rebuild error:', error)
+      // Preserve the existing behavior: raw event sync remains successful even
+      // if rebuilding derived data fails.
+    }
+  }
+
+  private async saveRebuiltEntities(entities: ReturnType<EntityConverter['flush']>): Promise<void> {
+    await saveEntities(this.db, entities, {
+      onProgress: (counts) => {
+        if (counts.hands + counts.phases + counts.actions > 0) {
+          console.log(`[AutoSync] Generated entities - Hands: ${counts.hands}, Phases: ${counts.phases}, Actions: ${counts.actions}`)
+        }
+      }
+    })
+  }
+
+  private restoreSessionEvent(service: any, event: ApiEvent): void {
+    if (!service?.session) return
+
+    if (event.ApiTypeId === ApiType.EVT_SESSION_RESULTS) {
+      service.session.reset()
+    } else if (isApiEventType(event, ApiType.EVT_ENTRY_QUEUED)) {
+      service.session.setId(event.Id)
+      service.session.setBattleType(event.BattleType)
+    } else if (isApiEventType(event, ApiType.EVT_SESSION_DETAILS)) {
+      service.session.setName(event.Name)
+    } else if (isApiEventType(event, ApiType.EVT_PLAYER_SEAT_ASSIGNED)) {
+      event.TableUsers?.forEach(tableUser => {
+        service.session.setPlayer(tableUser.UserId, {
+          name: tableUser.UserName,
+          rank: tableUser.Rank.RankId
+        })
+      })
+    } else if (isApiEventType(event, ApiType.EVT_PLAYER_JOIN) && event.JoinUser) {
+      service.session.setPlayer(event.JoinUser.UserId, {
+        name: event.JoinUser.UserName,
+        rank: event.JoinUser.Rank.RankId
+      })
+    }
+  }
+
+  private restoreLatestDeal(service: any, latestDealEvent?: ApiEvent): void {
+    if (!service) return
+
+    if (service.session?.id) {
+      console.log(`[AutoSync] Restored session: ${service.session.id} - ${service.session.name || 'Unknown'}`)
+    }
+
+    if (latestDealEvent && isApiEventType(latestDealEvent, ApiType.EVT_DEAL)) {
+      service.latestEvtDeal = latestDealEvent
+      const playerSeatIndex = latestDealEvent.Player?.SeatIndex
+      if (playerSeatIndex !== undefined && playerSeatIndex >= 0) {
+        const playerId = latestDealEvent.SeatUserIds?.[playerSeatIndex]
+        if (playerId && playerId !== -1) service.playerId = playerId
+      }
+    }
+
+    if (service.latestEvtDeal?.SeatUserIds) {
+      const playerIds = service.latestEvtDeal.SeatUserIds.filter((id: number) => id !== -1)
+      if (playerIds.length > 0) service.statsOutputStream.write(playerIds)
     }
   }
 

--- a/src/services/firestore-backup-service.test.ts
+++ b/src/services/firestore-backup-service.test.ts
@@ -5,6 +5,18 @@ import type { ApiEvent } from '../types'
 describe('FirestoreBackupService', () => {
   const originalFetch = global.fetch
 
+  beforeEach(() => {
+    jest.spyOn(firebaseAuthService, 'ready').mockResolvedValue()
+    jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue({
+      uid: 'XK00mmVIZdg8J52OlfyKvN467SK2',
+      email: null,
+      displayName: null,
+      photoURL: null,
+      getIdToken: jest.fn()
+    })
+    jest.spyOn(firebaseAuthService, 'getIdToken').mockResolvedValue('test-token')
+  })
+
   afterEach(() => {
     jest.restoreAllMocks()
     if (originalFetch) {
@@ -15,19 +27,9 @@ describe('FirestoreBackupService', () => {
   })
 
   test('batchWrite uses a Firestore resource name instead of a REST URL', async () => {
-    jest.spyOn(firebaseAuthService, 'ready').mockResolvedValue()
-    jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue({
-      uid: 'XK00mmVIZdg8J52OlfyKvN467SK2',
-      email: null,
-      displayName: null,
-      photoURL: null,
-      getIdToken: jest.fn()
-    })
-    jest.spyOn(firebaseAuthService, 'getIdToken').mockResolvedValue('test-token')
-
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({})
+      text: async () => '{}'
     } as Response)
     global.fetch = fetchMock
     const event = {
@@ -51,5 +53,17 @@ describe('FirestoreBackupService', () => {
       'XK00mmVIZdg8J52OlfyKvN467SK2/apiEvents/1779859063171_304'
     )
     expect(body.writes[0].update.name).not.toMatch(/^https?:\/\//)
+  })
+
+  test.each([
+    ['an empty response body', ''],
+    ['a metadata-only query response', JSON.stringify([{ readTime: '2026-07-15T00:00:00Z' }])]
+  ])('syncFromCloud treats %s as no events', async (_description, responseBody) => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: async () => responseBody
+    } as Response)
+
+    await expect(new FirestoreBackupService().syncFromCloud()).resolves.toEqual([])
   })
 })

--- a/src/services/firestore-backup-service.test.ts
+++ b/src/services/firestore-backup-service.test.ts
@@ -111,7 +111,6 @@ describe('FirestoreBackupService', () => {
     const receivedBatches: ApiEvent[][] = []
     const onProgress = jest.fn()
     await expect(new FirestoreBackupService().syncFromCloud({
-      afterEvent: { timestamp: 100, apiTypeId: 304 },
       onBatch: async events => { receivedBatches.push(events) },
       onProgress
     })).resolves.toBe(1001)
@@ -119,13 +118,7 @@ describe('FirestoreBackupService', () => {
     expect(receivedBatches.map(batch => batch.length)).toEqual([1000, 1])
     expect(onProgress).toHaveBeenLastCalledWith({ current: 1001, total: 1001 })
 
-    expect(aggregationBody.structuredAggregationQuery.structuredQuery.startAt).toEqual({
-      values: [
-        { integerValue: '100' },
-        { referenceValue: documentName(100) }
-      ],
-      before: false
-    })
+    expect(aggregationBody.structuredAggregationQuery.structuredQuery.startAt).toBeUndefined()
 
     const firstQuery = queryBodies[0].structuredQuery
     expect(firstQuery.limit).toBe(1000)
@@ -133,13 +126,7 @@ describe('FirestoreBackupService', () => {
       { field: { fieldPath: 'timestamp' }, direction: 'ASCENDING' },
       { field: { fieldPath: '__name__' }, direction: 'ASCENDING' }
     ])
-    expect(firstQuery.startAt).toEqual({
-      values: [
-        { integerValue: '100' },
-        { referenceValue: documentName(100) }
-      ],
-      before: false
-    })
+    expect(firstQuery.startAt).toBeUndefined()
 
     const secondQuery = queryBodies[1].structuredQuery
     expect(secondQuery.startAt).toEqual({

--- a/src/services/firestore-backup-service.test.ts
+++ b/src/services/firestore-backup-service.test.ts
@@ -27,10 +27,12 @@ describe('FirestoreBackupService', () => {
   })
 
   test('batchWrite uses a Firestore resource name instead of a REST URL', async () => {
-    const fetchMock = jest.fn().mockResolvedValue({
+    const fetchMock = jest.fn().mockImplementation(async (url: string) => ({
       ok: true,
-      text: async () => '{}'
-    } as Response)
+      text: async () => String(url).endsWith(':batchWrite')
+        ? JSON.stringify({ status: [{}] })
+        : '{}'
+    } as Response))
     global.fetch = fetchMock
     const event = {
       timestamp: 1779859063171,
@@ -55,15 +57,113 @@ describe('FirestoreBackupService', () => {
     expect(body.writes[0].update.name).not.toMatch(/^https?:\/\//)
   })
 
+  test('batchWrite rejects an individual write failure returned with HTTP 200', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({
+        status: [{ code: 7, message: 'Missing or insufficient permissions.' }]
+      })
+    } as Response)
+
+    const event = { timestamp: 1779859063171, ApiTypeId: 304 } as unknown as ApiEvent
+    await expect(new FirestoreBackupService().syncToCloudBatch([event], null))
+      .rejects.toThrow('Firestore batchWrite failed for 1/1 writes')
+  })
+
+  test('syncFromCloud downloads matching events in bounded, cursor-based pages', async () => {
+    const uid = 'XK00mmVIZdg8J52OlfyKvN467SK2'
+    const documentName = (timestamp: number) =>
+      `projects/pokerchase-hud/databases/(default)/documents/users/${uid}/apiEvents/${timestamp}_304`
+    const queryBodies: any[] = []
+    let aggregationBody: any
+    let queryCount = 0
+
+    global.fetch = jest.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      if (String(url).endsWith(':runAggregationQuery')) {
+        aggregationBody = JSON.parse(String(init?.body))
+        return {
+          ok: true,
+          text: async () => JSON.stringify([{
+            result: { aggregateFields: { eventCount: { integerValue: '1001' } } }
+          }])
+        } as Response
+      }
+
+      queryBodies.push(JSON.parse(String(init?.body)))
+      queryCount++
+      const timestamps = queryCount === 1
+        ? Array.from({ length: 1000 }, (_, index) => 101 + index)
+        : [1101]
+      return {
+        ok: true,
+        text: async () => JSON.stringify(timestamps.map(timestamp => ({
+          document: {
+            name: documentName(timestamp),
+            fields: {
+              timestamp: { integerValue: String(timestamp) },
+              ApiTypeId: { integerValue: '304' }
+            }
+          }
+        })))
+      } as Response
+    })
+
+    const receivedBatches: ApiEvent[][] = []
+    const onProgress = jest.fn()
+    await expect(new FirestoreBackupService().syncFromCloud({
+      afterEvent: { timestamp: 100, apiTypeId: 304 },
+      onBatch: async events => { receivedBatches.push(events) },
+      onProgress
+    })).resolves.toBe(1001)
+
+    expect(receivedBatches.map(batch => batch.length)).toEqual([1000, 1])
+    expect(onProgress).toHaveBeenLastCalledWith({ current: 1001, total: 1001 })
+
+    expect(aggregationBody.structuredAggregationQuery.structuredQuery.startAt).toEqual({
+      values: [
+        { integerValue: '100' },
+        { referenceValue: documentName(100) }
+      ],
+      before: false
+    })
+
+    const firstQuery = queryBodies[0].structuredQuery
+    expect(firstQuery.limit).toBe(1000)
+    expect(firstQuery.orderBy).toEqual([
+      { field: { fieldPath: 'timestamp' }, direction: 'ASCENDING' },
+      { field: { fieldPath: '__name__' }, direction: 'ASCENDING' }
+    ])
+    expect(firstQuery.startAt).toEqual({
+      values: [
+        { integerValue: '100' },
+        { referenceValue: documentName(100) }
+      ],
+      before: false
+    })
+
+    const secondQuery = queryBodies[1].structuredQuery
+    expect(secondQuery.startAt).toEqual({
+      values: [
+        { integerValue: '1100' },
+        { referenceValue: documentName(1100) }
+      ],
+      before: false
+    })
+  })
+
   test.each([
     ['an empty response body', ''],
     ['a metadata-only query response', JSON.stringify([{ readTime: '2026-07-15T00:00:00Z' }])]
   ])('syncFromCloud treats %s as no events', async (_description, responseBody) => {
-    global.fetch = jest.fn().mockResolvedValue({
+    global.fetch = jest.fn().mockImplementation(async (url: string) => ({
       ok: true,
-      text: async () => responseBody
-    } as Response)
+      text: async () => String(url).endsWith(':runAggregationQuery')
+        ? JSON.stringify([{ result: { aggregateFields: { eventCount: { integerValue: '0' } } } }])
+        : responseBody
+    } as Response))
 
-    await expect(new FirestoreBackupService().syncFromCloud()).resolves.toEqual([])
+    const onBatch = jest.fn()
+    await expect(new FirestoreBackupService().syncFromCloud({ onBatch })).resolves.toBe(0)
+    expect(onBatch).not.toHaveBeenCalled()
   })
 })

--- a/src/services/firestore-backup-service.test.ts
+++ b/src/services/firestore-backup-service.test.ts
@@ -1,0 +1,55 @@
+import { FirestoreBackupService } from './firestore-backup-service'
+import { firebaseAuthService } from './firebase-auth-service'
+import type { ApiEvent } from '../types'
+
+describe('FirestoreBackupService', () => {
+  const originalFetch = global.fetch
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    if (originalFetch) {
+      global.fetch = originalFetch
+    } else {
+      delete (global as { fetch?: typeof fetch }).fetch
+    }
+  })
+
+  test('batchWrite uses a Firestore resource name instead of a REST URL', async () => {
+    jest.spyOn(firebaseAuthService, 'ready').mockResolvedValue()
+    jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue({
+      uid: 'XK00mmVIZdg8J52OlfyKvN467SK2',
+      email: null,
+      displayName: null,
+      photoURL: null,
+      getIdToken: jest.fn()
+    })
+    jest.spyOn(firebaseAuthService, 'getIdToken').mockResolvedValue('test-token')
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({})
+    } as Response)
+    global.fetch = fetchMock
+    const event = {
+      timestamp: 1779859063171,
+      ApiTypeId: 304
+    } as unknown as ApiEvent
+
+    await new FirestoreBackupService().syncToCloudBatch([event], null)
+
+    const batchWriteCall = fetchMock.mock.calls.find(([url]) => String(url).endsWith(':batchWrite'))
+    expect(batchWriteCall).toBeDefined()
+
+    const [url, init] = batchWriteCall!
+    expect(url).toBe(
+      'https://firestore.googleapis.com/v1/projects/pokerchase-hud/databases/(default)/documents:batchWrite'
+    )
+
+    const body = JSON.parse(String(init?.body))
+    expect(body.writes[0].update.name).toBe(
+      'projects/pokerchase-hud/databases/(default)/documents/users/' +
+      'XK00mmVIZdg8J52OlfyKvN467SK2/apiEvents/1779859063171_304'
+    )
+    expect(body.writes[0].update.name).not.toMatch(/^https?:\/\//)
+  })
+})

--- a/src/services/firestore-backup-service.ts
+++ b/src/services/firestore-backup-service.ts
@@ -40,7 +40,8 @@ export class FirestoreBackupService {
   private readonly BATCH_SIZE = DATABASE_CONSTANTS.FIRESTORE_BATCH_SIZE
   private readonly BATCH_DELAY_MS = DATABASE_CONSTANTS.FIRESTORE_BATCH_DELAY_MS
   private readonly DELETE_BATCH_SIZE = DATABASE_CONSTANTS.FIRESTORE_DELETE_BATCH
-  private readonly baseUrl = `https://firestore.googleapis.com/v1/projects/${firebaseConfig.projectId}/databases/(default)/documents`
+  private readonly documentsPath = `projects/${firebaseConfig.projectId}/databases/(default)/documents`
+  private readonly baseUrl = `https://firestore.googleapis.com/v1/${this.documentsPath}`
 
   /**
    * Sync local events to cloud (upload events newer than cloud's latest timestamp).
@@ -209,7 +210,7 @@ export class FirestoreBackupService {
       const eventId = `${event.timestamp}_${event.ApiTypeId}`
       return {
         update: {
-          name: `${this.baseUrl}/${this.docPath(this.USERS_COLLECTION, uid, this.EVENTS_COLLECTION, eventId)}`,
+          name: `${this.documentsPath}/${this.docPath(this.USERS_COLLECTION, uid, this.EVENTS_COLLECTION, eventId)}`,
           fields: encodeFields(event as Record<string, unknown>)
         }
       }

--- a/src/services/firestore-backup-service.ts
+++ b/src/services/firestore-backup-service.ts
@@ -16,12 +16,19 @@ export interface BackupSummary {
   lastSyncTime: Date
 }
 
+export interface CloudSyncOptions {
+  afterEvent?: { timestamp: number, apiTypeId: number }
+  onBatch: (events: ApiEvent[]) => Promise<void>
+  onProgress?: (progress: { current: number, total: number }) => void
+}
+
 type FirestoreValue =
   | { nullValue: null }
   | { booleanValue: boolean }
   | { integerValue: string }
   | { doubleValue: number }
   | { stringValue: string }
+  | { referenceValue: string }
   | { arrayValue: { values?: FirestoreValue[] } }
   | { mapValue: { fields?: Record<string, FirestoreValue> } }
 
@@ -34,12 +41,44 @@ interface RunQueryResult {
   document?: FirestoreDocument
 }
 
+interface RunAggregationQueryResult {
+  result?: {
+    aggregateFields?: Record<string, FirestoreValue>
+  }
+}
+
+interface FirestoreStatus {
+  code?: number
+  message?: string
+}
+
+interface BatchWriteResponse {
+  status?: FirestoreStatus[]
+}
+
+interface EventQueryCursor {
+  timestamp: FirestoreValue
+  documentName: string
+}
+
+class FirestoreBatchWriteError extends Error {
+  constructor(
+    readonly code: number,
+    readonly failedWrites: number,
+    message: string
+  ) {
+    super(message)
+    this.name = 'FirestoreBatchWriteError'
+  }
+}
+
 export class FirestoreBackupService {
   private readonly USERS_COLLECTION = 'users'
   private readonly EVENTS_COLLECTION = 'apiEvents'
   private readonly BATCH_SIZE = DATABASE_CONSTANTS.FIRESTORE_BATCH_SIZE
   private readonly BATCH_DELAY_MS = DATABASE_CONSTANTS.FIRESTORE_BATCH_DELAY_MS
   private readonly DELETE_BATCH_SIZE = DATABASE_CONSTANTS.FIRESTORE_DELETE_BATCH
+  private readonly DOWNLOAD_PAGE_SIZE = DATABASE_CONSTANTS.FIRESTORE_DOWNLOAD_PAGE_SIZE
   private readonly documentsPath = `projects/${firebaseConfig.projectId}/databases/(default)/documents`
   private readonly baseUrl = `https://firestore.googleapis.com/v1/${this.documentsPath}`
 
@@ -59,8 +98,8 @@ export class FirestoreBackupService {
    */
   async getCloudStatus(): Promise<{ eventCount: number }> {
     try {
-      const events = await this.queryEvents('asc')
-      return { eventCount: events.length }
+      const user = await this.requireUser()
+      return { eventCount: await this.countEventDocuments(user.uid) }
     } catch (error) {
       console.error('Failed to get cloud status:', error)
       return { eventCount: 0 }
@@ -70,22 +109,28 @@ export class FirestoreBackupService {
   /**
    * Sync cloud events to local (cloud as source of truth).
    */
-  async syncFromCloud(
-    onProgress?: (progress: { current: number, total: number }) => void
-  ): Promise<ApiEvent[]> {
+  async syncFromCloud(options: CloudSyncOptions): Promise<number> {
     try {
-      const newEvents = await this.queryEvents('asc')
-      const total = newEvents.length
-      console.log(`[Firestore] Found ${total} events in cloud`)
+      const user = await this.requireUser()
+      const initialCursor = options.afterEvent
+        ? this.eventCursor(user.uid, options.afterEvent.timestamp, options.afterEvent.apiTypeId)
+        : undefined
+      const total = await this.countEventDocuments(user.uid, initialCursor)
+      let processed = 0
 
-      if (onProgress) {
-        for (let processed = 100; processed < total; processed += 100) {
-          onProgress({ current: processed, total })
-        }
-        onProgress({ current: total, total })
+      for await (const documents of this.queryEventDocumentPages(user.uid, initialCursor)) {
+        const events = documents.map(doc => decodeFields(doc.fields ?? {}) as ApiEvent)
+        await options.onBatch(events)
+        processed += events.length
+        options.onProgress?.({ current: processed, total })
       }
 
-      return newEvents
+      if (processed === 0) {
+        options.onProgress?.({ current: 0, total })
+      }
+
+      console.log(`[Firestore] Downloaded ${processed} of ${total} matching cloud events`)
+      return processed
     } catch (error) {
       console.error('Failed to sync from cloud:', error)
       throw new Error(`Cloud sync failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
@@ -222,7 +267,11 @@ export class FirestoreBackupService {
         await this.batchWrite(writes)
         return
       } catch (error: any) {
-        if ((error?.message || '').includes('RESOURCE_EXHAUSTED') && retries > 1) {
+        const message = error instanceof Error ? error.message : ''
+        const rateLimited = (error instanceof FirestoreBatchWriteError && error.code === 8) ||
+          message.includes('RESOURCE_EXHAUSTED') ||
+          message.includes('REST request failed: 429')
+        if (rateLimited && retries > 1) {
           console.warn(`[Firestore] Rate limit hit, retrying in ${this.BATCH_DELAY_MS}ms...`)
           await new Promise(resolve => setTimeout(resolve, this.BATCH_DELAY_MS))
           retries--
@@ -258,17 +307,61 @@ export class FirestoreBackupService {
     return docs.map(doc => decodeFields(doc.fields ?? {}) as ApiEvent)
   }
 
-  private async queryEventDocuments(uid: string, direction: 'asc' | 'desc', maxResults?: number): Promise<FirestoreDocument[]> {
+  private async *queryEventDocumentPages(uid: string, initialCursor?: EventQueryCursor): AsyncGenerator<FirestoreDocument[]> {
+    let cursor = initialCursor
+
+    while (true) {
+      const documents = await this.queryEventDocuments(
+        uid,
+        'asc',
+        this.DOWNLOAD_PAGE_SIZE,
+        cursor
+      )
+      if (documents.length === 0) break
+
+      yield documents
+      if (documents.length < this.DOWNLOAD_PAGE_SIZE) break
+
+      const lastDocument = documents.at(-1)!
+      const timestamp = lastDocument.fields?.timestamp
+      if (!timestamp || !('integerValue' in timestamp)) {
+        throw new Error(`Firestore event document lacks an integer timestamp: ${lastDocument.name}`)
+      }
+      cursor = { timestamp, documentName: lastDocument.name }
+    }
+  }
+
+  private async queryEventDocuments(
+    uid: string,
+    direction: 'asc' | 'desc',
+    maxResults?: number,
+    cursor?: EventQueryCursor
+  ): Promise<FirestoreDocument[]> {
     const results = await this.request<RunQueryResult[]>(`${this.baseUrl}/${this.docPath(this.USERS_COLLECTION, uid)}:runQuery`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         structuredQuery: {
           from: [{ collectionId: this.EVENTS_COLLECTION }],
-          orderBy: [{
-            field: { fieldPath: 'timestamp' },
-            direction: direction === 'asc' ? 'ASCENDING' : 'DESCENDING'
-          }],
+          orderBy: [
+            {
+              field: { fieldPath: 'timestamp' },
+              direction: direction === 'asc' ? 'ASCENDING' : 'DESCENDING'
+            },
+            {
+              field: { fieldPath: '__name__' },
+              direction: direction === 'asc' ? 'ASCENDING' : 'DESCENDING'
+            }
+          ],
+          ...(cursor ? {
+            startAt: {
+              values: [
+                cursor.timestamp,
+                { referenceValue: cursor.documentName }
+              ],
+              before: false
+            }
+          } : {}),
           ...(maxResults ? { limit: maxResults } : {})
         }
       })
@@ -277,12 +370,67 @@ export class FirestoreBackupService {
     return results.map(result => result.document).filter((doc): doc is FirestoreDocument => !!doc)
   }
 
+  private async countEventDocuments(uid: string, cursor?: EventQueryCursor): Promise<number> {
+    const alias = 'eventCount'
+    const results = await this.request<RunAggregationQueryResult[]>(
+      `${this.baseUrl}/${this.docPath(this.USERS_COLLECTION, uid)}:runAggregationQuery`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          structuredAggregationQuery: {
+            structuredQuery: {
+              from: [{ collectionId: this.EVENTS_COLLECTION }],
+              ...(cursor ? {
+                orderBy: [
+                  { field: { fieldPath: 'timestamp' }, direction: 'ASCENDING' },
+                  { field: { fieldPath: '__name__' }, direction: 'ASCENDING' }
+                ],
+                startAt: {
+                  values: [cursor.timestamp, { referenceValue: cursor.documentName }],
+                  before: false
+                }
+              } : {})
+            },
+            aggregations: [{ alias, count: {} }]
+          }
+        })
+      }
+    ) ?? []
+
+    const count = results[0]?.result?.aggregateFields?.[alias]
+    return count && 'integerValue' in count ? Number(count.integerValue) : 0
+  }
+
   private async batchWrite(writes: Array<Record<string, unknown>>): Promise<void> {
-    await this.request(`${this.baseUrl}:batchWrite`, {
+    const response = await this.request<BatchWriteResponse>(`${this.baseUrl}:batchWrite`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ writes })
     })
+
+    const statuses = response?.status ?? []
+    if (statuses.length !== writes.length) {
+      throw new Error(
+        `Firestore batchWrite returned ${statuses.length} statuses for ${writes.length} writes`
+      )
+    }
+
+    const failures = statuses
+      .map((status, index) => ({ status, index }))
+      .filter(({ status }) => (status.code ?? 0) !== 0)
+    if (failures.length > 0) {
+      const first = failures[0]!
+      const code = first.status.code ?? 2
+      const details = failures.slice(0, 3)
+        .map(({ status, index }) => `write ${index}: code ${status.code ?? 2} ${status.message ?? 'Unknown error'}`)
+        .join('; ')
+      throw new FirestoreBatchWriteError(
+        code,
+        failures.length,
+        `Firestore batchWrite failed for ${failures.length}/${writes.length} writes (${details})`
+      )
+    }
   }
 
   private async request<T = unknown>(url: string, init: RequestInit): Promise<T | null> {
@@ -300,7 +448,15 @@ export class FirestoreBackupService {
       throw new Error(`Firestore REST request failed: ${response.status} ${responseText}`)
     }
 
-    return responseText.trim() ? JSON.parse(responseText) as T : null
+    if (!responseText.trim()) return null
+
+    try {
+      return JSON.parse(responseText) as T
+    } catch (error) {
+      throw new Error(
+        `Firestore REST response was invalid JSON (${responseText.length} bytes): ${error instanceof Error ? error.message : 'Unknown error'}`
+      )
+    }
   }
 
   private async requireUser() {
@@ -314,6 +470,14 @@ export class FirestoreBackupService {
 
   private docPath(...segments: string[]): string {
     return segments.map(segment => encodeURIComponent(segment)).join('/')
+  }
+
+  private eventCursor(uid: string, timestamp: number, apiTypeId: number): EventQueryCursor {
+    const eventId = `${timestamp}_${apiTypeId}`
+    return {
+      timestamp: { integerValue: String(timestamp) },
+      documentName: `${this.documentsPath}/${this.docPath(this.USERS_COLLECTION, uid, this.EVENTS_COLLECTION, eventId)}`
+    }
   }
 }
 
@@ -353,6 +517,7 @@ function decodeValue(value: FirestoreValue): unknown {
   if ('integerValue' in value) return Number(value.integerValue)
   if ('doubleValue' in value) return value.doubleValue
   if ('stringValue' in value) return value.stringValue
+  if ('referenceValue' in value) return value.referenceValue
   if ('arrayValue' in value) return (value.arrayValue.values ?? []).map(decodeValue)
   if ('mapValue' in value) return decodeFields(value.mapValue.fields ?? {})
   return null

--- a/src/services/firestore-backup-service.ts
+++ b/src/services/firestore-backup-service.ts
@@ -17,7 +17,6 @@ export interface BackupSummary {
 }
 
 export interface CloudSyncOptions {
-  afterEvent?: { timestamp: number, apiTypeId: number }
   onBatch: (events: ApiEvent[]) => Promise<void>
   onProgress?: (progress: { current: number, total: number }) => void
 }
@@ -112,13 +111,10 @@ export class FirestoreBackupService {
   async syncFromCloud(options: CloudSyncOptions): Promise<number> {
     try {
       const user = await this.requireUser()
-      const initialCursor = options.afterEvent
-        ? this.eventCursor(user.uid, options.afterEvent.timestamp, options.afterEvent.apiTypeId)
-        : undefined
-      const total = await this.countEventDocuments(user.uid, initialCursor)
+      const total = await this.countEventDocuments(user.uid)
       let processed = 0
 
-      for await (const documents of this.queryEventDocumentPages(user.uid, initialCursor)) {
+      for await (const documents of this.queryEventDocumentPages(user.uid)) {
         const events = documents.map(doc => decodeFields(doc.fields ?? {}) as ApiEvent)
         await options.onBatch(events)
         processed += events.length
@@ -472,13 +468,6 @@ export class FirestoreBackupService {
     return segments.map(segment => encodeURIComponent(segment)).join('/')
   }
 
-  private eventCursor(uid: string, timestamp: number, apiTypeId: number): EventQueryCursor {
-    const eventId = `${timestamp}_${apiTypeId}`
-    return {
-      timestamp: { integerValue: String(timestamp) },
-      documentName: `${this.documentsPath}/${this.docPath(this.USERS_COLLECTION, uid, this.EVENTS_COLLECTION, eventId)}`
-    }
-  }
 }
 
 function encodeFields(input: Record<string, unknown>): Record<string, FirestoreValue> {

--- a/src/services/firestore-backup-service.ts
+++ b/src/services/firestore-backup-service.ts
@@ -259,7 +259,7 @@ export class FirestoreBackupService {
   }
 
   private async queryEventDocuments(uid: string, direction: 'asc' | 'desc', maxResults?: number): Promise<FirestoreDocument[]> {
-    const results = await this.request(`${this.baseUrl}/${this.docPath(this.USERS_COLLECTION, uid)}:runQuery`, {
+    const results = await this.request<RunQueryResult[]>(`${this.baseUrl}/${this.docPath(this.USERS_COLLECTION, uid)}:runQuery`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -272,7 +272,7 @@ export class FirestoreBackupService {
           ...(maxResults ? { limit: maxResults } : {})
         }
       })
-    }) as RunQueryResult[]
+    }) ?? []
 
     return results.map(result => result.document).filter((doc): doc is FirestoreDocument => !!doc)
   }
@@ -285,7 +285,7 @@ export class FirestoreBackupService {
     })
   }
 
-  private async request(url: string, init: RequestInit): Promise<unknown> {
+  private async request<T = unknown>(url: string, init: RequestInit): Promise<T | null> {
     const token = await firebaseAuthService.getIdToken()
     const response = await fetch(url, {
       ...init,
@@ -294,13 +294,13 @@ export class FirestoreBackupService {
         Authorization: `Bearer ${token}`
       }
     })
+    const responseText = await response.text()
 
     if (!response.ok) {
-      const errorText = await response.text()
-      throw new Error(`Firestore REST request failed: ${response.status} ${errorText}`)
+      throw new Error(`Firestore REST request failed: ${response.status} ${responseText}`)
     }
 
-    return await response.json()
+    return responseText.trim() ? JSON.parse(responseText) as T : null
   }
 
   private async requireUser() {


### PR DESCRIPTION
## Summary

- use Firestore resource names (not REST URLs) in `batchWrite` documents
- validate every per-write status returned by `batchWrite`, including failures delivered with HTTP 200
- download the complete cloud history in bounded 1,000-document pages
- use the actual Firestore `(timestamp, document name)` cursor only between pages of the same download
- persist each page immediately and rebuild derived entities in IndexedDB chunks
- keep empty Firestore responses valid and report malformed JSON with response-size context

## Root cause

Firestore `Write.update.name` accepts a resource name beginning with `projects/...`, but the extension sent the full REST URL. After that fix, cloud download still requested the complete event collection in one `runQuery` response and parsed it as one JSON array. The production backup currently has more than 310,000 events, so the response was large enough to be truncated before `response.json()` completed. Uploads could also appear successful because `batchWrite` reports each write status in the response even when the HTTP request itself succeeds.

The initial pagination implementation derived its exclusive starting cursor from the newest local `[timestamp+ApiTypeId]` key. That could omit the user's older cloud history and remote-only events at the same timestamp because the local numeric key ordering does not match Firestore's `timestamp + __name__` ordering. Downloads now start without a local-derived cursor; only subsequent pages advance from an actual Firestore document.

## Validation

- `npm run typecheck`
- `npm test -- --runInBand src/services/firestore-backup-service.test.ts src/services/auto-sync-service.test.ts` (2 suites, 6 tests)
- `npm test -- --runInBand` (57 suites, 507 tests)
- `npm run build`
- read-only production Firestore `runQuery` and `runAggregationQuery` probes using the same two-field page cursor
- Head: `29b86b1bd047734937c5790df02cef83c2845e7a`

No Firestore documents were written or deleted during the production-data investigation.