### PR TITLE
fix(e2e): keep compositor alive so screenshots survive idle pages

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -249,6 +249,21 @@ and DOM dump on any failure. Checks:
 
 ## Flaky bits / timing waits
 
+- **Idle-compositor screenshot stall (headless Chrome for Testing 151)**:
+  after a page sits idle for a few minutes (typical agent think-time between
+  `run.ts` CLI commands), the compositor stops producing on-demand frames
+  and every CDP `Page.captureScreenshot` hangs until protocol timeout --
+  while `evaluate` on the same page keeps working, so the session *looks*
+  healthy right up until the screenshot call. `--disable-gpu` does not fix
+  it. The harness works around this permanently by injecting an invisible
+  1x1px element with an infinite CSS animation into every page it owns
+  (`ensureCompositorKeepalive` in `harness.ts`: on fixture-page load, on
+  popup open, and re-asserted before every `screenshot()` call), which
+  keeps BeginFrames flowing so the stall never happens -- and, because
+  injection also *recovers* an already-stalled compositor, the
+  pre-screenshot re-assert self-heals page reloads and sessions started by
+  an older build. Discovered and verified live 2026-07-20 during a
+  README/store screenshot session.
 - The `document_idle` WebSocket-patch race described above -- mitigated
   with a bounded poll on an observable effect (`window.WebSocket` no
   longer being native code), not a fixed sleep.

--- a/e2e/harness.ts
+++ b/e2e/harness.ts
@@ -90,12 +90,56 @@ const findGamePage = async (browser: Browser, fixtureOrigin: string): Promise<Pa
   return pages.find((p) => p.url().startsWith(fixtureOrigin))
 }
 
+/**
+ * Workaround for a headless Chrome for Testing compositor stall (observed on
+ * the pinned build, Chrome 151): once a page has been *idle* for a few
+ * minutes, the compositor stops producing on-demand frames, and every
+ * subsequent CDP `Page.captureScreenshot` hangs until protocol timeout --
+ * while `evaluate` on the same page keeps working fine. `--disable-gpu` does
+ * not help. An invisible, infinitely-running CSS animation keeps BeginFrames
+ * flowing so the stall never happens, and injecting it also *recovers* an
+ * already-stalled compositor (verified live: after injection, previously
+ * hanging screenshots all succeed). Idempotent per page (keyed on element
+ * id). Called on every harness-owned page at load time, and re-asserted
+ * before each `screenshot()` so it self-heals across page reloads and
+ * `attachHarness` sessions started by an older build. See e2e/README.md
+ * "Flaky bits".
+ */
+const COMPOSITOR_KEEPALIVE_ID = '__e2e-compositor-keepalive'
+
+const ensureCompositorKeepalive = async (page: Page): Promise<void> => {
+  await page.evaluate((id: string) => {
+    if (document.getElementById(id)) return
+    const style = document.createElement('style')
+    style.textContent =
+      `@keyframes ${id}-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }`
+    const el = document.createElement('div')
+    el.id = id
+    // 1x1px at the viewport corner, near-zero opacity: effectively invisible
+    // but NOT opacity:0 or offscreen -- the compositor may cull those,
+    // defeating the whole point of forcing continuous frame production.
+    el.style.cssText =
+      'position:fixed;top:0;left:0;width:1px;height:1px;opacity:0.01;' +
+      `pointer-events:none;animation:${id}-spin 1s linear infinite;`
+    const parent = document.body ?? document.documentElement
+    parent.appendChild(style)
+    parent.appendChild(el)
+  }, COMPOSITOR_KEEPALIVE_ID)
+}
+
 const buildHelpers = (browser: Browser, gamePage: Page): HarnessHelpers => {
   const withPage = (page?: Page): Page => page ?? gamePage
 
   const screenshot = async (path: string, page?: Page): Promise<string> => {
+    const target = withPage(page)
     mkdirSync(dirname(path), { recursive: true })
-    await withPage(page).screenshot({ path: path as `${string}.png`, fullPage: false })
+    // Re-assert the anti-stall animation right before capturing (idempotent,
+    // one cheap evaluate). This both prevents and *recovers from* the
+    // idle-compositor stall -- see ensureCompositorKeepalive. Best-effort:
+    // if the page is mid-navigation the screenshot below fails with its own,
+    // more useful error.
+    await ensureCompositorKeepalive(target).catch(() => {})
+    await target.screenshot({ path: path as `${string}.png`, fullPage: false })
     return path
   }
 
@@ -123,6 +167,10 @@ const buildHelpers = (browser: Browser, gamePage: Page): HarnessHelpers => {
     popupPage.on('pageerror', (err) => console.error('[popupPage pageerror]', err))
     onPageCreated?.(popupPage)
     await popupPage.goto(`chrome-extension://${extensionId}/dist/index.html`, { waitUntil: 'domcontentloaded' })
+    // Popup tabs are screenshotted directly (popupPage.screenshot) by
+    // smoke.ts / run.ts, bypassing the screenshot() helper's re-assert -- so
+    // install the anti-stall keepalive here at open time.
+    await ensureCompositorKeepalive(popupPage)
     return popupPage
   }
 
@@ -199,6 +247,10 @@ export const launchHarness = async (options: LaunchOptions = {}): Promise<Harnes
     gamePage.on('pageerror', (err) => console.error('[gamePage pageerror]', err))
 
     await gamePage.goto(fixtureServer.origin, { waitUntil: 'domcontentloaded' })
+    // Keep the compositor producing frames from the start so screenshots
+    // still work after the page idles for minutes (agent think-time between
+    // CLI commands) -- see ensureCompositorKeepalive.
+    await ensureCompositorKeepalive(gamePage)
   } catch (err) {
     await fixtureServer.close().catch(() => {})
     await launchedBrowser?.close().catch(() => {})


### PR DESCRIPTION
## Summary

Headless Chrome for Testing 151 stops producing on-demand compositor frames once a page has been **idle for a few minutes** — every subsequent CDP `Page.captureScreenshot` then hangs until protocol timeout, while `evaluate` on the same page keeps working (so the session looks healthy right up until the screenshot call). `--disable-gpu` does not help. This bit every exploratory `e2e/run.ts` session with agent think-time between CLI commands.

This PR permanently bakes in the workaround proven live in the 2026-07-20 README/store screenshot session: **inject an invisible 1x1px element with an infinite CSS animation**, which keeps BeginFrames flowing so the stall never happens — and, because injection also *recovers* an already-stalled compositor, re-asserting it before each capture self-heals page reloads and sessions started by an older build.

## Changes

- `e2e/harness.ts`: new `ensureCompositorKeepalive(page)` (idempotent, keyed on element id), installed at three points:
  - fixture-page load in `launchHarness`
  - popup open in `openPopup` (popup tabs are screenshotted directly via `popupPage.screenshot()` in smoke.ts/run.ts, bypassing the helper)
  - re-asserted before every `screenshot()` call (one cheap evaluate; covers `attachHarness` sessions and reloads)
- `e2e/README.md`: documented the stall + workaround under **Flaky bits / timing waits**

## Verification

- `npm run typecheck` green
- `npm test` green (702/702)
- `npm run e2e:smoke` green (6/6 checks)
- **Idle repro**: `run.ts launch` → keepalive element confirmed present via `eval` → baseline screenshot at t=0 → **5.5 min idle** → screenshot at t=330s succeeded (valid 1920x1080 PNG). Previously this exact sequence hung with a protocol timeout.

@codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)