### PR TITLE
feat(db): restore raw event Lake, remove apiEvents hook-based filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,7 @@ data storage (Dexie.js), normalized entities, Firestore strategy, and v3 index o
 13. **Optimistic UI + Server Guard**: Popup sets state immediately on click (responsive UX), background validates and rejects if busy (correctness)
 14. **Cache-First Rendering**: Frequently needed state (Firebase auth) cached in `chrome.storage.local` for instant popup rendering
 15. **Rebuild Advisory Versioning**: Bump `REBUILD_ADVISORY_VERSION` (`src/constants/database.ts`) whenever a change alters write-time entity derivation for already-recorded data, so existing users get prompted (badge/notification/popup banner via `src/background/rebuild-advisory.ts`) to run データ再構築 after updating
+16. **Raw Event Lake**: `apiEvents` is the raw wire log — any event with a numeric `timestamp`+`ApiTypeId` is stored, independent of whether it parses under the current Zod schema or is an application type. Validation gates only the real-time pipeline (streams/stats/entity generation), never storage. This is what makes データ再構築 an actual recovery path after a PokerChase payload change breaks a schema: rebuild re-validates every stored raw row against the *current* schema, so a later schema fix retroactively recovers rows that failed to parse when first received — no separate promotion mechanism needed. See "ApiEvent Architecture" and `docs/architecture.md` for the full rationale and history.
 
 ### Data Flow
 
@@ -214,6 +215,12 @@ data storage (Dexie.js), normalized entities, Firestore strategy, and v3 index o
 WebSocket Events (from content_script)
     │
     ├─► Database (apiEvents.add) ─── Persistent storage
+    │   (numeric timestamp+ApiTypeId only — the Raw Event Lake;
+    │    independent of parseApiEvent/isApplicationApiEvent below)
+    │
+    ▼ parseApiEvent + isApplicationApiEvent gate
+    (non-application / unparseable events stop here — already durably
+     stored above, just not forwarded into the real-time pipeline)
     │
     ├─► HandLogStream ─────────────► Hand Log Output
     │   (Independent stream)          (via 'data' event)
@@ -239,6 +246,7 @@ WebSocket Events (from content_script)
 - Only the main statistics pipeline uses `.pipe()` for sequential processing
 - HandLogStream and RealTimeStatsStream operate in parallel, not as branches
 - Each stream emits results via 'data' events to update different UI components
+- Storage happens *before* the validation gate, not alongside it — see "Raw Event Lake" (Design Principles #16)
 
 **Event Order Handling:**
 
@@ -252,13 +260,14 @@ WebSocket Events (from content_script)
 ```
 NDJSON File (.ndjson)
     ↓
-Parse & Validate
-    ↓
 Chunk Processing
-    ├─► Duplicate Detection (Set-based, O(1))
-    └─► New Events Collection
+    ├─► Duplicate Detection (Set-based, O(1) — keyed on timestamp+ApiTypeId)
+    ├─► Raw Event Storage: every line with numeric timestamp+ApiTypeId is
+    │   bulkAdd'ed to apiEvents (the Lake), regardless of Zod validity
+    └─► Valid Application Events Collection (subset that also parses AND
+        isApplicationApiEvent — tracked only for rows confirmed stored)
          ↓
-EntityConverter (Direct generation)
+EntityConverter (Direct generation, fed only the valid-application subset)
     ├─► Extracts session/player info
     ├─► Generates entities without streams
     └─► Uses statistics modules for ActionDetails
@@ -277,12 +286,16 @@ Statistics Refresh (batch mode)
 - Batch mode disables real-time updates during import
 - Direct entity conversion bypasses stream overhead
 - Falls back to individual inserts on bulk operation failure
+- Storage and entity generation are decoupled: a line that fails to parse (or
+  is a known non-application type) is still stored raw — it just doesn't
+  reach `EntityConverter`. See "Raw Event Lake" (Design Principles #16).
 
 **Critical Design Constraints (learned 2026-03):**
 
 > **Data model & event edge cases** are consolidated in [docs/api-events.md](docs/api-events.md) — see "Data Constraints & Edge Cases", "Field Relationships", and "Enum Reference" sections.
 
 - **EntityConverter state**: `convertEventsToEntities()` tracks hand boundaries via internal local variables (`currentHandEvents`). Must NOT be called in chunks — a hand spanning chunk boundaries will be lost. Always pass all events in a single call.
+- **EntityConverter/HandLogProcessor never see raw, unvalidated rows**: both read required fields (e.g. `EVT_DEAL.Game.SmallBlind`) via unguarded `switch (event.ApiTypeId)` dispatch, with no `default:` case protecting against a well-known-ApiTypeId-but-malformed payload. Every call site that reads from `apiEvents` (the raw Lake) and feeds either of them re-validates first with `filterValidApplicationEvents()` (`src/utils/database-utils.ts`): `rebuildAllData`, `AutoSyncService.rebuildLocalEntities`, `HandLogExporter.exportHand`/`exportMultipleHands`. This re-validation on every rebuild is also the *entire* recovery mechanism for a PokerChase schema break — a later schema fix makes previously-unparseable rows parse on the next rebuild automatically, no promotion step required.
 - **Dexie Collection reuse**: `processInChunks()` uses `.offset().limit()` on a Collection object, but Dexie Collections accumulate state. For reliable pagination, use cursor-based approach with `where('[timestamp+ApiTypeId]').above(lastKey).limit(N)`.
 - **Export size limits**: Service Worker → content_script message limit is 64MiB. Data URL limit is ~2MB. Large exports use chunked message passing with Blob-based download in content_script.
 - **PokerStars hand history format**: `calls` shows additional call amount (not total bet). `Dealt to` is hero-only. Summary uses `folded on the Flop/Turn/River`. See [docs/pokerstars-export.md](docs/pokerstars-export.md).
@@ -542,6 +555,8 @@ Dynamic statistics for all players, with hero having additional hand improvement
 - **Entity schemas** in `src/types/entities.ts`: `Hand`, `Phase`, `Action`, `User` with parse functions
 - **Type guards** (no type assertions): `isApiEventType()`, `parseApiEvent()`, `isApplicationApiEvent()`, `getValidationError()`
 - **Breaking changes**: Use `ApiEvent` (removed: `ApiEventType`, `ApiEventUnion`, `ApiEventSubset`, `ApiEventMap`)
+- **Validation gates the pipeline, never storage** (Raw Event Lake — see Design Principles #16 and `docs/architecture.md`): `apiEvents.add()` in `src/background/event-ingestion.ts` runs before `parseApiEvent`/`isApplicationApiEvent` and stores anything with a numeric `timestamp`+`ApiTypeId` — non-application events (202/205 keepalive/timer), ApiTypeIds unknown to `apiEventSchemas`, and app-type events that currently fail to parse are all persisted. The same event is only forwarded to `eventLogger`/`handLogStream`/`handAggregateStream`/`realTimeStatsStream` when it *does* parse as a known application event. Any code path that reads raw `apiEvents` rows and feeds them into `EntityConverter` or `HandLogProcessor` (which read required fields like `EVT_DEAL.Game.SmallBlind` without guards) must first re-validate with `filterValidApplicationEvents()` (`src/utils/database-utils.ts`) — see `rebuildAllData`, `AutoSyncService.rebuildLocalEntities`, and `HandLogExporter`'s two prefetch sites for the pattern.
+- **Cloud sync is application-type-only** (cost decision, not a data-loss concern): `AutoSyncService.syncToCloud()` filters each raw chunk to `isApplicationApiEvent` before upload — non-application noise and unparseable rows never leave the device. The upload cursor still advances on the *raw* chunk boundary (not the filtered subset), otherwise a chunk that's 100% noise would never advance and the sync loop would refetch it forever.
 
 ### Database Schema
 
@@ -551,13 +566,15 @@ Defined in `src/db/poker-chase-db.ts` (Dexie/IndexedDB). See [docs/architecture.
 
 | Table | Primary Key | Key Indexes | Purpose |
 |---|---|---|---|
-| `apiEvents` | `[timestamp+ApiTypeId]` | `[ApiTypeId+timestamp]` | Raw WebSocket events |
+| `apiEvents` | `[timestamp+ApiTypeId]` | `[ApiTypeId+timestamp]` | Raw WebSocket events — the full Lake (see above), not just application events |
 | `hands` | `id` (auto) | `*seatUserIds`, `approxTimestamp` | Processed hand data |
 | `phases` | `[handId+phase]` | `handId`, `*seatUserIds` | Per-street state |
 | `actions` | `[handId+index]` | `[playerId+phase]`, `[playerId+actionType]`, `*actionDetails` | Player actions with stat markers |
 | `meta` | `id` | `updatedAt` | Import status, stats cache, sync state |
 
-v3 migration added composite indexes for player-specific queries. `MetaRecord` replaced `ImportMeta`.
+v3 migration added composite indexes for player-specific queries. `MetaRecord` replaced `ImportMeta`. No later version bump was needed to restore full-Lake storage (removing the `creating`/`reading` hooks is not an index change).
+
+**Storage growth**: `apiEvents` now also durably stores non-application noise (202/205 keepalive/timer events at roughly the same volume as application events per session — expect apiEvents row count to grow, not just its "useful" subset). IndexedDB quota is browser-managed and generally GB-scale (much larger than `storage.local`'s ~10MB), so this is not expected to be a practical problem. There is currently **no automatic pruning** of `apiEvents`: the existing quota-exceeded handling in `src/services/poker-chase-service.ts` (`cleanupOldStorageData`) and `src/utils/database-utils.ts` (`withTransaction`'s `QuotaExceededError` branch) targets `chrome.storage.local` service-state persistence and IndexedDB transaction errors respectively — neither actively prunes `apiEvents` rows. Users can reset via the popup's "全データ削除" if this ever becomes a real problem; revisit with active pruning only if it does.
 
 ### Configuration & Storage
 
@@ -593,6 +610,7 @@ Key `pokerChaseServiceState` in `storage.local`. Auto-saved with 500ms debounce 
 - **Data Structure**: `/users/{userId}/apiEvents/{timestamp_ApiTypeId}`
 - **Sync Strategy**: Incremental upload, full download (cloud as source of truth)
 - **Cost Optimized**: 100+ event threshold, no periodic sync
+- **Application-type-only sync**: unlike local `apiEvents` (the full Raw Event Lake), Firestore only ever receives application-type events — `AutoSyncService.syncToCloud()` filters each raw chunk with `isApplicationApiEvent` before upload. Non-application noise (202/205 keepalive/timer) and anything that fails to parse stay local-only; this is a cost decision (Firestore write/storage cost), not a data-loss risk, since the local Lake already has the raw copy.
 
 ### Key Features
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,77 @@
 
 > データストレージ、データモデル、クラウド同期、インデックス最適化に関する設計判断とその根拠。
 
+## 0. Raw Event Lake: `apiEvents` は生ログ、バリデーションは保存を左右しない
+
+### 設計原則
+`apiEvents`テーブルは**受信した生イベントの完全なログ**であり、Zodスキーマ検証の
+成否やアプリケーションイベントか否かに関わらず、数値の`timestamp`+`ApiTypeId`を
+持つイベントは全て保存する。バリデーションが左右するのはリアルタイム処理
+パイプライン（`handLogStream`/`handAggregateStream`/`realTimeStatsStream`と
+`EntityConverter`/`HandLogProcessor`への投入可否）だけであり、保存そのものを
+左右しない。
+
+### 経緯（設計のドリフトと復元）
+- **2024年（初期実装、コミット5f7d60c/fce0343）**: 当初から「APIイベントの生ログを
+  保存」する設計だった（`src/db/poker-chase-db.ts`のクラスdocコメントに今も残る文言）。
+- **2025-07-24（コミットa6480ff）**: `apiEvents`テーブルに`creating`/`reading`の
+  Dexieフックを追加し、非アプリケーションイベントを自動フィルタリングする実装に
+  リファクタ。意図は「フィルタリングをDB層に一元化する」ことだったが、副作用として:
+  - `creating`フックは`this.onsuccess = null`しか行っておらず、配下の
+    `IDBObjectStore.add()`自体は既に発行済みのため**実際には書き込みを止められて
+    いなかった**（非アプリケーションイベントは静かに物理保存されたまま、
+    `reading`フックが読み取り結果からnullとして除外することで見えなくしていた）。
+  - より深刻な問題: `event-ingestion.ts`/`import-export.ts`側で
+    Zodパース失敗時に`db.apiEvents.add()`を呼ぶ前に`return`していたため、
+    **パースに失敗したイベントはそもそも保存されていなかった**。PokerChase側の
+    ペイロード仕様変更でスキーマ検証が壊れた場合（2026年シーズン3の
+    `EVT_SESSION_RESULTS`）、そのイベント種別のデータは月単位で完全に失われ、
+    データ再構築でも復旧不能だった。
+- **本バージョン（2026年、feat/restore-raw-event-lake）**: `creating`/`reading`
+  フックを完全に撤廃し、`event-ingestion.ts`/`import-export.ts`の保存判定を
+  「`validateMessage()`が通る（timestamp/ApiTypeIdが数値）」だけに緩和。元々の
+  設計意図を復元しつつ、実際のデータ損失の原因（パース失敗イベントが保存前に
+  discardされていたこと）を修正した。
+
+### 保存とパイプライン投入の分離
+| 判定 | 保存（`apiEvents.add`） | パイプライン投入（ストリーム/EntityConverter） |
+|---|---|---|
+| `timestamp`/`ApiTypeId`が数値でない | ✗ 不可（キーが作れない） | ✗ |
+| 数値だがZodパース失敗（未知の`ApiTypeId`含む） | ✓ 生のまま保存 | ✗（`console.warn`のみ） |
+| パース成功・非アプリケーションイベント（202/205等） | ✓ 保存 | ✗（`console.info`のみ） |
+| パース成功・アプリケーションイベント | ✓ 保存 | ✓ |
+
+### リビルド = 復旧経路
+`rebuildAllData`（`src/background/import-export.ts`）は`apiEvents`の全行を
+`filterValidApplicationEvents()`（`src/utils/database-utils.ts`）で**再検証**して
+から`EntityConverter`に渡す。これにより、PokerChase側のペイロード変更で
+一時的にパースできなくなったイベント種別も、後日スキーマ側を修正して
+データ再構築を実行するだけで自動的に復旧する。dead-letterテーブルや
+プロモーション処理のような別機構は不要——同じ生の行を、直近のスキーマで
+再解釈するだけで済む。同じ再検証は`AutoSyncService.rebuildLocalEntities`
+（クラウドダウンロード後の再構築）と`HandLogExporter`（PokerStarsエクスポート）
+でも行っている。`EntityConverter`/`HandLogProcessor`は`switch (event.ApiTypeId)`
+で必須フィールド（例: `EVT_DEAL.Game.SmallBlind`）を無検証で読むため、
+未検証の生の行を直接渡すとクラッシュしうる。
+
+### クラウド同期は対象外
+Firestoreへのアップロードはアプリケーションイベントのみに限定する
+（`AutoSyncService.syncToCloud()`の`isApplicationApiEvent`フィルタ）。
+これはコスト上の判断（Firestore書き込み/ストレージ課金）であり、データ損失の
+懸念ではない——非アプリケーションイベントや未検証イベントはローカルの
+Raw Event Lakeに既に生のまま残っている。
+
+### ストレージ増加とプルーニング
+`apiEvents`は非アプリケーションノイズ（202/205のキープアライブ/タイマー等、
+セッションあたりアプリケーションイベントとほぼ同程度の件数）も恒久的に保存する
+ため行数は増加するが、IndexedDBのクォータはブラウザ管理でGB級が一般的であり、
+実務上問題になる可能性は低いと想定している。**現時点で`apiEvents`の自動
+プルーニングは実装していない**（`src/services/poker-chase-service.ts`の
+`cleanupOldStorageData`は`chrome.storage.local`のサービス状態用、
+`src/utils/database-utils.ts`の`withTransaction`の`QuotaExceededError`分岐は
+ログのみで能動的なクリーンアップは行わない）。将来的に問題が顕在化した場合の
+フォローアップ候補（詳細な設計は本バージョンでは意図的に見送り）。
+
 ## 1. データストレージ: Dexie.js (IndexedDB)
 
 ### 採用理由
@@ -34,6 +105,9 @@
 大規模なデータ重複、個別アクションのクエリ困難、スケールでの性能低下。
 
 ## 3. クラウド同期: Firestore + 生イベントのみ
+
+> ローカルの`apiEvents`（Raw Event Lake、セクション0参照）とは異なり、Firestoreへの
+> 同期対象はアプリケーションイベントのみ（コスト最適化。データ損失の懸念ではない）。
 
 ### データ構造
 ```

--- a/src/background/event-ingestion.test.ts
+++ b/src/background/event-ingestion.test.ts
@@ -1,0 +1,118 @@
+/**
+ * event-ingestion.ts - Raw Event Lake real-time storage path
+ *
+ * Verifies registerEventIngestion() stores every event with a numeric
+ * timestamp+ApiTypeId in apiEvents *before* and independent of Zod
+ * validation, while only forwarding validated application events into the
+ * real-time pipeline (eventLogger + handLogStream/handAggregateStream/
+ * realTimeStatsStream). This is the fix for the season-3 data-loss bug: a
+ * parse failure used to `return` before ever reaching `db.apiEvents.add()`.
+ */
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { registerEventIngestion } from './event-ingestion'
+import { connectedPorts } from './ports'
+
+describe('registerEventIngestion (Raw Event Lake)', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+  let onMessageHandler: (message: any) => Promise<void>
+  let disconnectHandlers: Array<() => void>
+  let mockPort: any
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    service = new PokerChaseService({ db })
+    await service.ready
+
+    ;(chrome.runtime as any).onConnect = { addListener: jest.fn() }
+    registerEventIngestion(service)
+    const connectListener = (chrome.runtime as any).onConnect.addListener.mock.calls[0][0]
+
+    disconnectHandlers = []
+    mockPort = {
+      name: PokerChaseService.POKER_CHASE_SERVICE_EVENT,
+      onMessage: { addListener: jest.fn() },
+      onDisconnect: { addListener: jest.fn((fn: () => void) => disconnectHandlers.push(fn)) },
+      postMessage: jest.fn()
+    }
+    connectListener(mockPort)
+    onMessageHandler = mockPort.onMessage.addListener.mock.calls[0][0]
+  })
+
+  afterEach(async () => {
+    disconnectHandlers.forEach(fn => fn())
+    connectedPorts.clear()
+    db.close()
+    await db.delete()
+  })
+
+  test('a valid application event is stored AND forwarded to the real-time streams', async () => {
+    const handLogSpy = jest.spyOn(service.handLogStream, 'write')
+    const aggregateSpy = jest.spyOn(service.handAggregateStream, 'write')
+    const realTimeSpy = jest.spyOn(service.realTimeStatsStream, 'write')
+
+    const validEvent = {
+      ApiTypeId: 201, timestamp: 111, Code: 0, BattleType: 0, Id: 'stage000_003', IsRetire: false
+    }
+    await onMessageHandler(validEvent)
+
+    const stored = await db.apiEvents.get([111, 201])
+    expect(stored).toEqual(validEvent)
+
+    expect(handLogSpy).toHaveBeenCalledTimes(1)
+    expect(aggregateSpy).toHaveBeenCalledTimes(1)
+    expect(realTimeSpy).toHaveBeenCalledTimes(1)
+  })
+
+  test('an application-type event that fails Zod validation is stored raw but NOT forwarded to streams', async () => {
+    const handLogSpy = jest.spyOn(service.handLogStream, 'write')
+    const aggregateSpy = jest.spyOn(service.handAggregateStream, 'write')
+    const realTimeSpy = jest.spyOn(service.realTimeStatsStream, 'write')
+
+    // EVT_DEAL (303) missing every required field — simulates a PokerChase
+    // payload shape change breaking the schema (the season-3 EVT_SESSION_RESULTS
+    // incident this whole redesign is fixing).
+    const brokenDealEvent = { ApiTypeId: 303, timestamp: 222 }
+    await onMessageHandler(brokenDealEvent)
+
+    const stored = await db.apiEvents.get([222, 303])
+    expect(stored).toEqual(brokenDealEvent)
+
+    expect(handLogSpy).not.toHaveBeenCalled()
+    expect(aggregateSpy).not.toHaveBeenCalled()
+    expect(realTimeSpy).not.toHaveBeenCalled()
+  })
+
+  test('a known non-application event (202 keepalive/ack) is stored raw but NOT forwarded to streams', async () => {
+    const handLogSpy = jest.spyOn(service.handLogStream, 'write')
+
+    const nonAppEvent = { ApiTypeId: 202, timestamp: 333, Code: 0 }
+    await onMessageHandler(nonAppEvent)
+
+    const stored = await db.apiEvents.get([333, 202])
+    expect(stored).toEqual(nonAppEvent)
+    expect(handLogSpy).not.toHaveBeenCalled()
+  })
+
+  test('an ApiTypeId entirely unknown to apiEventSchemas is stored raw (future PokerChase payload type)', async () => {
+    const unknownEvent = { ApiTypeId: 9999, timestamp: 444, SomeFutureField: 'x' }
+    await onMessageHandler(unknownEvent)
+
+    const stored = await db.apiEvents.get([444, 9999])
+    expect(stored).toEqual(unknownEvent)
+  })
+
+  test('an event without a numeric timestamp/ApiTypeId is not stored (no usable key)', async () => {
+    await onMessageHandler({ ApiTypeId: 201 }) // missing timestamp
+    await onMessageHandler({ timestamp: 555 }) // missing ApiTypeId
+
+    expect(await db.apiEvents.count()).toBe(0)
+  })
+
+  test('keepalive messages are ignored entirely (not stored, not forwarded)', async () => {
+    await onMessageHandler({ type: 'keepalive' })
+    expect(await db.apiEvents.count()).toBe(0)
+  })
+})

--- a/src/background/event-ingestion.ts
+++ b/src/background/event-ingestion.ts
@@ -2,11 +2,13 @@
 import PokerChaseService, {
   ApiType,
   ApiMessage,
+  validateMessage,
   validateApiEvent,
   parseApiEvent,
   getValidationError,
   isApplicationApiEvent
 } from '../app'
+import type { ApiEvent } from '../app'
 import { autoSyncService } from '../services/auto-sync-service'
 import { connectedPorts, startPortPing } from './ports'
 
@@ -33,21 +35,40 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
           return
         }
 
+        // Raw Event Lake（docs/architecture.md参照）: timestamp/ApiTypeIdが数値である
+        // 限り、Zodパースの成否・アプリケーションイベントか否かに関わらず生のまま
+        // 保存する。バリデーションは後続のリアルタイム処理パイプライン（ストリーム）
+        // への投入可否のみを左右し、保存の可否は左右しない。これにより将来
+        // PokerChase側のペイロード変更でスキーマ検証が壊れても、修正後のデータ
+        // 再構築で復旧可能になる（2026年シーズン3のEVT_SESSION_RESULTS破壊的変更で
+        // 実際にデータが失われた反省による）。
+        if (validateMessage(message).success) {
+          // Dexieの型はApiEvent（既知スキーマ）を想定しているが、Lakeとして未検証・
+          // 未知のApiTypeIdの生イベントも意図的に保存するためアサーションが必要
+          service.db.apiEvents.add(message as ApiEvent)
+            .catch(err => console.error('[background] Failed to save event:', err))
+        } else {
+          // timestamp/ApiTypeIdが数値でない = キーとして使えないため保存不可
+          console.warn('[background] Event missing numeric timestamp/ApiTypeId, cannot store:', message)
+        }
+
         // 通常のAPIメッセージ処理
         // Zodスキーマでパース（passthrough: 未知プロパティは保持）
         const data = parseApiEvent(message as ApiMessage)
 
         if (!data) {
-          // パース失敗 = 必須プロパティ欠損など破壊的変更の可能性
+          // パース失敗 = 必須プロパティ欠損など破壊的変更の可能性。生ログは上で
+          // 既に保存済みなので、ここではリアルタイムパイプラインへの投入のみ諦める
           const validationResult = validateApiEvent(message as ApiMessage)
           const errorDetails = validationResult.error ? getValidationError(validationResult.error) : null
-          console.warn(`[background] Schema validation failed (event dropped):\n  Errors: ${JSON.stringify(errorDetails, null, 2)}\n  Event: ${JSON.stringify(message, null, 2)}`)
+          console.warn(`[background] Schema validation failed (stored raw, pipeline skipped):\n  Errors: ${JSON.stringify(errorDetails, null, 2)}\n  Event: ${JSON.stringify(message, null, 2)}`)
           return
         }
 
         // アプリケーション用のイベントかチェック
         if (!isApplicationApiEvent(data)) {
-          // アプリケーションで使用しないApiTypeIdのイベントはDB保存しないが内容は記録
+          // アプリケーションで使用しないApiTypeIdのイベントはパイプラインに投入しないが
+          // 内容は記録（生ログとしては上で既に保存済み）
           console.info(`[background] Non-application event (${data.ApiTypeId}): ${JSON.stringify(data)}`)
           return
         }
@@ -55,9 +76,7 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
         // ここでdataはApiEvent型（isApplicationApiEventで保証済み）
         service.eventLogger(data, 'info')
 
-        // DB保存とストリーム処理
-        service.db.apiEvents.add(data)
-          .catch(err => console.error('[background] Failed to save event:', err))
+        // ストリーム処理（DB保存は上で完了済み）
         service.handLogStream.write(data)
         service.handAggregateStream.write(data)
         service.realTimeStatsStream.write(data)

--- a/src/background/import-export.rebuild.test.ts
+++ b/src/background/import-export.rebuild.test.ts
@@ -1,0 +1,125 @@
+/**
+ * rebuildAllData() - Raw Event Lake recovery path
+ *
+ * Proves the core claim of the Lake redesign: rebuildAllData re-validates
+ * every raw apiEvents row (via filterValidApplicationEvents) immediately
+ * before EntityConverter, rather than trusting whatever's stored. This is
+ * what makes rebuild the *entire* recovery mechanism after a PokerChase
+ * schema break gets fixed -- no separate dead-letter/promotion table is
+ * needed, because the exact same raw row already sitting in apiEvents gets
+ * re-parsed against the current schema on every rebuild.
+ *
+ * This test is deliberately schema-agnostic: it doesn't depend on the
+ * parallel EVT_SESSION_RESULTS schema fix (PR #134 / branch
+ * fix/session-results-schema-legend-season3, not merged into this branch).
+ * Instead it proves the generic mechanism -- a raw row that fails today
+ * would be recovered by a future schema fix, and a raw row that already
+ * passes gets converted into entities purely by re-reading apiEvents, with
+ * no promotion step. The concrete real-world instance of this mechanism
+ * (season-3 EVT_SESSION_RESULTS) is exercised by the verify-stats gate
+ * against real captures once both PRs land.
+ */
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { createImportExportHandlers } from './import-export'
+
+// A known-good hand (EVT_DEAL -> 3x EVT_ACTION -> EVT_HAND_RESULTS), copied
+// verbatim from src/app.test.ts's event_timeline fixture (already exercised
+// there against the real stats pipeline) so this test isn't hand-authoring
+// a new Zod-shaped fixture from scratch.
+const VALID_HAND_EVENTS = [
+  { "ApiTypeId": 303, "SeatUserIds": [2, 4, 3, 1], "Game": { "CurrentBlindLv": 1, "NextBlindUnixSeconds": 1752427424, "Ante": 50, "SmallBlind": 100, "BigBlind": 200, "ButtonSeat": 3, "SmallBlindSeat": 0, "BigBlindSeat": 1 }, "Player": { "SeatIndex": 1, "BetStatus": 1, "HoleCards": [5, 21], "Chip": 5750, "BetChip": 200 }, "OtherPlayers": [{ "SeatIndex": 0, "Status": 0, "BetStatus": 1, "Chip": 5850, "BetChip": 100, "IsSafeLeave": false }, { "SeatIndex": 2, "Status": 0, "BetStatus": 1, "Chip": 5950, "BetChip": 0, "IsSafeLeave": false }, { "SeatIndex": 3, "Status": 0, "BetStatus": 1, "Chip": 5950, "BetChip": 0, "IsSafeLeave": false }], "Progress": { "Phase": 0, "NextActionSeat": 2, "NextActionTypes": [2, 3, 4, 5], "NextExtraLimitSeconds": 1, "MinRaise": 400, "Pot": 500, "SidePot": [] }, "timestamp": 1752427313426 },
+  { "ApiTypeId": 304, "SeatIndex": 2, "ActionType": 2, "Chip": 5950, "BetChip": 0, "Progress": { "Phase": 0, "NextActionSeat": 3, "NextActionTypes": [2, 3, 4, 5], "NextExtraLimitSeconds": 1, "MinRaise": 400, "Pot": 500, "SidePot": [] }, "timestamp": 1752427315428 },
+  { "ApiTypeId": 304, "SeatIndex": 3, "ActionType": 2, "Chip": 5950, "BetChip": 0, "Progress": { "Phase": 0, "NextActionSeat": 0, "NextActionTypes": [2, 3, 4, 5], "NextExtraLimitSeconds": 1, "MinRaise": 400, "Pot": 500, "SidePot": [] }, "timestamp": 1752427316928 },
+  { "ApiTypeId": 304, "SeatIndex": 0, "ActionType": 2, "Chip": 5850, "BetChip": 100, "Progress": { "Phase": 3, "NextActionSeat": -2, "NextActionTypes": [], "NextExtraLimitSeconds": 0, "MinRaise": 0, "Pot": 500, "SidePot": [] }, "timestamp": 1752427318516 },
+  { "ApiTypeId": 306, "CommunityCards": [], "Pot": 500, "SidePot": [], "ResultType": 0, "DefeatStatus": 0, "HandId": 384370064, "HandLog": "", "Results": [{ "UserId": 4, "HoleCards": [], "RankType": 10, "Hands": [], "HandRanking": 1, "Ranking": -2, "RewardChip": 500 }], "Player": { "SeatIndex": 1, "BetStatus": -1, "Chip": 6250, "BetChip": 0 }, "OtherPlayers": [{ "SeatIndex": 0, "Status": 0, "BetStatus": -1, "Chip": 5850, "BetChip": 0, "IsSafeLeave": false }, { "SeatIndex": 2, "Status": 0, "BetStatus": -1, "Chip": 5950, "BetChip": 0, "IsSafeLeave": false }, { "SeatIndex": 3, "Status": 0, "BetStatus": -1, "Chip": 5950, "BetChip": 0, "IsSafeLeave": false }], "timestamp": 1752427319431 },
+]
+
+describe('rebuildAllData Raw Event Lake recovery', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    service = new PokerChaseService({ db })
+    await service.ready
+
+    // rebuildAllData chains .catch() off chrome.runtime.sendMessage(); the
+    // shared test-setup.ts mock returns undefined by default (no implementation)
+    ;(chrome.runtime.sendMessage as jest.Mock).mockReturnValue(Promise.resolve())
+  })
+
+  afterEach(async () => {
+    db.close()
+    await db.delete()
+  })
+
+  test('rebuild converts a valid hand purely from raw apiEvents rows, tolerating noise/malformed rows alongside it', async () => {
+    // Seed apiEvents directly (bypassing event-ingestion.ts) to simulate rows
+    // that arrived and were stored by the Lake at some point in the past.
+    await db.apiEvents.bulkAdd(VALID_HAND_EVENTS as any)
+
+    // Noise that must NOT crash the rebuild and must NOT produce any entity:
+    // a malformed application-type event (still fails today -- no schema fix
+    // for it), a known non-application event, and an unknown ApiTypeId.
+    await db.apiEvents.bulkAdd([
+      { ApiTypeId: 303, timestamp: 999999999 }, // malformed EVT_DEAL, still invalid
+      { ApiTypeId: 202, timestamp: 1000000000, Code: 0 }, // known non-app event
+      { ApiTypeId: 9999, timestamp: 1000000001, Unknown: true }, // unknown type
+    ] as any)
+
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+    await expect(handlers.rebuildAllData()).resolves.toBeUndefined()
+
+    const hand = await db.hands.get(384370064)
+    expect(hand).toBeDefined()
+    expect(hand?.winningPlayerIds).toEqual([4])
+    expect(hand?.seatUserIds).toEqual([2, 4, 3, 1])
+
+    const actions = await db.actions.where('handId').equals(384370064).toArray()
+    expect(actions.length).toBeGreaterThan(0)
+
+    const phases = await db.phases.where('handId').equals(384370064).toArray()
+    expect(phases.length).toBeGreaterThan(0)
+
+    // Noise rows are untouched raw rows in apiEvents -- nothing was lost or
+    // silently rewritten, and none of it produced a spurious entity.
+    expect(await db.apiEvents.count()).toBe(VALID_HAND_EVENTS.length + 3)
+    expect(await db.hands.count()).toBe(1)
+  })
+
+  test('a raw row that now parses under the current schema is picked up automatically -- no promotion step', async () => {
+    // Simulates "this row failed to parse when first stored (an old/foreign
+    // PokerChase payload shape), but the schema has since been fixed": for
+    // the test, that just means the raw row IS today a fully valid
+    // application event. The mechanism under test is generic re-validation
+    // on rebuild, not any specific historical schema diff.
+    await db.apiEvents.bulkAdd(VALID_HAND_EVENTS as any)
+
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+    await handlers.rebuildAllData()
+
+    // Sanity: without any dead-letter/promotion table anywhere in this
+    // codebase, the hand is still recovered purely by re-reading apiEvents.
+    expect(await db.hands.count()).toBe(1)
+    expect((db as any).deadLetterEvents).toBeUndefined()
+  })
+
+  test('rebuild is a safe no-op-for-entities when apiEvents contains only unparseable/non-application rows', async () => {
+    await db.apiEvents.bulkAdd([
+      { ApiTypeId: 303, timestamp: 1 }, // malformed EVT_DEAL
+      { ApiTypeId: 202, timestamp: 2, Code: 0 }, // non-app
+      { ApiTypeId: 9999, timestamp: 3 }, // unknown
+    ] as any)
+
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+    await expect(handlers.rebuildAllData()).resolves.toBeUndefined()
+
+    expect(await db.hands.count()).toBe(0)
+    expect(await db.actions.count()).toBe(0)
+    // The raw rows themselves are untouched -- still there for a future
+    // rebuild once/if a schema fix makes them parseable.
+    expect(await db.apiEvents.count()).toBe(3)
+  })
+})

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -7,11 +7,12 @@ import PokerChaseService, {
   isApiEventType,
   parseApiEvent,
   validateApiEvent,
+  validateMessage,
   getValidationError,
   isApplicationApiEvent
 } from '../app'
 import { EntityConverter } from '../entity-converter'
-import { saveEntities, findLatestPlayerDealEvent } from '../utils/database-utils'
+import { saveEntities, findLatestPlayerDealEvent, filterValidApplicationEvents } from '../utils/database-utils'
 import { DATABASE_CONSTANTS } from '../constants/database'
 import type {
   ExportProgressMessage,
@@ -106,7 +107,12 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
 
       for (let i = 0; i < lines.length; i += IMPORT_CHUNK_SIZE) {
         const chunkLines = lines.slice(i, i + IMPORT_CHUNK_SIZE)
-        const newEvents: ApiEvent[] = []
+        // Raw Event Lake: 保存対象は「timestamp/ApiTypeIdが数値」の行すべて
+        // （Zod検証の成否・アプリケーションイベントか否かは問わない）
+        const rawEventsToStore: Array<Record<string, unknown> & { timestamp: number, ApiTypeId: number }> = []
+        // エンティティ生成対象（検証済みアプリケーションイベントのみ）。
+        // key（`${timestamp}-${ApiTypeId}`）で対応するrawEventsToStoreの要素と紐付ける
+        const validAppEventsByKey = new Map<string, ApiEvent>()
 
         // チャンク内の各行をパース
         for (let j = 0; j < chunkLines.length; j++) {
@@ -117,36 +123,39 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
           try {
             const parsed = JSON.parse(line)
 
-            // タイムスタンプチェック（インポートでは必須）
-            if (!('timestamp' in parsed && parsed.timestamp)) {
-              errors.push(`Line ${lineNumber}: Missing timestamp`)
+            // 保存条件のチェック（インポートでは必須）: timestamp/ApiTypeIdが数値であること
+            if (!validateMessage(parsed).success) {
+              errors.push(`Line ${lineNumber}: Missing/invalid timestamp or ApiTypeId`)
               continue
             }
 
-            // Zodスキーマ検証
+            const key = `${parsed.timestamp}-${parsed.ApiTypeId}`
+
+            // メモリ内で重複チェック（最適化ポイント2）
+            if (existingKeys.has(key)) {
+              duplicateCount++
+              continue
+            }
+
+            rawEventsToStore.push(parsed)
+            existingKeys.add(key) // 次の重複チェック用
+
+            // Zodスキーマ検証（エンティティ生成対象かどうかの判定のみ。保存は上で確定済み）
             const event = parseApiEvent(parsed)
             if (!event) {
               const result = validateApiEvent(parsed)
               const errorDetails = result.error ? getValidationError(result.error)[0] : null
-              errors.push(`Line ${lineNumber}: ${errorDetails?.message || 'Validation failed'}`)
+              errors.push(`Line ${lineNumber}: ${errorDetails?.message || 'Validation failed'} (保存済み・エンティティ生成対象外)`)
               continue
             }
 
             // アプリケーション用のイベントかチェック
             if (!isApplicationApiEvent(event)) {
-              // アプリケーションで使用しないApiTypeIdのイベントをスキップ
+              // 非アプリケーションイベント: 生ログとしては保存対象だがエンティティ生成対象外
               continue
             }
 
-            const key = `${event.timestamp}-${event.ApiTypeId}`
-
-            // メモリ内で重複チェック（最適化ポイント2）
-            if (!existingKeys.has(key)) {
-              newEvents.push(event)
-              existingKeys.add(key) // 次の重複チェック用
-            } else {
-              duplicateCount++
-            }
+            validAppEventsByKey.set(key, event)
           } catch (parseError) {
             // 無効なJSON行をスキップ
             if (line.trim()) {
@@ -155,32 +164,45 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
           }
         }
 
-        // 新規イベントをbulkAddで一括保存（最適化ポイント3）
-        if (newEvents.length > 0) {
+        // 生イベントをbulkAddで一括保存（最適化ポイント3。検証可否に関わらず全件保存）
+        if (rawEventsToStore.length > 0) {
+          const storedKeys = new Set<string>()
+
           try {
-            await db.apiEvents.bulkAdd(newEvents)
-            successCount += newEvents.length
-            allNewEvents.push(...newEvents)
+            // apiEvents is the raw Lake (see docs/architecture.md): rows may not
+            // conform to the ApiEvent union (non-application types, unknown
+            // ApiTypeIds, or app-type payloads that fail the current schema) —
+            // the assertion is intentional, mirroring the same pattern used in
+            // event-ingestion.ts's real-time storage path.
+            await db.apiEvents.bulkAdd(rawEventsToStore as ApiEvent[])
+            successCount += rawEventsToStore.length
+            rawEventsToStore.forEach(raw => storedKeys.add(`${raw.timestamp}-${raw.ApiTypeId}`))
           } catch (dbError) {
             // 部分的な失敗の場合、個別に保存を試みる
             console.warn(`Bulk add failed for chunk ${Math.floor(i / IMPORT_CHUNK_SIZE) + 1}, falling back to individual adds:`, dbError)
 
-            for (const event of newEvents) {
+            for (const raw of rawEventsToStore) {
+              const key = `${raw.timestamp}-${raw.ApiTypeId}`
               try {
-                await db.apiEvents.add(event)
+                await db.apiEvents.add(raw as ApiEvent)
                 successCount++
-                allNewEvents.push(event)
+                storedKeys.add(key)
               } catch (individualError) {
                 // 個別エラーは重複以外の場合のみログ
                 const errorMessage = individualError instanceof Error ? individualError.message : String(individualError)
                 if (!errorMessage.includes('Key already exists')) {
-                  errors.push(`Event at timestamp ${event.timestamp}: ${errorMessage}`)
+                  errors.push(`Event at timestamp ${raw.timestamp}: ${errorMessage}`)
                 } else {
                   duplicateCount++
                   successCount-- // 重複の場合は成功数から除外
                 }
               }
             }
+          }
+
+          // エンティティ生成には、実際に保存が確認できたアプリケーションイベントのみを渡す
+          for (const [key, event] of validAppEventsByKey) {
+            if (storedKeys.has(key)) allNewEvents.push(event)
           }
         }
 
@@ -331,7 +353,10 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
       const totalCount = await db.apiEvents.count()
       console.log(`[Export] Exporting ${totalCount} events...`)
 
-      // Direct chunked export using primary key cursor to avoid Dexie Collection offset issues
+      // Direct chunked export using primary key cursor to avoid Dexie Collection offset issues.
+      // Dumps the full apiEvents Lake verbatim (raw fidelity, "a line is a line") — no
+      // filtering by validity or application-type here; this is what feeds the warehouse
+      // and offline schema-diff tooling (see docs/architecture.md "Raw Event Lake").
       const chunks: string[] = []
       let processedCount = 0
       let lastKey: any = undefined
@@ -636,11 +661,24 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
         }
         const converter = new EntityConverter(defaultSession)
 
-        // Load all events and convert in one pass
+        // Load all raw events and convert in one pass
         // (EntityConverter tracks hand state internally, so chunked conversion loses cross-chunk hands)
         console.log(`[rebuildAllData] Loading all events...`)
-        const allEvents = await db.apiEvents.orderBy('[timestamp+ApiTypeId]').toArray()
-        console.log(`[rebuildAllData] Loaded ${allEvents.length} events, converting to entities...`)
+        const rawEvents = await db.apiEvents.orderBy('[timestamp+ApiTypeId]').toArray()
+
+        // apiEvents is the raw Lake: it may contain non-application noise (202/205
+        // keepalive/timer events), ApiTypeIds unknown to the current schema, or
+        // application-type events whose payload doesn't match the current Zod schema
+        // (either not-yet-fixed, or already fixed since the row was first stored).
+        // Re-validating here — rather than trusting raw rows — is what makes this the
+        // recovery path: any row a schema fix now makes parseable is automatically
+        // picked up, no separate promotion mechanism required (docs/architecture.md
+        // "Raw Event Lake"). It's also what keeps EntityConverter (which reads
+        // required fields like EVT_DEAL.Game.SmallBlind without guards) from
+        // throwing on a still-malformed row.
+        const allEvents = await filterValidApplicationEvents(rawEvents)
+        const skippedCount = rawEvents.length - allEvents.length
+        console.log(`[rebuildAllData] Loaded ${rawEvents.length} raw events, ${allEvents.length} valid application events after re-validation${skippedCount > 0 ? ` (${skippedCount} non-application/unparseable rows skipped)` : ''}`)
 
         setOperationState({ type: 'rebuild', progress: 40, message: `${allEvents.length.toLocaleString()}件のイベントを変換中...` })
         chrome.runtime.sendMessage<RebuildProgressMessage>({

--- a/src/db/poker-chase-db.test.ts
+++ b/src/db/poker-chase-db.test.ts
@@ -1,0 +1,75 @@
+/**
+ * PokerChaseDB - Raw Event Lake (apiEvents hook removal)
+ *
+ * Verifies apiEvents is a raw, unfiltered log again (docs/architecture.md
+ * "Raw Event Lake"). The `creating`/`reading` hooks added in commit a6480ff
+ * (2025-07-24) silently hid non-application events from every reader — and,
+ * because the `creating` hook's `this.onsuccess = null` never actually
+ * aborted the underlying IndexedDB write, those rows were already being
+ * physically stored while invisible. This suite locks in that both hooks are
+ * gone: whatever is written is exactly what comes back on read.
+ */
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import { PokerChaseDB } from './poker-chase-db'
+
+describe('PokerChaseDB Raw Event Lake', () => {
+  let db: PokerChaseDB
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+  })
+
+  afterEach(async () => {
+    db.close()
+    await db.delete()
+  })
+
+  it('stays on database version 3 (no index change was needed to remove the hooks)', () => {
+    expect(db.verno).toBe(3)
+  })
+
+  it('stores and reads back a known non-application event (202) unfiltered', async () => {
+    const nonAppEvent = { ApiTypeId: 202, Code: 0, timestamp: 123 }
+    await db.apiEvents.add(nonAppEvent as any)
+
+    const stored = await db.apiEvents.toArray()
+    expect(stored).toHaveLength(1)
+    expect(stored[0]).toEqual(nonAppEvent)
+
+    const byKey = await db.apiEvents.get([123, 202])
+    expect(byKey).toEqual(nonAppEvent)
+  })
+
+  it('stores and reads back an event with an ApiTypeId unknown to any schema', async () => {
+    const unknownEvent = { ApiTypeId: 9999, timestamp: 456, SomeFutureField: 'x' }
+    await db.apiEvents.add(unknownEvent as any)
+
+    const stored = await db.apiEvents.toArray()
+    expect(stored).toEqual([unknownEvent])
+  })
+
+  it('stores and reads back an application-type event whose payload fails the current schema', async () => {
+    // A malformed EVT_DEAL (303) missing every required field — simulates a
+    // PokerChase payload shape change that broke Zod validation.
+    const brokenAppEvent = { ApiTypeId: 303, timestamp: 789 }
+    await db.apiEvents.add(brokenAppEvent as any)
+
+    const stored = await db.apiEvents.toArray()
+    expect(stored).toEqual([brokenAppEvent])
+  })
+
+  it('mixes application, non-application, and unknown events without any of them disappearing on read', async () => {
+    const events = [
+      { ApiTypeId: 201, timestamp: 1, Code: 0, BattleType: 0, Id: 'a', IsRetire: false }, // valid app event
+      { ApiTypeId: 202, timestamp: 2, Code: 0 }, // valid non-app event
+      { ApiTypeId: 9999, timestamp: 3 }, // unknown type
+      { ApiTypeId: 303, timestamp: 4 }, // broken app event
+    ]
+    await db.apiEvents.bulkAdd(events as any)
+
+    const stored = await db.apiEvents.orderBy('[timestamp+ApiTypeId]').toArray()
+    expect(stored).toHaveLength(4)
+    expect(stored.map((e: any) => e.ApiTypeId)).toEqual([201, 202, 9999, 303])
+  })
+})

--- a/src/db/poker-chase-db.ts
+++ b/src/db/poker-chase-db.ts
@@ -6,15 +6,26 @@ import type {
   Action,
   MetaRecord
 } from '../types'
-import { isApplicationApiEvent } from '../types'
 
 /**
  * PokerChase HUD用IndexedDBクラス
  *
  * ポーカーゲームのデータ永続化を担当する。
- * - APIイベントの生ログを保存
+ * - APIイベントの生ログを保存（"Raw Event Lake" — 検証可否・アプリケーション種別に
+ *   関わらず、数値のtimestamp+ApiTypeIdを持つ受信イベントは全て保存する。バリデー
+ *   ションはリアルタイム処理パイプラインへの投入可否のみを左右し、保存そのものを
+ *   左右しない。詳細はdocs/architecture.md「Raw Event Lake」参照）
  * - 処理済みのハンド、フェーズ、アクションデータを構造化して保存
  * - 統計計算のための効率的なインデックスを提供
+ *
+ * 設計変遷: 2024年の初期実装（コミット5f7d60c/fce0343）は生ログ全件保存だったが、
+ * 2025-07-24のリファクタ（a6480ff）でapiEventsのcreating/readingフックにより
+ * アプリケーションイベント以外を実質的に不可視化していた（creatingフックは
+ * `this.onsuccess = null`のみで実際の書き込み自体は防げておらず、reading側の
+ * フックだけが読み取り結果からnullとして除外していた）。この結果、スキーマ変更で
+ * Zodパースに失敗したイベント（2026年シーズン3のEVT_SESSION_RESULTS等）は保存
+ * すらされず、リビルドでも復旧不能なデータ損失が発生した。本バージョンで
+ * フックを撤廃し、元々の「生ログは常に保存する」設計に復元した。
  */
 export class PokerChaseDB extends Dexie {
   apiEvents!: Table<ApiEvent, number>
@@ -52,33 +63,17 @@ export class PokerChaseDB extends Dexie {
       meta: 'id,updatedAt'
     })
 
-    // apiEventsテーブルのフックを設定
-    // 非ゲームイベントを自動的にフィルタリング
-    this.setupApiEventHooks()
-  }
-
-  /**
-   * apiEventsテーブルのフックを設定
-   * 非アプリケーションイベントを自動的にフィルタリング
-   */
-  private setupApiEventHooks(): void {
-    // 作成時のフィルタリング - 非ゲームイベントの保存を防ぐ
-    this.apiEvents.hook('creating', function(_primKey, obj, _trans) {
-      if (!isApplicationApiEvent(obj)) {
-        // 非アプリケーションイベントは保存しない
-        // @ts-ignore - Dexie内部APIを使用
-        this.onsuccess = null
-        return
-      }
-    })
-
-    // 読み取り時のフィルタリング - 既存の非ゲームイベントを除外
-    this.apiEvents.hook('reading', function(obj) {
-      if (obj && !isApplicationApiEvent(obj)) {
-        // 非アプリケーションイベントはnullとして扱う（結果から除外）
-        return null
-      }
-      return obj
-    })
+    // v4以降へのバンプは不要: [timestamp+ApiTypeId]キーは検証可否・ApiTypeIdの
+    // 既知/未知に関わらずどんな生イベントにも適用できるため、フック撤廃だけなら
+    // インデックス変更は発生しない（意図的にバンプしていない。CLAUDE.md参照）。
+    //
+    // 旧: apiEventsのcreating/readingフックで非アプリケーションイベントを自動
+    // フィルタリングしていたが撤廃した（setupApiEventHooks削除）。フィルタリングは
+    // 各読み取り箇所（EntityConverter/HandLogProcessorへ渡す直前）で明示的に行う。
+    // 理由: (1) creatingフックは実際には書き込みを止められておらず有名無実だった
+    // （`this.onsuccess = null`はDexieの完了コールバックを止めるだけで、配下の
+    // IDBObjectStore.add()自体は既に発行済み）、(2) readingフックがあると
+    // apiEvents.toArray()等で「生ログの全件保存」という本来の目的を果たせない
+    // （エクスポート/インポート/リビルドが常に部分集合しか見えなくなる）。
   }
 }

--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -2,6 +2,7 @@ import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
 import { PokerChaseDB } from '../db/poker-chase-db'
 import { ApiType, BattleType } from '../types'
 import type { ApiEvent } from '../types'
+import { DATABASE_CONSTANTS } from '../constants/database'
 import { AutoSyncService } from './auto-sync-service'
 import { firestoreBackupService } from './firestore-backup-service'
 
@@ -64,4 +65,44 @@ describe('AutoSyncService cloud downloads', () => {
       lastProcessedEventCount: 2
     })
   })
+
+  test('upload: filters non-application noise before syncing, and still advances past a chunk that is 100% noise', async () => {
+    // apiEvents is the raw Lake -- seed one full raw chunk (SYNC_CHUNK_SIZE)
+    // of nothing but non-application keepalive noise, followed by a single
+    // valid application event just past that chunk boundary. Without
+    // advancing the upload cursor on the *raw* chunk boundary (rather than
+    // the app-type-filtered subset), the first chunk would filter down to
+    // zero events, `lastEvent` would be undefined, lastProcessedTimestamp
+    // would never advance, and the loop would refetch the same all-noise
+    // chunk forever.
+    const chunkSize = DATABASE_CONSTANTS.SYNC_CHUNK_SIZE
+    const noiseEvents = Array.from({ length: chunkSize }, (_, i) => ({
+      ApiTypeId: 202, Code: 0, timestamp: i + 1
+    }))
+    const validEvent = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Code: 0,
+      BattleType: BattleType.SIT_AND_GO,
+      Id: 'stage-past-noise',
+      IsRetire: false,
+      timestamp: chunkSize + 1
+    } as ApiEvent
+
+    await db.apiEvents.bulkAdd(noiseEvents as any)
+    await db.apiEvents.add(validEvent)
+
+    jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockResolvedValue(null)
+    const syncBatchSpy = jest.spyOn(firestoreBackupService, 'syncToCloudBatch')
+      .mockResolvedValue({ totalEvents: 1, syncedEvents: 1, lastSyncTime: new Date() })
+
+    const service = new AutoSyncService(db)
+    await service.performSync('upload')
+
+    // Loop must have terminated (performSync resolved) and reached the second,
+    // real chunk -- proving the cursor advanced past the all-noise first chunk.
+    expect(syncBatchSpy).toHaveBeenCalledTimes(1)
+    const [uploadedChunk] = syncBatchSpy.mock.calls[0]!
+    expect(uploadedChunk).toEqual([validEvent])
+    expect(service.getSyncState().status).toBe('success')
+  }, 15000)
 })

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -7,9 +7,9 @@ import { firestoreBackupService } from './firestore-backup-service'
 import { firebaseAuthService } from './firebase-auth-service'
 import { PokerChaseDB } from '../db/poker-chase-db'
 import { EntityConverter } from '../entity-converter'
-import { ApiType, isApiEventType } from '../types'
+import { ApiType, isApiEventType, isApplicationApiEvent } from '../types'
 import type { ApiEvent } from '../types'
-import { processInChunks, saveEntities } from '../utils/database-utils'
+import { processInChunks, saveEntities, filterValidApplicationEvents } from '../utils/database-utils'
 import { DATABASE_CONSTANTS } from '../constants/database'
 
 export type SyncStatus = 'idle' | 'syncing' | 'error' | 'success'
@@ -161,40 +161,53 @@ export class AutoSyncService {
     let lastProcessedTimestamp = cloudMaxTimestamp || 0
     
     while (processed < totalCount) {
-      // Get chunk of events newer than lastProcessedTimestamp
-      const chunk = await this.db.apiEvents
+      // Get chunk of raw events newer than lastProcessedTimestamp. apiEvents is the
+      // raw Lake (see docs/architecture.md) — it may contain non-application noise
+      // (202/205 keepalive/timer events) that we deliberately never sync to cloud
+      // (cost decision: only application-type events go to Firestore).
+      const rawChunk = await this.db.apiEvents
         .where('timestamp')
         .above(lastProcessedTimestamp)
         .limit(CHUNK_SIZE)
         .toArray()
-      
-      if (chunk.length === 0) break
-      
+
+      if (rawChunk.length === 0) break
+
       // Sort chunk by timestamp to ensure order
-      chunk.sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0))
-      
-      // Sync this chunk
-      const summary = await firestoreBackupService.syncToCloudBatch(
-        chunk, 
-        cloudMaxTimestamp,
-        (progress) => {
-          this.updateSyncState({
-            progress: { 
-              current: processed + progress.current, 
-              total: totalCount, 
-              direction: 'upload' 
-            }
-          })
-        }
-      )
-      
-      synced += summary.syncedEvents
-      processed += chunk.length
-      
-      // Update timestamp for next chunk
-      const lastEvent = chunk[chunk.length - 1]
-      if (lastEvent && lastEvent.timestamp) {
-        lastProcessedTimestamp = lastEvent.timestamp
+      rawChunk.sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0))
+
+      // Application-type-only filter for cloud upload. Deliberately filtered AFTER
+      // sorting/tracking the raw chunk's boundary, not before: lastProcessedTimestamp
+      // must advance based on the raw chunk regardless of how many rows in it are
+      // noise, otherwise a chunk containing only non-application events would never
+      // advance the cursor and the loop would refetch it forever.
+      const chunk = rawChunk.filter(isApplicationApiEvent)
+
+      // Sync this chunk (skip the Firestore round-trip entirely if it's all noise)
+      if (chunk.length > 0) {
+        const summary = await firestoreBackupService.syncToCloudBatch(
+          chunk,
+          cloudMaxTimestamp,
+          (progress) => {
+            this.updateSyncState({
+              progress: {
+                current: processed + progress.current,
+                total: totalCount,
+                direction: 'upload'
+              }
+            })
+          }
+        )
+
+        synced += summary.syncedEvents
+      }
+
+      processed += rawChunk.length
+
+      // Update timestamp for next chunk (based on the raw chunk, see comment above)
+      const lastRawEvent = rawChunk[rawChunk.length - 1]
+      if (lastRawEvent && lastRawEvent.timestamp) {
+        lastProcessedTimestamp = lastRawEvent.timestamp
       }
     }
 
@@ -258,7 +271,14 @@ export class AutoSyncService {
         this.db.apiEvents.orderBy('[timestamp+ApiTypeId]'),
         DATABASE_CONSTANTS.SYNC_CHUNK_SIZE
       )) {
-        const entities = converter.convertEventChunk(events)
+        // events is a raw Lake chunk (see docs/architecture.md) — it may contain
+        // non-application noise, unknown ApiTypeIds, or app-type payloads that
+        // fail the current schema. EntityConverter reads required fields (e.g.
+        // EVT_DEAL.Game.SmallBlind) without guards, so only hand it validated
+        // application events; isApiEventType()/restoreSessionEvent() below
+        // already re-validate internally so they're safe on the raw chunk as-is.
+        const validEvents = await filterValidApplicationEvents(events)
+        const entities = converter.convertEventChunk(validEvents)
         await this.saveRebuiltEntities(entities)
 
         for (const event of events) {
@@ -380,6 +400,17 @@ export class AutoSyncService {
       this.updateSyncState({ status: 'idle', lastSyncTime: undefined })
     }
   }
+
+  // Note on the raw `.count()`/`.where(...).count()` calls below (onGameSessionEnd,
+  // getUnsyncedEventCount, getSyncInfo): apiEvents is the raw Lake and these counts
+  // include non-application noise (202/205 keepalive/timer events) that syncToCloud()
+  // never actually uploads (see its isApplicationApiEvent filter above). This was
+  // already true before the Lake restoration — Dexie's `.count()` doesn't invoke the
+  // `reading` hook that used to hide non-application rows, so these thresholds/UI
+  // counts have always been raw-row counts, not "events that will actually sync"
+  // counts. Left as-is here (not over-engineered into per-call `.and(isApplicationApiEvent)`
+  // filters): they're a "is there enough new activity to justify a sync" threshold and a
+  // rough "pending" UI number, not billing-accurate counts.
 
   /**
    * Handle game session events

--- a/src/tools/verify-stats.ts
+++ b/src/tools/verify-stats.ts
@@ -37,6 +37,7 @@ import { createInterface } from 'readline'
 import { runPipeline } from './verify-stats/pipeline'
 import { runOracle } from './verify-stats/oracle'
 import { compareResults, formatReport } from './verify-stats/compare'
+import { filterValidApplicationEvents } from '../utils/database-utils'
 import type { ApiEvent } from '../types'
 
 interface CliOptions {
@@ -71,7 +72,7 @@ function parseArgs(argv: string[]): CliOptions {
 }
 
 async function readNdjson(filePath: string): Promise<ApiEvent[]> {
-  const events: ApiEvent[] = []
+  const rawEvents: unknown[] = []
   // 実際のインポート経路（src/background/import-export.ts）は apiEvents の主キー
   // [timestamp+ApiTypeId] に基づき `${timestamp}-${ApiTypeId}` キーの先勝ちで
   // 重複イベントを除外してから EntityConverter に渡す。ハーネスも同じ前処理を
@@ -89,12 +90,22 @@ async function readNdjson(filePath: string): Promise<ApiEvent[]> {
       continue
     }
     seenKeys.add(key)
-    events.push(event)
+    rawEvents.push(event)
   }
   if (duplicateCount > 0) {
     console.log(`Skipped ${duplicateCount} duplicate event(s) ([timestamp+ApiTypeId] first-wins, mirroring the import path)`)
   }
-  return events
+  // ファイルは Raw Event Lake の生ダンプたり得る（docs/architecture.md）: 202/205
+  // keepalive、未知の ApiTypeId、スキーマ検証に失敗したアプリケーションイベントを
+  // 含み得る。EntityConverter は EVT_DEAL.Game 等を無防備に参照するため、rebuild
+  // 経路（import-export.ts, auto-sync-service.ts, hand-log-exporter.ts）と同じく
+  // filterValidApplicationEvents() で再検証してから渡す。
+  const validEvents = await filterValidApplicationEvents(rawEvents)
+  const skippedCount = rawEvents.length - validEvents.length
+  if (skippedCount > 0) {
+    console.log(`Filtered out ${skippedCount} non-application/invalid event(s) (raw Lake noise — see filterValidApplicationEvents)`)
+  }
+  return validEvents
 }
 
 async function main() {

--- a/src/utils/database-utils.ts
+++ b/src/utils/database-utils.ts
@@ -5,6 +5,7 @@
 
 import type { PokerChaseDB } from '../db/poker-chase-db'
 import type { EntityBundle } from '../entity-converter'
+import type { ApiEvent } from '../types/api'
 import type Dexie from 'dexie'
 
 /**
@@ -110,6 +111,37 @@ export async function findLatestPlayerDealEvent(
   }
   
   return undefined
+}
+
+/**
+ * Filter raw `apiEvents` rows down to ones that currently parse as a known,
+ * validated application event.
+ *
+ * `apiEvents` is the raw "Lake" (see docs/architecture.md "Raw Event Lake") —
+ * it may contain non-application noise (202/205 keepalive/timer spam),
+ * ApiTypeIds unknown to the current schema (a future PokerChase payload
+ * type), or application-type events whose payload doesn't match the current
+ * Zod schema (either a PokerChase payload change not yet accounted for, or
+ * one already fixed since the row was first stored). `EntityConverter` and
+ * `HandLogProcessor` assume well-typed, schema-valid `ApiEvent` shapes and
+ * read required fields (e.g. `EVT_DEAL.Game.SmallBlind`) without guards —
+ * feeding them raw, unvalidated rows can throw and abort a whole rebuild or
+ * export. Re-running `parseApiEvent` here before handing events to either of
+ * those is what keeps that safe.
+ *
+ * It's also what makes a later schema fix retroactively recover previously
+ * unparseable rows on the very next rebuild: no separate promotion mechanism
+ * is needed, because the fix is validated against the exact same raw rows
+ * that have been sitting in `apiEvents` all along.
+ */
+export async function filterValidApplicationEvents(rawEvents: unknown[]): Promise<ApiEvent[]> {
+  const { parseApiEvent, isApplicationApiEvent } = await import('../types/api')
+  const valid: ApiEvent[] = []
+  for (const raw of rawEvents) {
+    const parsed = parseApiEvent(raw)
+    if (parsed && isApplicationApiEvent(parsed)) valid.push(parsed)
+  }
+  return valid
 }
 
 /**

--- a/src/utils/filter-valid-application-events.test.ts
+++ b/src/utils/filter-valid-application-events.test.ts
@@ -1,0 +1,70 @@
+/**
+ * filterValidApplicationEvents (src/utils/database-utils.ts)
+ *
+ * Uses the real Zod schemas (no jest.mock('../types/api')) — unlike
+ * database-utils.test.ts, which mocks Dexie and '../types/api' wholesale for
+ * its own unit tests. This function's entire job is re-running real
+ * validation over raw apiEvents rows, so a real schema is the point.
+ */
+import { filterValidApplicationEvents } from './database-utils'
+
+describe('filterValidApplicationEvents', () => {
+  it('passes through a valid application event unchanged', async () => {
+    const validEntryEvent = {
+      ApiTypeId: 201, timestamp: 100, Code: 0, BattleType: 0, Id: 'stage000_003', IsRetire: false
+    }
+
+    const result = await filterValidApplicationEvents([validEntryEvent])
+
+    expect(result).toEqual([validEntryEvent])
+  })
+
+  it('drops a known non-application event even though it parses fine (202 keepalive)', async () => {
+    const nonAppEvent = { ApiTypeId: 202, timestamp: 200, Code: 0 }
+
+    const result = await filterValidApplicationEvents([nonAppEvent])
+
+    expect(result).toEqual([])
+  })
+
+  it('drops an application-type event whose payload fails the current schema', async () => {
+    // EVT_DEAL (303) missing every required field
+    const brokenAppEvent = { ApiTypeId: 303, timestamp: 300 }
+
+    const result = await filterValidApplicationEvents([brokenAppEvent])
+
+    expect(result).toEqual([])
+  })
+
+  it('drops an event with an ApiTypeId entirely unknown to apiEventSchemas', async () => {
+    const unknownEvent = { ApiTypeId: 9999, timestamp: 400 }
+
+    const result = await filterValidApplicationEvents([unknownEvent])
+
+    expect(result).toEqual([])
+  })
+
+  it('handles a mixed batch, keeping only the valid application events and preserving order', async () => {
+    const validEntry = { ApiTypeId: 201, timestamp: 1, Code: 0, BattleType: 0, Id: 'a', IsRetire: false }
+    const nonApp = { ApiTypeId: 202, timestamp: 2, Code: 0 }
+    const broken = { ApiTypeId: 303, timestamp: 3 }
+    const unknown = { ApiTypeId: 9999, timestamp: 4 }
+    const validEntry2 = { ApiTypeId: 201, timestamp: 5, Code: 0, BattleType: 1, Id: '6078', IsRetire: false }
+
+    const result = await filterValidApplicationEvents([validEntry, nonApp, broken, unknown, validEntry2])
+
+    expect(result).toEqual([validEntry, validEntry2])
+  })
+
+  it('returns an empty array for an empty input', async () => {
+    expect(await filterValidApplicationEvents([])).toEqual([])
+  })
+
+  it('does not throw on completely non-object/malformed inputs mixed into the batch', async () => {
+    const validEntry = { ApiTypeId: 201, timestamp: 1, Code: 0, BattleType: 0, Id: 'a', IsRetire: false }
+
+    const result = await filterValidApplicationEvents([null, undefined, 'garbage', 42, validEntry])
+
+    expect(result).toEqual([validEntry])
+  })
+})

--- a/src/utils/hand-log-exporter.ts
+++ b/src/utils/hand-log-exporter.ts
@@ -9,7 +9,7 @@ import { ApiType, isApiEventType } from '../types/api'
 import { HandLogProcessor, HandLogContext } from './hand-log-processor'
 import { DEFAULT_HAND_LOG_CONFIG } from '../types/hand-log'
 import { DATABASE_CONSTANTS } from '../constants/database'
-import { processInChunks } from '../utils/database-utils'
+import { processInChunks, filterValidApplicationEvents } from '../utils/database-utils'
 
 export class HandLogExporter {
   // Cache for player names across all exports
@@ -214,14 +214,21 @@ export class HandLogExporter {
 
     // 4. Fetch ALL events in the range in ONE query
     console.log(`[HandLogExporter] Prefetching events from ${new Date(minTime).toISOString()} to ${new Date(maxTime).toISOString()}`)
-    const allEvents = await db.apiEvents
+    const rawEvents = await db.apiEvents
       .where('timestamp')
       .between(minTime, maxTime)
       .toArray()
 
+    // apiEvents is the raw Lake (see docs/architecture.md): the time window may
+    // include non-application noise, unknown ApiTypeIds, or app-type payloads
+    // that fail the current schema. HandLogProcessor's switch on ApiTypeId
+    // reads required fields (e.g. EVT_DEAL.Game) without guards, so only
+    // validated application events may reach it.
+    const allEvents = await filterValidApplicationEvents(rawEvents)
+
     // Sort once for all hands
     allEvents.sort((a, b) => a.timestamp! - b.timestamp!)
-    console.log(`[HandLogExporter] Prefetched ${allEvents.length} events`)
+    console.log(`[HandLogExporter] Prefetched ${allEvents.length} events (${rawEvents.length} raw)`)
 
     // 5. Process each hand using the prefetched events
     // プリパス: セッションごとの最小ハンドIDを確定（トーナメントID用）
@@ -380,10 +387,15 @@ export class HandLogExporter {
     const startTime = hand.approxTimestamp! - this.TIME_BUFFER_MS
     const endTime = hand.approxTimestamp! + this.POST_HAND_BUFFER_MS
 
-    const allEvents = await db.apiEvents
+    const rawEvents = await db.apiEvents
       .where('timestamp')
       .between(startTime, endTime)
       .toArray()
+
+    // apiEvents is the raw Lake (see docs/architecture.md): filter to validated
+    // application events before this feeds HandLogProcessor, same reasoning as
+    // exportMultipleHands's prefetch above.
+    const allEvents = await filterValidApplicationEvents(rawEvents)
 
     // Time range for hand events
     // Found total events in time range


### PR DESCRIPTION
## Summary

Git archaeology (commits `5f7d60c`/`fce0343`, 2024) shows the original design stored **all** API events raw in `apiEvents` ("APIイベントの生ログを保存") specifically so data could be rebuilt after a schema/logic fix. The 2025-07-24 refactor (`a6480ff`) added `creating`/`reading` Dexie hooks to filter non-application events — and, because the `creating` hook's `this.onsuccess = null` never actually aborted the underlying `IDBObjectStore.add()`, non-application rows were *already* being physically stored while invisible to every reader via the `reading` hook. Worse: any event that failed Zod validation never reached `db.apiEvents.add()` at all (in either the real-time or import path), which is the actual hole that silently destroyed months of `EVT_SESSION_RESULTS` data when PokerChase changed its season-3 payload shape (schema fix tracked separately in #134 / `fix/session-results-schema-legend-season3`).

This PR restores the original "raw Lake" design and closes that hole:

- **`src/db/poker-chase-db.ts`**: removed the `creating`/`reading` hooks entirely. No Dexie version bump — `[timestamp+ApiTypeId]` already accepts any raw shape, so no index change is required (still v3).
- **`src/background/event-ingestion.ts`**: stores the raw message whenever it has a numeric `timestamp`+`ApiTypeId` (via `validateMessage`), independent of `parseApiEvent`/`isApplicationApiEvent`. Validation now only gates whether the event proceeds into `eventLogger` + the three real-time streams, never whether it's persisted.
- **`src/background/import-export.ts`**:
  - `importData` stores every line with a numeric `timestamp`+`ApiTypeId` (full lake), while only validated application events feed `EntityConverter` — entity generation is fed strictly from rows confirmed stored (tracked via `storedKeys`), so an event never produces an entity without a backing raw row.
  - Export was already an unfiltered dump of `apiEvents`, so once storage is unfiltered the NDJSON export becomes the full lake automatically ("a line is a line").
  - `rebuildAllData` now re-validates every raw `apiEvents` row (`parseApiEvent` + `isApplicationApiEvent`) immediately before `EntityConverter` instead of trusting raw rows. **This is the entire recovery path**: once a schema fix lands (e.g. #134), the very next rebuild re-parses the same stored raw rows and picks up whatever now validates — no separate promotion table/mechanism needed.
- **`src/utils/database-utils.ts`**: new `filterValidApplicationEvents()`, shared by `rebuildAllData`, `AutoSyncService.rebuildLocalEntities`, and `HandLogExporter`'s two PokerStars-export prefetch sites — everywhere a raw `apiEvents` read previously flowed straight into `EntityConverter`/`HandLogProcessor` (both read required fields like `EVT_DEAL.Game.SmallBlind` via unguarded `switch (event.ApiTypeId)`, with no `default:` case, so a malformed-but-well-known-type row could throw and abort a whole rebuild/export).
- **`src/services/auto-sync-service.ts`**: cloud sync now uploads only application-type events (cost decision — non-app noise stays local-only), with the upload cursor fixed to advance on the *raw* chunk boundary rather than the app-type-filtered subset (a chunk that's 100% noise must still advance the cursor, or the sync loop would refetch it forever — this was a real bug introduced-and-fixed together with the filter).
- **`CLAUDE.md`** / **`docs/architecture.md`**: documents the "Raw Event Lake" principle, the hook-filtering drift and why it was reverted, the validation-gates-pipeline-not-storage split, cloud sync's app-type-only filter, and the (currently absent, by design) `apiEvents` pruning story.

`REBUILD_ADVISORY_VERSION` intentionally **not** bumped — already-valid stored data's derivation is unchanged.

This PR is independent of #134, but the rebuild-recovery mechanism only demonstrates its full real-world value once both land (this PR makes rebuild re-validate against whatever schema is current; #134 fixes the schema itself).

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — 622/622 passing (69 suites), including new coverage:
  - `src/db/poker-chase-db.test.ts` — hooks are gone; non-app/unknown/malformed rows round-trip through `add()`/`toArray()` unfiltered; DB stays v3
  - `src/utils/filter-valid-application-events.test.ts` — keeps valid app events, drops non-app/malformed/unknown rows
  - `src/background/event-ingestion.test.ts` — valid events stored + forwarded to streams; malformed/non-app/unknown events stored raw but never forwarded; events without numeric timestamp/ApiTypeId aren't stored
  - `src/background/import-export.rebuild.test.ts` — a known-good hand seeded directly into `apiEvents` is recovered into `hands`/`phases`/`actions` purely by re-reading raw rows on rebuild, with noise alongside it safely ignored (no crash, no spurious entities); schema-agnostic by design since #134 isn't merged into this branch
  - `src/services/auto-sync-service.test.ts` — a full raw chunk of pure noise still advances the upload cursor
- [x] `npm run verify-stats -- ~/Downloads/pokerchase_raw_data_2026-07-04T18-31-12-252Z.ndjson` — 100.00% agreement (623/623 eligible players)
- [x] `npm run verify-stats -- ~/Downloads/pokerchase_raw_data_2026-07-17T23-34-07-287Z.ndjson` — 100.00% agreement (45/45 eligible players)
- [x] `npm run validate-schema` on both captures above — 100.00% schema validation success

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>