### PR TITLE
fix(sync): switch cloud upload/delete writes to Firestore :commit

### DIFF
--- a/src/services/firestore-backup-service.test.ts
+++ b/src/services/firestore-backup-service.test.ts
@@ -26,11 +26,11 @@ describe('FirestoreBackupService', () => {
     }
   })
 
-  test('batchWrite uses a Firestore resource name instead of a REST URL', async () => {
+  test('commitWrites uses a Firestore resource name instead of a REST URL', async () => {
     const fetchMock = jest.fn().mockImplementation(async (url: string) => ({
       ok: true,
-      text: async () => String(url).endsWith(':batchWrite')
-        ? JSON.stringify({ status: [{}] })
+      text: async () => String(url).endsWith(':commit')
+        ? JSON.stringify({ writeResults: [{}], commitTime: '2026-07-18T00:00:00Z' })
         : '{}'
     } as Response))
     global.fetch = fetchMock
@@ -41,12 +41,12 @@ describe('FirestoreBackupService', () => {
 
     await new FirestoreBackupService().syncToCloudBatch([event], null)
 
-    const batchWriteCall = fetchMock.mock.calls.find(([url]) => String(url).endsWith(':batchWrite'))
-    expect(batchWriteCall).toBeDefined()
+    const commitCall = fetchMock.mock.calls.find(([url]) => String(url).endsWith(':commit'))
+    expect(commitCall).toBeDefined()
 
-    const [url, init] = batchWriteCall!
+    const [url, init] = commitCall!
     expect(url).toBe(
-      'https://firestore.googleapis.com/v1/projects/pokerchase-hud/databases/(default)/documents:batchWrite'
+      'https://firestore.googleapis.com/v1/projects/pokerchase-hud/databases/(default)/documents:commit'
     )
 
     const body = JSON.parse(String(init?.body))
@@ -57,17 +57,47 @@ describe('FirestoreBackupService', () => {
     expect(body.writes[0].update.name).not.toMatch(/^https?:\/\//)
   })
 
-  test('batchWrite rejects an individual write failure returned with HTTP 200', async () => {
+  test('commitWrites rejects when Firestore denies the write at the HTTP level (e.g. rules PERMISSION_DENIED)', async () => {
     global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
+      ok: false,
+      status: 403,
       text: async () => JSON.stringify({
-        status: [{ code: 7, message: 'Missing or insufficient permissions.' }]
+        error: { code: 403, message: 'Missing or insufficient permissions.', status: 'PERMISSION_DENIED' }
       })
     } as Response)
 
     const event = { timestamp: 1779859063171, ApiTypeId: 304 } as unknown as ApiEvent
     await expect(new FirestoreBackupService().syncToCloudBatch([event], null))
-      .rejects.toThrow('Firestore batchWrite failed for 1/1 writes')
+      .rejects.toThrow('Firestore REST request failed: 403')
+  })
+
+  test('commitWrites retries on HTTP 429 RESOURCE_EXHAUSTED', async () => {
+    let commitCalls = 0
+    global.fetch = jest.fn().mockImplementation(async (url: string) => {
+      if (!String(url).endsWith(':commit')) {
+        return { ok: true, text: async () => '{}' } as Response
+      }
+      commitCalls++
+      if (commitCalls === 1) {
+        return {
+          ok: false,
+          status: 429,
+          text: async () => JSON.stringify({
+            error: { code: 429, message: 'RESOURCE_EXHAUSTED', status: 'RESOURCE_EXHAUSTED' }
+          })
+        } as Response
+      }
+      return {
+        ok: true,
+        text: async () => JSON.stringify({ writeResults: [{}], commitTime: '2026-07-18T00:00:00Z' })
+      } as Response
+    })
+
+    const event = { timestamp: 1779859063171, ApiTypeId: 304 } as unknown as ApiEvent
+    const summary = await new FirestoreBackupService().syncToCloudBatch([event], null)
+
+    expect(summary.syncedEvents).toBe(1)
+    expect(commitCalls).toBe(2)
   })
 
   test('syncFromCloud downloads matching events in bounded, cursor-based pages', async () => {

--- a/src/services/firestore-backup-service.ts
+++ b/src/services/firestore-backup-service.ts
@@ -46,13 +46,9 @@ interface RunAggregationQueryResult {
   }
 }
 
-interface FirestoreStatus {
-  code?: number
-  message?: string
-}
-
-interface BatchWriteResponse {
-  status?: FirestoreStatus[]
+interface CommitResponse {
+  writeResults?: unknown[]
+  commitTime?: string
 }
 
 interface EventQueryCursor {
@@ -60,20 +56,11 @@ interface EventQueryCursor {
   documentName: string
 }
 
-class FirestoreBatchWriteError extends Error {
-  constructor(
-    readonly code: number,
-    readonly failedWrites: number,
-    message: string
-  ) {
-    super(message)
-    this.name = 'FirestoreBatchWriteError'
-  }
-}
-
 export class FirestoreBackupService {
   private readonly USERS_COLLECTION = 'users'
   private readonly EVENTS_COLLECTION = 'apiEvents'
+  // Writes go through Firestore's :commit REST method, which applies at most
+  // 500 writes atomically in a single request. Both of these must stay <=500.
   private readonly BATCH_SIZE = DATABASE_CONSTANTS.FIRESTORE_BATCH_SIZE
   private readonly BATCH_DELAY_MS = DATABASE_CONSTANTS.FIRESTORE_BATCH_DELAY_MS
   private readonly DELETE_BATCH_SIZE = DATABASE_CONSTANTS.FIRESTORE_DELETE_BATCH
@@ -224,7 +211,7 @@ export class FirestoreBackupService {
         const docs = await this.queryEventDocuments(user.uid, 'asc', this.DELETE_BATCH_SIZE)
         if (docs.length === 0) break
 
-        await this.batchWrite(docs.map(doc => ({ delete: doc.name })))
+        await this.commitWrites(docs.map(doc => ({ delete: doc.name })))
         totalDeleted += docs.length
 
         if (Math.floor(totalDeleted / 10000) > Math.floor((totalDeleted - docs.length) / 10000)) {
@@ -260,12 +247,11 @@ export class FirestoreBackupService {
     let retries = 3
     while (retries > 0) {
       try {
-        await this.batchWrite(writes)
+        await this.commitWrites(writes)
         return
       } catch (error: any) {
         const message = error instanceof Error ? error.message : ''
-        const rateLimited = (error instanceof FirestoreBatchWriteError && error.code === 8) ||
-          message.includes('RESOURCE_EXHAUSTED') ||
+        const rateLimited = message.includes('RESOURCE_EXHAUSTED') ||
           message.includes('REST request failed: 429')
         if (rateLimited && retries > 1) {
           console.warn(`[Firestore] Rate limit hit, retrying in ${this.BATCH_DELAY_MS}ms...`)
@@ -398,35 +384,23 @@ export class FirestoreBackupService {
     return count && 'integerValue' in count ? Number(count.integerValue) : 0
   }
 
-  private async batchWrite(writes: Array<Record<string, unknown>>): Promise<void> {
-    const response = await this.request<BatchWriteResponse>(`${this.baseUrl}:batchWrite`, {
+  /**
+   * Apply up to 500 writes atomically via Firestore's `:commit` REST method.
+   *
+   * `:commit` (unlike `:batchWrite`) reports failures as a normal HTTP error
+   * on the request itself (handled by `request()`'s `!response.ok` check),
+   * rather than embedding a per-write `status` array inside an HTTP 200
+   * response. That keeps failure handling identical to every other call in
+   * this service (`setUserMetadata`, `runQuery`, ...) and means a write that
+   * a security rule denies fails the whole call instead of silently
+   * succeeding for the rest of the batch.
+   */
+  private async commitWrites(writes: Array<Record<string, unknown>>): Promise<void> {
+    await this.request<CommitResponse>(`${this.baseUrl}:commit`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ writes })
     })
-
-    const statuses = response?.status ?? []
-    if (statuses.length !== writes.length) {
-      throw new Error(
-        `Firestore batchWrite returned ${statuses.length} statuses for ${writes.length} writes`
-      )
-    }
-
-    const failures = statuses
-      .map((status, index) => ({ status, index }))
-      .filter(({ status }) => (status.code ?? 0) !== 0)
-    if (failures.length > 0) {
-      const first = failures[0]!
-      const code = first.status.code ?? 2
-      const details = failures.slice(0, 3)
-        .map(({ status, index }) => `write ${index}: code ${status.code ?? 2} ${status.message ?? 'Unknown error'}`)
-        .join('; ')
-      throw new FirestoreBatchWriteError(
-        code,
-        failures.length,
-        `Firestore batchWrite failed for ${failures.length}/${writes.length} writes (${details})`
-      )
-    }
   }
 
   private async request<T = unknown>(url: string, init: RequestInit): Promise<T | null> {


### PR DESCRIPTION
## 実機診断で確定した症状

有効な Firebase ID トークン(uid/aud/期限すべて正常を実測)で:

- runAggregationQuery(読み取り): **200**(クラウド 310,218 イベント)
- 単発 PATCH(users/{uid}): **200**
- **`:batchWrite` のみ HTTP 403** `PERMISSION_DENIED "Missing or insufficient permissions"`(スタックトレースで確認)

さらにクラウド側 `lastSyncTime = 2026-03-26`(REST 化 #82 の直後)— **アップロードは REST 化以来ほぼ一度も成功していない**とみられる(クラウド 31 万件は SDK 時代の遺産、約 8.4 万件が未同期)。

## 修正: `:batchWrite` → `:commit`

書き込み(アップロード/削除)を `:commit` エンドポイントへ移行:

- 観測された 403 は HTTP レベルであり、#124 が実装した per-write status(code 7)処理では**説明も捕捉もできない別経路**だった(エラーメッセージ形式が不一致)
- `:commit` はルール拒否を**アトミックに通常の HTTP エラーとして返す**ため、他の全呼び出しと同じ `request()` の統一エラー処理に載る(#124 で導入した per-write 解析 `FirestoreBatchWriteError` 群は削除)
- 既存のチャンクサイズ(アップロード300 / 削除500)は commit の 500 writes 上限内でそのまま

注記: 「batchWrite はエンドユーザー認証非対応」という仮説は**公式ドキュメントでは裏付けが取れていません**(スコープ・無認証時挙動とも commit と同一)。本修正の正当性は仕様の解釈ではなく挙動保証に依ります — batchWrite 固有の問題なら根治、ペイロード起因の rules 拒否が真因の場合も「静かな失敗」が「明確なアトミック失敗」に変わり、次の診断で即座に原因種別(PERMISSION_DENIED / INVALID_ARGUMENT 等)を判別できます。実ユーザー環境での `:commit` vs `:batchWrite` 同一ペイロード比較テストを並行実施中。

## 検証

- `npm run typecheck` ✅ / `npx jest` — **508/508(57 suites)** ✅ / `npm run build` ✅
- テストは `:commit` モックへ更新し、HTTP 403/429 の伝播を検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)