### PR TITLE
feat(hud): add session-start fallback trigger for auto-sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -614,7 +614,9 @@ Key `pokerChaseServiceState` in `storage.local`. Auto-saved with 500ms debounce 
 
 ### Key Features
 
-- **Auto Sync**: Triggers on game end with 100+ new events
+- **Auto Sync**: Triggers on two independent events, both gated by the same 100+ new-event backlog threshold (`AutoSyncService.EVENTS_THRESHOLD`) via a shared `syncIfBacklogExceedsThreshold()` helper:
+  - **Primary — session end** (`EVT_SESSION_RESULTS`/309): `AutoSyncService.onGameSessionEnd()`
+  - **Fallback — session start** (`EVT_ENTRY_QUEUED`/201 or `EVT_SESSION_DETAILS`/308): `AutoSyncService.onNewSessionStart()`. Added after the 2026 season-3 incident (`docs/postmortems/2026-07-session-results-drop.md`) where 309 alone was a single point of failure — a PokerChase payload change broke its schema and silently stopped auto-sync for ~2 months. Session start is a safe moment to sync (no hand is in flight), and reusing the same threshold check means a broken 309 now costs at most one session's lag instead of indefinite silence. No extra debounce is needed: the in-flight guard (`isSyncing`) and the fact that a successful sync advances `lastSyncTime` (shrinking the backlog below threshold) together prevent a double-fire when 309 fired normally just before session start.
 - **Manual Sync**: Upload/download controls in popup
 - **BigQuery Export**: Automatic daily snapshots for analysis
 - **Free Tier Friendly**: Typical usage stays within limits

--- a/src/background/event-ingestion.auto-sync-trigger.test.ts
+++ b/src/background/event-ingestion.auto-sync-trigger.test.ts
@@ -1,0 +1,153 @@
+/**
+ * event-ingestion.ts - auto-sync trigger wiring
+ *
+ * Verifies which ApiTypeIds fire AutoSyncService's sync triggers:
+ *  - EVT_SESSION_RESULTS (309, session end) -> onGameSessionEnd (primary trigger)
+ *  - EVT_ENTRY_QUEUED (201) / EVT_SESSION_DETAILS (308, session start) ->
+ *    onNewSessionStart (fallback trigger added per postmortem
+ *    docs/postmortems/2026-07-session-results-drop.md 再発防止#3, so a
+ *    broken 309 doesn't leave sync stuck forever)
+ *  - no other application event fires either trigger
+ */
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { ApiType } from '../types'
+import { registerEventIngestion } from './event-ingestion'
+import { connectedPorts } from './ports'
+import { autoSyncService } from '../services/auto-sync-service'
+
+describe('registerEventIngestion (auto-sync triggers)', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+  let onMessageHandler: (message: any) => Promise<void>
+  let disconnectHandlers: Array<() => void>
+  let mockPort: any
+  let onGameSessionEndSpy: jest.SpyInstance
+  let onNewSessionStartSpy: jest.SpyInstance
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    service = new PokerChaseService({ db })
+    await service.ready
+
+    onGameSessionEndSpy = jest.spyOn(autoSyncService, 'onGameSessionEnd').mockResolvedValue(undefined)
+    onNewSessionStartSpy = jest.spyOn(autoSyncService, 'onNewSessionStart').mockResolvedValue(undefined)
+
+    ;(chrome.runtime as any).onConnect = { addListener: jest.fn() }
+    registerEventIngestion(service)
+    const connectListener = (chrome.runtime as any).onConnect.addListener.mock.calls[0][0]
+
+    disconnectHandlers = []
+    mockPort = {
+      name: PokerChaseService.POKER_CHASE_SERVICE_EVENT,
+      onMessage: { addListener: jest.fn() },
+      onDisconnect: { addListener: jest.fn((fn: () => void) => disconnectHandlers.push(fn)) },
+      postMessage: jest.fn()
+    }
+    connectListener(mockPort)
+    onMessageHandler = mockPort.onMessage.addListener.mock.calls[0][0]
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    disconnectHandlers.forEach(fn => fn())
+    connectedPorts.clear()
+    db.close()
+    await db.delete()
+  })
+
+  test('EVT_SESSION_RESULTS (309, session end) triggers onGameSessionEnd, not onNewSessionStart', async () => {
+    const sessionResultsEvent = {
+      ApiTypeId: ApiType.EVT_SESSION_RESULTS,
+      timestamp: 1000,
+      Ranking: 3,
+      IsLeave: false,
+      IsRebuy: false,
+      TotalMatch: 100,
+      RankReward: {
+        IsSeasonal: true,
+        RankPoint: 10,
+        RankPointDiff: 1,
+        Rank: { RankId: 'gold', RankName: 'ゴールド', RankLvId: 'gold', RankLvName: 'ゴールド' },
+        SeasonalRanking: 0
+      },
+      Rewards: [],
+      EventRewards: [],
+      Charas: [],
+      Costumes: [],
+      Decos: [],
+      Items: [],
+      Money: { FreeMoney: -1, PaidMoney: -1 },
+      Emblems: []
+    }
+    await onMessageHandler(sessionResultsEvent)
+
+    expect(onGameSessionEndSpy).toHaveBeenCalledTimes(1)
+    expect(onNewSessionStartSpy).not.toHaveBeenCalled()
+  })
+
+  test('EVT_ENTRY_QUEUED (201, session start) triggers onNewSessionStart, not onGameSessionEnd', async () => {
+    const entryQueuedEvent = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      timestamp: 2000,
+      Code: 0,
+      BattleType: 0,
+      Id: 'stage000_003',
+      IsRetire: false
+    }
+    await onMessageHandler(entryQueuedEvent)
+
+    expect(onNewSessionStartSpy).toHaveBeenCalledTimes(1)
+    expect(onGameSessionEndSpy).not.toHaveBeenCalled()
+  })
+
+  test('EVT_SESSION_DETAILS (308, session start) triggers onNewSessionStart, not onGameSessionEnd', async () => {
+    const sessionDetailsEvent = {
+      ApiTypeId: ApiType.EVT_SESSION_DETAILS,
+      timestamp: 3000,
+      BlindStructures: [{ ActiveMinutes: 4, Ante: 50, BigBlind: 200, Lv: 1 }],
+      CoinNum: -1,
+      DefaultChip: 20000,
+      IsReplay: false,
+      Items: [],
+      LimitSeconds: 8,
+      MoneyList: [],
+      Name: 'テストセッション',
+      Name2: ''
+    }
+    await onMessageHandler(sessionDetailsEvent)
+
+    expect(onNewSessionStartSpy).toHaveBeenCalledTimes(1)
+    expect(onGameSessionEndSpy).not.toHaveBeenCalled()
+  })
+
+  test('an unrelated application event (EVT_DEAL) triggers neither sync path', async () => {
+    const dealEvent = {
+      ApiTypeId: ApiType.EVT_DEAL,
+      timestamp: 4000,
+      SeatUserIds: [1, 2, 3],
+      Game: { CurrentBlindLv: 1, NextBlindUnixSeconds: 0, Ante: 0, SmallBlind: 100, BigBlind: 200, ButtonSeat: 0, SmallBlindSeat: 1, BigBlindSeat: 2 },
+      Player: { SeatIndex: 0, BetStatus: 1, HoleCards: [0, 1], Chip: 5000, BetChip: 0 },
+      OtherPlayers: [
+        { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 100 },
+        { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 200 }
+      ],
+      Progress: { Phase: 0, NextActionSeat: 0, NextActionTypes: [2, 3, 4, 5], NextExtraLimitSeconds: 1, MinRaise: 400, Pot: 300, SidePot: [] }
+    }
+    await onMessageHandler(dealEvent)
+
+    expect(onGameSessionEndSpy).not.toHaveBeenCalled()
+    expect(onNewSessionStartSpy).not.toHaveBeenCalled()
+  })
+
+  test('a parse-failed EVT_ENTRY_QUEUED (201) does not trigger onNewSessionStart (never reaches the pipeline dispatch)', async () => {
+    // Missing every required field -- fails Zod validation, so this never
+    // reaches the ApiTypeId dispatch below the isApplicationApiEvent gate.
+    const brokenEntryQueuedEvent = { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, timestamp: 5000 }
+    await onMessageHandler(brokenEntryQueuedEvent)
+
+    expect(onNewSessionStartSpy).not.toHaveBeenCalled()
+    expect(onGameSessionEndSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/background/event-ingestion.ts
+++ b/src/background/event-ingestion.ts
@@ -100,6 +100,15 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
           autoSyncService.onGameSessionEnd().catch(err =>
             console.error('[background] Auto sync on game end failed:', err)
           )
+        } else if (data.ApiTypeId === ApiType.EVT_ENTRY_QUEUED || data.ApiTypeId === ApiType.EVT_SESSION_DETAILS) {
+          // フォールバックトリガー（docs/postmortems/2026-07-session-results-drop.md
+          // 再発防止#3）: 309単一トリガーのSPOF対策。新セッション開始時点は
+          // 進行中ハンドが存在しない安全なタイミングなので、ここでも同じ閾値判定
+          // でuploadを起動する（309が正常なら直前で既にバックログが閾値未満に
+          // なっているため二重発火しない）
+          autoSyncService.onNewSessionStart().catch(err =>
+            console.error('[background] Auto sync on new session start failed:', err)
+          )
         }
       })
       const stopPing = startPortPing(port)

--- a/src/services/auto-sync-service.session-triggers.test.ts
+++ b/src/services/auto-sync-service.session-triggers.test.ts
@@ -1,0 +1,133 @@
+/**
+ * AutoSyncService - session start/end sync trigger tests
+ *
+ * postmortem docs/postmortems/2026-07-session-results-drop.md 再発防止#3:
+ * EVT_SESSION_RESULTS (309) was a single point of failure for auto-sync --
+ * when PokerChase's season-3 payload change broke its schema, sync silently
+ * stopped firing for ~2 months. onNewSessionStart() is a fallback trigger
+ * fired on EVT_ENTRY_QUEUED (201) / EVT_SESSION_DETAILS (308, session start)
+ * that reuses the same 100+-event backlog threshold as onGameSessionEnd(),
+ * so a broken 309 now costs at most one session's lag instead of silence
+ * forever.
+ */
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import { PokerChaseDB } from '../db/poker-chase-db'
+import { ApiType, BattleType } from '../types'
+import type { ApiEvent } from '../types'
+import { AutoSyncService } from './auto-sync-service'
+import { firebaseAuthService } from './firebase-auth-service'
+
+const mockUser = { uid: 'test-user', email: 'test@example.com' } as any
+
+const makeEvent = (timestamp: number): ApiEvent => ({
+  ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+  Code: 0,
+  BattleType: BattleType.SIT_AND_GO,
+  Id: `stage-${timestamp}`,
+  IsRetire: false,
+  timestamp
+} as ApiEvent)
+
+describe('AutoSyncService session start/end sync triggers', () => {
+  let db: PokerChaseDB
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue(mockUser)
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    db.close()
+    await db.delete()
+  })
+
+  test('onNewSessionStart triggers an upload sync when the backlog exceeds the threshold', async () => {
+    const events = Array.from({ length: 120 }, (_, i) => makeEvent(i + 1))
+    await db.apiEvents.bulkAdd(events)
+
+    const service = new AutoSyncService(db)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue(undefined)
+
+    await service.onNewSessionStart()
+
+    expect(performSyncSpy).toHaveBeenCalledWith('upload')
+  })
+
+  test('onNewSessionStart does not sync when the backlog is below the threshold', async () => {
+    const events = Array.from({ length: 10 }, (_, i) => makeEvent(i + 1))
+    await db.apiEvents.bulkAdd(events)
+
+    const service = new AutoSyncService(db)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue(undefined)
+
+    await service.onNewSessionStart()
+
+    expect(performSyncSpy).not.toHaveBeenCalled()
+  })
+
+  test('onGameSessionEnd (309) still triggers an upload sync when the backlog exceeds the threshold (unchanged behavior)', async () => {
+    const events = Array.from({ length: 120 }, (_, i) => makeEvent(i + 1))
+    await db.apiEvents.bulkAdd(events)
+
+    const service = new AutoSyncService(db)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue(undefined)
+
+    await service.onGameSessionEnd()
+
+    expect(performSyncSpy).toHaveBeenCalledWith('upload')
+  })
+
+  test('onNewSessionStart does not double-fire when a sync is already in-flight (in-flight guard)', async () => {
+    const events = Array.from({ length: 120 }, (_, i) => makeEvent(i + 1))
+    await db.apiEvents.bulkAdd(events)
+
+    const service = new AutoSyncService(db)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue(undefined)
+
+    // Simulate a sync already in progress (e.g. 309's onGameSessionEnd fired
+    // just before this session-start event arrived)
+    ;(service as any).isSyncing = true
+
+    await service.onNewSessionStart()
+
+    expect(performSyncSpy).not.toHaveBeenCalled()
+  })
+
+  test('onNewSessionStart does not re-sync backlog a normal 309-triggered sync already cleared (no double-fire)', async () => {
+    const events = Array.from({ length: 120 }, (_, i) => makeEvent(i + 1))
+    await db.apiEvents.bulkAdd(events)
+
+    const service = new AutoSyncService(db)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockImplementation(async () => {
+      // performSync('upload') succeeding advances lastSyncTime past the
+      // backlog it just cleared -- mirror that here without exercising the
+      // full Firestore path.
+      ;(service as any).syncState.lastSyncTime = new Date(events[events.length - 1]!.timestamp!)
+    })
+
+    // 309 fires first (session end) and clears the backlog
+    await service.onGameSessionEnd()
+    expect(performSyncSpy).toHaveBeenCalledTimes(1)
+
+    // 201/308 for the next session arrives right after -- backlog is now
+    // empty relative to the just-updated lastSyncTime, so no second sync
+    await service.onNewSessionStart()
+    expect(performSyncSpy).toHaveBeenCalledTimes(1)
+  })
+
+  test('neither trigger syncs when the user is not authenticated', async () => {
+    jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue(null)
+    const events = Array.from({ length: 120 }, (_, i) => makeEvent(i + 1))
+    await db.apiEvents.bulkAdd(events)
+
+    const service = new AutoSyncService(db)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue(undefined)
+
+    await service.onNewSessionStart()
+    await service.onGameSessionEnd()
+
+    expect(performSyncSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -413,9 +413,16 @@ export class AutoSyncService {
   // rough "pending" UI number, not billing-accurate counts.
 
   /**
-   * Handle game session events
+   * バックログが閾値を超えていればuploadを起動する共通ロジック。
+   * `onGameSessionEnd`（309到着時）と`onNewSessionStart`（201/308到着時、
+   * postmortem再発防止#3のフォールバックトリガー）の両方から呼ばれる。
+   *
+   * 二重発火ガード: `this.isSyncing`チェックと、成功した同期が
+   * `syncState.lastSyncTime`を進める（＝以降のバックログ件数を減らす）ことの
+   * 組み合わせで自然に防がれる。309が正常に動作していれば、その直後に
+   * 201/308が来てもバックログは既に閾値未満になっているため再発火しない。
    */
-  async onGameSessionEnd(): Promise<void> {
+  private async syncIfBacklogExceedsThreshold(trigger: string): Promise<void> {
     // Only sync if there are enough new events to justify the cost
     const user = firebaseAuthService.getCurrentUser()
     if (!user || this.isSyncing) return
@@ -429,14 +436,34 @@ export class AutoSyncService {
         .count()
 
       if (newEventsCount >= this.EVENTS_THRESHOLD) {
-        console.log(`[AutoSync] Game ended with ${newEventsCount} new events, performing upload sync...`)
+        console.log(`[AutoSync] ${trigger} with ${newEventsCount} new events, performing upload sync...`)
         await this.performSync('upload')
       } else {
-        console.log(`[AutoSync] Game ended with only ${newEventsCount} new events, skipping sync (threshold: ${this.EVENTS_THRESHOLD})`)
+        console.log(`[AutoSync] ${trigger} with only ${newEventsCount} new events, skipping sync (threshold: ${this.EVENTS_THRESHOLD})`)
       }
     } catch (error) {
-      console.error('[AutoSync] Error checking event count:', error)
+      console.error(`[AutoSync] Error checking event count (${trigger}):`, error)
     }
+  }
+
+  /**
+   * Handle game session end (EVT_SESSION_RESULTS / 309). Primary auto-sync trigger.
+   */
+  async onGameSessionEnd(): Promise<void> {
+    await this.syncIfBacklogExceedsThreshold('Game ended')
+  }
+
+  /**
+   * Handle new session start (EVT_ENTRY_QUEUED / 201, EVT_SESSION_DETAILS / 308).
+   *
+   * postmortem再発防止#3（docs/postmortems/2026-07-session-results-drop.md）:
+   * 309単一トリガーはSPOFだった（2026年シーズン3で実際にRP/セッション結果が
+   * 半年間喪失した）。新セッション開始はまだ進行中ハンドが存在しない安全な
+   * タイミングなので、ここでも同じ閾値判定でuploadを起動し、309が再び壊れても
+   * 「最大1セッション遅れ」を保証するフォールバックにする。
+   */
+  async onNewSessionStart(): Promise<void> {
+    await this.syncIfBacklogExceedsThreshold('New session started')
   }
 
   /**


### PR DESCRIPTION
## Summary
- Postmortem action item #3 (`docs/postmortems/2026-07-session-results-drop.md`, 再発防止): `EVT_SESSION_RESULTS` (309, session end) was the sole auto-sync trigger — a single point of failure that actually broke in the 2026 season-3 incident, silently halting auto-sync for ~2 months with no other signal.
- Adds `AutoSyncService.onNewSessionStart()`, fired on `EVT_ENTRY_QUEUED` (201) or `EVT_SESSION_DETAILS` (308) — new-session-start events. No hand is in flight at that point, so it's a safe moment to sync.
- Reuses the exact same 100+-event backlog threshold as the existing `onGameSessionEnd()` via a new shared `syncIfBacklogExceedsThreshold()` private helper (both public methods are now one-line wrappers around it).
- No new dedup/debounce mechanism needed: the existing `isSyncing` in-flight guard, plus the fact that a successful sync advances `lastSyncTime` (shrinking the backlog below threshold), together prevent a double-fire when 309 fires normally right before the next session's 201/308 arrives. Covered by an explicit test.
- Documents the trigger set in CLAUDE.md's Cloud Sync section.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test` (635/635 passing, including new `auto-sync-service.session-triggers.test.ts` — threshold-exceeded fires sync, below-threshold doesn't, in-flight guard blocks, no double-fire after a 309-triggered sync clears backlog, unauthenticated user blocks both — and new `event-ingestion.auto-sync-trigger.test.ts` verifying 309→onGameSessionEnd / 201,308→onNewSessionStart wiring)
- [x] `npm run verify-stats` — 100.00% on both real-data captures (393,829-event and 23,461-event)
- [x] `npm run validate-schema` — 100.00% on both captures
- [x] `npm run build` sanity check

🤖 Generated with [Claude Code](https://claude.com/claude-code)