### PR TITLE
fix(popup): eliminate white flash before first paint

### DIFF
--- a/esbuild.config.ts
+++ b/esbuild.config.ts
@@ -38,7 +38,13 @@ const options: BuildOptions = {
     'src/' + parse(content_script).name + '.ts',
     'src/' + parse(service_worker).name + '.ts',
     'src/' + parse(web_accessible_resource).name + '.ts',
-    'src/popup.ts'
+    'src/popup.ts',
+    // Tiny synchronous, non-module boot script loaded in index.html's
+    // <head> before popup.js -- see src/popup-boot.ts for why (eliminates
+    // the white-flash-before-paint bug, fix/popup-white-flash). Emitted as
+    // popup-boot.js alongside popup.js; no manifest change needed since
+    // it's referenced only from index.html, not `manifest.json`.
+    'src/popup-boot.ts'
   ],
   format: 'iife',
   logLevel: 'info',

--- a/src/components/popup/popup-boot-theme.test.ts
+++ b/src/components/popup/popup-boot-theme.test.ts
@@ -1,0 +1,52 @@
+import {
+  DARK_FELT_BACKGROUND,
+  MODERN_LIGHT_BACKGROUND,
+  POPUP_BOOT_LOCAL_STORAGE_KEY,
+  resolveBootBackgroundColor,
+} from './popup-boot-theme'
+import { getPopupTheme } from './theme'
+import { POPUP_THEME_LOCAL_STORAGE_KEY } from './popup-theme-storage'
+
+// popup-boot-theme.ts deliberately duplicates its color/key constants
+// instead of importing theme.ts / popup-theme-storage.ts (see its top
+// comment -- importing either would pull in MUI's createTheme() work the
+// boot script exists to run *before*). These two tests are the drift guard:
+// if theme.ts's colors or popup-theme-storage.ts's localStorage key ever
+// change without updating popup-boot-theme.ts to match, the white-flash fix
+// silently regresses -- fail loudly here instead.
+describe('popup-boot-theme drift guards', () => {
+  it('DARK_FELT_BACKGROUND stays in sync with theme.ts', () => {
+    expect(DARK_FELT_BACKGROUND).toBe(getPopupTheme('dark-felt').palette.background.default)
+  })
+
+  it('MODERN_LIGHT_BACKGROUND stays in sync with theme.ts', () => {
+    expect(MODERN_LIGHT_BACKGROUND).toBe(getPopupTheme('modern-light').palette.background.default)
+  })
+
+  it('POPUP_BOOT_LOCAL_STORAGE_KEY stays in sync with popup-theme-storage.ts', () => {
+    expect(POPUP_BOOT_LOCAL_STORAGE_KEY).toBe(POPUP_THEME_LOCAL_STORAGE_KEY)
+  })
+})
+
+describe('resolveBootBackgroundColor', () => {
+  it('明示的な dark 指定は OS のライト配色設定より優先される', () => {
+    expect(resolveBootBackgroundColor('dark', false)).toBe(DARK_FELT_BACKGROUND)
+  })
+
+  it('明示的な light 指定は OS のダーク配色設定より優先される', () => {
+    expect(resolveBootBackgroundColor('light', true)).toBe(MODERN_LIGHT_BACKGROUND)
+  })
+
+  it('未設定(null) + OSがダーク配色を優先 → ダークフェルトの背景色', () => {
+    expect(resolveBootBackgroundColor(null, true)).toBe(DARK_FELT_BACKGROUND)
+  })
+
+  it('未設定(null) + OSがライト配色を優先 → モダンライトの背景色', () => {
+    expect(resolveBootBackgroundColor(null, false)).toBe(MODERN_LIGHT_BACKGROUND)
+  })
+
+  it('壊れた/未知の値(auto以外の任意の文字列)は auto と同様にOS設定へフォールバックする', () => {
+    expect(resolveBootBackgroundColor('sepia', true)).toBe(DARK_FELT_BACKGROUND)
+    expect(resolveBootBackgroundColor('sepia', false)).toBe(MODERN_LIGHT_BACKGROUND)
+  })
+})

--- a/src/components/popup/popup-boot-theme.ts
+++ b/src/components/popup/popup-boot-theme.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure, dependency-free logic for `popup-boot.ts` (the synchronous,
+ * non-module boot script loaded in `index.html`'s `<head>` *before*
+ * `popup.js`, to paint the popup's correct background before the
+ * MUI+React bundle has even parsed -- see `popup-boot.ts` for the full
+ * white-flash rationale, and `fix/popup-white-flash`).
+ *
+ * Deliberately standalone: does NOT import `theme.ts` or
+ * `popup-theme-storage.ts`. `theme.ts` builds both full MUI themes
+ * (`createTheme()`) at module-scope import time, and
+ * `popup-theme-storage.ts` transitively imports `theme.ts` -- either would
+ * make importing this module pull in the same slow MUI/React work the boot
+ * script exists to run *before*, defeating the whole point of it being tiny
+ * and synchronous. The two hex values and the localStorage key name are
+ * therefore intentionally duplicated (in miniature) from theme.ts's
+ * `DARK_FELT.background` / `MODERN_LIGHT.background` and from
+ * `popup-theme-storage.ts`'s `POPUP_THEME_LOCAL_STORAGE_KEY`.
+ * `popup-boot-theme.test.ts` cross-checks both against their sources of
+ * truth so drift fails a test instead of silently reintroducing the flash.
+ */
+
+/** Keep in sync with `POPUP_THEME_LOCAL_STORAGE_KEY` in `popup-theme-storage.ts`. */
+export const POPUP_BOOT_LOCAL_STORAGE_KEY = 'popupThemeMode'
+
+/** Keep in sync with `DARK_FELT.background` in `theme.ts`. */
+export const DARK_FELT_BACKGROUND = '#0d1512'
+/** Keep in sync with `MODERN_LIGHT.background` in `theme.ts`. */
+export const MODERN_LIGHT_BACKGROUND = '#faf9f6'
+
+/**
+ * Mirrors `resolvePopupThemeVariant` in `theme.ts` (persisted mode + live OS
+ * signal -> which side), collapsed straight to the ground color since
+ * that's all the boot script needs (it never touches MUI theme objects).
+ */
+export const resolveBootBackgroundColor = (
+  storedMode: string | null,
+  prefersDarkScheme: boolean,
+): string => {
+  if (storedMode === 'dark') return DARK_FELT_BACKGROUND
+  if (storedMode === 'light') return MODERN_LIGHT_BACKGROUND
+  return prefersDarkScheme ? DARK_FELT_BACKGROUND : MODERN_LIGHT_BACKGROUND
+}

--- a/src/components/popup/popup-theme-storage.test.ts
+++ b/src/components/popup/popup-theme-storage.test.ts
@@ -1,4 +1,9 @@
-import { loadPopupThemeMode, savePopupThemeMode, POPUP_THEME_STORAGE_KEY } from './popup-theme-storage'
+import {
+  loadPopupThemeMode,
+  savePopupThemeMode,
+  POPUP_THEME_STORAGE_KEY,
+  POPUP_THEME_LOCAL_STORAGE_KEY,
+} from './popup-theme-storage'
 
 // global.chrome.storage.sync mock backed by src/test-setup.ts (chromeStorageMockData.sync),
 // reset between tests via chrome.storage.sync.remove.
@@ -6,6 +11,7 @@ import { loadPopupThemeMode, savePopupThemeMode, POPUP_THEME_STORAGE_KEY } from 
 describe('popup-theme-storage', () => {
   afterEach(async () => {
     await new Promise<void>((resolve) => chrome.storage.sync.remove(POPUP_THEME_STORAGE_KEY, () => resolve()))
+    window.localStorage.removeItem(POPUP_THEME_LOCAL_STORAGE_KEY)
   })
 
   it('未設定（新規インストール/移行前）は auto にフォールバックする', async () => {
@@ -37,5 +43,36 @@ describe('popup-theme-storage', () => {
     )
     expect(result[POPUP_THEME_STORAGE_KEY]).toBe('dark')
     expect(result.uiConfig).toBeUndefined()
+  })
+
+  describe('localStorage ミラー（popup-boot.ts が次回起動時に同期的に読む）', () => {
+    it('savePopupThemeMode は localStorage にも同じ値を書き込む', async () => {
+      await savePopupThemeMode('dark')
+      expect(window.localStorage.getItem(POPUP_THEME_LOCAL_STORAGE_KEY)).toBe('dark')
+
+      await savePopupThemeMode('light')
+      expect(window.localStorage.getItem(POPUP_THEME_LOCAL_STORAGE_KEY)).toBe('light')
+
+      await savePopupThemeMode('auto')
+      expect(window.localStorage.getItem(POPUP_THEME_LOCAL_STORAGE_KEY)).toBe('auto')
+    })
+
+    it('loadPopupThemeMode は chrome.storage.sync の値で localStorage をバックフィルする（例: 別デバイスからの同期）', async () => {
+      expect(window.localStorage.getItem(POPUP_THEME_LOCAL_STORAGE_KEY)).toBeNull()
+      await new Promise<void>((resolve) => chrome.storage.sync.set({ [POPUP_THEME_STORAGE_KEY]: 'light' }, () => resolve()))
+
+      await loadPopupThemeMode()
+
+      expect(window.localStorage.getItem(POPUP_THEME_LOCAL_STORAGE_KEY)).toBe('light')
+    })
+
+    it('壊れた/未知の値も auto として localStorage にバックフィルされる', async () => {
+      await new Promise<void>((resolve) => chrome.storage.sync.set({ [POPUP_THEME_STORAGE_KEY]: 'sepia' }, () => resolve()))
+
+      const mode = await loadPopupThemeMode()
+
+      expect(mode).toBe('auto')
+      expect(window.localStorage.getItem(POPUP_THEME_LOCAL_STORAGE_KEY)).toBe('auto')
+    })
   })
 })

--- a/src/components/popup/popup-theme-storage.ts
+++ b/src/components/popup/popup-theme-storage.ts
@@ -12,29 +12,70 @@
  * theme change. A dedicated key keeps the write popup-local, matching
  * `options-storage.ts`'s pattern of one flat `chrome.storage.sync` key per
  * independent concern.
+ *
+ * The mode is *also* mirrored to `localStorage` (same-origin, synchronous,
+ * readable before anything async resolves) so that `popup-boot.ts` -- a
+ * tiny synchronous script that runs before `popup.js` parses -- can paint
+ * the correct background for users who explicitly forced 'dark'/'light'
+ * against their OS scheme, closing the last gap in the white-flash fix (see
+ * `fix/popup-white-flash`). `chrome.storage.sync` stays the source of
+ * truth; `localStorage` is a best-effort read-side cache the boot script
+ * consults, never the other way around.
  */
 import type { PopupThemeMode } from './theme'
 import { DEFAULT_POPUP_THEME_MODE } from './theme'
 
 export const POPUP_THEME_STORAGE_KEY = 'popupTheme'
 
+/**
+ * Deliberately a different key name than `POPUP_THEME_STORAGE_KEY`, even
+ * though the two storages (`chrome.storage.sync` vs. `localStorage`) can't
+ * collide -- keeps it obvious at a glance which key belongs to which API.
+ * Keep in sync with `POPUP_BOOT_LOCAL_STORAGE_KEY` in `popup-boot-theme.ts`
+ * (that file is intentionally standalone and can't import this constant --
+ * see its top comment).
+ */
+export const POPUP_THEME_LOCAL_STORAGE_KEY = 'popupThemeMode'
+
 const isPopupThemeMode = (value: unknown): value is PopupThemeMode =>
   value === 'auto' || value === 'dark' || value === 'light'
 
 /**
+ * Best-effort mirror to `localStorage` for `popup-boot.ts` to read
+ * synchronously on the next popup open. Guarded: `localStorage` can throw
+ * (disabled storage, locked-down context) and that must never break the
+ * actual `chrome.storage.sync` persistence this mirrors.
+ */
+const mirrorPopupThemeModeToLocalStorage = (mode: PopupThemeMode): void => {
+  try {
+    window.localStorage.setItem(POPUP_THEME_LOCAL_STORAGE_KEY, mode)
+  } catch {
+    // localStorage unavailable/blocked -- popup-boot.ts just falls back to
+    // its CSS defaults next time; never worse than before this fix.
+  }
+}
+
+/**
  * Resolves with the persisted mode, or `DEFAULT_POPUP_THEME_MODE` ('auto')
  * if unset (fresh install) or malformed (defensive against corrupted sync
- * data / a future value this build doesn't know about).
+ * data / a future value this build doesn't know about). Also backfills the
+ * `localStorage` mirror on every load -- covers the case where the mode was
+ * never explicitly saved from *this* browser profile (e.g. it arrived via
+ * `chrome.storage.sync` from another device) so the mirror still exists in
+ * time for the boot script's next read.
  */
 export const loadPopupThemeMode = (): Promise<PopupThemeMode> =>
   new Promise((resolve) => {
     chrome.storage.sync.get(POPUP_THEME_STORAGE_KEY, (result: Record<string, unknown>) => {
       const value = result[POPUP_THEME_STORAGE_KEY]
-      resolve(isPopupThemeMode(value) ? value : DEFAULT_POPUP_THEME_MODE)
+      const mode = isPopupThemeMode(value) ? value : DEFAULT_POPUP_THEME_MODE
+      mirrorPopupThemeModeToLocalStorage(mode)
+      resolve(mode)
     })
   })
 
 export const savePopupThemeMode = (mode: PopupThemeMode): Promise<void> =>
   new Promise((resolve) => {
+    mirrorPopupThemeModeToLocalStorage(mode)
     chrome.storage.sync.set({ [POPUP_THEME_STORAGE_KEY]: mode }, () => resolve())
   })

--- a/src/components/popup/theme.ts
+++ b/src/components/popup/theme.ts
@@ -45,6 +45,15 @@ export const resolvePopupThemeVariant = (
 // HUDオーバーレイと世界観を統一: フェルト地の暗い背景 + ポーカーゴールドの
 // アクセント。HUDの統計色（青/オレンジ/赤）はここでは使わない
 // （このポップアップにスタッツ表示要素は無いため、意図的に持ち込まない）。
+//
+// NOTE: `background` below (and MODERN_LIGHT.background further down) is
+// duplicated in two other places, to eliminate the white-flash-before-paint
+// bug (see fix/popup-white-flash) without paying MUI's import/build cost
+// before first paint:
+//   - src/index.html's inline <style> (CSS-only, handles 'auto' mode)
+//   - src/components/popup/popup-boot-theme.ts (handles explicit dark/light
+//     overrides, via the tiny synchronous src/popup-boot.ts boot script)
+// Keep all three in sync by hand when these hex values change.
 const DARK_FELT = {
   background: '#0d1512',
   paper: '#16201b',

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,53 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <!-- Avoids a white scrollbar flash alongside the background fix below. -->
+    <meta name="color-scheme" content="dark light" />
     <title>PokerChase HUD</title>
+    <!--
+      Instant paint, before popup.js (a minified MUI+React bundle) has even
+      been fetched/parsed, and before the #145 defer-until-theme-loaded first
+      render -- without this, the popup window shows the browser's default
+      white background for ~0.5s on every open (see fix/popup-white-flash).
+
+      `html` carries the actual theme ground color; `body` stays transparent
+      so that color shows through underneath it. This CSS-only rule handles
+      'auto' mode (the default) via `prefers-color-scheme`. Users who
+      explicitly forced a mode that disagrees with their OS scheme are
+      handled by `popup-boot.js` below, which overrides `html`'s inline
+      style before popup.js runs once it knows the saved mode.
+
+      Colors are duplicated from DARK_FELT.background / MODERN_LIGHT.background
+      in src/components/popup/theme.ts -- keep in sync (see the comment
+      there, and in src/components/popup/popup-boot-theme.ts).
+    -->
+    <style>
+      html,
+      body {
+        margin: 0;
+      }
+      body {
+        width: 380px;
+        min-height: 400px;
+        background: transparent;
+      }
+      html {
+        background-color: #faf9f6; /* MODERN_LIGHT.background */
+      }
+      @media (prefers-color-scheme: dark) {
+        html {
+          background-color: #0d1512; /* DARK_FELT.background */
+        }
+      }
+    </style>
+    <!--
+      Deliberately non-module and loaded before popup.js: a tiny synchronous
+      script that reads the saved theme mode back out of localStorage (see
+      popup-theme-storage.ts) and, if it disagrees with the OS scheme,
+      overrides `html`'s background before anything else paints. See
+      popup-boot.ts for the full rationale.
+    -->
+    <script src="./popup-boot.js"></script>
   </head>
 
   <body>

--- a/src/popup-boot.ts
+++ b/src/popup-boot.ts
@@ -1,0 +1,34 @@
+/**
+ * Synchronous, non-module boot script -- loaded in `index.html`'s `<head>`
+ * BEFORE `popup.js` (see that file's script order) to eliminate the
+ * white-flash-before-first-paint bug: `popup.js` is a minified MUI+React
+ * bundle, and parsing/executing it -- plus the #145 defer-until-theme-loaded
+ * first `render()` in `popup.ts` -- takes long enough that the popup
+ * window's unstyled default white background is visible for ~0.5s on every
+ * open (see `fix/popup-white-flash`).
+ *
+ * `index.html`'s inline CSS already paints the right ground color for
+ * `auto` mode via `prefers-color-scheme`. This script exists only for the
+ * remaining gap: a user who explicitly forced 'dark' or 'light' while their
+ * OS scheme disagrees would otherwise still get one frame of the *other*
+ * theme's color (never white, but still wrong) before `popup.js` mounts
+ * React and applies the real MUI theme. It reads the mode mirrored to
+ * `localStorage` by `savePopupThemeMode` (see `popup-theme-storage.ts`) and,
+ * if set, overrides `documentElement`'s background immediately.
+ *
+ * Must stay tiny and side-effect-only: no MUI, no React, no chrome.* APIs.
+ * See `popup-boot-theme.ts` for why its constants are duplicated rather than
+ * imported from `theme.ts` / `popup-theme-storage.ts`.
+ */
+import { POPUP_BOOT_LOCAL_STORAGE_KEY, resolveBootBackgroundColor } from './components/popup/popup-boot-theme'
+
+try {
+  const storedMode = window.localStorage.getItem(POPUP_BOOT_LOCAL_STORAGE_KEY)
+  const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)').matches
+  document.documentElement.style.backgroundColor = resolveBootBackgroundColor(storedMode, prefersDarkScheme)
+} catch {
+  // localStorage / matchMedia unavailable or throwing (locked-down context,
+  // very old browser, etc.) -- leave index.html's CSS defaults
+  // (the `prefers-color-scheme` media query) in place. Never worse than
+  // before this fix.
+}


### PR DESCRIPTION
## Summary

Fixes the ~0.5s white rectangle sola reported when opening the popup. No external/network resources were involved (everything is bundled locally) — the flash was the popup window's default-white background showing during popup.js parse + the #145 deferred first render.

- **Instant CSS ground**: inline `<style>` in index.html (MV3 CSP allows inline style, not script) paints the theme ground color from the first frame — light `#faf9f6` by default, dark-felt `#0d1512` under `prefers-color-scheme: dark` — plus `color-scheme` meta so the scrollbar doesn't flash, fixed 380px body width to stop the resize jump.
- **Explicit-override correctness**: the saved theme mode is mirrored to `localStorage`; a 276-byte non-module boot script (`popup-boot.js`, same-origin so CSP-clean) loaded before popup.js resolves it synchronously and sets the background — so a user forced to light while their OS is dark (or vice versa) also never sees a wrong-color frame.
- Constants are duplicated by necessity in 3 places (theme.ts, index.html, boot resolver) — each carries a sync note, and a **drift-guard test** asserts they stay equal to `getPopupTheme().palette.background.default`.

## Verification

- Computed-style timeline via the harness (before/after using main's index.html against the same popup.js): pre-fix background stayed transparent (=white) until mount at t≈53ms; post-fix `#0d1512` at t≈1ms (auto+OS-dark); explicit-light-under-OS-dark corrected by the boot script at t≈3.4ms, during synchronous head parsing — before first paint. (Sub-frame screencast capture not attempted; ordering proof documented instead.)
- 759/759 tests ×2 (+11: boot resolver, localStorage mirror/backfill, drift guards); typecheck clean; smoke 6/6; `npm run build` emits popup-boot.js + updated index.html, manifest untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)