### PR TITLE
fix(popup): render before sync theme lookup

### DIFF
--- a/src/components/Popup.test.tsx
+++ b/src/components/Popup.test.tsx
@@ -181,6 +181,32 @@ describe('Popup', () => {
     expect(screen.getByRole('radio', { name: 'ダーク' })).toBeChecked()
   })
 
+  it('同期キャッシュのテーマで即時描画し、storage.syncの正本を描画後に反映する', async () => {
+    let resolveThemeRead: ((result: Record<string, any>) => void) | undefined
+    mockChromeStorageGet.mockImplementation((keys, callback) => {
+      if (keys === 'popupTheme') {
+        resolveThemeRead = callback
+        return
+      }
+      const keyList = Array.isArray(keys) ? keys : [keys]
+      callback(keyList.reduce((acc: Record<string, any>, key: string) => ({ ...acc, [key]: syncData[key] }), {}))
+    })
+
+    render(<Popup initialPopupThemeMode="light" />)
+
+    // The popup is usable before chrome.storage.sync answers.
+    expect(screen.getByRole('radio', { name: 'ライト' })).toBeChecked()
+    expect(resolveThemeRead).toBeDefined()
+
+    act(() => {
+      resolveThemeRead?.({ popupTheme: 'dark' })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: 'ダーク' })).toBeChecked()
+    })
+  })
+
   it('旧storageのuiConfigにhudDisplayMode/hudColorCodingキーが無いユーザーはコンパクト+カラーONで復元される（グレースフルなマイグレーション, #143）', async () => {
     syncData = {
       options: {

--- a/src/components/Popup.test.tsx
+++ b/src/components/Popup.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import Popup from './Popup'
 import { DEFAULT_UI_CONFIG } from '../types/hand-log'
 import { defaultStatDisplayConfigs } from '../stats'
+import { POPUP_THEME_LOCAL_STORAGE_KEY } from './popup/popup-theme-storage'
 
 // Mock chrome APIs
 const mockChromeRuntimeSendMessage = jest.fn()
@@ -74,6 +75,7 @@ describe('Popup', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    window.localStorage.removeItem(POPUP_THEME_LOCAL_STORAGE_KEY)
 
     // Default mock implementations: Popupはフラットな`options`キーを読む
     syncData = {
@@ -205,6 +207,33 @@ describe('Popup', () => {
     await waitFor(() => {
       expect(screen.getByRole('radio', { name: 'ダーク' })).toBeChecked()
     })
+  })
+
+  it('起動時のstorage.sync読込中に選んだテーマを古い応答で巻き戻さない', async () => {
+    let resolveThemeRead: ((result: Record<string, any>) => void) | undefined
+    mockChromeStorageGet.mockImplementation((keys, callback) => {
+      if (keys === 'popupTheme') {
+        resolveThemeRead = callback
+        return
+      }
+      const keyList = Array.isArray(keys) ? keys : [keys]
+      callback(keyList.reduce((acc: Record<string, any>, key: string) => ({ ...acc, [key]: syncData[key] }), {}))
+    })
+
+    render(<Popup initialPopupThemeMode="light" />)
+    expect(screen.getByRole('radio', { name: 'ライト' })).toBeChecked()
+
+    await userEvent.click(screen.getByRole('radio', { name: 'ダーク' }))
+    expect(screen.getByRole('radio', { name: 'ダーク' })).toBeChecked()
+    expect(window.localStorage.getItem(POPUP_THEME_LOCAL_STORAGE_KEY)).toBe('dark')
+
+    await act(async () => {
+      resolveThemeRead?.({ popupTheme: 'light' })
+      await Promise.resolve()
+    })
+
+    expect(screen.getByRole('radio', { name: 'ダーク' })).toBeChecked()
+    expect(window.localStorage.getItem(POPUP_THEME_LOCAL_STORAGE_KEY)).toBe('dark')
   })
 
   it('旧storageのuiConfigにhudDisplayMode/hudColorCodingキーが無いユーザーはコンパクト+カラーONで復元される（グレースフルなマイグレーション, #143）', async () => {

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -36,15 +36,16 @@ import { PopupHeader } from './popup/PopupHeader'
 import { SectionCard } from './popup/SectionCard'
 import type { PopupThemeMode } from './popup/theme'
 import { DEFAULT_POPUP_THEME_MODE, getPopupTheme, resolvePopupThemeVariant } from './popup/theme'
-import { POPUP_THEME_STORAGE_KEY, savePopupThemeMode } from './popup/popup-theme-storage'
+import { loadPopupThemeMode, savePopupThemeMode } from './popup/popup-theme-storage'
 
 export type { Options }
 
 export interface PopupProps {
   /**
-   * Pre-resolved `popupTheme` mode, read from `chrome.storage.sync` by
-   * `popup.ts` *before* the first `render()` call so the popup never paints
-   * with the wrong theme and then swaps (flash-of-wrong-theme). Left
+   * Synchronously cached `popupTheme` mode read from localStorage by
+   * `popup.ts` before the first render. The authoritative sync value is
+   * reconciled after mount, keeping async storage off the click-to-content
+   * critical path. Left
    * `undefined` in tests / any caller that renders `<Popup />` directly
    * (e.g. `Popup.test.tsx`), where it falls back to `DEFAULT_POPUP_THEME_MODE`
    * and gets reconciled from storage in the mount effect below like every
@@ -77,6 +78,21 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
   // (e.g. jsdom under Jest).
   const prefersDarkScheme = useMediaQuery('(prefers-color-scheme: dark)')
   const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Reconcile the synchronous startup hint with chrome.storage.sync after the
+  // first commit. Avoid setting an identical primitive so the common cached
+  // path does not cause another full popup render.
+  useEffect(() => {
+    let cancelled = false
+    loadPopupThemeMode().then((mode) => {
+      if (!cancelled) {
+        setPopupThemeMode((currentMode) => currentMode === mode ? currentMode : mode)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   // Firebase states
   const [isFirebaseSignedIn, setIsFirebaseSignedIn] = useState<boolean>(false)
@@ -196,21 +212,6 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
           })
         }
       })
-
-      // Load popupTheme (自動/ダーク/ライト) from chrome.storage.sync.
-      // Skipped when `initialPopupThemeMode` was already supplied by the
-      // caller (popup.ts pre-fetches it before the first render to avoid a
-      // flash-of-wrong-theme); this effect exists so `<Popup />` rendered
-      // directly (tests, or any future embedding) still picks up a
-      // persisted value on mount.
-      if (initialPopupThemeMode === undefined) {
-        chrome.storage.sync.get(POPUP_THEME_STORAGE_KEY, (result: Record<string, any>) => {
-          const value = result[POPUP_THEME_STORAGE_KEY]
-          if (value === 'auto' || value === 'dark' || value === 'light') {
-            setPopupThemeMode(value)
-          }
-        })
-      }
 
       // Load cached Firebase auth state first for instant rendering
       chrome.storage.local.get('firebaseAuthCache', (result: Record<string, any>) => {

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -36,7 +36,11 @@ import { PopupHeader } from './popup/PopupHeader'
 import { SectionCard } from './popup/SectionCard'
 import type { PopupThemeMode } from './popup/theme'
 import { DEFAULT_POPUP_THEME_MODE, getPopupTheme, resolvePopupThemeVariant } from './popup/theme'
-import { loadPopupThemeMode, savePopupThemeMode } from './popup/popup-theme-storage'
+import {
+  cachePopupThemeMode,
+  readSyncedPopupThemeMode,
+  savePopupThemeMode,
+} from './popup/popup-theme-storage'
 
 export type { Options }
 
@@ -78,14 +82,16 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
   // (e.g. jsdom under Jest).
   const prefersDarkScheme = useMediaQuery('(prefers-color-scheme: dark)')
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const popupThemeChangedByUserRef = useRef(false)
 
   // Reconcile the synchronous startup hint with chrome.storage.sync after the
   // first commit. Avoid setting an identical primitive so the common cached
   // path does not cause another full popup render.
   useEffect(() => {
     let cancelled = false
-    loadPopupThemeMode().then((mode) => {
-      if (!cancelled) {
+    readSyncedPopupThemeMode().then((mode) => {
+      if (!cancelled && !popupThemeChangedByUserRef.current) {
+        cachePopupThemeMode(mode)
         setPopupThemeMode((currentMode) => currentMode === mode ? currentMode : mode)
       }
     })
@@ -427,6 +433,10 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
   }
 
   const handlePopupThemeModeChange = (mode: PopupThemeMode) => {
+    // A pending startup read may contain the value from before this user
+    // action. Mark the local choice first so a late response cannot revert
+    // either the open popup or its local startup cache.
+    popupThemeChangedByUserRef.current = true
     setPopupThemeMode(mode)
     // Popup-only setting: persisted directly, no chrome.tabs broadcast (see
     // popup-theme-storage.ts -- unlike updateUIConfig, this must not

--- a/src/components/popup/popup-theme-storage.test.ts
+++ b/src/components/popup/popup-theme-storage.test.ts
@@ -1,4 +1,5 @@
 import {
+  loadCachedPopupThemeMode,
   loadPopupThemeMode,
   savePopupThemeMode,
   POPUP_THEME_STORAGE_KEY,
@@ -46,6 +47,22 @@ describe('popup-theme-storage', () => {
   })
 
   describe('localStorage ミラー（popup-boot.ts が次回起動時に同期的に読む）', () => {
+    it('初回描画では localStorage を同期的に読み、chrome.storage.sync を待たない', () => {
+      window.localStorage.setItem(POPUP_THEME_LOCAL_STORAGE_KEY, 'dark')
+      const syncGet = chrome.storage.sync.get as jest.Mock
+      const callsBefore = syncGet.mock.calls.length
+
+      expect(loadCachedPopupThemeMode()).toBe('dark')
+      expect(syncGet).toHaveBeenCalledTimes(callsBefore)
+    })
+
+    it('同期キャッシュが未設定または不正なら auto で即時描画できる', () => {
+      expect(loadCachedPopupThemeMode()).toBe('auto')
+
+      window.localStorage.setItem(POPUP_THEME_LOCAL_STORAGE_KEY, 'sepia')
+      expect(loadCachedPopupThemeMode()).toBe('auto')
+    })
+
     it('savePopupThemeMode は localStorage にも同じ値を書き込む', async () => {
       await savePopupThemeMode('dark')
       expect(window.localStorage.getItem(POPUP_THEME_LOCAL_STORAGE_KEY)).toBe('dark')

--- a/src/components/popup/popup-theme-storage.ts
+++ b/src/components/popup/popup-theme-storage.ts
@@ -64,7 +64,7 @@ export const loadCachedPopupThemeMode = (): PopupThemeMode => {
  * (disabled storage, locked-down context) and that must never break the
  * actual `chrome.storage.sync` persistence this mirrors.
  */
-const mirrorPopupThemeModeToLocalStorage = (mode: PopupThemeMode): void => {
+export const cachePopupThemeMode = (mode: PopupThemeMode): void => {
   try {
     window.localStorage.setItem(POPUP_THEME_LOCAL_STORAGE_KEY, mode)
   } catch {
@@ -72,6 +72,15 @@ const mirrorPopupThemeModeToLocalStorage = (mode: PopupThemeMode): void => {
     // its CSS defaults next time; never worse than before this fix.
   }
 }
+
+/** Read the authoritative synced value without mutating the startup cache. */
+export const readSyncedPopupThemeMode = (): Promise<PopupThemeMode> =>
+  new Promise((resolve) => {
+    chrome.storage.sync.get(POPUP_THEME_STORAGE_KEY, (result: Record<string, unknown>) => {
+      const value = result[POPUP_THEME_STORAGE_KEY]
+      resolve(isPopupThemeMode(value) ? value : DEFAULT_POPUP_THEME_MODE)
+    })
+  })
 
 /**
  * Resolves with the persisted mode, or `DEFAULT_POPUP_THEME_MODE` ('auto')
@@ -82,18 +91,14 @@ const mirrorPopupThemeModeToLocalStorage = (mode: PopupThemeMode): void => {
  * `chrome.storage.sync` from another device) so the mirror still exists in
  * time for the boot script's next read.
  */
-export const loadPopupThemeMode = (): Promise<PopupThemeMode> =>
-  new Promise((resolve) => {
-    chrome.storage.sync.get(POPUP_THEME_STORAGE_KEY, (result: Record<string, unknown>) => {
-      const value = result[POPUP_THEME_STORAGE_KEY]
-      const mode = isPopupThemeMode(value) ? value : DEFAULT_POPUP_THEME_MODE
-      mirrorPopupThemeModeToLocalStorage(mode)
-      resolve(mode)
-    })
-  })
+export const loadPopupThemeMode = async (): Promise<PopupThemeMode> => {
+  const mode = await readSyncedPopupThemeMode()
+  cachePopupThemeMode(mode)
+  return mode
+}
 
 export const savePopupThemeMode = (mode: PopupThemeMode): Promise<void> =>
   new Promise((resolve) => {
-    mirrorPopupThemeModeToLocalStorage(mode)
+    cachePopupThemeMode(mode)
     chrome.storage.sync.set({ [POPUP_THEME_STORAGE_KEY]: mode }, () => resolve())
   })

--- a/src/components/popup/popup-theme-storage.ts
+++ b/src/components/popup/popup-theme-storage.ts
@@ -14,13 +14,11 @@
  * independent concern.
  *
  * The mode is *also* mirrored to `localStorage` (same-origin, synchronous,
- * readable before anything async resolves) so that `popup-boot.ts` -- a
- * tiny synchronous script that runs before `popup.js` parses -- can paint
- * the correct background for users who explicitly forced 'dark'/'light'
- * against their OS scheme, closing the last gap in the white-flash fix (see
- * `fix/popup-white-flash`). `chrome.storage.sync` stays the source of
- * truth; `localStorage` is a best-effort read-side cache the boot script
- * consults, never the other way around.
+ * readable before anything async resolves). `popup-boot.ts` uses it to paint
+ * the correct background before `popup.js` parses, and `popup.ts` uses it as
+ * the first-render hint so chrome.storage.sync never blocks popup content.
+ * `chrome.storage.sync` stays the source of truth; `localStorage` is only a
+ * best-effort startup cache.
  */
 import type { PopupThemeMode } from './theme'
 import { DEFAULT_POPUP_THEME_MODE } from './theme'
@@ -39,6 +37,26 @@ export const POPUP_THEME_LOCAL_STORAGE_KEY = 'popupThemeMode'
 
 const isPopupThemeMode = (value: unknown): value is PopupThemeMode =>
   value === 'auto' || value === 'dark' || value === 'light'
+
+/**
+ * Returns the best theme hint available synchronously for the very first
+ * React render. The mirror is written whenever the authoritative
+ * `chrome.storage.sync` value is loaded or saved, so normal subsequent popup
+ * opens use the right theme without putting an async storage call on the
+ * click-to-content critical path.
+ *
+ * A missing/stale mirror is safe: callers render `auto` immediately and then
+ * reconcile with `loadPopupThemeMode()` after mount. `localStorage` is only a
+ * startup cache; `chrome.storage.sync` remains the source of truth.
+ */
+export const loadCachedPopupThemeMode = (): PopupThemeMode => {
+  try {
+    const value = window.localStorage.getItem(POPUP_THEME_LOCAL_STORAGE_KEY)
+    return isPopupThemeMode(value) ? value : DEFAULT_POPUP_THEME_MODE
+  } catch {
+    return DEFAULT_POPUP_THEME_MODE
+  }
+}
 
 /**
  * Best-effort mirror to `localStorage` for `popup-boot.ts` to read

--- a/src/index.html
+++ b/src/index.html
@@ -9,9 +9,9 @@
     <title>PokerChase HUD</title>
     <!--
       Instant paint, before popup.js (a minified MUI+React bundle) has even
-      been fetched/parsed, and before the #145 defer-until-theme-loaded first
-      render -- without this, the popup window shows the browser's default
-      white background for ~0.5s on every open (see fix/popup-white-flash).
+      been fetched/parsed or started its first render -- without this, the
+      popup window shows the browser's default white background while that
+      bundle initializes (see fix/popup-white-flash).
 
       `html` carries the actual theme ground color; `body` stays transparent
       so that color shows through underneath it. This CSS-only rule handles

--- a/src/popup-boot.ts
+++ b/src/popup-boot.ts
@@ -2,10 +2,9 @@
  * Synchronous, non-module boot script -- loaded in `index.html`'s `<head>`
  * BEFORE `popup.js` (see that file's script order) to eliminate the
  * white-flash-before-first-paint bug: `popup.js` is a minified MUI+React
- * bundle, and parsing/executing it -- plus the #145 defer-until-theme-loaded
- * first `render()` in `popup.ts` -- takes long enough that the popup
- * window's unstyled default white background is visible for ~0.5s on every
- * open (see `fix/popup-white-flash`).
+ * bundle, and parsing/executing it before the first `render()` takes long
+ * enough that the popup window's unstyled default white background can be
+ * visible while it initializes (see `fix/popup-white-flash`).
  *
  * `index.html`'s inline CSS already paints the right ground color for
  * `auto` mode via `prefers-color-scheme`. This script exists only for the

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,14 +1,12 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import Popup, { type PopupProps } from './components/Popup'
-import { loadPopupThemeMode } from './components/popup/popup-theme-storage'
+import { loadCachedPopupThemeMode } from './components/popup/popup-theme-storage'
 
-// Resolve the persisted popupTheme mode *before* the first render() call so
-// the popup never paints with the wrong theme and then swaps
-// (flash-of-wrong-theme). chrome.storage.sync reads are served from a local
-// cache and resolve well before anything would otherwise have painted,
-// since nothing is rendered yet at this point.
-loadPopupThemeMode().then((initialPopupThemeMode) => {
-  const root = createRoot(document.getElementById('popup-root')!)
-  root.render(React.createElement<PopupProps>(Popup, { initialPopupThemeMode }))
-})
+// Render synchronously from the local theme mirror. Waiting for
+// chrome.storage.sync here used to put an unbounded async callback directly
+// on the extension-icon-click -> first-content critical path. Popup reconciles
+// this startup hint with the authoritative sync value after mount.
+const initialPopupThemeMode = loadCachedPopupThemeMode()
+const root = createRoot(document.getElementById('popup-root')!)
+root.render(React.createElement<PopupProps>(Popup, { initialPopupThemeMode }))


### PR DESCRIPTION
## Summary

- render the popup immediately from its synchronous local theme mirror
- reconcile the authoritative `chrome.storage.sync` value after the first commit
- preserve a theme selected while startup reconciliation is still pending
- skip redundant theme state updates when the cached and synced values match
- add regression coverage for rendering before sync storage resolves and for late stale responses
- update startup comments to match the new critical path

## Root cause

`popup.ts` waited for `chrome.storage.sync.get` before calling `createRoot().render()`. That placed an unbounded asynchronous storage callback directly on the extension-icon click-to-content path, so storage latency was visible as popup startup delay.

## User impact

Popup content now starts rendering without waiting for sync storage. The synced setting remains the source of truth at startup, while a theme selected in the open popup takes precedence over a late startup response. The reported popup startup improvement was confirmed manually.

## Validation

- `npm test -- --runInBand` — 88 suites / 830 tests passed
- `npm run typecheck`
- `npm run build`
- `npm run e2e:smoke` — 6/6 checks passed
- 10 production popup opens — median FCP 96 ms

Head: `8eeaad79011e48917685da8767bfcfc1a28802a7`