### PR TITLE
fix(e2e): game-realistic 1920x1080 default viewport for QA harness

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -184,6 +184,15 @@ pointed at `e2e/.build/extension/`. Headless was verified to work fine for
 this harness (Chrome for Testing supports extensions in headless mode) and
 is the default; pass `{ headed: true }` to watch it.
 
+The default viewport is **1920x1080** (`DEFAULT_VIEWPORT` in
+`e2e/config.ts`), not puppeteer's own ~1280x800 default -- real gameplay
+runs on a fullscreen ~1920x1080 Unity WebGL canvas, and the HUD
+(`src/components/Hud.tsx`) positions player panels with percentage
+coordinates plus fixed 240px widths, so a smaller viewport visibly crowds
+or overlaps panels that don't overlap in the real game. Override it with
+`{ viewport: { width, height } }` on `launchHarness`, `--viewport WxH` on
+`e2e/run.ts launch`, or `--viewport WxH` on `e2e/scenarios/smoke.ts`.
+
 ## AI-agent QA: the step-by-step CLI
 
 For exploratory QA (by a human or an AI agent), `e2e/run.ts` gives you a
@@ -193,9 +202,10 @@ you've opened, popup tabs, etc.) persists across calls until `close`.
 
 ```sh
 # Start a session (builds the e2e extension automatically if none exists).
-npx tsx e2e/run.ts launch                       # headless, default fixture
+npx tsx e2e/run.ts launch                       # headless, default fixture, 1920x1080 viewport
 npx tsx e2e/run.ts launch --headed               # watch the browser
 npx tsx e2e/run.ts launch --fixture path/to.ndjson --replay-delay 300
+npx tsx e2e/run.ts launch --viewport 1280x800    # override the default (game-realistic) viewport
 
 npx tsx e2e/run.ts status                        # is a session running? where?
 npx tsx e2e/run.ts wait-hud                       # block until the HUD mounts

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -47,6 +47,30 @@ export const CHROME_BUILD_ID = process.env.E2E_CHROME_BUILD_ID || '151.0.7922.34
 /** Default fixture replayed by the smoke scenario / CLI when none is given. */
 export const DEFAULT_FIXTURE = join(E2E_DIR, 'fixtures', 'session-3hands.ndjson')
 
+export interface Viewport {
+  width: number
+  height: number
+}
+
+/**
+ * Default browser viewport. Real gameplay happens on a ~1920x1080
+ * fullscreen Unity WebGL canvas, and the HUD (`src/components/Hud.tsx`)
+ * positions player panels with percentage coordinates plus fixed 240px
+ * widths -- geometry that only reproduces game-realistic (non-overlapping)
+ * panel layout at a game-realistic viewport size. Puppeteer's own default
+ * (~1280x800) is too small and causes panels to visibly overlap. Override
+ * with `--viewport WxH` (`e2e/run.ts launch`, `e2e/scenarios/smoke.ts`) or
+ * the `viewport` option to `launchHarness`.
+ */
+export const DEFAULT_VIEWPORT: Viewport = { width: 1920, height: 1080 }
+
+/** Parses a `WIDTHxHEIGHT` string (e.g. `"1920x1080"`) into a {@link Viewport}. Throws on malformed input. */
+export const parseViewport = (spec: string): Viewport => {
+  const match = /^(\d+)x(\d+)$/.exec(spec.trim())
+  if (!match) throw new Error(`Invalid --viewport value ${JSON.stringify(spec)} -- expected "WIDTHxHEIGHT", e.g. "1920x1080"`)
+  return { width: Number(match[1]), height: Number(match[2]) }
+}
+
 /** Default directory for screenshots / DOM snapshots written by the CLI. */
 export const DEFAULT_OUTPUT_DIR = join(E2E_DIR, 'out')
 

--- a/e2e/harness.ts
+++ b/e2e/harness.ts
@@ -24,7 +24,7 @@ import { dirname } from 'node:path'
 import { install, computeExecutablePath, Browser as BrowserId, detectBrowserPlatform } from '@puppeteer/browsers'
 import puppeteer, { type Browser, type Page } from 'puppeteer-core'
 import { startFixtureServer, type FixtureServerHandle } from './fixture-server.ts'
-import { FIXTURE_PORT, EXTENSION_DIR, BROWSER_CACHE_DIR, CHROME_BUILD_ID, DEFAULT_FIXTURE } from './config.ts'
+import { FIXTURE_PORT, EXTENSION_DIR, BROWSER_CACHE_DIR, CHROME_BUILD_ID, DEFAULT_FIXTURE, DEFAULT_VIEWPORT, type Viewport } from './config.ts'
 
 export interface LaunchOptions {
   /** Path to the built e2e extension directory (must contain manifest.json + dist/). */
@@ -34,6 +34,8 @@ export interface LaunchOptions {
   port?: number
   /** Show the Chrome window. Extensions are unreliable in headless Chrome, but headless has been verified to also work for this harness (see e2e/README.md) -- defaults to false (headless) for unattended/CI-style use. */
   headed?: boolean
+  /** Browser viewport size. Defaults to {@link DEFAULT_VIEWPORT} (1920x1080, matching the real game's fullscreen Unity canvas -- see its doc comment for why this matters for HUD panel geometry). */
+  viewport?: Viewport
 }
 
 export interface HarnessHelpers {
@@ -143,6 +145,7 @@ export const launchHarness = async (options: LaunchOptions = {}): Promise<Harnes
   const extensionDir = options.extensionDir ?? EXTENSION_DIR
   const port = options.port ?? FIXTURE_PORT
   const headed = options.headed ?? false
+  const viewport = options.viewport ?? DEFAULT_VIEWPORT
 
   const fixtureServer = await startFixtureServer({
     fixturePath: options.fixturePath ?? DEFAULT_FIXTURE,
@@ -170,9 +173,20 @@ export const launchHarness = async (options: LaunchOptions = {}): Promise<Harnes
         `--load-extension=${extensionDir}`,
         '--no-first-run',
         '--no-default-browser-check',
-        '--window-size=1280,900',
+        // Window size in *headed* mode only affects the outer OS window
+        // (Chrome adds its own title/tab/toolbar chrome on top of this);
+        // it has no effect headless, where there's no window chrome to
+        // account for. The actual page viewport -- what the HUD's
+        // percentage-based panel positioning sees -- is controlled by
+        // `defaultViewport` below via CDP, independent of this flag. Kept
+        // equal to the viewport so a `--headed` run's window is at least
+        // as large as the content it's showing.
+        `--window-size=${viewport.width},${viewport.height}`,
       ],
-      defaultViewport: null,
+      // Explicit (not `null`) so the viewport is game-realistic regardless
+      // of window size/chrome -- see DEFAULT_VIEWPORT's doc comment in
+      // e2e/config.ts for why 1920x1080 matters to HUD panel geometry.
+      defaultViewport: { width: viewport.width, height: viewport.height, deviceScaleFactor: 1 },
     })
     launchedBrowser = browser
 

--- a/e2e/run.ts
+++ b/e2e/run.ts
@@ -5,7 +5,7 @@
  * number of small commands against the *same* running browser/HUD, in any
  * order, with normal shell tool calls.
  *
- *   npx tsx e2e/run.ts launch [--headed] [--fixture <path>] [--replay-delay <ms>] [--build]
+ *   npx tsx e2e/run.ts launch [--headed] [--fixture <path>] [--replay-delay <ms>] [--build] [--viewport <WxH>]
  *   npx tsx e2e/run.ts status
  *   npx tsx e2e/run.ts wait-hud [--timeout <ms>]
  *   npx tsx e2e/run.ts screenshot <out.png>
@@ -28,7 +28,7 @@ import { isAbsolute, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { launchHarness, attachHarness } from './harness.ts'
 import { buildE2E } from './tools/build-e2e.ts'
-import { BUILD_DIR, DEFAULT_FIXTURE, DEFAULT_OUTPUT_DIR, E2E_DIR } from './config.ts'
+import { BUILD_DIR, DEFAULT_FIXTURE, DEFAULT_OUTPUT_DIR, E2E_DIR, parseViewport } from './config.ts'
 
 const SESSION_FILE = join(BUILD_DIR, 'session.json')
 
@@ -59,8 +59,9 @@ const runDaemon = async (argv: string[]): Promise<void> => {
   const headed = argv.includes('--headed')
   const fixturePath = flag(argv, '--fixture') ?? DEFAULT_FIXTURE
   const replayDelayMs = flag(argv, '--replay-delay') ? Number(flag(argv, '--replay-delay')) : 0
+  const viewport = flag(argv, '--viewport') ? parseViewport(flag(argv, '--viewport')!) : undefined
 
-  const harness = await launchHarness({ headed, fixturePath, replayDelayMs })
+  const harness = await launchHarness({ headed, fixturePath, replayDelayMs, viewport })
   const state: SessionState = {
     browserWSEndpoint: harness.browser.wsEndpoint(),
     fixtureOrigin: harness.fixtureServer.origin,
@@ -249,7 +250,7 @@ const cmdClose = async (): Promise<void> => {
 const HELP = `Usage: npx tsx e2e/run.ts <command> [args]
 
 Commands:
-  launch [--headed] [--fixture <path>] [--replay-delay <ms>] [--build]
+  launch [--headed] [--fixture <path>] [--replay-delay <ms>] [--build] [--viewport <WxH>]
   status
   wait-hud [--timeout <ms>]
   screenshot [out.png]

--- a/e2e/scenarios/smoke.ts
+++ b/e2e/scenarios/smoke.ts
@@ -3,7 +3,7 @@
  * 3-hand fixture, and assert the HUD + popup actually work end to end.
  *
  *   npm run e2e:smoke
- *   tsx e2e/scenarios/smoke.ts [--headed] [--screenshot-dir <dir>] [--fixture <path>]
+ *   tsx e2e/scenarios/smoke.ts [--headed] [--screenshot-dir <dir>] [--fixture <path>] [--viewport <WxH>]
  *
  * On any failure this dumps a screenshot + DOM snapshot before exiting
  * non-zero, so a failed CI/local run always leaves evidence behind.
@@ -12,7 +12,7 @@ import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { buildE2E } from '../tools/build-e2e.ts'
 import { launchHarness, type Harness } from '../harness.ts'
-import { DEFAULT_OUTPUT_DIR, DEFAULT_FIXTURE } from '../config.ts'
+import { DEFAULT_OUTPUT_DIR, DEFAULT_FIXTURE, DEFAULT_VIEWPORT, parseViewport } from '../config.ts'
 
 interface CheckResult {
   name: string
@@ -28,6 +28,9 @@ const parseArgs = (argv: string[]) => ({
   fixturePath: argv.includes('--fixture')
     ? argv[argv.indexOf('--fixture') + 1]!
     : DEFAULT_FIXTURE,
+  viewport: argv.includes('--viewport')
+    ? parseViewport(argv[argv.indexOf('--viewport') + 1]!)
+    : DEFAULT_VIEWPORT,
 })
 
 /**
@@ -62,14 +65,14 @@ const dumpFailureEvidence = async (harness: Harness, screenshotDir: string, labe
 }
 
 const run = async (): Promise<void> => {
-  const { headed, screenshotDir, fixturePath } = parseArgs(process.argv.slice(2))
+  const { headed, screenshotDir, fixturePath, viewport } = parseArgs(process.argv.slice(2))
   mkdirSync(screenshotDir, { recursive: true })
 
   console.log('[smoke] building e2e extension (npm run build:e2e logic)...')
   const extensionDir = buildE2E()
   console.log(`[smoke] extension built at ${extensionDir}`)
 
-  console.log('[smoke] launching harness and replaying fixture...')
+  console.log(`[smoke] launching harness (viewport ${viewport.width}x${viewport.height}) and replaying fixture...`)
   let harness: Harness | undefined
   const checks: CheckResult[] = []
   const check = (name: string, pass: boolean, detail?: string) => {
@@ -78,7 +81,7 @@ const run = async (): Promise<void> => {
   }
 
   try {
-    harness = await launchHarness({ headed, fixturePath, extensionDir })
+    harness = await launchHarness({ headed, fixturePath, extensionDir, viewport })
     // 1. HUD appears (at least one player panel mounted).
     try {
       await harness.waitForHudMount(20000)
@@ -153,7 +156,10 @@ const run = async (): Promise<void> => {
     }
 
     console.log(`\n[smoke] PASSED: all ${checks.length} checks passed`)
-    console.log(`[smoke] screenshots: ${join(screenshotDir, 'smoke-hud.png')}, ${join(screenshotDir, 'smoke-popup.png')}`)
+    console.log(
+      `[smoke] screenshots (viewport ${viewport.width}x${viewport.height}): ` +
+      `${join(screenshotDir, 'smoke-hud.png')}, ${join(screenshotDir, 'smoke-popup.png')}`
+    )
   } catch (err) {
     console.error('[smoke] unexpected error:', err)
     if (harness) await dumpFailureEvidence(harness, screenshotDir, 'unexpected')


### PR DESCRIPTION
## Summary

Smoke screenshots at the previous default viewport (~1280x800, puppeteer default) showed overlapping UI — the hero hand-improvement table covered Player2's panel and the hand log covered Player1's (reported by sola from `e2e/out/smoke-hud.png`). Real gameplay happens on a ~1920x1080 Unity canvas, and HUD panels use percentage positions with fixed 240px widths, so a small viewport makes panels proportionally oversized and collide. The harness now reproduces game-realistic geometry.

- Default viewport **1920x1080, deviceScaleFactor 1** via `defaultViewport` (CDP — what the percentage layout actually sees), with matching `--window-size` for headed mode. Single source of truth in `e2e/config.ts` (`DEFAULT_VIEWPORT`, `parseViewport`).
- Configurable: `--viewport WxH` on both `e2e/run.ts launch` and the smoke scenario.
- Smoke output is now self-describing (prints the viewport used alongside screenshot paths).
- `fixture.html` needed no change (already full-viewport); no production code touched (`git diff --name-only` = e2e/ only).

## Verification

- `npm run e2e:smoke` at 1920x1080: all 6 checks pass; new `smoke-hud.png` visually inspected (by the implementing agent and the orchestrator) — all player panels cleanly separated, hand-improvement table and hand log no longer overlap any panel.
- typecheck clean; jest ×2 green (65 suites / 600 tests, matching current main + no source changes outside e2e/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)