### PR TITLE
docs(api): RankReward is BattleType=0-only

### DIFF
--- a/docs/api-events.md
+++ b/docs/api-events.md
@@ -154,7 +154,7 @@ EVT_HAND_RESULTS.Results[].UserId             ──► UserId 直接参照（Se
 | `EVT_PLAYER_SEAT_ASSIGNED` | `SeatUserIds`, `TableUsers` | 席→プレイヤーマッピング |
 | `EVT_DEAL` | `SeatUserIds`, `Game` | ハンドごとの席マッピングとブラインド情報 |
 | `EVT_HAND_RESULTS` | `HandId` | ユニークなハンド識別子（ここでのみ取得可能） |
-| `EVT_SESSION_RESULTS` | `Ranking`, `RankReward` | 最終順位とランク変動 |
+| `EVT_SESSION_RESULTS` | `Ranking`, `RankReward` | 最終順位とランク変動。`RankReward` はランク戦 SNG（BattleType=0）のみで、MTT 含む他の BattleType には出現しない（BQ実測: BattleType=0 は 643/661 セッションに存在、他タイプ 260 セッションで 0 件） |
 
 ### 主要な制約
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -483,7 +483,7 @@ export const apiEventSchemas = {
       LegendMatchWeeklyPoint: z.int().nonnegative().optional().describe('Legend Match週間トラックのポイント。season3/legend match 2026で新規観測（例: 35）'),
       LegendMatchWeeklyPointDiff: z.int().optional().describe('このセッションでのLegend Match週間ポイント変動。season3/legend match 2026で新規観測（例: 35）'),
       LegendMatchWeeklyBattleCount: z.int().nonnegative().optional().describe('Legend Match週間トラックでの対戦回数。season3/legend match 2026で新規観測（例: 1）'),
-    }).optional().describe('ランク報酬。SNG/MTT（BattleType=0,1）の場合のみ。存在する場合は基本フィールド（Rank/RankPoint/RankPointDiff/SeasonalRanking）は揃うが、season3/legend match 2026以降はIsSeasonal省略やLegend Match専用フィールドの有無でシェイプが変わる'),
+    }).optional().describe('ランク報酬。ランク戦SNG（BattleType=0）のみで出現し、MTT（BattleType=1）含む他タイプでは出現しない（BQ実測643/661 vs 他タイプ0/260）。SNG/MTT（BattleType=0,1）の場合のみ。存在する場合は基本フィールド（Rank/RankPoint/RankPointDiff/SeasonalRanking）は揃うが、season3/legend match 2026以降はIsSeasonal省略やLegend Match専用フィールドの有無でシェイプが変わる'),
     ResultChip: z.int().nonnegative().optional(),
     RingReward: z.object({
       Class: z.record(z.string(), z.string()).optional(),


### PR DESCRIPTION
BQ実測(643/661 vs 他タイプ0/260)に基づくRankRewardのスコープ注記を、#134マージ後の本文に再適用。別セッション(doc-fixチップ)の未コミット作業の救済。

🤖 Generated with [Claude Code](https://claude.com/claude-code)