### PR TITLE
feat(hud): surface undecoded-event (drop) counts in the popup

### DIFF
--- a/src/background/event-ingestion.test.ts
+++ b/src/background/event-ingestion.test.ts
@@ -10,8 +10,10 @@
  */
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
 import PokerChaseService, { PokerChaseDB } from '../app'
+import { ApiType } from '../types'
 import { registerEventIngestion } from './event-ingestion'
 import { connectedPorts } from './ports'
+import { getUndecodedEventStats, resetUndecodedEventStats, UNDECODED_EVENT_STATS_KEY } from './undecoded-event-tracker'
 
 describe('registerEventIngestion (Raw Event Lake)', () => {
   let db: PokerChaseDB
@@ -23,6 +25,11 @@ describe('registerEventIngestion (Raw Event Lake)', () => {
   beforeEach(async () => {
     db = new PokerChaseDB(indexedDB, IDBKeyRange)
     await db.open()
+    // undecoded-event-tracker caches its in-memory state at module scope
+    // (mirrors production, where there's exactly one db for the service
+    // worker's lifetime); reset it so tests don't leak counts across the
+    // fresh `db` instance each test creates.
+    await resetUndecodedEventStats(db)
     service = new PokerChaseService({ db })
     await service.ready
 
@@ -102,6 +109,53 @@ describe('registerEventIngestion (Raw Event Lake)', () => {
 
     const stored = await db.apiEvents.get([444, 9999])
     expect(stored).toEqual(unknownEvent)
+  })
+
+  test('drop visibility: an app-type parse failure is counted in the dangerous appTypeParseFailed class', async () => {
+    const brokenDealEvent = { ApiTypeId: ApiType.EVT_DEAL, timestamp: 222 }
+    await onMessageHandler(brokenDealEvent)
+    await new Promise(resolve => setTimeout(resolve, 550))
+
+    const stats = await getUndecodedEventStats(db)
+    expect(stats.total).toBe(1)
+    expect(stats.perApiTypeId[ApiType.EVT_DEAL]).toEqual({ count: 1, lastSeen: 222 })
+
+    const persisted = await db.meta.get(UNDECODED_EVENT_STATS_KEY)
+    expect(persisted?.value).toEqual(stats)
+  })
+
+  test('drop visibility: an ApiTypeId unknown to the ApiType enum is counted in the unknownApiType class', async () => {
+    const unknownEvent = { ApiTypeId: 9999, timestamp: 444, SomeFutureField: 'x' }
+    await onMessageHandler(unknownEvent)
+    await new Promise(resolve => setTimeout(resolve, 550))
+
+    const stats = await getUndecodedEventStats(db)
+    expect(stats.total).toBe(1)
+    expect(stats.perApiTypeId[9999]).toEqual({ count: 1, lastSeen: 444 })
+  })
+
+  test('drop visibility: a known non-application event (202) is NOT counted (by-design, not a drop)', async () => {
+    const nonAppEvent = { ApiTypeId: 202, timestamp: 333, Code: 0 }
+    await onMessageHandler(nonAppEvent)
+    await new Promise(resolve => setTimeout(resolve, 550))
+
+    const stats = await getUndecodedEventStats(db)
+    expect(stats.total).toBe(0)
+    // No new undecoded event was recorded, so the meta record still reflects
+    // the empty baseline written by the beforeEach's resetUndecodedEventStats
+    // call rather than being entirely absent.
+    expect((await db.meta.get(UNDECODED_EVENT_STATS_KEY))?.value).toEqual({ total: 0, perApiTypeId: {} })
+  })
+
+  test('drop visibility: a valid application event is NOT counted', async () => {
+    const validEvent = {
+      ApiTypeId: 201, timestamp: 111, Code: 0, BattleType: 0, Id: 'stage000_003', IsRetire: false
+    }
+    await onMessageHandler(validEvent)
+    await new Promise(resolve => setTimeout(resolve, 550))
+
+    const stats = await getUndecodedEventStats(db)
+    expect(stats.total).toBe(0)
   })
 
   test('an event without a numeric timestamp/ApiTypeId is not stored (no usable key)', async () => {

--- a/src/background/event-ingestion.ts
+++ b/src/background/event-ingestion.ts
@@ -11,6 +11,7 @@ import PokerChaseService, {
 import type { ApiEvent } from '../app'
 import { autoSyncService } from '../services/auto-sync-service'
 import { connectedPorts, startPortPing } from './ports'
+import { recordUndecodedEvent } from './undecoded-event-tracker'
 
 /**
  * `chrome.runtime.onConnect`のハンドラーを登録する。
@@ -62,6 +63,19 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
           const validationResult = validateApiEvent(message as ApiMessage)
           const errorDetails = validationResult.error ? getValidationError(validationResult.error) : null
           console.warn(`[background] Schema validation failed (stored raw, pipeline skipped):\n  Errors: ${JSON.stringify(errorDetails, null, 2)}\n  Event: ${JSON.stringify(message, null, 2)}`)
+
+          // drop可視化（docs/postmortems/2026-07-session-results-drop.md 再発防止#2）:
+          // 検証失敗イベントの件数をApiTypeIdごとに集計してmetaテーブルへ永続化し、
+          // Popupから可視化できるようにする。309インシデントは半年間これが
+          // console.warnの中にしか無かったために気づけなかった
+          const rawApiTypeId = (message as { ApiTypeId?: unknown }).ApiTypeId
+          if (typeof rawApiTypeId === 'number') {
+            const rawTimestamp = (message as { timestamp?: unknown }).timestamp
+            const eventTimestamp = typeof rawTimestamp === 'number' ? rawTimestamp : Date.now()
+            recordUndecodedEvent(service.db, rawApiTypeId, eventTimestamp).catch(err =>
+              console.error('[background] Failed to record undecoded event stats:', err)
+            )
+          }
           return
         }
 

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -12,6 +12,7 @@ import { autoSyncService } from '../services/auto-sync-service'
 import { getOperationState, isOperationIdle } from './operation-state'
 import { getLastKnownStats, setLastKnownStats } from './ports'
 import { resolveAdvisory } from './rebuild-advisory'
+import { getUndecodedEventStats, resetUndecodedEventStats } from './undecoded-event-tracker'
 import {
   createImportExportHandlers,
   getCurrentImportSession,
@@ -315,6 +316,26 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
         })
         .catch(error => {
           console.error('[getPositionalStats] Error:', error)
+          sendResponse({ success: false, error: error.message })
+        })
+      return true
+    } else if (request.action === 'getUndecodedEventStats') {
+      // drop可視化: 未解釈イベントの集計値を取得
+      getUndecodedEventStats(db)
+        .then(undecodedEventStats => {
+          sendResponse({ success: true, undecodedEventStats })
+        })
+        .catch(error => {
+          console.error('[getUndecodedEventStats] Error:', error)
+          sendResponse({ success: false, error: error.message })
+        })
+      return true
+    } else if (request.action === 'acknowledgeUndecodedEventStats') {
+      // Popupの「確認済みにする」操作: カウンタをリセット
+      resetUndecodedEventStats(db)
+        .then(() => sendResponse({ success: true }))
+        .catch(error => {
+          console.error('[acknowledgeUndecodedEventStats] Error:', error)
           sendResponse({ success: false, error: error.message })
         })
       return true

--- a/src/background/message-router.undecoded-events.test.ts
+++ b/src/background/message-router.undecoded-events.test.ts
@@ -1,0 +1,78 @@
+/**
+ * message-router.ts - getUndecodedEventStats / acknowledgeUndecodedEventStats plumbing
+ *
+ * Verifies the drop-visibility Chrome messages (postmortem
+ * docs/postmortems/2026-07-session-results-drop.md 再発防止#2) are wired
+ * end-to-end: registerMessageRouter() responds to 'getUndecodedEventStats'
+ * with the persisted counters, and 'acknowledgeUndecodedEventStats' resets them.
+ */
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { registerMessageRouter } from './message-router'
+import { recordUndecodedEvent, resetUndecodedEventStats, UNDECODED_EVENT_STATS_KEY } from './undecoded-event-tracker'
+import { ApiType } from '../types'
+import type { ChromeMessage, MessageResponse } from '../types/messages'
+
+// See undecoded-event-tracker.test.ts: real (not fake) timers, since
+// fake-indexeddb's own event scheduling conflicts with Jest's fake timers.
+const flush = () => new Promise(resolve => setTimeout(resolve, 550))
+
+describe('message-router undecoded event stats', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+  let listener: (request: ChromeMessage, sender: chrome.runtime.MessageSender, sendResponse: (response: MessageResponse) => void) => boolean | void
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    await resetUndecodedEventStats(db)
+    service = new PokerChaseService({ db })
+    await service.ready
+
+    ;(chrome.runtime.onMessage.addListener as jest.Mock).mockClear()
+    registerMessageRouter(service, db, 'https://example.com/*')
+    listener = (chrome.runtime.onMessage.addListener as jest.Mock).mock.calls[0][0]
+  })
+
+  afterEach(async () => {
+    db.close()
+    await db.delete()
+  })
+
+  test('getUndecodedEventStats responds with the persisted counters', async () => {
+    await recordUndecodedEvent(db, ApiType.EVT_SESSION_RESULTS, 1000)
+    await flush()
+
+    const sendResponse = jest.fn()
+    const handled = listener({ action: 'getUndecodedEventStats' } as ChromeMessage, {}, sendResponse)
+    expect(handled).toBe(true)
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    expect(sendResponse).toHaveBeenCalledTimes(1)
+    const response = sendResponse.mock.calls[0]![0] as any
+    expect(response.success).toBe(true)
+    expect(response.undecodedEventStats).toEqual({
+      total: 1,
+      perApiTypeId: { [ApiType.EVT_SESSION_RESULTS]: { count: 1, lastSeen: 1000 } }
+    })
+  })
+
+  test('acknowledgeUndecodedEventStats resets the counters', async () => {
+    await recordUndecodedEvent(db, ApiType.EVT_SESSION_RESULTS, 1000)
+    await flush()
+
+    const ackResponse = jest.fn()
+    listener({ action: 'acknowledgeUndecodedEventStats' } as ChromeMessage, {}, ackResponse)
+    await new Promise(resolve => setTimeout(resolve, 50))
+    expect(ackResponse).toHaveBeenCalledWith({ success: true })
+
+    const getResponse = jest.fn()
+    listener({ action: 'getUndecodedEventStats' } as ChromeMessage, {}, getResponse)
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    const response = getResponse.mock.calls[0]![0] as any
+    expect(response.undecodedEventStats).toEqual({ total: 0, perApiTypeId: {} })
+    expect((await db.meta.get(UNDECODED_EVENT_STATS_KEY))?.value).toEqual({ total: 0, perApiTypeId: {} })
+  })
+})

--- a/src/background/undecoded-event-tracker.test.ts
+++ b/src/background/undecoded-event-tracker.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for undecoded-event-tracker.ts (drop visibility, postmortem
+ * docs/postmortems/2026-07-session-results-drop.md 再発防止#2)
+ */
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import { PokerChaseDB } from '../db/poker-chase-db'
+import { ApiType } from '../types'
+import {
+  classifyUndecodedApiTypeId,
+  getUndecodedEventStats,
+  recordUndecodedEvent,
+  resetUndecodedEventStats,
+  UNDECODED_EVENT_STATS_KEY
+} from './undecoded-event-tracker'
+
+// Debounce window in undecoded-event-tracker.ts is 500ms. fake-indexeddb relies
+// on real macrotask scheduling (Immediate/setTimeout) to surface its own
+// events, which conflicts with Jest's fake timers (see event-ingestion.test.ts
+// for the same real-timer convention) -- so these tests wait out the real
+// debounce window instead of faking it.
+const FLUSH_WAIT_MS = 550
+const flush = () => new Promise(resolve => setTimeout(resolve, FLUSH_WAIT_MS))
+
+describe('undecoded-event-tracker', () => {
+  let db: PokerChaseDB
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    // Start each test from a clean slate regardless of module-level cache
+    // left over from a previous test's in-flight debounce.
+    await resetUndecodedEventStats(db)
+  })
+
+  afterEach(async () => {
+    db.close()
+    await db.delete()
+  })
+
+  describe('classifyUndecodedApiTypeId', () => {
+    it('classifies a known application ApiTypeId as appTypeParseFailed', () => {
+      expect(classifyUndecodedApiTypeId(ApiType.EVT_SESSION_RESULTS)).toBe('appTypeParseFailed')
+      expect(classifyUndecodedApiTypeId(ApiType.EVT_DEAL)).toBe('appTypeParseFailed')
+    })
+
+    it('classifies an ApiTypeId outside the ApiType enum as unknownApiType', () => {
+      expect(classifyUndecodedApiTypeId(9999)).toBe('unknownApiType')
+      // 202/205 are known non-application types but are NOT in the ApiType enum
+      // (application types only) -- if they ever reached this classifier (they
+      // shouldn't, since parseApiEvent succeeds for them), they'd read as
+      // unknownApiType rather than the dangerous appTypeParseFailed class.
+      expect(classifyUndecodedApiTypeId(202)).toBe('unknownApiType')
+    })
+  })
+
+  describe('recordUndecodedEvent / getUndecodedEventStats', () => {
+    it('accumulates per-ApiTypeId counts and lastSeen, debounced to a single write', async () => {
+      await recordUndecodedEvent(db, ApiType.EVT_SESSION_RESULTS, 1000)
+      await recordUndecodedEvent(db, ApiType.EVT_SESSION_RESULTS, 2000)
+      await recordUndecodedEvent(db, 9999, 1500)
+
+      // Before the debounce elapses, meta table should still reflect the
+      // empty baseline written by the beforeEach's resetUndecodedEventStats
+      // call, not these three in-flight (unflushed) records.
+      expect((await db.meta.get(UNDECODED_EVENT_STATS_KEY))?.value).toEqual({ total: 0, perApiTypeId: {} })
+
+      const stats = await getUndecodedEventStats(db)
+      expect(stats.total).toBe(3)
+      expect(stats.perApiTypeId[ApiType.EVT_SESSION_RESULTS]).toEqual({ count: 2, lastSeen: 2000 })
+      expect(stats.perApiTypeId[9999]).toEqual({ count: 1, lastSeen: 1500 })
+
+      // Flush the debounce timer
+      await flush()
+
+      const persisted = await db.meta.get(UNDECODED_EVENT_STATS_KEY)
+      expect(persisted?.value).toEqual(stats)
+    })
+
+    it('coalesces bursts within the debounce window into one meta.put', async () => {
+      const putSpy = jest.spyOn(db.meta, 'put')
+
+      for (let i = 0; i < 5; i++) {
+        await recordUndecodedEvent(db, ApiType.EVT_DEAL, 100 + i)
+      }
+
+      await flush()
+
+      expect(putSpy).toHaveBeenCalledTimes(1)
+      const stats = await getUndecodedEventStats(db)
+      expect(stats.perApiTypeId[ApiType.EVT_DEAL]).toEqual({ count: 5, lastSeen: 104 })
+    })
+  })
+
+  describe('resetUndecodedEventStats', () => {
+    it('clears counters both in-memory and in the meta table', async () => {
+      await recordUndecodedEvent(db, ApiType.EVT_SESSION_RESULTS, 1000)
+      await flush()
+      expect((await getUndecodedEventStats(db)).total).toBe(1)
+
+      await resetUndecodedEventStats(db)
+
+      expect(await getUndecodedEventStats(db)).toEqual({ total: 0, perApiTypeId: {} })
+      expect((await db.meta.get(UNDECODED_EVENT_STATS_KEY))?.value).toEqual({ total: 0, perApiTypeId: {} })
+    })
+
+    it('cancels a pending debounced flush so it does not resurrect old counts', async () => {
+      await recordUndecodedEvent(db, ApiType.EVT_SESSION_RESULTS, 1000)
+      await resetUndecodedEventStats(db)
+
+      // If the earlier flush timer were still pending, this would overwrite
+      // the reset with the pre-reset stats.
+      await flush()
+
+      expect((await db.meta.get(UNDECODED_EVENT_STATS_KEY))?.value).toEqual({ total: 0, perApiTypeId: {} })
+    })
+  })
+})

--- a/src/background/undecoded-event-tracker.ts
+++ b/src/background/undecoded-event-tracker.ts
@@ -1,0 +1,132 @@
+/** !!! CONTENT_SCRIPTS、WEB_ACCESSIBLE_RESOURCESからインポートしないこと !!! */
+/**
+ * 未解釈イベント（drop）追跡。
+ *
+ * ポストモーテム（docs/postmortems/2026-07-session-results-drop.md）の教訓:
+ * Zod検証に失敗したイベントは Raw Event Lake には保存されるが、リアルタイム
+ * パイプラインには投入されない（`event-ingestion.ts`）。この drop の痕跡は
+ * これまで console.warn のみで、通常運用では半年間気づかれなかった。
+ * 本モジュールはその件数を`meta`テーブル（既存テーブル、スキーマ変更不要）に
+ * 集計し、Popupから可視化できるようにする。
+ *
+ * 分類（呼び出し元 = event-ingestion.ts の `parseApiEvent` 失敗時のみが対象）:
+ * - `appTypeParseFailed`: `ApiTypeId` が `ApiType` enum（アプリケーション種別）に
+ *   含まれるのに検証に失敗した。309インシデントと同じ危険クラス
+ * - `unknownApiType`: `ApiTypeId` が `ApiType` enum に含まれない（新種イベントの
+ *   可能性、または既知の非アプリケーションスキーマ自体が変化した稀なケース）
+ *
+ * 202/205等の「検証は通るが非アプリケーション」イベント（`isApplicationApiEvent`
+ * が false を返すが `parseApiEvent` 自体は成功する）は仕様通りの挙動であり、
+ * このモジュールの対象外（呼び出し元でそもそもこの関数を呼ばない）。
+ */
+import type { PokerChaseDB } from '../db/poker-chase-db'
+import { ApiTypeValues, type ApiType } from '../types'
+
+export const UNDECODED_EVENT_STATS_KEY = 'undecodedEventStats'
+
+export type UndecodedEventClass = 'appTypeParseFailed' | 'unknownApiType'
+
+export interface UndecodedEventTypeStat {
+  count: number
+  lastSeen: number
+}
+
+export interface UndecodedEventStats {
+  total: number
+  perApiTypeId: Record<number, UndecodedEventTypeStat>
+}
+
+const EMPTY_STATS: UndecodedEventStats = { total: 0, perApiTypeId: {} }
+
+const cloneStats = (stats: UndecodedEventStats): UndecodedEventStats => ({
+  total: stats.total,
+  perApiTypeId: { ...stats.perApiTypeId }
+})
+
+/** `ApiTypeId`からdropクラスを判定する（(c)非アプリケーションは呼び出し元でフィルタ済みの前提） */
+export const classifyUndecodedApiTypeId = (apiTypeId: number): UndecodedEventClass =>
+  ApiTypeValues.includes(apiTypeId as ApiType) ? 'appTypeParseFailed' : 'unknownApiType'
+
+// モジュールスコープの状態。Service Workerのライフタイム内でのみ有効
+// （SW再起動時はmetaテーブルから再読込される）。
+let statsPromise: Promise<UndecodedEventStats> | null = null
+let flushTimer: ReturnType<typeof setTimeout> | undefined
+
+const FLUSH_DEBOUNCE_MS = 500
+
+const loadStats = async (db: PokerChaseDB): Promise<UndecodedEventStats> => {
+  try {
+    const record = await db.meta.get(UNDECODED_EVENT_STATS_KEY)
+    const value = record?.value as UndecodedEventStats | undefined
+    return value ? cloneStats(value) : cloneStats(EMPTY_STATS)
+  } catch (error) {
+    console.error('[undecoded-event-tracker] Failed to load stats:', error)
+    return cloneStats(EMPTY_STATS)
+  }
+}
+
+/**
+ * 同一Promiseをキャッシュすることで、`recordUndecodedEvent`が短時間に連続で
+ * 呼ばれても同じ`UndecodedEventStats`オブジェクト参照を返し、DB読み込み完了前の
+ * 複数呼び出し間で更新を取りこぼさないようにする（JSのマイクロタスクは
+ * 実行完了まで割り込まれないため、参照共有だけで直列化される）。
+ */
+const ensureLoaded = (db: PokerChaseDB): Promise<UndecodedEventStats> => {
+  if (!statsPromise) {
+    statsPromise = loadStats(db)
+  }
+  return statsPromise
+}
+
+const scheduleFlush = (db: PokerChaseDB, stats: UndecodedEventStats): void => {
+  if (flushTimer) clearTimeout(flushTimer)
+  flushTimer = setTimeout(() => {
+    flushTimer = undefined
+    db.meta.put({
+      id: UNDECODED_EVENT_STATS_KEY,
+      value: cloneStats(stats),
+      updatedAt: Date.now()
+    }).catch(err => console.error('[undecoded-event-tracker] Failed to persist stats:', err))
+  }, FLUSH_DEBOUNCE_MS)
+}
+
+/**
+ * 未解釈イベントを記録する。呼び出し側は既に(c)（既知の非アプリケーション
+ * イベント）を除外していること。書き込みは500msデバウンスされる
+ * （Service Worker Compatibility: グローバル`setTimeout`を使用）。
+ */
+export const recordUndecodedEvent = async (
+  db: PokerChaseDB,
+  apiTypeId: number,
+  timestamp: number
+): Promise<void> => {
+  const stats = await ensureLoaded(db)
+  const existing = stats.perApiTypeId[apiTypeId]
+  stats.perApiTypeId[apiTypeId] = {
+    count: (existing?.count ?? 0) + 1,
+    lastSeen: Math.max(existing?.lastSeen ?? 0, timestamp)
+  }
+  stats.total += 1
+  scheduleFlush(db, stats)
+}
+
+/** Popup向け: 現在の集計値を取得する（デバウンス中の未flush分も含む） */
+export const getUndecodedEventStats = async (db: PokerChaseDB): Promise<UndecodedEventStats> => {
+  const stats = await ensureLoaded(db)
+  return cloneStats(stats)
+}
+
+/** Popupの「確認済みにする」操作: カウンタをリセットする */
+export const resetUndecodedEventStats = async (db: PokerChaseDB): Promise<void> => {
+  if (flushTimer) {
+    clearTimeout(flushTimer)
+    flushTimer = undefined
+  }
+  const fresh = cloneStats(EMPTY_STATS)
+  statsPromise = Promise.resolve(fresh)
+  await db.meta.put({
+    id: UNDECODED_EVENT_STATS_KEY,
+    value: cloneStats(fresh),
+    updatedAt: Date.now()
+  })
+}

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -27,6 +27,7 @@ import { GameTypeFilterSection } from './popup/GameTypeFilterSection'
 import { TableSizeFilterSection } from './popup/TableSizeFilterSection'
 import { HandLimitSection } from './popup/HandLimitSection'
 import { StatisticsConfigSection } from './popup/StatisticsConfigSection'
+import { UndecodedEventSection } from './popup/UndecodedEventSection'
 
 export type { Options }
 
@@ -445,6 +446,8 @@ const Popup = () => {
       setImportSuccess={setImportSuccess}
       setImportStartTime={setImportStartTime}
     />
+
+    <UndecodedEventSection />
   </div>
 }
 

--- a/src/components/popup/UndecodedEventSection.test.tsx
+++ b/src/components/popup/UndecodedEventSection.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { UndecodedEventSection } from './UndecodedEventSection'
+import { ApiType } from '../../types'
+
+describe('UndecodedEventSection', () => {
+  let mockSendMessage: jest.Mock
+
+  beforeEach(() => {
+    mockSendMessage = jest.fn()
+    global.chrome = {
+      ...global.chrome,
+      runtime: {
+        ...global.chrome.runtime,
+        sendMessage: mockSendMessage,
+      },
+    } as any
+  })
+
+  it('N=0のときは何も表示しない', async () => {
+    mockSendMessage.mockImplementation((_message, callback) => {
+      callback({ undecodedEventStats: { total: 0, perApiTypeId: {} } })
+    })
+
+    const { container } = render(<UndecodedEventSection />)
+
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        { action: 'getUndecodedEventStats' },
+        expect.any(Function)
+      )
+    })
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('app-typeパース失敗を含む場合は警告表示(warning)になる', async () => {
+    mockSendMessage.mockImplementation((_message, callback) => {
+      callback({
+        undecodedEventStats: {
+          total: 15,
+          perApiTypeId: {
+            [ApiType.EVT_SESSION_RESULTS]: { count: 12, lastSeen: new Date('2026-07-20T14:32:00').getTime() },
+            9999: { count: 3, lastSeen: new Date('2026-07-19T10:00:00').getTime() }
+          }
+        }
+      })
+    })
+
+    render(<UndecodedEventSection />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/未解釈イベント: 15件/)).toBeInTheDocument()
+    })
+
+    expect(screen.getByText(/309×12/)).toBeInTheDocument()
+    expect(screen.getByText(/9999×3/)).toBeInTheDocument()
+    expect(screen.getByText(/07-20 14:32/)).toBeInTheDocument()
+
+    // MUI Alert severity="warning" renders role="alert" with a warning-flavored class
+    const alert = screen.getByRole('alert')
+    expect(alert.className).toMatch(/colorWarning|standardWarning/)
+  })
+
+  it('unknownApiTypeのみの場合は危険クラスなし(info)になる', async () => {
+    mockSendMessage.mockImplementation((_message, callback) => {
+      callback({
+        undecodedEventStats: {
+          total: 3,
+          perApiTypeId: {
+            9999: { count: 3, lastSeen: new Date('2026-07-19T10:00:00').getTime() }
+          }
+        }
+      })
+    })
+
+    render(<UndecodedEventSection />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/未解釈イベント: 3件/)).toBeInTheDocument()
+    })
+
+    const alert = screen.getByRole('alert')
+    expect(alert.className).toMatch(/colorInfo|standardInfo/)
+  })
+
+  it('確認済みにするボタンでリセットメッセージを送り、表示を消す', async () => {
+    mockSendMessage.mockImplementation((message, callback) => {
+      if (message.action === 'getUndecodedEventStats') {
+        callback({
+          undecodedEventStats: {
+            total: 5,
+            perApiTypeId: { 9999: { count: 5, lastSeen: 1000 } }
+          }
+        })
+      }
+    })
+
+    render(<UndecodedEventSection />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/未解釈イベント: 5件/)).toBeInTheDocument()
+    })
+
+    const dismissButton = screen.getByLabelText('確認済みにする')
+    await userEvent.click(dismissButton)
+
+    expect(mockSendMessage).toHaveBeenCalledWith({ action: 'acknowledgeUndecodedEventStats' })
+    expect(screen.queryByText(/未解釈イベント/)).not.toBeInTheDocument()
+  })
+})

--- a/src/components/popup/UndecodedEventSection.tsx
+++ b/src/components/popup/UndecodedEventSection.tsx
@@ -1,0 +1,81 @@
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import IconButton from '@mui/material/IconButton'
+import Typography from '@mui/material/Typography'
+import { Close } from '@mui/icons-material'
+import { useCallback, useEffect, useState } from 'react'
+import { ApiTypeValues, type ApiType } from '../../types'
+import type { UndecodedEventStats } from '../../background/undecoded-event-tracker'
+import type { AcknowledgeUndecodedEventStatsMessage } from '../../types/messages'
+import { sendMessageWithTimeout } from './send-message'
+
+/**
+ * drop可視化（docs/postmortems/2026-07-session-results-drop.md 再発防止#2）。
+ *
+ * 検証失敗イベント（Zodパース失敗）の件数をPopupに表示する。309インシデントは
+ * この情報がconsole.warnにしかなかったために半年間気づかれなかった。
+ * N=0の間は何も表示しない（既定は非表示、ユーザーの目に触れるのは異常時のみ）。
+ */
+export const UndecodedEventSection = () => {
+  const [stats, setStats] = useState<UndecodedEventStats | null>(null)
+
+  const refresh = useCallback(() => {
+    // フェイルオープン: タイムアウト/エラー時は現状維持（ブロッキングしない）
+    sendMessageWithTimeout<{ undecodedEventStats?: UndecodedEventStats }>({
+      action: 'getUndecodedEventStats'
+    }).then((response) => {
+      if (response?.undecodedEventStats) {
+        setStats(response.undecodedEventStats)
+      }
+    })
+  }, [])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const handleAcknowledge = useCallback(() => {
+    // 楽観的に即座に消す（background側の書き込みでも問題ない）
+    setStats(null)
+    chrome.runtime.sendMessage<AcknowledgeUndecodedEventStatsMessage>({
+      action: 'acknowledgeUndecodedEventStats'
+    })
+  }, [])
+
+  if (!stats || stats.total === 0) return null
+
+  const entries = Object.entries(stats.perApiTypeId)
+    .map(([apiTypeIdStr, entry]) => ({ apiTypeId: Number(apiTypeIdStr), ...entry }))
+    .sort((a, b) => b.count - a.count)
+
+  const isDangerous = entries.some(({ apiTypeId }) => ApiTypeValues.includes(apiTypeId as ApiType))
+  const lastSeen = entries.reduce((max, e) => Math.max(max, e.lastSeen), 0)
+
+  const formatTimestamp = (timestamp: number) => {
+    const date = new Date(timestamp)
+    const month = String(date.getMonth() + 1).padStart(2, '0')
+    const day = String(date.getDate()).padStart(2, '0')
+    const hours = String(date.getHours()).padStart(2, '0')
+    const minutes = String(date.getMinutes()).padStart(2, '0')
+    return `${month}-${day} ${hours}:${minutes}`
+  }
+
+  const breakdown = entries.map(({ apiTypeId, count }) => `${apiTypeId}×${count}`).join(', ')
+
+  return (
+    <Box sx={{ mt: 2, pt: 2, borderTop: 1, borderColor: 'divider' }}>
+      <Alert
+        severity={isDangerous ? 'warning' : 'info'}
+        action={
+          <IconButton size="small" onClick={handleAcknowledge} aria-label="確認済みにする">
+            <Close fontSize="inherit" />
+          </IconButton>
+        }
+      >
+        <Typography variant="body2">
+          未解釈イベント: {stats.total.toLocaleString()}件 ({breakdown} / 最新 {formatTimestamp(lastSeen)})
+        </Typography>
+      </Alert>
+    </Box>
+  )
+}

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -6,6 +6,7 @@
 import type { FilterOptions, PlayerStats, PositionalStatsResult } from './index'
 import { HandLogConfig, HandLogEvent, UIConfig } from './hand-log'
 import type { SyncState } from '../services/auto-sync-service'
+import type { UndecodedEventStats } from '../background/undecoded-event-tracker'
 
 // Message action constants
 export const MESSAGE_ACTIONS = {
@@ -53,6 +54,9 @@ export const MESSAGE_ACTIONS = {
   ACKNOWLEDGE_REBUILD_ADVISORY: 'acknowledgeRebuildAdvisory',
   // Positional drill-down
   GET_POSITIONAL_STATS: 'getPositionalStats',
+  // Undecoded event (drop) visibility
+  GET_UNDECODED_EVENT_STATS: 'getUndecodedEventStats',
+  ACKNOWLEDGE_UNDECODED_EVENT_STATS: 'acknowledgeUndecodedEventStats',
 } as const
 
 // Import/Export related messages
@@ -241,6 +245,15 @@ export interface GetPositionalStatsMessage {
   playerId: number
 }
 
+// Undecoded event (drop) visibility messages
+export interface GetUndecodedEventStatsMessage {
+  action: 'getUndecodedEventStats'
+}
+
+export interface AcknowledgeUndecodedEventStatsMessage {
+  action: 'acknowledgeUndecodedEventStats'
+}
+
 export interface FirebaseBackupProgressMessage {
   action: 'firebaseBackupProgress'
   progress: number
@@ -312,7 +325,11 @@ export interface PositionalStatsResponse extends SuccessResponse {
   positionalStats: PositionalStatsResult
 }
 
-export type MessageResponse = SuccessResponse | ErrorResponse | BackupListResponse | BackupDownloadResponse | AuthStatusResponse | SyncStateResponse | UnsyncedCountResponse | SyncInfoResponse | OperationStateResponse | PositionalStatsResponse
+export interface UndecodedEventStatsResponse extends SuccessResponse {
+  undecodedEventStats: UndecodedEventStats
+}
+
+export type MessageResponse = SuccessResponse | ErrorResponse | BackupListResponse | BackupDownloadResponse | AuthStatusResponse | SyncStateResponse | UnsyncedCountResponse | SyncInfoResponse | OperationStateResponse | PositionalStatsResponse | UndecodedEventStatsResponse
 
 // Union type of all possible messages
 export type ChromeMessage =
@@ -352,6 +369,8 @@ export type ChromeMessage =
   | GetOperationStateMessage
   | AcknowledgeRebuildAdvisoryMessage
   | GetPositionalStatsMessage
+  | GetUndecodedEventStatsMessage
+  | AcknowledgeUndecodedEventStatsMessage
 
 // Helper function for type guard implementation
 const isMessageWithAction = (msg: unknown, action: string): msg is { action: string } =>
@@ -441,3 +460,9 @@ export const isAcknowledgeRebuildAdvisoryMessage = (msg: unknown): msg is Acknow
 
 export const isGetPositionalStatsMessage = (msg: unknown): msg is GetPositionalStatsMessage =>
   isMessageWithAction(msg, 'getPositionalStats')
+
+export const isGetUndecodedEventStatsMessage = (msg: unknown): msg is GetUndecodedEventStatsMessage =>
+  isMessageWithAction(msg, 'getUndecodedEventStats')
+
+export const isAcknowledgeUndecodedEventStatsMessage = (msg: unknown): msg is AcknowledgeUndecodedEventStatsMessage =>
+  isMessageWithAction(msg, 'acknowledgeUndecodedEventStats')


### PR DESCRIPTION
## Summary
- Postmortem action item #2 (`docs/postmortems/2026-07-session-results-drop.md`, 再発防止): make the next schema break visible from the popup within days, not the ~6 months it took last time.
- Classifies each Zod-parse-failure at ingestion into `appTypeParseFailed` (ApiTypeId is a known application type but the payload failed to parse — the dangerous class, exactly what the 309 incident looked like) vs `unknownApiType` (ApiTypeId outside the `ApiType` enum). Known non-application noise (202/205 keepalive/timer) is intentionally excluded from both — it's by-design, not a drop.
- Counters (total + per-ApiTypeId count/lastSeen) persist to the existing `meta` Dexie table (no schema bump), 500ms-debounced so bursts coalesce into a single write.
- Popup shows a small Alert (warning if the dangerous class is present, info otherwise) only when count > 0, with a "確認済みにする" reset button. Hidden entirely at N=0.
- Skipped the rebuild-advisory badge pattern: `chrome.action`'s badge text is a single shared slot: stacking a second independent writer on it risked the two features clobbering each other, so this ships without a badge (popup visibility is the core ask).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test` (640/640 passing, including new `undecoded-event-tracker.test.ts`, extended `event-ingestion.test.ts`, new `message-router.undecoded-events.test.ts`, new `UndecodedEventSection.test.tsx`)
- [x] `npm run verify-stats` — 100.00% on both real-data captures (393,829-event and 23,461-event)
- [x] `npm run validate-schema` — 100.00% on both captures
- [x] `npm run build` sanity check

🤖 Generated with [Claude Code](https://claude.com/claude-code)