### PR TITLE
fix(popup): time out service-worker requests and stop 5s getSyncInfo re-fires

### DIFF
--- a/src/components/Popup.test.tsx
+++ b/src/components/Popup.test.tsx
@@ -516,4 +516,41 @@ describe('Popup', () => {
       jest.useRealTimers()
     }, 10000)
   })
+
+  describe('Service Worker無応答時のフェイルオープン', () => {
+    it('firebaseAuthStatus/getSyncStateがタイムアウトしてもUIはブロックされず既定状態で使用可能', async () => {
+      jest.useFakeTimers()
+
+      // Simulate a busy/unresponsive service worker: sendMessage never calls its callback
+      mockChromeRuntimeSendMessage.mockImplementation(() => {
+        // no-op: never invokes the callback
+      })
+
+      render(<Popup />)
+
+      // The mount effect calls chrome.storage.sync/local.get synchronously,
+      // and sendMessage is invoked (even though it never responds)
+      await waitFor(() => {
+        expect(mockChromeRuntimeSendMessage).toHaveBeenCalledWith(
+          { action: 'firebaseAuthStatus' },
+          expect.any(Function)
+        )
+      })
+
+      // The rest of the popup renders immediately — not blocked on the SW response
+      expect(screen.getByText('サイズ:')).toBeInTheDocument()
+
+      // Advance past the sendMessageWithTimeout window (8s default default) for
+      // both getSyncState poll and firebaseAuthStatus; must not throw or hang
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(9000)
+      })
+
+      // Fail-open default: still shows the "enable backup" sign-in button
+      // (isFirebaseSignedIn stayed at its default `false`), not a stuck spinner
+      expect(screen.getByText('自動バックアップを有効にする')).toBeInTheDocument()
+
+      jest.useRealTimers()
+    }, 15000)
+  })
 })

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -16,6 +16,7 @@ import type {
 } from '../types/messages'
 import type { SyncState } from '../services/auto-sync-service'
 import { content_scripts } from '../../manifest.json'
+import { sendMessageWithTimeout } from './popup/send-message'
 
 // Import sub-components
 import { UIScaleSection } from './popup/UIScaleSection'
@@ -52,8 +53,10 @@ const Popup = () => {
   // Fetch sync state
   useEffect(() => {
     const fetchSyncState = () => {
-      chrome.runtime.sendMessage({ action: 'getSyncState' }, (response: any) => {
-        if (response && response.syncState) {
+      // Fails open: on timeout/error, leave syncState as-is rather than
+      // blocking the poll loop or surfacing a stuck spinner.
+      sendMessageWithTimeout<{ syncState?: SyncState }>({ action: 'getSyncState' }).then((response) => {
+        if (response?.syncState) {
           setSyncState(response.syncState)
         }
       })
@@ -161,15 +164,19 @@ const Popup = () => {
         }
       })
 
-      // Then verify with background (authoritative source)
-      chrome.runtime.sendMessage({ action: 'firebaseAuthStatus' }, (response: any) => {
+      // Then verify with background (authoritative source).
+      // Fails open: on timeout/error, keep whatever was already set from
+      // the chrome.storage.local cache above instead of blocking the UI.
+      sendMessageWithTimeout<{ isSignedIn?: boolean; userInfo?: { email: string; uid: string } | null }>({
+        action: 'firebaseAuthStatus'
+      }).then((response) => {
         if (response) {
           setIsFirebaseSignedIn(response.isSignedIn || false)
           setFirebaseUserInfo(response.userInfo || null)
-          
+
           // Also get sync state if signed in
-          chrome.runtime.sendMessage({ action: 'getSyncState' }, (syncResponse: any) => {
-            if (syncResponse && syncResponse.syncState) {
+          sendMessageWithTimeout<{ syncState?: SyncState }>({ action: 'getSyncState' }).then((syncResponse) => {
+            if (syncResponse?.syncState) {
               setSyncState(syncResponse.syncState)
             }
           })

--- a/src/components/popup/FirebaseAuthSection.test.tsx
+++ b/src/components/popup/FirebaseAuthSection.test.tsx
@@ -45,7 +45,7 @@ describe('FirebaseAuthSection', () => {
     expect(screen.queryByText('ログアウト')).not.toBeInTheDocument()
   })
 
-  it('サインイン時はユーザー情報と同期ボタンを表示', () => {
+  it('サインイン時はユーザー情報と同期ボタンを表示', async () => {
     const syncState: SyncState = {
       status: 'idle',
       lastSyncTime: new Date(Date.now() - 60000), // 1分前
@@ -62,7 +62,9 @@ describe('FirebaseAuthSection', () => {
 
     expect(screen.getByText('test@example.com')).toBeInTheDocument()
     // 最終同期時刻が表示されることを確認（日時形式）
-    expect(screen.getByText(/最終同期:/)).toBeInTheDocument()
+    // getSyncInfo is now fetched via sendMessageWithTimeout (resolves as a
+    // microtask), so the timestamp line appears asynchronously
+    expect(await screen.findByText(/最終同期:/)).toBeInTheDocument()
     expect(screen.getByText('アップロード')).toBeInTheDocument()
     expect(screen.getByText('ダウンロード')).toBeInTheDocument()
     expect(screen.getByText('ログアウト')).toBeInTheDocument()

--- a/src/components/popup/ImportExportSection.test.tsx
+++ b/src/components/popup/ImportExportSection.test.tsx
@@ -31,7 +31,13 @@ describe('ImportExportSection - rebuild advisory banner', () => {
   beforeEach(() => {
     storageChangeListeners = []
     storageLocalData = {}
-    mockSendMessage = jest.fn()
+    // Default: respond synchronously with no operationState (mirrors "nothing in
+    // progress"), so the sendMessageWithTimeout() call in the mount effect
+    // resolves immediately instead of leaving a real 8s timeout timer pending
+    // after each test.
+    mockSendMessage = jest.fn((_message: unknown, callback?: (response: unknown) => void) => {
+      if (typeof callback === 'function') callback({})
+    })
 
     global.chrome = {
       ...global.chrome,

--- a/src/components/popup/ImportExportSection.tsx
+++ b/src/components/popup/ImportExportSection.tsx
@@ -17,6 +17,7 @@ import type {
 } from '../../types/messages'
 import { isExportProgressMessage, isRebuildProgressMessage } from '../../types/messages'
 import { REBUILD_ADVISORY_STORAGE_KEY, type RebuildAdvisoryState } from '../../background/rebuild-advisory'
+import { sendMessageWithTimeout } from './send-message'
 
 interface ImportExportSectionProps {
   importStatus: string
@@ -73,9 +74,10 @@ export const ImportExportSection = ({
 
   // Listen for export/rebuild progress messages and query state on mount
   useEffect(() => {
-    // Query current operation state on mount (handles popup close/reopen)
-    chrome.runtime.sendMessage({ action: 'getOperationState' }, (response: any) => {
-      if (chrome.runtime.lastError) return // Extension context may be invalid
+    // Query current operation state on mount (handles popup close/reopen).
+    // Fails open: on timeout/error, leave export/rebuild state at their
+    // 'idle' defaults instead of blocking the buttons or showing a spinner.
+    sendMessageWithTimeout<{ operationState?: any }>({ action: 'getOperationState' }).then((response) => {
       if (response?.operationState) {
         const state = response.operationState
         if (state.type === 'export') {

--- a/src/components/popup/SyncStatusSection.test.tsx
+++ b/src/components/popup/SyncStatusSection.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { SyncStatusSection } from './SyncStatusSection'
+import type { SyncState } from '../../services/auto-sync-service'
+
+const noop = () => {}
+
+describe('SyncStatusSection', () => {
+  let mockSendMessage: jest.Mock
+
+  beforeEach(() => {
+    mockSendMessage = jest.fn()
+    global.chrome = {
+      ...global.chrome,
+      runtime: {
+        ...global.chrome.runtime,
+        sendMessage: mockSendMessage,
+      },
+    } as any
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('getSyncInfoがタイムアウトしてもフェイルオープンし、UIはブロックされない', async () => {
+    jest.useFakeTimers()
+
+    // Simulate a hung/busy service worker: sendMessage never calls its callback
+    mockSendMessage.mockImplementation(() => {
+      // no-op: never invokes the callback
+    })
+
+    render(
+      <SyncStatusSection
+        syncState={{ status: 'idle' }}
+        handleManualSyncUpload={noop}
+        handleManualSyncDownload={noop}
+      />
+    )
+
+    // Status text renders immediately from props — never blocked on getSyncInfo
+    expect(screen.getByText('待機中')).toBeInTheDocument()
+    expect(screen.getByText('アップロード')).not.toBeDisabled()
+    expect(screen.getByText('ダウンロード')).not.toBeDisabled()
+
+    // Advance past the sendMessageWithTimeout window (8s default); must not
+    // throw or leave an unhandled rejection
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(9000)
+    })
+
+    // Fails open: no timestamp line ever appears (syncInfo never arrived),
+    // but the rest of the UI stays fully interactive — no stuck spinner
+    expect(screen.queryByText(/最終同期:/)).not.toBeInTheDocument()
+    expect(screen.getByText('アップロード')).not.toBeDisabled()
+    expect(screen.getByText('ダウンロード')).not.toBeDisabled()
+  })
+
+  it('syncStateの内容が同一なら新しいオブジェクト参照で再レンダーしてもgetSyncInfoを再送しない', async () => {
+    const lastSyncTime = new Date('2026-07-18T00:00:00Z')
+    mockSendMessage.mockImplementation((_message, callback) => {
+      callback({ syncInfo: { uploadPendingCount: 0 } })
+    })
+
+    const makeState = (): SyncState => ({ status: 'idle', lastSyncTime })
+
+    const { rerender } = render(
+      <SyncStatusSection
+        syncState={makeState()}
+        handleManualSyncUpload={noop}
+        handleManualSyncDownload={noop}
+      />
+    )
+
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalledTimes(1)
+    })
+
+    // A brand-new object identity every poll tick, same content — this is
+    // exactly what Popup.tsx's 5s getSyncState poll produces
+    for (let i = 0; i < 3; i++) {
+      rerender(
+        <SyncStatusSection
+          syncState={makeState()}
+          handleManualSyncUpload={noop}
+          handleManualSyncDownload={noop}
+        />
+      )
+    }
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // Still only the single initial call — no db.apiEvents.count() re-fires
+    expect(mockSendMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('syncStateのstatusが実際に変化したらgetSyncInfoを再送する', async () => {
+    mockSendMessage.mockImplementation((_message, callback) => {
+      callback({ syncInfo: { uploadPendingCount: 0 } })
+    })
+
+    const { rerender } = render(
+      <SyncStatusSection
+        syncState={{ status: 'idle' }}
+        handleManualSyncUpload={noop}
+        handleManualSyncDownload={noop}
+      />
+    )
+
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalledTimes(1)
+    })
+
+    rerender(
+      <SyncStatusSection
+        syncState={{ status: 'syncing' }}
+        handleManualSyncUpload={noop}
+        handleManualSyncDownload={noop}
+      />
+    )
+
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/src/components/popup/SyncStatusSection.tsx
+++ b/src/components/popup/SyncStatusSection.tsx
@@ -4,6 +4,7 @@ import Typography from '@mui/material/Typography'
 import { ArrowUpward, ArrowDownward } from '@mui/icons-material'
 import type { SyncState } from '../../services/auto-sync-service'
 import { useEffect, useState } from 'react'
+import { sendMessageWithTimeout } from './send-message'
 
 interface SyncStatusSectionProps {
   syncState: SyncState
@@ -25,13 +26,28 @@ export const SyncStatusSection = ({
   const [syncInfo, setSyncInfo] = useState<SyncInfo | null>(null)
 
   useEffect(() => {
-    // Get sync info on mount and when syncState changes
-    chrome.runtime.sendMessage({ action: 'getSyncInfo' }, (response: any) => {
-      if (response && response.syncInfo) {
+    // Get sync info on mount and when syncState actually transitions.
+    // Depend on primitive fields (content), not the syncState object
+    // identity — Popup.tsx polls getSyncState every 5s and always sets a
+    // freshly-identitied object, which would otherwise re-fire this on
+    // every poll tick and re-run a live db.apiEvents.count() over the
+    // full event store each time.
+    let cancelled = false
+
+    // Fails open: on timeout/error, keep the last known syncInfo (or the
+    // initial null) rather than blocking — the timestamp line simply
+    // stays hidden/stale, nothing spins forever.
+    sendMessageWithTimeout<{ syncInfo?: SyncInfo }>({ action: 'getSyncInfo' }).then((response) => {
+      if (cancelled) return
+      if (response?.syncInfo) {
         setSyncInfo(response.syncInfo)
       }
     })
-  }, [syncState])
+
+    return () => {
+      cancelled = true
+    }
+  }, [syncState.status, syncState.lastSyncTime])
 
   const formatTimestamp = (timestamp?: number) => {
     if (!timestamp) return '未確認'

--- a/src/components/popup/send-message.ts
+++ b/src/components/popup/send-message.ts
@@ -1,0 +1,49 @@
+/**
+ * Wraps chrome.runtime.sendMessage with a timeout so popup UI never hangs
+ * forever waiting on a busy/unresponsive MV3 service worker.
+ *
+ * Background: before #124, a multi-second synchronous JSON.parse in the
+ * legacy sync path re-ran on every service-worker wake, so popup widgets
+ * that awaited a plain callback-style sendMessage() could hang indefinitely
+ * with no feedback ("popup won't open / frozen" reports). This helper
+ * bounds that wait and always resolves.
+ *
+ * Resolves `undefined` if the service worker never responds within
+ * `timeoutMs`, or if chrome.runtime.lastError is set (e.g. extension
+ * context invalidated / no receiving end). Callers MUST treat `undefined`
+ * as "unknown state" and fail open to a sensible default rather than
+ * blocking the UI — never render an indefinite spinner while waiting on
+ * this call.
+ */
+export function sendMessageWithTimeout<T = unknown>(
+  message: unknown,
+  timeoutMs = 8000
+): Promise<T | undefined> {
+  return new Promise((resolve) => {
+    let settled = false
+
+    const finish = (value: T | undefined) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve(value)
+    }
+
+    const timer = setTimeout(() => finish(undefined), timeoutMs)
+
+    try {
+      chrome.runtime.sendMessage(message, (response: T) => {
+        // Reading lastError acknowledges it so Chrome doesn't log an
+        // "Unchecked runtime.lastError" warning to the console.
+        if (chrome.runtime.lastError) {
+          finish(undefined)
+          return
+        }
+        finish(response)
+      })
+    } catch {
+      // Synchronous throw (e.g. extension context invalidated)
+      finish(undefined)
+    }
+  })
+}


### PR DESCRIPTION
## 背景(popup「開かない/凍る」報告の恒久対策)

実プロファイルでのみ発症した popup フリーズの主因は、pre-#124 の sync が SW スレッドを長時間ブロックし(31万件の同期 JSON parse を SW 起床毎に再実行)、popup の全 `sendMessage` が飢餓状態になることでした(#124 のページネーション化で主因は解消済み)。ただし popup 側には「SW が無応答だと**無期限に固まる**」構造が残っており、今後の SW ビジー時(大規模 rebuild / import 等)にも同じ症状が再発しうるため、防御を入れます。

## 変更

1. **`sendMessageWithTimeout`(8秒)を新設**し、popup のマウント/ポーリング系呼び出し(`getSyncState` / `firebaseAuthStatus` / `getOperationState` / `getSyncInfo`)を移行。タイムアウト時は各所で **fail-open**(キャッシュ済み auth 表示を維持・ボタンは有効のまま・次ポーリングで自然回復)し、スピナーが永久に固まらない
2. **SyncStatusSection の 5 秒毎 `db.apiEvents.count()` 再発火を停止**: effect 依存をオブジェクト同一性(`[syncState]`、ポーリング毎に新参照)から内容(`[status, lastSyncTime]`)へ — 40万行 DB への常時カウント負荷を除去
3. 長時間操作(export/import/rebuild)の進捗イベントフローは対象外(別経路のまま)

## テスト

- SW 無応答シミュレーション(コールバック永久未到達 + fake timers 9 秒経過)→ UI 非ブロック・未処理 rejection なし
- 同一内容の新規オブジェクトで3回再レンダー → `getSyncInfo` 呼び出しが 1 回のまま(遷移時のみ再送のコントロール付き)
- 既存テスト側の潜在問題2件(同期アサーションのマイクロタスク化 / 実タイマー残留)も修正

`npm run typecheck` ✅ / `npx jest` — **511/511(58 suites)** ×2 ✅ / `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)