### PR TITLE
feat(hud): compact display mode with color-coded stats and stat tooltips

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,9 @@ Recent toArray() optimizations achieved:
   - Cannot query DOM for position information
 - **Empty Seats**: Show "Waiting for Hand..." in UI
 - **Chrome Extension**: Work within Manifest V3 constraints
+- **HUD display modes** (#143, `UIConfig.hudDisplayMode: 'full' | 'compact'`, default `'compact'`): `'compact'` (`CompactStatDisplay.tsx`) shows one classic-HUD line (`VPIP/PFR/3B (HAND)`, rounded integers) plus a secondary AF/CB/STL line, suppressing zero-opportunity secondary stats instead of rendering `'-'`. `'full'` (`StatDisplay.tsx`) is the existing 16-stat grid, unchanged. Clicking the compact stat body toggles the full grid inline for that player (local per-`Hud`-instance state, so multiple panels can be expanded independently); the click handler `stopPropagation()`s so it doesn't trigger the HUD's click-to-copy or the `#128` positional drill-down chevron. Existing `uiConfig` missing these keys (pre-#143) resolve to the new defaults via the `{...DEFAULT_UI_CONFIG, ...stored}` merge in both `App.tsx` and `Popup.tsx`.
+- **HUD color coding** (#143, `UIConfig.hudColorCoding: boolean`, default `true`): threshold-based value coloring for VPIP/PFR/3bet/AF in both display modes, data-driven in `src/components/hud/statColorRules.ts` (`STAT_COLOR_RULES`). n-gated: a stat is only colored once its own `[numerator, denominator]` has `denominator >= 20`; below that it keeps the existing dimmed low-confidence gray (`#888888`).
+- **Stat tooltips** (#143, `src/components/hud/statTooltip.ts`): every stat cell (compact segments and full-grid rows) gets a native `title` composed of a base line — the stat's dynamic `StatDefinition.tooltip(context)` (#130, e.g. `vpipF`'s per-layer breakdown) if defined, else `"{name}: {value (num/den)}"` — followed by `StatDefinition.helpText`, a static one-line Japanese explanation defined per stat in `src/stats/core/*.ts`.
 
 ### Real-time Processing
 

--- a/e2e/scenarios/smoke.ts
+++ b/e2e/scenarios/smoke.ts
@@ -110,13 +110,22 @@ const run = async (): Promise<void> => {
 
     await harness.screenshot(join(screenshotDir, 'smoke-hud.png'))
 
-    // 2. At least one player panel shows a HAND count > 0.
+    // 2. At least one player panel shows a HAND count > 0. Selects on the
+    // stable `data-stat-id="hands"` marker (StatDisplay.tsx / #143's
+    // CompactStatDisplay.tsx) rather than the `title` attribute -- #143
+    // made `title` a composed tooltip (name + value + helpText, and in
+    // compact mode a bare "(n)" text node) instead of a plain "HAND"
+    // string, so it's no longer a stable value-extraction target. Full
+    // mode's `[data-stat-id="hands"]` is a `div` wrapping "HAND:" + value
+    // spans (text like "HAND:67"); compact mode's is a single `span`
+    // rendering "(67)". `parseInt` on either textContent skips the
+    // non-numeric prefix and finds the count.
     const handCount = await harness.evaluate(() => {
-      const labels = Array.from(document.querySelectorAll('span[title="HAND"]'))
+      const cells = Array.from(document.querySelectorAll('[data-stat-id="hands"]'))
       let max = 0
-      for (const label of labels) {
-        const valueEl = label.nextElementSibling
-        const value = valueEl ? parseInt(valueEl.textContent || '', 10) : NaN
+      for (const cell of cells) {
+        const match = (cell.textContent || '').match(/\d+/)
+        const value = match ? parseInt(match[0], 10) : NaN
         if (!Number.isNaN(value)) max = Math.max(max, value)
       }
       return max

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -10,7 +10,7 @@ import type { ApiEvent } from '../types'
 // Mock components
 jest.mock('./Hud', () => ({
   __esModule: true,
-  default: ({ actualSeatIndex, stat, scale, statDisplayConfigs, realTimeStats, playerPotOdds, isPositionalPanelOpen, onTogglePositionalPanel }: any) => (
+  default: ({ actualSeatIndex, stat, scale, statDisplayConfigs, realTimeStats, playerPotOdds, isPositionalPanelOpen, onTogglePositionalPanel, hudDisplayMode, hudColorCoding }: any) => (
     <div data-testid={`hud-${actualSeatIndex}`}>
       Player: {stat.playerId}
       Scale: {scale}
@@ -18,6 +18,8 @@ jest.mock('./Hud', () => ({
       RealTime: {realTimeStats ? 'yes' : 'no'}
       PotOdds: {playerPotOdds ? 'yes' : 'no'}
       PositionalPanelOpen: {isPositionalPanelOpen ? 'yes' : 'no'}
+      DisplayMode: {hudDisplayMode ?? 'undefined'}
+      ColorCoding: {hudColorCoding === undefined ? 'undefined' : hudColorCoding ? 'yes' : 'no'}
       {onTogglePositionalPanel && (
         <button onClick={onTogglePositionalPanel}>toggle-{stat.playerId}</button>
       )}
@@ -92,10 +94,45 @@ describe('App', () => {
     })
 
     const { container } = render(<App />)
-    
+
     await waitFor(() => {
       expect(container.firstChild).toBeNull()
     })
+  })
+
+  it('uiConfigにhudDisplayMode/hudColorCodingが渡された場合、そのままHudへ伝播する', async () => {
+    (global.chrome.storage.sync.get as jest.Mock).mockImplementation((_, callback) => {
+      callback({
+        uiConfig: { ...DEFAULT_UI_CONFIG, hudDisplayMode: 'full', hudColorCoding: false },
+      })
+    })
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('hud-0')).toBeInTheDocument()
+    })
+
+    expect(screen.getByTestId('hud-0')).toHaveTextContent('DisplayMode: full')
+    expect(screen.getByTestId('hud-0')).toHaveTextContent('ColorCoding: no')
+  })
+
+  it('旧storageのuiConfigにhudDisplayMode/hudColorCodingキーが無い場合、DEFAULT_UI_CONFIGとマージしてcompact+カラーONになる（グレースフルなマイグレーション, #143）', async () => {
+    (global.chrome.storage.sync.get as jest.Mock).mockImplementation((_, callback) => {
+      callback({
+        // #143以前に保存されたuiConfig相当（新フィールドが無い）
+        uiConfig: { displayEnabled: true, scale: 1.0 },
+      })
+    })
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('hud-0')).toBeInTheDocument()
+    })
+
+    expect(screen.getByTestId('hud-0')).toHaveTextContent('DisplayMode: compact')
+    expect(screen.getByTestId('hud-0')).toHaveTextContent('ColorCoding: yes')
   })
 
   it('PokerChaseServiceイベントでstatsが更新される', async () => {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -287,6 +287,8 @@ const App = memo(() => {
               playerPotOdds={allPlayersRealTimeStats?.playerStats[position.originalSeatIndex]}
               isPositionalPanelOpen={openPositionalStatsPlayerId === position.stat.playerId}
               onTogglePositionalPanel={() => handleTogglePositionalPanel(position.stat.playerId)}
+              hudDisplayMode={uiConfig.hudDisplayMode}
+              hudColorCoding={uiConfig.hudColorCoding}
             />
           )
       )}

--- a/src/components/Hud.test.tsx
+++ b/src/components/Hud.test.tsx
@@ -453,4 +453,146 @@ describe('Hud', () => {
       })
     })
   })
+
+  describe('コンパクト表示モード（#143）', () => {
+    it('hudDisplayModeを渡さない場合はフルの16統計グリッドのまま（ゼロリグレッション）', () => {
+      render(
+        <Hud
+          actualSeatIndex={0}
+          stat={mockPlayerStats}
+          scale={1}
+          statDisplayConfigs={mockStatDisplayConfigs}
+        />
+      )
+
+      // フルグリッドの完全な値表示（"30.0% (30/100)"）が出る = compactの丸め表示("30")ではない
+      expect(screen.getByText('VPIP:')).toBeInTheDocument()
+      expect(screen.getByText('30.0% (30/100)')).toBeInTheDocument()
+    })
+
+    it('hudDisplayMode="compact"の場合はクラシックライン(VPIP/PFR/3B (HAND))を表示する', () => {
+      render(
+        <Hud
+          actualSeatIndex={0}
+          stat={mockPlayerStats}
+          scale={1}
+          statDisplayConfigs={mockStatDisplayConfigs}
+          hudDisplayMode="compact"
+        />
+      )
+
+      // compactは丸めた整数のみ表示（フルの"30.0% (30/100)"は出ない）
+      expect(screen.getByText('30')).toBeInTheDocument()
+      expect(screen.queryByText('30.0% (30/100)')).not.toBeInTheDocument()
+      expect(screen.queryByText('VPIP:')).not.toBeInTheDocument()
+    })
+
+    it('compactの統計ボディをクリックするとフルの16統計グリッドが展開され、クリップボードコピーは発火しない', async () => {
+      render(
+        <Hud
+          actualSeatIndex={0}
+          stat={mockPlayerStats}
+          scale={1}
+          statDisplayConfigs={mockStatDisplayConfigs}
+          hudDisplayMode="compact"
+        />
+      )
+
+      // 展開前: compact表示
+      expect(screen.getByText('30')).toBeInTheDocument()
+      expect(screen.queryByText('30.0% (30/100)')).not.toBeInTheDocument()
+
+      // クリックで展開
+      await userEvent.click(screen.getByText('30'))
+
+      expect(screen.getByText('30.0% (30/100)')).toBeInTheDocument()
+      expect(screen.getByText('VPIP:')).toBeInTheDocument()
+      expect(navigator.clipboard.writeText).not.toHaveBeenCalled()
+
+      // 再クリックで折りたたむ
+      await userEvent.click(screen.getByText('30.0% (30/100)'))
+      expect(screen.getByText('30')).toBeInTheDocument()
+      expect(screen.queryByText('30.0% (30/100)')).not.toBeInTheDocument()
+      expect(navigator.clipboard.writeText).not.toHaveBeenCalled()
+    })
+
+    it('compactモードでもヘッダー領域のクリックはクリップボードコピーを発火する（コピー機能が壊れていない）', async () => {
+      render(
+        <Hud
+          actualSeatIndex={0}
+          stat={mockPlayerStats}
+          scale={1}
+          statDisplayConfigs={mockStatDisplayConfigs}
+          hudDisplayMode="compact"
+        />
+      )
+
+      await userEvent.click(screen.getByText('TestPlayer'))
+
+      await waitFor(() => {
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+          expect.stringContaining('Player: TestPlayer')
+        )
+      })
+    })
+
+    it('#128のポジション別ドリルダウンはcompactモードでも独立して機能する', async () => {
+      const handleToggle = jest.fn()
+
+      render(
+        <Hud
+          actualSeatIndex={0}
+          stat={mockPlayerStats}
+          scale={1}
+          statDisplayConfigs={mockStatDisplayConfigs}
+          hudDisplayMode="compact"
+          onTogglePositionalPanel={handleToggle}
+        />
+      )
+
+      const trigger = screen.getByTitle('ポジション別スタッツ')
+      await userEvent.click(trigger)
+
+      expect(handleToggle).toHaveBeenCalledTimes(1)
+      expect(navigator.clipboard.writeText).not.toHaveBeenCalled()
+      // ポジション別トリガーのクリックはcompactの展開もトグルしない
+      expect(screen.getByText('30')).toBeInTheDocument()
+    })
+
+    it('hudColorCoding=trueをcompact/fullどちらのStatDisplayにも伝播する', () => {
+      const highVpipStats = {
+        playerId: 123,
+        statResults: [
+          { id: 'playerName', name: 'Name', value: 'TestPlayer', formatted: 'TestPlayer' },
+          { id: 'vpip', name: 'VPIP', value: [45, 100], formatted: '45.0% (45/100)' },
+        ],
+      }
+
+      const { rerender } = render(
+        <Hud
+          actualSeatIndex={0}
+          stat={highVpipStats}
+          scale={1}
+          statDisplayConfigs={mockStatDisplayConfigs}
+          hudDisplayMode="full"
+          hudColorCoding
+        />
+      )
+
+      expect(screen.getByText('45.0% (45/100)')).toHaveStyle({ color: '#e57373' })
+
+      rerender(
+        <Hud
+          actualSeatIndex={0}
+          stat={highVpipStats}
+          scale={1}
+          statDisplayConfigs={mockStatDisplayConfigs}
+          hudDisplayMode="compact"
+          hudColorCoding
+        />
+      )
+
+      expect(screen.getByText('45')).toHaveStyle({ color: '#e57373' })
+    })
+  })
 })

--- a/src/components/Hud.test.tsx
+++ b/src/components/Hud.test.tsx
@@ -594,5 +594,47 @@ describe('Hud', () => {
 
       expect(screen.getByText('45')).toHaveStyle({ color: '#e57373' })
     })
+
+    it('statDisplayConfigsでvpipを無効化しても、compactラインは実際のVPIP値を表示する（#143 review）', async () => {
+      // read-entity-stream.ts はcompact必須統計(vpip等)を、ユーザーがフルグリッドで
+      // 無効化していても常に計算してstatResultsに含める(stats/compactStats.ts)。
+      // ここではその後段(Hud.tsx)の挙動を検証する: statDisplayConfigsでvpipを
+      // enabled:falseにしても、statResultsには実データが乗っている想定。
+      const statsWithVpipDisabled: PlayerStats = {
+        playerId: 123,
+        statResults: [
+          { id: 'playerName', name: 'Name', value: 'TestPlayer', formatted: 'TestPlayer' },
+          { id: 'vpip', name: 'VPIP', value: [30, 100], formatted: '30.0% (30/100)' },
+          { id: 'pfr', name: 'PFR', value: [20, 100], formatted: '20.0% (20/100)' },
+          { id: '3bet', name: '3B', value: [5, 50], formatted: '10.0% (5/50)' },
+        ],
+      }
+      const configsWithVpipDisabled: StatDisplayConfig[] = [
+        { id: 'vpip', enabled: false, order: 0 },
+        { id: 'pfr', enabled: true, order: 1 },
+        { id: '3bet', enabled: true, order: 2 },
+      ]
+
+      render(
+        <Hud
+          actualSeatIndex={0}
+          stat={statsWithVpipDisabled}
+          scale={1}
+          statDisplayConfigs={configsWithVpipDisabled}
+          hudDisplayMode="compact"
+        />
+      )
+
+      // compactのクラシックラインはvpipが無効化されていても実値(30)を表示する
+      // ("-"や0にフォールバックしない)
+      expect(screen.getByText('30')).toBeInTheDocument()
+
+      // フルグリッドを展開すると、無効化されたvpipは行として現れない
+      // （可視性設定が支配するのはフルグリッドの行のみ、という仕様どおり）
+      await userEvent.click(screen.getByText('30'))
+      expect(screen.queryByText('VPIP:')).not.toBeInTheDocument()
+      expect(screen.getByText('PFR:')).toBeInTheDocument()
+      expect(screen.getByText('3B:')).toBeInTheDocument()
+    })
   })
 })

--- a/src/components/Hud.tsx
+++ b/src/components/Hud.tsx
@@ -7,6 +7,7 @@ import { useDraggable } from './hud/hooks/useDraggable'
 import { DragHandle } from './hud/DragHandle'
 import { HudHeader } from './hud/HudHeader'
 import { StatDisplay } from './hud/StatDisplay'
+import { CompactStatDisplay } from './hud/CompactStatDisplay'
 import { PlayerTypeIcons } from './hud/PlayerTypeIcons'
 import { RealTimeStatsDisplay } from './hud/RealTimeStatsDisplay'
 import { PositionalStatsPanel } from './hud/PositionalStatsPanel'
@@ -35,6 +36,10 @@ interface HudProps {
   isPositionalPanelOpen?: boolean
   /** ドリルダウンパネルの開閉トグル。渡された時のみヘッダーにトリガーを表示する */
   onTogglePositionalPanel?: () => void
+  /** HUD表示密度。'full'（デフォルト、既存の16統計グリッド）または'compact'（クラシックHUDライン）。UIConfig.hudDisplayMode参照 */
+  hudDisplayMode?: 'full' | 'compact'
+  /** しきい値ベースの値カラーリング（compact/full両モード共通）。UIConfig.hudColorCoding参照 */
+  hudColorCoding?: boolean
 }
 
 // Constants
@@ -103,6 +108,10 @@ const styles = {
     cursor: 'pointer',
     transition: 'opacity 0.2s ease',
   } as CSSProperties,
+
+  expandableStatBody: {
+    cursor: 'pointer',
+  } as CSSProperties,
 }
 
 // Helper functions
@@ -146,8 +155,12 @@ const getPlayerName = (stat: PlayerStats): string | null => {
 // Main component
 const Hud = memo((props: HudProps) => {
   const [isHovering, setIsHovering] = useState(false)
+  // クリックで展開する16統計グリッド（compactモードのみ）。パネルごとのローカル
+  // state -- 各Hudインスタンスが自分のstateを持つため、複数プレイヤーを同時に
+  // 展開できる。
+  const [isStatBodyExpanded, setIsStatBodyExpanded] = useState(false)
   const defaultPosition = SEAT_POSITIONS[props.actualSeatIndex] || { top: '50%', left: '50%' }
-  
+
   const {
     containerRef,
     isDragging,
@@ -158,6 +171,16 @@ const Hud = memo((props: HudProps) => {
   const displayStats = useMemo(() => getDisplayStats(props.stat), [props.stat])
   const playerName = useMemo(() => getPlayerName(props.stat), [props.stat])
   const scale = props.scale || 1
+  const hudDisplayMode = props.hudDisplayMode || 'full'
+  const hudColorCoding = props.hudColorCoding || false
+
+  // compactモードの統計ボディをクリックすると16統計グリッドをその場で展開する
+  // （#128のポジション別ドリルダウン用トリガーと同様、stopPropagationでHUD全体の
+  // クリップボードコピーハンドラーへの伝播とドラッグ開始を断つ）。
+  const toggleStatBodyExpand = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    setIsStatBodyExpanded(prev => !prev)
+  }, [])
 
   const copyStatsToClipboard = useCallback(async () => {
     try {
@@ -287,7 +310,19 @@ const Hud = memo((props: HudProps) => {
             isPositionalPanelOpen={props.isPositionalPanelOpen}
             onTogglePositionalPanel={props.onTogglePositionalPanel}
           />
-          <StatDisplay displayStats={displayStats} formatValue={formatStatValue} />
+          {hudDisplayMode === 'compact' ? (
+            <div
+              style={styles.expandableStatBody}
+              onClick={toggleStatBodyExpand}
+              title={isStatBodyExpanded ? 'クリックで折りたたむ' : 'クリックで全統計を表示'}
+            >
+              {isStatBodyExpanded
+                ? <StatDisplay displayStats={displayStats} formatValue={formatStatValue} colorCoding={hudColorCoding} />
+                : <CompactStatDisplay displayStats={displayStats} colorCoding={hudColorCoding} />}
+            </div>
+          ) : (
+            <StatDisplay displayStats={displayStats} formatValue={formatStatValue} colorCoding={hudColorCoding} />
+          )}
           {props.isPositionalPanelOpen && (
             <PositionalStatsPanel playerId={props.stat.playerId} />
           )}
@@ -300,6 +335,8 @@ const Hud = memo((props: HudProps) => {
   if (prevProps.stat.playerId !== nextProps.stat.playerId) return false
   if (prevProps.scale !== nextProps.scale) return false
   if (prevProps.isPositionalPanelOpen !== nextProps.isPositionalPanelOpen) return false
+  if (prevProps.hudDisplayMode !== nextProps.hudDisplayMode) return false
+  if (prevProps.hudColorCoding !== nextProps.hudColorCoding) return false
 
   // Check real-time stats changes for hero
   if (prevProps.actualSeatIndex === 0) {

--- a/src/components/Hud.tsx
+++ b/src/components/Hud.tsx
@@ -127,7 +127,7 @@ const formatStatValue = (value: number | [number, number]): string => {
 
 const getDisplayStats = (stat: PlayerStats): Array<[string, any, StatResult?]> => {
   if (stat.playerId === EMPTY_SEAT_ID) return []
-  
+
   if ('statResults' in stat && stat.statResults && stat.statResults.length > 0) {
     return stat.statResults.map(s => [
       s.name || s.id.toUpperCase(),
@@ -135,8 +135,31 @@ const getDisplayStats = (stat: PlayerStats): Array<[string, any, StatResult?]> =
       s
     ])
   }
-  
+
   return []
+}
+
+/**
+ * Filters the (unfiltered) displayStats tuples down to only the stats the
+ * user has enabled via the HUD statistics settings (statDisplayConfigs).
+ * Used for the full 16-stat grid and the clipboard copy.
+ *
+ * NOT used for CompactStatDisplay: read-entity-stream.ts always computes a
+ * fixed set of compact-required stats (vpip/pfr/3bet/hands/af/cbet/steal,
+ * see stats/compactStats.ts) regardless of the user's enabled flag, so that
+ * the compact line's fixed format never silently blanks out a stat the
+ * user merely hid from the full grid (PR #143 review). CompactStatDisplay
+ * is handed the raw, unfiltered displayStats so it can still find those
+ * stats even when this filter would have excluded them.
+ */
+const filterEnabledDisplayStats = (
+  displayStats: Array<[string, any, StatResult?]>,
+  statDisplayConfigs: StatDisplayConfig[]
+): Array<[string, any, StatResult?]> => {
+  const enabledIds = new Set(
+    statDisplayConfigs.filter(config => config.enabled).map(config => config.id)
+  )
+  return displayStats.filter(([, , statResult]) => !!statResult && enabledIds.has(statResult.id))
 }
 
 const getPlayerName = (stat: PlayerStats): string | null => {
@@ -168,7 +191,15 @@ const Hud = memo((props: HudProps) => {
     handleMouseDown
   } = useDraggable(props.actualSeatIndex, defaultPosition)
 
+  // Unfiltered: every stat currently computed for this player (includes
+  // compact-required stats even when the user disabled them, see
+  // stats/compactStats.ts). Feed this to CompactStatDisplay directly.
   const displayStats = useMemo(() => getDisplayStats(props.stat), [props.stat])
+  // Full-grid rows honor the user's HUD statistics visibility settings.
+  const gridDisplayStats = useMemo(
+    () => filterEnabledDisplayStats(displayStats, props.statDisplayConfigs),
+    [displayStats, props.statDisplayConfigs]
+  )
   const playerName = useMemo(() => getPlayerName(props.stat), [props.stat])
   const scale = props.scale || 1
   const hudDisplayMode = props.hudDisplayMode || 'full'
@@ -191,16 +222,16 @@ const Hud = memo((props: HudProps) => {
         statsText += '---\n'
       }
       
-      displayStats.forEach(([key, value, statResult]) => {
+      gridDisplayStats.forEach(([key, value, statResult]) => {
         const formattedValue = statResult?.formatted || formatStatValue(value as number | [number, number])
         statsText += `${key}: ${formattedValue}\n`
       })
-      
+
       await navigator.clipboard.writeText(statsText.trim())
     } catch (error) {
       console.error('Failed to copy stats to clipboard:', error)
     }
-  }, [displayStats, playerName])
+  }, [gridDisplayStats, playerName])
 
   // Container styles
   const containerStyle: CSSProperties = {
@@ -317,11 +348,11 @@ const Hud = memo((props: HudProps) => {
               title={isStatBodyExpanded ? 'クリックで折りたたむ' : 'クリックで全統計を表示'}
             >
               {isStatBodyExpanded
-                ? <StatDisplay displayStats={displayStats} formatValue={formatStatValue} colorCoding={hudColorCoding} />
+                ? <StatDisplay displayStats={gridDisplayStats} formatValue={formatStatValue} colorCoding={hudColorCoding} />
                 : <CompactStatDisplay displayStats={displayStats} colorCoding={hudColorCoding} />}
             </div>
           ) : (
-            <StatDisplay displayStats={displayStats} formatValue={formatStatValue} colorCoding={hudColorCoding} />
+            <StatDisplay displayStats={gridDisplayStats} formatValue={formatStatValue} colorCoding={hudColorCoding} />
           )}
           {props.isPositionalPanelOpen && (
             <PositionalStatsPanel playerId={props.stat.playerId} />
@@ -337,6 +368,10 @@ const Hud = memo((props: HudProps) => {
   if (prevProps.isPositionalPanelOpen !== nextProps.isPositionalPanelOpen) return false
   if (prevProps.hudDisplayMode !== nextProps.hudDisplayMode) return false
   if (prevProps.hudColorCoding !== nextProps.hudColorCoding) return false
+  // statDisplayConfigs governs which stats reach the full grid
+  // (filterEnabledDisplayStats) -- a config change must re-render even if
+  // statResults itself is unchanged.
+  if (prevProps.statDisplayConfigs !== nextProps.statDisplayConfigs) return false
 
   // Check real-time stats changes for hero
   if (prevProps.actualSeatIndex === 0) {

--- a/src/components/Popup.test.tsx
+++ b/src/components/Popup.test.tsx
@@ -134,6 +134,46 @@ describe('Popup', () => {
     )
   })
 
+  it('HUD表示設定（コンパクト/フル・統計カラー表示）を表示・変更できる', async () => {
+    render(<Popup />)
+
+    await waitForAsyncOperations()
+
+    expect(screen.getByText('表示モード:')).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'コンパクト' })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: '統計カラー表示' })).toBeChecked()
+
+    await userEvent.click(screen.getByRole('radio', { name: 'フル' }))
+
+    await waitFor(() => {
+      expect(syncData.uiConfig).toEqual(
+        expect.objectContaining({ hudDisplayMode: 'full' })
+      )
+    })
+  })
+
+  it('旧storageのuiConfigにhudDisplayMode/hudColorCodingキーが無いユーザーはコンパクト+カラーONで復元される（グレースフルなマイグレーション, #143）', async () => {
+    syncData = {
+      options: {
+        sendUserData: true,
+        filterOptions: {
+          gameTypes: { sng: true, mtt: true, ring: true },
+          handLimit: 500,
+          statDisplayConfigs: defaultStatDisplayConfigs,
+        },
+      },
+      // #143以前に保存されたuiConfig相当（新フィールドが無い）
+      uiConfig: { displayEnabled: true, scale: 1.0 },
+    }
+
+    render(<Popup />)
+
+    await waitForAsyncOperations()
+
+    expect(screen.getByRole('radio', { name: 'コンパクト' })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: '統計カラー表示' })).toBeChecked()
+  })
+
   it('UIスケール設定を表示・変更できる', async () => {
     render(<Popup />)
 

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -21,6 +21,7 @@ import { sendMessageWithTimeout } from './popup/send-message'
 
 // Import sub-components
 import { UIScaleSection } from './popup/UIScaleSection'
+import { HudDisplaySection } from './popup/HudDisplaySection'
 import { ImportExportSection } from './popup/ImportExportSection'
 import { FirebaseAuthSection } from './popup/FirebaseAuthSection'
 import { GameTypeFilterSection } from './popup/GameTypeFilterSection'
@@ -155,9 +156,16 @@ const Popup = () => {
       }
 
       // Load UI config from chrome.storage.sync
+      // DEFAULT_UI_CONFIGとマージする: 新フィールド追加前（#143以前）に保存された
+      // uiConfigにはhudDisplayMode/hudColorCodingが存在しないため、マージせず
+      // そのまま使うとポップアップのHUD表示設定セクションが未定義値を表示して
+      // しまう（App.tsx側の読み込みは既にこのマージを行っている）。
       chrome.storage.sync.get('uiConfig', (result: Record<string, any>) => {
         if (result.uiConfig) {
-          setUIConfig(result.uiConfig)
+          setUIConfig({
+            ...DEFAULT_UI_CONFIG,
+            ...result.uiConfig,
+          })
         }
       })
 
@@ -377,6 +385,11 @@ const Popup = () => {
   return <div style={{ width: 300, padding: '10px' }}>
     {/* UI Display Controls */}
     <UIScaleSection
+      uiConfig={uiConfig}
+      setUIConfig={setUIConfig}
+    />
+
+    <HudDisplaySection
       uiConfig={uiConfig}
       setUIConfig={setUIConfig}
     />

--- a/src/components/hud/CompactStatDisplay.test.tsx
+++ b/src/components/hud/CompactStatDisplay.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react'
+import { CompactStatDisplay } from './CompactStatDisplay'
+import type { StatResult } from '../../types/stats'
+
+describe('CompactStatDisplay', () => {
+  const buildDisplayStats = (overrides: Partial<Record<string, StatResult>> = {}): Array<[string, any, StatResult?]> => {
+    const defaults: Record<string, StatResult> = {
+      vpip: { id: 'vpip', name: 'VPIP', value: [30, 100], formatted: '30.0% (30/100)' },
+      pfr: { id: 'pfr', name: 'PFR', value: [20, 100], formatted: '20.0% (20/100)' },
+      '3bet': { id: '3bet', name: '3B', value: [8, 100], formatted: '8.0% (8/100)' },
+      hands: { id: 'hands', name: 'HAND', value: 67, formatted: '67' },
+      af: { id: 'af', name: 'AF', value: [30, 10], formatted: '3.00 (30/10)' },
+      cbet: { id: 'cbet', name: 'CB', value: [12, 20], formatted: '60.0% (12/20)' },
+      steal: { id: 'steal', name: 'STL', value: [0, 0], formatted: '-' },
+    }
+    const merged = { ...defaults, ...overrides }
+    return Object.entries(merged).map(([id, statResult]) => [statResult?.name || id, statResult?.value, statResult])
+  }
+
+  it('クラシックライン (VPIP/PFR/3B (HAND)) を丸めた整数で表示', () => {
+    render(<CompactStatDisplay displayStats={buildDisplayStats()} />)
+
+    expect(screen.getByText('30')).toBeInTheDocument()
+    expect(screen.getByText('20')).toBeInTheDocument()
+    expect(screen.getByText('8')).toBeInTheDocument()
+    expect(screen.getByText('(67)')).toBeInTheDocument()
+  })
+
+  it('機会数0の副次スタッツ（分母0）は行ごと表示から除外される', () => {
+    render(<CompactStatDisplay displayStats={buildDisplayStats()} />)
+
+    // steal は分母0なので STL: 行が出ない
+    expect(screen.queryByText('STL:')).not.toBeInTheDocument()
+    // af/cbetは機会があるので表示される
+    expect(screen.getByText('AF:')).toBeInTheDocument()
+    expect(screen.getByText('CB:')).toBeInTheDocument()
+  })
+
+  it('機会がない場合クラシックラインの個別セグメントは"-"にフォールバックする', () => {
+    render(
+      <CompactStatDisplay
+        displayStats={buildDisplayStats({ vpip: { id: 'vpip', name: 'VPIP', value: [0, 0], formatted: '-' } })}
+      />
+    )
+
+    expect(screen.getByText('-')).toBeInTheDocument()
+  })
+
+  it('colorCoding未指定時は色を適用しない', () => {
+    render(<CompactStatDisplay displayStats={buildDisplayStats()} />)
+
+    const vpipSegment = screen.getByText('30')
+    expect(vpipSegment).not.toHaveStyle({ color: '#e57373' })
+  })
+
+  it('colorCoding有効時はしきい値に応じて色を適用する（n>=20のみ）', () => {
+    render(
+      <CompactStatDisplay
+        displayStats={buildDisplayStats({
+          vpip: { id: 'vpip', name: 'VPIP', value: [45, 100], formatted: '45.0% (45/100)' }, // >40% -> red, n=100>=20
+        })}
+        colorCoding
+      />
+    )
+
+    const vpipSegment = screen.getByText('45')
+    expect(vpipSegment).toHaveStyle({ color: '#e57373' })
+  })
+
+  it('colorCoding有効でもn<20の場合は低信頼度グレーになる', () => {
+    render(
+      <CompactStatDisplay
+        displayStats={buildDisplayStats({
+          vpip: { id: 'vpip', name: 'VPIP', value: [5, 10], formatted: '50.0% (5/10)' }, // n=10 < 20
+        })}
+        colorCoding
+      />
+    )
+
+    const vpipSegment = screen.getByText('50')
+    expect(vpipSegment).toHaveStyle({ color: '#888888' })
+  })
+
+  it('各セグメントに統計名+値+一言説明を含むtitleが付与される', () => {
+    render(<CompactStatDisplay displayStats={buildDisplayStats()} />)
+
+    const vpipSegment = screen.getByText('30')
+    expect(vpipSegment).toHaveAttribute(
+      'title',
+      'VPIP: 30.0% (30/100)\n自発的にチップをポットに入れたハンドの割合(ウォーク除外)'
+    )
+
+    const handSegment = screen.getByText('(67)')
+    expect(handSegment).toHaveAttribute(
+      'title',
+      'HAND: 67\nこれまでにプレイしたハンド数'
+    )
+  })
+})

--- a/src/components/hud/CompactStatDisplay.tsx
+++ b/src/components/hud/CompactStatDisplay.tsx
@@ -1,0 +1,132 @@
+import { memo } from 'react'
+import type { CSSProperties } from 'react'
+import type { StatResult, StatValue } from '../../types/stats'
+import { getStatValueColor } from './statColorRules'
+import { composeStatTitle } from './statTooltip'
+
+interface CompactStatDisplayProps {
+  displayStats: Array<[string, any, StatResult?]>
+  /** Threshold-based value coloring, see statColorRules.ts. */
+  colorCoding?: boolean
+}
+
+const styles = {
+  container: {
+    padding: '4px 6px',
+  } as CSSProperties,
+
+  classicLine: {
+    fontSize: '11px',
+    fontWeight: 'bold',
+    color: '#dddddd',
+    whiteSpace: 'nowrap' as const,
+  } as CSSProperties,
+
+  secondaryLine: {
+    display: 'flex',
+    gap: '8px',
+    marginTop: '2px',
+    whiteSpace: 'nowrap' as const,
+  } as CSSProperties,
+
+  secondaryKey: {
+    fontWeight: 'bold',
+    color: '#aaaaaa',
+    fontSize: '9px',
+  } as CSSProperties,
+
+  secondaryValue: {
+    color: '#dddddd',
+    fontSize: '9px',
+    marginLeft: '2px',
+  } as CSSProperties,
+}
+
+/** Secondary line stat ids, in display order: AF / CB (cbet) / STL (steal). */
+const SECONDARY_STAT_IDS = ['af', 'cbet', 'steal']
+
+const findStat = (displayStats: CompactStatDisplayProps['displayStats'], id: string): StatResult | undefined =>
+  displayStats.find(([, , statResult]) => statResult?.id === id)?.[2]
+
+/** Classic-HUD segment format: a bare rounded percentage (no '%' sign), or '-' when there's no opportunity yet. */
+const formatClassicSegment = (value: StatValue | undefined): string => {
+  if (!Array.isArray(value) || value.length !== 2) return '-'
+  const [numerator, denominator] = value
+  if (denominator === 0) return '-'
+  return String(Math.round((numerator / denominator) * 100))
+}
+
+const formatSecondaryValue = (statResult: StatResult): string => {
+  const value = statResult.value
+  if (!Array.isArray(value) || value.length !== 2) return typeof value === 'number' ? String(value) : '-'
+  const [numerator, denominator] = value
+  if (statResult.id === 'af') return (numerator / denominator).toFixed(1)
+  return `${Math.round((numerator / denominator) * 100)}%`
+}
+
+/**
+ * Compact HUD display (#143): a single classic-HUD line
+ * (`VPIP/PFR/3B (HAND)`, e.g. `24/18/8 (67)`) plus a secondary line for
+ * AF/CB/STL. Zero-opportunity secondary stats are dropped entirely rather
+ * than rendered as '-' rows (the classic line's own VPIP/PFR/3B segments
+ * still fall back to '-' individually -- it's one fused line, not
+ * per-stat rows, so there's nothing to suppress without breaking the
+ * familiar "x/y/z (n)" shape).
+ *
+ * Every segment carries its own composed `title` tooltip (name + full
+ * value + one-line explanation, see statTooltip.ts) even though the
+ * on-screen text is abbreviated.
+ *
+ * Click-to-expand to the full 16-stat grid is handled by the parent
+ * (Hud.tsx), which wraps this component in a click target -- this
+ * component has no click handling of its own.
+ */
+export const CompactStatDisplay = memo(({ displayStats, colorCoding }: CompactStatDisplayProps) => {
+  const vpip = findStat(displayStats, 'vpip')
+  const pfr = findStat(displayStats, 'pfr')
+  const threeBet = findStat(displayStats, '3bet')
+  const hands = findStat(displayStats, 'hands')
+  const handCount = hands && typeof hands.value === 'number' ? hands.value : 0
+
+  const colorFor = (statResult: StatResult | undefined): CSSProperties | undefined => {
+    if (!colorCoding || !statResult) return undefined
+    const color = getStatValueColor(statResult.id, statResult.value)
+    return color ? { color } : undefined
+  }
+
+  const titleFor = (id: string, name: string, statResult: StatResult | undefined): string =>
+    composeStatTitle(id, name, statResult?.formatted ?? '-', statResult?.tooltip)
+
+  const secondaryStats = SECONDARY_STAT_IDS.map((id) => findStat(displayStats, id)).filter(
+    (statResult): statResult is StatResult =>
+      !!statResult && Array.isArray(statResult.value) && statResult.value.length === 2 && statResult.value[1] > 0
+  )
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.classicLine}>
+        <span data-stat-id="vpip" style={colorFor(vpip)} title={titleFor('vpip', 'VPIP', vpip)}>{formatClassicSegment(vpip?.value)}</span>
+        /
+        <span data-stat-id="pfr" style={colorFor(pfr)} title={titleFor('pfr', 'PFR', pfr)}>{formatClassicSegment(pfr?.value)}</span>
+        /
+        <span data-stat-id="3bet" style={colorFor(threeBet)} title={titleFor('3bet', '3B', threeBet)}>{formatClassicSegment(threeBet?.value)}</span>
+        {' '}
+        <span data-stat-id="hands" title={titleFor('hands', 'HAND', hands)}>({handCount})</span>
+      </div>
+      {secondaryStats.length > 0 && (
+        <div style={styles.secondaryLine}>
+          {secondaryStats.map((statResult) => (
+            <span key={statResult.id} data-stat-id={statResult.id}>
+              <span style={styles.secondaryKey} title={titleFor(statResult.id, statResult.name, statResult)}>{statResult.name}:</span>
+              <span style={{ ...styles.secondaryValue, ...colorFor(statResult) }} title={titleFor(statResult.id, statResult.name, statResult)}>
+                {formatSecondaryValue(statResult)}
+              </span>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+})
+
+CompactStatDisplay.displayName = 'CompactStatDisplay'

--- a/src/components/hud/StatDisplay.test.tsx
+++ b/src/components/hud/StatDisplay.test.tsx
@@ -86,4 +86,75 @@ describe('StatDisplay', () => {
     const dashes = screen.getAllByText('-')
     expect(dashes).toHaveLength(2)
   })
+
+  describe('カラーコーディング', () => {
+    it('colorCoding未指定時は色を適用しない（デフォルトのstatValue色のまま）', () => {
+      render(<StatDisplay displayStats={mockDisplayStats} formatValue={mockFormatValue} />)
+
+      const vpipValue = screen.getByText('30.0% (30/100)')
+      expect(vpipValue).toHaveStyle({ color: '#dddddd' })
+    })
+
+    it('colorCoding有効時はしきい値に応じた色を適用する（n>=20）', () => {
+      const highVpip: Array<[string, any, StatResult?]> = [
+        ['VPIP', [45, 100], { id: 'vpip', name: 'VPIP', value: [45, 100], formatted: '45.0% (45/100)' }],
+      ]
+
+      render(<StatDisplay displayStats={highVpip} formatValue={mockFormatValue} colorCoding />)
+
+      expect(screen.getByText('45.0% (45/100)')).toHaveStyle({ color: '#e57373' })
+    })
+
+    it('colorCoding有効でもn<20の場合は低信頼度グレーになる', () => {
+      const lowSample: Array<[string, any, StatResult?]> = [
+        ['VPIP', [5, 10], { id: 'vpip', name: 'VPIP', value: [5, 10], formatted: '50.0% (5/10)' }],
+      ]
+
+      render(<StatDisplay displayStats={lowSample} formatValue={mockFormatValue} colorCoding />)
+
+      expect(screen.getByText('50.0% (5/10)')).toHaveStyle({ color: '#888888' })
+    })
+
+    it('しきい値ルールのない統計はcolorCoding有効でも既定色のまま', () => {
+      const handsOnly: Array<[string, any, StatResult?]> = [
+        ['Hands', 100, { id: 'hands', name: 'Hands', value: 100, formatted: '100' }],
+      ]
+
+      render(<StatDisplay displayStats={handsOnly} formatValue={mockFormatValue} colorCoding />)
+
+      expect(screen.getByText('100')).toHaveStyle({ color: '#dddddd' })
+    })
+  })
+
+  describe('title tooltip合成（#143）', () => {
+    it('helpTextのみ（動的tooltipなし）: "統計名: 値"の次にhelpTextを続ける', () => {
+      const stats: Array<[string, any, StatResult?]> = [
+        ['VPIP', [30, 100], { id: 'vpip', name: 'VPIP', value: [30, 100], formatted: '30.0% (30/100)' }],
+      ]
+
+      render(<StatDisplay displayStats={stats} formatValue={mockFormatValue} />)
+
+      const expectedTitle = 'VPIP: 30.0% (30/100)\n自発的にチップをポットに入れたハンドの割合(ウォーク除外)'
+      expect(screen.getByText('VPIP:')).toHaveAttribute('title', expectedTitle)
+      expect(screen.getByText('30.0% (30/100)')).toHaveAttribute('title', expectedTitle)
+    })
+
+    it('helpText + 動的tooltip: 動的tooltipを基底行にしてhelpTextを続ける（vpipFの例）', () => {
+      const dynamicTooltip = 'VPIP·F 35.2% (n=1252) | 4p 47.0% (n=279) | 3p 56.1% (n=221) | HU 71.9% (n=146)'
+      const stats: Array<[string, any, StatResult?]> = [
+        ['VPIP·F', [441, 1252], {
+          id: 'vpipF',
+          name: 'VPIP·F',
+          value: [441, 1252],
+          formatted: '35.2% (n=1252)',
+          tooltip: dynamicTooltip,
+        }],
+      ]
+
+      render(<StatDisplay displayStats={stats} formatValue={mockFormatValue} />)
+
+      const expectedTitle = `${dynamicTooltip}\n全員着席した卓に限定したVPIP。卓が縮小するほどVPIPは自然に上がるため、比較しやすいよう絞った指標(HUD独自指標)`
+      expect(screen.getByText('35.2% (n=1252)')).toHaveAttribute('title', expectedTitle)
+    })
+  })
 })

--- a/src/components/hud/StatDisplay.tsx
+++ b/src/components/hud/StatDisplay.tsx
@@ -1,10 +1,14 @@
 import { memo } from 'react'
 import type { CSSProperties } from 'react'
 import type { StatResult } from '../../types/stats'
+import { getStatValueColor } from './statColorRules'
+import { composeStatTitle } from './statTooltip'
 
 interface StatDisplayProps {
   displayStats: Array<[string, any, StatResult?]>
   formatValue: (value: number | [number, number]) => string
+  /** Threshold-based value coloring, see statColorRules.ts. Defaults to off. */
+  colorCoding?: boolean
 }
 
 const styles = {
@@ -44,20 +48,21 @@ const styles = {
   } as CSSProperties,
 }
 
-export const StatDisplay = memo(({ displayStats, formatValue }: StatDisplayProps) => (
+export const StatDisplay = memo(({ displayStats, formatValue, colorCoding }: StatDisplayProps) => (
   <div style={styles.statsContainer}>
     {displayStats
       .filter(([, , statResult]) => statResult?.id !== 'playerName')
       .map(([key, value, statResult], index) => {
         const displayValue = statResult?.formatted || formatValue(value as number | [number, number])
-        // native title tooltip: stats that define StatDefinition.tooltip (e.g.
-        // vpipF's per-layer breakdown) surface it here instead of repeating
-        // the cell's own display value on hover.
-        const tooltipText = statResult?.tooltip || displayValue
+        // native title tooltip: stat name + value (num/den), plus the stat's
+        // dynamic tooltip when defined (e.g. vpipF's per-layer breakdown)
+        // and its static beginner-friendly helpText -- see statTooltip.ts.
+        const tooltipText = composeStatTitle(statResult?.id ?? '', key, displayValue, statResult?.tooltip)
+        const color = colorCoding && statResult ? getStatValueColor(statResult.id, statResult.value) : null
         return (
-          <div key={index} style={styles.statItem}>
-            <span style={styles.statKey} title={key}>{key}:</span>
-            <span style={styles.statValue} title={tooltipText}>{displayValue}</span>
+          <div key={index} style={styles.statItem} data-stat-id={statResult?.id}>
+            <span style={styles.statKey} title={tooltipText}>{key}:</span>
+            <span style={color ? { ...styles.statValue, color } : styles.statValue} title={tooltipText}>{displayValue}</span>
           </div>
         )
       })}

--- a/src/components/hud/statColorRules.test.ts
+++ b/src/components/hud/statColorRules.test.ts
@@ -1,0 +1,77 @@
+import { getStatValueColor, LOW_SAMPLE_COLOR, MIN_DENOMINATOR_FOR_COLOR } from './statColorRules'
+
+describe('statColorRules', () => {
+  describe('n-gate（サンプルサイズ）', () => {
+    it('分母がMIN_DENOMINATOR_FOR_COLOR未満の場合は既存の低信頼度グレーを返す', () => {
+      expect(getStatValueColor('vpip', [3, MIN_DENOMINATOR_FOR_COLOR - 1])).toBe(LOW_SAMPLE_COLOR)
+    })
+
+    it('分母がMIN_DENOMINATOR_FOR_COLORちょうどの場合は帯に従って着色する', () => {
+      // 25% VPIP, n=20 -> tight/loose境界内（20-28）でデフォルト色（null）
+      expect(getStatValueColor('vpip', [5, 20])).toBeNull()
+    })
+
+    it('分母が0の場合はnull（"-"表示なので着色対象外）', () => {
+      expect(getStatValueColor('vpip', [0, 0])).toBeNull()
+    })
+  })
+
+  describe('VPIP/PFRの帯', () => {
+    it('20%未満はタイト/ブルー', () => {
+      expect(getStatValueColor('vpip', [10, 100])).toBe('#64b5f6')
+      expect(getStatValueColor('pfr', [10, 100])).toBe('#64b5f6')
+    })
+
+    it('20-28%はデフォルト色（null）', () => {
+      expect(getStatValueColor('vpip', [24, 100])).toBeNull()
+    })
+
+    it('28-40%はルース/オレンジ', () => {
+      expect(getStatValueColor('vpip', [35, 100])).toBe('#ffb74d')
+    })
+
+    it('40%超は非常にルース/レッド', () => {
+      expect(getStatValueColor('vpip', [45, 100])).toBe('#e57373')
+    })
+  })
+
+  describe('3betの帯', () => {
+    it('6%未満はブルー', () => {
+      expect(getStatValueColor('3bet', [3, 100])).toBe('#64b5f6')
+    })
+
+    it('6-10%はデフォルト色（null）', () => {
+      expect(getStatValueColor('3bet', [8, 100])).toBeNull()
+    })
+
+    it('10%超はオレンジ', () => {
+      expect(getStatValueColor('3bet', [15, 100])).toBe('#ffb74d')
+    })
+  })
+
+  describe('AFの帯', () => {
+    it('1.5未満はブルー', () => {
+      expect(getStatValueColor('af', [10, 100])).toBe('#64b5f6')
+    })
+
+    it('1.5-3はデフォルト色（null）', () => {
+      expect(getStatValueColor('af', [200, 100])).toBeNull()
+    })
+
+    it('3超はレッド', () => {
+      expect(getStatValueColor('af', [400, 100])).toBe('#e57373')
+    })
+  })
+
+  describe('ルール未定義の統計・不正な値', () => {
+    it('しきい値ルールを持たない統計IDはnullを返す', () => {
+      expect(getStatValueColor('hands', [67, 67])).toBeNull()
+      expect(getStatValueColor('wtsd', [30, 100])).toBeNull()
+    })
+
+    it('[num, den]形式でない値はnullを返す', () => {
+      expect(getStatValueColor('vpip', 42)).toBeNull()
+      expect(getStatValueColor('vpip', 'TestPlayer')).toBeNull()
+    })
+  })
+})

--- a/src/components/hud/statColorRules.test.ts
+++ b/src/components/hud/statColorRules.test.ts
@@ -33,6 +33,16 @@ describe('statColorRules', () => {
     it('40%超は非常にルース/レッド', () => {
       expect(getStatValueColor('vpip', [45, 100])).toBe('#e57373')
     })
+
+    it('境界値はちょうどの上限側の帯に属する（上限inclusive、#143 review）', () => {
+      // 20.0% ちょうど -> ブルー帯の上限（次の帯にフォールスルーしない）
+      expect(getStatValueColor('vpip', [20, 100])).toBe('#64b5f6')
+      // 28.0% ちょうど -> デフォルト帯の上限
+      expect(getStatValueColor('vpip', [28, 100])).toBeNull()
+      // 40.0% ちょうど -> オレンジ帯の上限（レッドに繰り上がらない）
+      expect(getStatValueColor('vpip', [40, 100])).toBe('#ffb74d')
+      expect(getStatValueColor('pfr', [40, 100])).toBe('#ffb74d')
+    })
   })
 
   describe('3betの帯', () => {
@@ -47,6 +57,13 @@ describe('statColorRules', () => {
     it('10%超はオレンジ', () => {
       expect(getStatValueColor('3bet', [15, 100])).toBe('#ffb74d')
     })
+
+    it('境界値はちょうどの上限側の帯に属する（上限inclusive、#143 review）', () => {
+      // 6.0% ちょうど -> ブルー帯の上限
+      expect(getStatValueColor('3bet', [6, 100])).toBe('#64b5f6')
+      // 10.0% ちょうど -> デフォルト帯の上限（オレンジに繰り上がらない）
+      expect(getStatValueColor('3bet', [10, 100])).toBeNull()
+    })
   })
 
   describe('AFの帯', () => {
@@ -60,6 +77,15 @@ describe('statColorRules', () => {
 
     it('3超はレッド', () => {
       expect(getStatValueColor('af', [400, 100])).toBe('#e57373')
+    })
+
+    it('境界値はちょうどの上限側の帯に属する（上限inclusive、#143 review）', () => {
+      // 分母はn-gate(MIN_DENOMINATOR_FOR_COLOR=20)以上にする -- 未満だと
+      // 帯にかかわらず低信頼度グレーになるため
+      // 1.5 ちょうど -> ブルー帯の上限
+      expect(getStatValueColor('af', [30, 20])).toBe('#64b5f6')
+      // 3.0 ちょうど -> デフォルト帯の上限（レッドに繰り上がらない）
+      expect(getStatValueColor('af', [60, 20])).toBeNull()
     })
   })
 

--- a/src/components/hud/statColorRules.ts
+++ b/src/components/hud/statColorRules.ts
@@ -20,7 +20,7 @@ export const MIN_DENOMINATOR_FOR_COLOR = 20
 /** Dimmed color shown for stats below {@link MIN_DENOMINATOR_FOR_COLOR}, matching StatDisplay's existing low-confidence style. */
 export const LOW_SAMPLE_COLOR = '#888888'
 
-/** One color band: values below `upTo` (exclusive) get `color`; `null` means "leave the default text color". */
+/** One color band: values at or below `upTo` (inclusive) get `color`; `null` means "leave the default text color". A boundary value belongs to the band whose `upTo` it matches, not the next band up. */
 interface ColorBand {
   upTo: number
   color: string | null
@@ -33,10 +33,11 @@ interface StatColorRule {
   bands: ColorBand[]
 }
 
-// Design brief thresholds (sola-approved, see PR #143):
-//  - VPIP/PFR: <20 tight/blue, 20-28 default, 28-40 loose/orange, >40 very loose/red
-//  - 3bet: <6 blue, 6-10 default, >10 orange (no red band specified)
-//  - AF: <1.5 blue, 1.5-3 default, >3 red (no orange band specified)
+// Design brief thresholds (sola-approved, see PR #143). Upper bounds are
+// inclusive -- a boundary value belongs to the lower band:
+//  - VPIP/PFR: <=20 tight/blue, (20,28] default, (28,40] loose/orange, >40 very loose/red
+//  - 3bet: <=6 blue, (6,10] default, >10 orange (no red band specified)
+//  - AF: <=1.5 blue, (1.5,3] default, >3 red (no orange band specified)
 const TIGHT_LOOSE_BANDS: ColorBand[] = [
   { upTo: 20, color: '#64b5f6' },
   { upTo: 28, color: null },
@@ -78,6 +79,12 @@ export const getStatValueColor = (statId: string, value: StatValue): string | nu
   if (denominator < MIN_DENOMINATOR_FOR_COLOR) return LOW_SAMPLE_COLOR
 
   const ratio = rule.scale === 'percent' ? (numerator / denominator) * 100 : numerator / denominator
-  const band = rule.bands.find((b) => ratio < b.upTo)
+  // Epsilon guards boundary values against float noise, e.g. (28/100)*100 ===
+  // 28.000000000000004 in IEEE 754 -- without it, an exact 28.0% VPIP would
+  // wrongly skip the `<=28` band and fall through to the next one (#143
+  // review). 1e-9 is far below any real stat's precision, so it can't blur
+  // two genuinely different values together.
+  const EPSILON = 1e-9
+  const band = rule.bands.find((b) => ratio <= b.upTo + EPSILON)
   return band?.color ?? null
 }

--- a/src/components/hud/statColorRules.ts
+++ b/src/components/hud/statColorRules.ts
@@ -1,0 +1,83 @@
+/**
+ * Threshold-based stat value coloring (#143, ported from the
+ * proto/hud-design-mock design review prototype).
+ *
+ * Data-driven on purpose: thresholds live in one table here rather than as
+ * inline conditionals scattered across StatDisplay/CompactStatDisplay JSX,
+ * so tuning a band is a one-line edit and both the full and compact
+ * renderers share identical logic.
+ *
+ * Gating: a stat is only colored once its own [numerator, denominator]
+ * StatValue has denominator >= MIN_DENOMINATOR_FOR_COLOR -- below that the
+ * sample is too small to mean anything, so the value keeps the existing
+ * dimmed gray used for low-confidence stats.
+ */
+import type { StatValue } from '../../types/stats'
+
+/** Minimum opportunities (StatValue denominator) before a stat gets colored instead of dimmed gray. */
+export const MIN_DENOMINATOR_FOR_COLOR = 20
+
+/** Dimmed color shown for stats below {@link MIN_DENOMINATOR_FOR_COLOR}, matching StatDisplay's existing low-confidence style. */
+export const LOW_SAMPLE_COLOR = '#888888'
+
+/** One color band: values below `upTo` (exclusive) get `color`; `null` means "leave the default text color". */
+interface ColorBand {
+  upTo: number
+  color: string | null
+}
+
+interface StatColorRule {
+  /** How to turn a [numerator, denominator] StatValue into the number compared against band thresholds. */
+  scale: 'percent' | 'factor'
+  /** Ascending by `upTo`; the last band should have `upTo: Infinity` to catch everything above the previous band. */
+  bands: ColorBand[]
+}
+
+// Design brief thresholds (sola-approved, see PR #143):
+//  - VPIP/PFR: <20 tight/blue, 20-28 default, 28-40 loose/orange, >40 very loose/red
+//  - 3bet: <6 blue, 6-10 default, >10 orange (no red band specified)
+//  - AF: <1.5 blue, 1.5-3 default, >3 red (no orange band specified)
+const TIGHT_LOOSE_BANDS: ColorBand[] = [
+  { upTo: 20, color: '#64b5f6' },
+  { upTo: 28, color: null },
+  { upTo: 40, color: '#ffb74d' },
+  { upTo: Infinity, color: '#e57373' },
+]
+
+export const STAT_COLOR_RULES: Record<string, StatColorRule> = {
+  vpip: { scale: 'percent', bands: TIGHT_LOOSE_BANDS },
+  pfr: { scale: 'percent', bands: TIGHT_LOOSE_BANDS },
+  '3bet': {
+    scale: 'percent',
+    bands: [
+      { upTo: 6, color: '#64b5f6' },
+      { upTo: 10, color: null },
+      { upTo: Infinity, color: '#ffb74d' },
+    ],
+  },
+  af: {
+    scale: 'factor',
+    bands: [
+      { upTo: 1.5, color: '#64b5f6' },
+      { upTo: 3, color: null },
+      { upTo: Infinity, color: '#e57373' },
+    ],
+  },
+}
+
+/**
+ * Returns the color to render a stat's value in, or `null` to leave the
+ * caller's default text color untouched (no rule for this stat id, or the
+ * value isn't a [numerator, denominator] pair).
+ */
+export const getStatValueColor = (statId: string, value: StatValue): string | null => {
+  const rule = STAT_COLOR_RULES[statId]
+  if (!rule || !Array.isArray(value) || value.length !== 2) return null
+  const [numerator, denominator] = value
+  if (denominator === 0) return null // formatted as '-' anyway; nothing to color
+  if (denominator < MIN_DENOMINATOR_FOR_COLOR) return LOW_SAMPLE_COLOR
+
+  const ratio = rule.scale === 'percent' ? (numerator / denominator) * 100 : numerator / denominator
+  const band = rule.bands.find((b) => ratio < b.upTo)
+  return band?.color ?? null
+}

--- a/src/components/hud/statTooltip.test.ts
+++ b/src/components/hud/statTooltip.test.ts
@@ -1,0 +1,30 @@
+import { composeStatTitle } from './statTooltip'
+
+// composeStatTitleはdefaultRegistryからhelpTextを引くため、実レジストリ
+// (../../stats経由で自動登録される本物のvpip/vpipF定義)を使う。
+
+describe('composeStatTitle', () => {
+  it('helpTextのみ（動的tooltipなし）: 名前+値の行の次にhelpTextを続ける', () => {
+    const title = composeStatTitle('vpip', 'VPIP', '30.0% (30/100)', undefined)
+    expect(title).toBe('VPIP: 30.0% (30/100)\n自発的にチップをポットに入れたハンドの割合(ウォーク除外)')
+  })
+
+  it('helpText + 動的tooltip: 動的tooltipを基底行として使い、helpTextを続ける（vpipFの例）', () => {
+    const dynamicTooltip = 'VPIP·F 35.2% (n=1252) | 4p 47.0% (n=279) | 3p 56.1% (n=221) | HU 71.9% (n=146)'
+    const title = composeStatTitle('vpipF', 'VPIP·F', '35.2% (n=1252)', dynamicTooltip)
+    expect(title).toBe(
+      'VPIP·F 35.2% (n=1252) | 4p 47.0% (n=279) | 3p 56.1% (n=221) | HU 71.9% (n=146)\n' +
+      '全員着席した卓に限定したVPIP。卓が縮小するほどVPIPは自然に上がるため、比較しやすいよう絞った指標(HUD独自指標)'
+    )
+  })
+
+  it('未知の統計ID（helpTextなし）: 名前+値の行のみ', () => {
+    const title = composeStatTitle('unknownStat', 'XYZ', '1', undefined)
+    expect(title).toBe('XYZ: 1')
+  })
+
+  it('IDが空文字（statResult未定義のフォールバックケース）でも壊れない', () => {
+    const title = composeStatTitle('', 'Invalid', '-', undefined)
+    expect(title).toBe('Invalid: -')
+  })
+})

--- a/src/components/hud/statTooltip.ts
+++ b/src/components/hud/statTooltip.ts
@@ -1,0 +1,29 @@
+/**
+ * Native `title` tooltip composition for HUD stat cells (#143).
+ *
+ * Shared by StatDisplay (full 16-stat grid) and CompactStatDisplay (compact
+ * mode's classic line + secondary line) so every stat cell -- full-grid row
+ * or compact element alike -- gets the same beginner-friendly tooltip:
+ *
+ *   {base line}
+ *   {helpText}
+ *
+ * The base line is the stat's dynamic tooltip (`StatDefinition.tooltip`,
+ * #130 -- e.g. vpipF's per-layer breakdown) when the stat defines one,
+ * otherwise `${name}: ${displayValue}` (name + value with its (num/den)).
+ * `helpText` (#143, `StatDefinition.helpText`) is a static, one-line
+ * Japanese explanation of what the stat means -- looked up from the shared
+ * stats registry by id, since it doesn't vary with calculation context.
+ */
+import { defaultRegistry } from '../../stats'
+
+export const composeStatTitle = (
+  id: string,
+  name: string,
+  displayValue: string,
+  dynamicTooltip?: string
+): string => {
+  const base = dynamicTooltip || `${name}: ${displayValue}`
+  const helpText = defaultRegistry.get(id)?.helpText
+  return helpText ? `${base}\n${helpText}` : base
+}

--- a/src/components/popup/HudDisplaySection.test.tsx
+++ b/src/components/popup/HudDisplaySection.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { HudDisplaySection } from './HudDisplaySection'
+import type { UIConfig } from '../../types/hand-log'
+import { DEFAULT_UI_CONFIG } from '../../types/hand-log'
+
+// Mock chrome storage and tabs
+const mockChromeStorageSet = jest.fn()
+const mockTabsQuery = jest.fn()
+const mockTabsSendMessage = jest.fn()
+global.chrome = {
+  ...global.chrome,
+  storage: {
+    sync: {
+      set: mockChromeStorageSet,
+    },
+  },
+  tabs: {
+    query: mockTabsQuery,
+    sendMessage: mockTabsSendMessage,
+  },
+} as any
+
+describe('HudDisplaySection', () => {
+  const mockSetUIConfig = jest.fn()
+
+  const defaultProps = {
+    uiConfig: DEFAULT_UI_CONFIG,
+    setUIConfig: mockSetUIConfig,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockTabsQuery.mockImplementation((_, callback) => {
+      callback([{ id: 1 }, { id: 2 }])
+    })
+  })
+
+  it('HUD表示モードと統計カラー表示のUIを表示する', () => {
+    render(<HudDisplaySection {...defaultProps} />)
+
+    expect(screen.getByText('表示モード:')).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'コンパクト' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'フル' })).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: '統計カラー表示' })).toBeInTheDocument()
+  })
+
+  it('DEFAULT_UI_CONFIG（新規/既存ユーザーのマイグレーション後）はコンパクト+カラーONが選択されている', () => {
+    render(<HudDisplaySection {...defaultProps} />)
+
+    expect(screen.getByRole('radio', { name: 'コンパクト' })).toBeChecked()
+    expect(screen.getByRole('radio', { name: 'フル' })).not.toBeChecked()
+    expect(screen.getByRole('checkbox', { name: '統計カラー表示' })).toBeChecked()
+  })
+
+  it('フルを選択すると保存され全ゲームタブへ通知される', async () => {
+    render(<HudDisplaySection {...defaultProps} />)
+
+    await userEvent.click(screen.getByRole('radio', { name: 'フル' }))
+
+    const expectedConfig: UIConfig = {
+      ...DEFAULT_UI_CONFIG,
+      hudDisplayMode: 'full',
+    }
+
+    expect(mockSetUIConfig).toHaveBeenCalledWith(expectedConfig)
+    expect(mockChromeStorageSet).toHaveBeenCalledWith({ uiConfig: expectedConfig })
+    expect(mockTabsSendMessage).toHaveBeenCalledWith(1, {
+      action: 'updateUIConfig',
+      config: expectedConfig,
+    })
+    expect(mockTabsSendMessage).toHaveBeenCalledWith(2, {
+      action: 'updateUIConfig',
+      config: expectedConfig,
+    })
+  })
+
+  it('統計カラー表示のチェックを外すと保存され全ゲームタブへ通知される', async () => {
+    render(<HudDisplaySection {...defaultProps} />)
+
+    await userEvent.click(screen.getByRole('checkbox', { name: '統計カラー表示' }))
+
+    const expectedConfig: UIConfig = {
+      ...DEFAULT_UI_CONFIG,
+      hudColorCoding: false,
+    }
+
+    expect(mockSetUIConfig).toHaveBeenCalledWith(expectedConfig)
+    expect(mockChromeStorageSet).toHaveBeenCalledWith({ uiConfig: expectedConfig })
+    expect(mockTabsSendMessage).toHaveBeenCalledWith(1, {
+      action: 'updateUIConfig',
+      config: expectedConfig,
+    })
+  })
+
+  it('旧フィールド欠落のuiConfig（マイグレーション前提未達のフォールバック）でもcompact+ONで描画される', () => {
+    // #143以前に保存されたuiConfig相当（hudDisplayMode/hudColorCodingが無い）
+    const legacyConfig = { displayEnabled: true, scale: 1.0 } as UIConfig
+
+    render(<HudDisplaySection uiConfig={legacyConfig} setUIConfig={mockSetUIConfig} />)
+
+    expect(screen.getByRole('radio', { name: 'コンパクト' })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: '統計カラー表示' })).toBeChecked()
+  })
+})

--- a/src/components/popup/HudDisplaySection.tsx
+++ b/src/components/popup/HudDisplaySection.tsx
@@ -1,0 +1,71 @@
+import Box from '@mui/material/Box'
+import Checkbox from '@mui/material/Checkbox'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import Radio from '@mui/material/Radio'
+import RadioGroup from '@mui/material/RadioGroup'
+import Typography from '@mui/material/Typography'
+import type { UIConfig } from '../../types/hand-log'
+
+interface HudDisplaySectionProps {
+  uiConfig: UIConfig
+  setUIConfig: (config: UIConfig) => void
+}
+
+/**
+ * HUD表示スタイル設定（#143）: 表示モード（コンパクト/フル）と統計カラー表示の
+ * ON/OFF。UIScaleSection と同じ保存パス（setUIConfig → chrome.storage.sync →
+ * 開いている全ゲームタブへ updateUIConfig メッセージ送信）に従う。
+ */
+export const HudDisplaySection = ({
+  uiConfig,
+  setUIConfig,
+}: HudDisplaySectionProps) => {
+  const updateUIConfig = (newConfig: UIConfig) => {
+    setUIConfig(newConfig)
+    chrome.storage.sync.set({ uiConfig: newConfig })
+    chrome.tabs.query({}, (tabs) => {
+      tabs.forEach(tab => {
+        if (tab.id) {
+          chrome.tabs.sendMessage(tab.id, {
+            action: 'updateUIConfig',
+            config: newConfig
+          })
+        }
+      })
+    })
+  }
+
+  // DEFAULT_UI_CONFIGとのマージ済みuiConfigが渡ってくる前提だが、念のため
+  // フォールバックしておく（#143のデフォルト = compact + カラーON）。
+  const hudDisplayMode = uiConfig.hudDisplayMode ?? 'compact'
+  const hudColorCoding = uiConfig.hudColorCoding ?? true
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Typography variant="body2" sx={{ mb: 0.5 }}>表示モード:</Typography>
+      <RadioGroup
+        row
+        aria-label="HUD表示モード"
+        value={hudDisplayMode}
+        onChange={(_event, newValue) => {
+          updateUIConfig({ ...uiConfig, hudDisplayMode: newValue as 'full' | 'compact' })
+        }}
+      >
+        <FormControlLabel value="compact" control={<Radio size="small" />} label="コンパクト" />
+        <FormControlLabel value="full" control={<Radio size="small" />} label="フル" />
+      </RadioGroup>
+      <FormControlLabel
+        control={
+          <Checkbox
+            size="small"
+            checked={hudColorCoding}
+            onChange={(event) => {
+              updateUIConfig({ ...uiConfig, hudColorCoding: event.target.checked })
+            }}
+          />
+        }
+        label="統計カラー表示"
+      />
+    </Box>
+  )
+}

--- a/src/stats/compactStats.ts
+++ b/src/stats/compactStats.ts
@@ -1,0 +1,21 @@
+/**
+ * Stat ids the compact HUD line (#143) always needs, regardless of the
+ * user's HUD statistics visibility settings (statDisplayConfigs).
+ *
+ * Compact mode renders a fixed-format classic line (`VPIP/PFR/3B (HAND)`)
+ * plus a fixed secondary line (AF/CB/STL) -- see CompactStatDisplay.tsx.
+ * That format has no per-stat visibility toggle of its own, so these ids
+ * must be calculated even when the user has disabled the corresponding
+ * row in the full 16-stat grid (PR #143 review: previously a disabled
+ * stat was omitted from `statResults` entirely, and the compact line
+ * would render it as a bogus '-'/`(0)` even though the player has real
+ * data).
+ *
+ * Used by:
+ *  - read-entity-stream.ts: forces these ids into the calculation
+ *    (calculateWithConfig) regardless of their configured `enabled` flag.
+ *  - Hud.tsx: keeps the enabled-only filtering for the full grid's
+ *    `displayStats` while still passing the full/unfiltered `statResults`
+ *    to CompactStatDisplay, so visibility config only governs the grid.
+ */
+export const COMPACT_REQUIRED_STAT_IDS: string[] = ['vpip', 'pfr', '3bet', 'hands', 'af', 'cbet', 'steal']

--- a/src/stats/core/3bet-fold.ts
+++ b/src/stats/core/3bet-fold.ts
@@ -11,6 +11,7 @@ export const threeBetFoldStat: StatDefinition = {
   id: '3betfold',
   name: '3BF',
   description: 'スリーベットに対するフォールド率',
+  helpText: '3ベットを受けてフォールドした割合',
   calculate: ({ actions }) => {
     const threeBetFoldChanceCount = actions.filter(a => 
       a.actionDetails.includes(ActionDetail.$3BET_FOLD_CHANCE)

--- a/src/stats/core/3bet.ts
+++ b/src/stats/core/3bet.ts
@@ -11,6 +11,7 @@ export const threeBetStat: StatDefinition = {
   id: '3bet',
   name: '3B',
   description: 'スリーベット率',
+  helpText: 'プリフロップで3ベットした割合',
   calculate: ({ actions }) => {
     const threeBetChanceCount = actions.filter(a => 
       a.actionDetails.includes(ActionDetail.$3BET_CHANCE)

--- a/src/stats/core/af.ts
+++ b/src/stats/core/af.ts
@@ -25,6 +25,7 @@ export const afStat: StatDefinition = {
   id: 'af',
   name: 'AF',
   description: 'アグレッションファクター（ポストフロップのベット・レイズ回数／コール回数）',
+  helpText: 'ポストフロップの(ベット+レイズ)÷コール。高いほどアグレッシブ',
   calculate: ({ actions }) => {
     // ポストフロップ（フロップ以降）のアクションのみを対象とする（PT4公式定義）
     const postflopActions = actions.filter(a => a.phase !== PhaseType.PREFLOP)

--- a/src/stats/core/afq.ts
+++ b/src/stats/core/afq.ts
@@ -26,6 +26,7 @@ export const afqStat: StatDefinition = {
   id: 'afq',
   name: 'AFq',
   description: 'アグレッション頻度（ポストフロップのベット・レイズ／ベット・レイズ・コール・フォールド）',
+  helpText: 'ポストフロップで(ベット+レイズ)を選んだ頻度。高いほどアグレッシブ',
   calculate: ({ actions }) => {
     // ポストフロップ（フロップ以降）のアクションのみを対象とする（PT4公式定義）
     const postflopActions = actions.filter(a => a.phase !== PhaseType.PREFLOP)

--- a/src/stats/core/cbet-fold.ts
+++ b/src/stats/core/cbet-fold.ts
@@ -10,6 +10,7 @@ export const cbetFoldStat: StatDefinition = {
   id: 'cbetFold',
   name: 'CBF',
   description: 'フロップコンティニュエーションベットに対するフォールド率',
+  helpText: 'フロップCベットを受けてフォールドした割合',
   calculate: ({ actions }) => {
     const cbetFoldChanceCount = actions.filter(a => 
       a.actionDetails.includes(ActionDetail.CBET_FOLD_CHANCE)

--- a/src/stats/core/cbet.ts
+++ b/src/stats/core/cbet.ts
@@ -18,6 +18,7 @@ export const cbetStat: StatDefinition = {
   id: 'cbet',
   name: 'CB',
   description: 'フロップコンティニュエーションベット率',
+  helpText: 'プリフロップの主導者がフロップで先制ベットした割合',
   calculate: ({ actions }) => {
     const flopCBChanceCount = actions.filter(a => 
       a.phase === PhaseType.FLOP && 

--- a/src/stats/core/fold-to-steal.ts
+++ b/src/stats/core/fold-to-steal.ts
@@ -28,6 +28,7 @@ export const foldToStealStat: StatDefinition = {
   id: 'foldToSteal',
   name: 'FTS',
   description: 'スチールに対するフォールド率',
+  helpText: 'スチール(盗み)レイズを受けてブラインドがフォールドした割合',
   calculate: ({ actions }) => {
     const foldToStealChanceCount = actions.filter(a =>
       a.actionDetails.includes(ActionDetail.FOLD_TO_STEAL_CHANCE)

--- a/src/stats/core/hands.ts
+++ b/src/stats/core/hands.ts
@@ -8,6 +8,7 @@ export const handsStat: StatDefinition = {
   id: 'hands',
   name: 'HAND',
   description: 'プレイしたハンド数',
+  helpText: 'これまでにプレイしたハンド数',
   calculate: ({ hands }) => {
     return hands.length
   },

--- a/src/stats/core/pfr.ts
+++ b/src/stats/core/pfr.ts
@@ -25,6 +25,7 @@ export const pfrStat: StatDefinition = {
   id: 'pfr',
   name: 'PFR',
   description: 'プリフロップレイズ率（ウォーク除外）',
+  helpText: 'プリフロップでレイズしたハンドの割合',
   calculate: ({ playerId, actions, hands }) => {
     // プリフロップでRAISEアクションを行ったユニークなハンド数を取得
     // ALL_INがRAISEに変換されたものも自動的に含まれる

--- a/src/stats/core/player-name.ts
+++ b/src/stats/core/player-name.ts
@@ -8,6 +8,7 @@ export const playerNameStat: StatDefinition = {
   id: 'playerName',
   name: 'Name',
   description: 'プレイヤー名',
+  helpText: 'プレイヤー名',
   calculate: (context) => {
     const playerInfo = context.session.players.get(context.playerId)
     if (playerInfo) {

--- a/src/stats/core/river-call-accuracy.ts
+++ b/src/stats/core/river-call-accuracy.ts
@@ -13,6 +13,7 @@ export const riverCallAccuracyStat: StatDefinition = {
   id: 'riverCallAccuracy',
   name: 'RCA',
   description: 'リバーコール精度',
+  helpText: 'リバーでコールした際に勝てた割合(HUD独自指標)',
   calculate: ({ actions }) => {
     // リバーでコールしたアクション
     const riverCalls = actions.filter(a => 

--- a/src/stats/core/steal.ts
+++ b/src/stats/core/steal.ts
@@ -31,6 +31,7 @@ export const stealStat: StatDefinition = {
   id: 'steal',
   name: 'STL',
   description: 'スチール試行率',
+  helpText: 'CO/BTN/SBからのファーストイン・レイズ率',
   calculate: ({ actions }) => {
     const stealChanceCount = actions.filter(a =>
       a.actionDetails.includes(ActionDetail.STEAL_CHANCE)

--- a/src/stats/core/vpip-full.ts
+++ b/src/stats/core/vpip-full.ts
@@ -118,6 +118,7 @@ export const vpipFullStat: StatDefinition = {
   id: 'vpipF',
   name: 'VPIP·F',
   description: 'フルテーブル層（6max≥5人 / 4max=4人）に限定したVPIP（ウォーク除外, HUD独自指標, opt-in）',
+  helpText: '全員着席した卓に限定したVPIP。卓が縮小するほどVPIPは自然に上がるため、比較しやすいよう絞った指標(HUD独自指標)',
   enabled: false,
   calculate: ({ playerId, actions, hands }) => {
     const { full } = groupHandsByLayer(hands)

--- a/src/stats/core/vpip.ts
+++ b/src/stats/core/vpip.ts
@@ -28,6 +28,7 @@ export const vpipStat: StatDefinition = {
   id: 'vpip',
   name: 'VPIP',
   description: 'プリフロップで自発的にポットに参加した割合（ウォーク除外）',
+  helpText: '自発的にチップをポットに入れたハンドの割合(ウォーク除外)',
   calculate: ({ playerId, actions, hands }) => {
     // ActionDetail.VPIPが付与されたアクションをカウント
     // このフラグは、プリフロップで自発的なCALL/RAISEアクション時に付与される

--- a/src/stats/core/wsd.ts
+++ b/src/stats/core/wsd.ts
@@ -10,6 +10,7 @@ export const wsdStat: StatDefinition = {
   id: 'wsd',
   name: 'W$SD',
   description: 'ショーダウン勝率',
+  helpText: 'ショーダウンに進んだ際に勝った割合',
   calculate: ({ phases, winningHandIds }) => {
     const showdownPhases = phases.filter(p => p.phase === PhaseType.SHOWDOWN)
     

--- a/src/stats/core/wtsd-no-ai.ts
+++ b/src/stats/core/wtsd-no-ai.ts
@@ -27,6 +27,7 @@ export const wtsdNoAiStat: StatDefinition = {
   id: 'wtsdNoAi',
   name: 'WTSDa',
   description: 'ショーダウン率（プリフロップオールイン除外、意思決定ベースの変種）',
+  helpText: 'フロップを見た後にショーダウンまで進んだ割合(プリフロップオールイン除外)',
   enabled: false,
   calculate: ({ actions, phases }) => {
     // フロップで最低1アクションを行ったハンドID（プリフロップオールイン除外）

--- a/src/stats/core/wtsd.ts
+++ b/src/stats/core/wtsd.ts
@@ -25,6 +25,7 @@ export const wtsdStat: StatDefinition = {
   id: 'wtsd',
   name: 'WTSD',
   description: 'ショーダウン率（フロップ以降、プリフロップオールイン含む）',
+  helpText: 'フロップを見た後にショーダウンまで進んだ割合(プリフロップオールイン含む)',
   calculate: ({ phases }) => {
     // フロップを見たハンドID（プリフロップオールインを含む。#115）
     const activeFlopHandIds = new Set(

--- a/src/stats/core/wwsf-no-ai.ts
+++ b/src/stats/core/wwsf-no-ai.ts
@@ -19,6 +19,7 @@ export const wwsfNoAiStat: StatDefinition = {
   id: 'wwsfNoAi',
   name: 'WWSFa',
   description: 'フロップ以降の勝率（プリフロップオールイン除外、意思決定ベースの変種）',
+  helpText: 'フロップを見た後に勝った割合(プリフロップオールイン除外)',
   enabled: false,
   calculate: ({ actions, winningHandIds }) => {
     // フロップで最低1アクションを行ったハンドID（プリフロップオールイン除外）

--- a/src/stats/core/wwsf.ts
+++ b/src/stats/core/wwsf.ts
@@ -25,6 +25,7 @@ export const wwsfStat: StatDefinition = {
   id: 'wwsf',
   name: 'WWSF',
   description: 'フロップ以降の勝率（プリフロップオールイン含む）',
+  helpText: 'フロップを見た後に勝った割合(プリフロップオールイン含む)',
   calculate: ({ phases, winningHandIds }) => {
     // フロップを見たハンド（プリフロップオールインを含む。#115）
     const flopPhases = phases.filter(p => p.phase === PhaseType.FLOP)

--- a/src/streams/read-entity-stream.ts
+++ b/src/streams/read-entity-stream.ts
@@ -11,6 +11,7 @@ import type {
 } from '../types'
 import { ErrorHandler } from '../utils/error-handler'
 import { defaultRegistry } from '../stats'
+import { COMPACT_REQUIRED_STAT_IDS } from '../stats/compactStats'
 import { matchesTableSizeFilter } from '../utils/table-size'
 import type { ErrorContext } from '../types/errors'
 
@@ -243,8 +244,22 @@ export class ReadEntityStream extends SimpleTransform<number[], PlayerStats[]> {
         session: this.service.session
       }
 
+      // Compact HUD mode (#143) has a fixed classic-line format (VPIP/PFR/3B
+      // (HAND) + AF/CB/STL) that must always be populated, even when the
+      // user has hidden one of those stats from the full 16-stat grid via
+      // statDisplayConfigs. Force those ids into the calculation regardless
+      // of their configured `enabled` flag -- Hud.tsx re-applies the user's
+      // actual enabled flag when building the full grid's displayStats, so
+      // this only widens what's calculated here, not what's shown in the
+      // grid (PR #143 review).
+      const configsForCalculation = this.service.statDisplayConfigs?.map(config =>
+        !config.enabled && COMPACT_REQUIRED_STAT_IDS.includes(config.id)
+          ? { ...config, enabled: true }
+          : config
+      )
+
       // Calculate stats using the registry with custom configuration
-      const statResults = await defaultRegistry.calculateWithConfig(context, this.service.statDisplayConfigs)
+      const statResults = await defaultRegistry.calculateWithConfig(context, configsForCalculation)
 
       // Return simple stat results format
       const stats: ExistPlayerStats = {

--- a/src/types/hand-log.ts
+++ b/src/types/hand-log.ts
@@ -62,6 +62,27 @@ export interface HandLogConfig {
 export interface UIConfig {
   displayEnabled: boolean     // Master ON/OFF for all UI elements (HUD + Log)
   scale: number              // UI scale factor (0.5 - 2.0)
+  /**
+   * HUD display density (#143).
+   * 'compact' (default) = single classic-HUD line (VPIP/PFR/3B (HAND)) plus
+   * a secondary line (AF/CB/STL); zero-opportunity stats are suppressed
+   * rather than shown as '-'. Click the stat body to expand the full grid
+   * inline for that player.
+   * 'full' = the existing 2-column 16-stat grid, unchanged.
+   * Optional so existing persisted configs / literals that predate this
+   * field keep compiling; callers merge with DEFAULT_UI_CONFIG so a missing
+   * key resolves to 'compact', not `undefined`.
+   */
+  hudDisplayMode?: 'full' | 'compact'
+  /**
+   * Threshold-based value coloring (#143), on by default.
+   * See src/components/hud/statColorRules.ts for the per-stat thresholds.
+   * Applies in both 'full' and 'compact' hudDisplayMode.
+   * Optional so existing persisted configs / literals that predate this
+   * field keep compiling; callers merge with DEFAULT_UI_CONFIG so a missing
+   * key resolves to `true`, not `undefined`.
+   */
+  hudColorCoding?: boolean
 }
 
 /**
@@ -93,6 +114,8 @@ export const DEFAULT_HAND_LOG_CONFIG: HandLogConfig = {
  * Default UI configuration
  */
 export const DEFAULT_UI_CONFIG: UIConfig = {
-  displayEnabled: true,  // UI is visible by default
-  scale: 1.0            // Normal size
+  displayEnabled: true,   // UI is visible by default
+  scale: 1.0,             // Normal size
+  hudDisplayMode: 'compact', // Compact classic-HUD line by default (#143)
+  hudColorCoding: true    // Threshold-based value coloring on by default (#143)
 }

--- a/src/types/stats.ts
+++ b/src/types/stats.ts
@@ -72,7 +72,15 @@ export interface StatDefinition {
   
   /** Optional description for documentation */
   description?: string
-  
+
+  /**
+   * Optional beginner-friendly one-line explanation (Japanese), shown as part
+   * of the native `title` tooltip on every HUD stat cell (compact elements
+   * and full-grid rows alike) — see `src/components/hud/statTooltip.ts`.
+   * Static per stat id (unlike `tooltip`, which is context-dependent).
+   */
+  helpText?: string
+
   /** The calculation function */
   calculate: (context: StatCalculationContext) => StatValue | Promise<StatValue>
   


### PR DESCRIPTION
## Summary

Production implementation of the sola-approved HUD redesign (variant C from the design mock review): **compact display + threshold color coding as the new default**, with the full 16-stat grid preserved via click-to-expand and a popup mode setting.

- **Compact mode (new default)**: classic HUD line `VPIP/PFR/3B (HAND)` + secondary AF / CB / STL line; zero-opportunity secondary stats suppressed instead of rendering `-` rows.
- **Click-to-expand**: clicking the stat body toggles the full grid inline per panel (local state; stopPropagation so it neither fires the click-to-copy handler nor the #128 positional drill-down chevron, which keeps working independently in both modes).
- **Color coding** (both modes, popup-toggleable): data-driven thresholds (`statColorRules.ts`) — VPIP/PFR tight <20 blue / 28–40 loose orange / >40 red; 3B, AF bands likewise — **n-gated at 20 opportunities** (below that stays the existing low-confidence gray).
- **Beginner-friendly stat tooltips (sola request)**: every stat cell (compact segments and full-grid rows) carries a composed native `title`: stat name + value `(num/den)` + a one-line Japanese explanation (`helpText`, written for all 18 stats, accurate to the PT4-aligned definitions). Composes with #130's dynamic `StatDefinition.tooltip` (vpipF layer breakdown keeps working).
- **Popup**: new HUD表示設定 section (mode radio コンパクト/フル + 統計カラー表示 checkbox) next to UIScaleSection.
- **Migration bug found & fixed**: `Popup.tsx` never merged `DEFAULT_UI_CONFIG` on load (unlike `App.tsx`), so stored configs lacking new keys would surface `undefined` — now merged identically. Existing users land on compact+color by default.

## Verification

- 698/698 tests ×2 (+47 new: color bands + n-gate, tooltip composition, compact rendering, popup section persistence, expand/copy non-interference, config migration); typecheck clean.
- `verify-stats` on the 07-17 capture: 45/45 stats 100.00% (stats files touched only for `helpText` — math unchanged, and proven so).
- E2E: smoke 6/6 green; visual verification at 1920×1080 with an 80-hand replay — compact+color default rendering (color assertions via `getComputedStyle`: 48.6% n=70 → red; n=11 values correctly gray-gated), inline expand/collapse of the full grid, popup section, and app-wide full-mode switch all screenshot-confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)