### PR TITLE
fix(import): enforce operation exclusivity

### DIFF
--- a/src/background/message-router.operation-exclusivity.test.ts
+++ b/src/background/message-router.operation-exclusivity.test.ts
@@ -1,0 +1,79 @@
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import type { ChromeMessage, MessageResponse } from '../types/messages'
+import { clearImportSession, getCurrentImportSession } from './import-export'
+import { registerMessageRouter } from './message-router'
+import { setOperationState } from './operation-state'
+
+describe('message-router import operation exclusivity', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+  let listener: (
+    request: ChromeMessage,
+    sender: chrome.runtime.MessageSender,
+    sendResponse: (response: MessageResponse) => void
+  ) => boolean | void
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    service = new PokerChaseService({ db })
+    await service.ready
+    setOperationState({ type: 'idle' })
+    clearImportSession()
+
+    ;(chrome.runtime.onMessage.addListener as jest.Mock).mockClear()
+    registerMessageRouter(service, db, 'https://example.com/*')
+    listener = (chrome.runtime.onMessage.addListener as jest.Mock).mock.calls[0][0]
+  })
+
+  afterEach(async () => {
+    setOperationState({ type: 'idle' })
+    clearImportSession()
+    jest.restoreAllMocks()
+    db.close()
+    await db.delete()
+  })
+
+  test('rejects a direct import while another operation is active', () => {
+    const setBatchMode = jest.spyOn(service, 'setBatchMode')
+    const sendResponse = jest.fn()
+    setOperationState({ type: 'export', format: 'json' })
+
+    const handled = listener({ action: 'importData', data: '{}' }, {}, sendResponse)
+
+    expect(handled).toBe(true)
+    expect(sendResponse).toHaveBeenCalledWith({ success: false, error: '別の処理が実行中です' })
+    expect(setBatchMode).not.toHaveBeenCalled()
+  })
+
+  test('rejects chunk-session initialization while another operation is active', () => {
+    const sendResponse = jest.fn()
+    setOperationState({ type: 'rebuild' })
+
+    listener({ action: 'importDataInit', totalChunks: 1, fileName: 'data.ndjson' }, {}, sendResponse)
+
+    expect(sendResponse).toHaveBeenCalledWith({ success: false, error: '別の処理が実行中です' })
+    expect(getCurrentImportSession()).toBeNull()
+  })
+
+  test('preserves a completed chunk session when processing is blocked', () => {
+    listener(
+      { action: 'importDataInit', totalChunks: 1, fileName: 'data.ndjson' },
+      {},
+      jest.fn()
+    )
+    listener(
+      { action: 'importDataChunk', chunkIndex: 0, chunkData: '{}' },
+      {},
+      jest.fn()
+    )
+    setOperationState({ type: 'export', format: 'pokerstars' })
+    const sendResponse = jest.fn()
+
+    listener({ action: 'importDataProcess' }, {}, sendResponse)
+
+    expect(sendResponse).toHaveBeenCalledWith({ success: false, error: '別の処理が実行中です' })
+    expect(getCurrentImportSession()?.chunks).toEqual(['{}'])
+  })
+})

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -58,14 +58,18 @@ const handleFirebaseSignOut = async (): Promise<void> => {
 export const registerMessageRouter = (service: PokerChaseService, db: PokerChaseDB, gameUrlPattern: string): void => {
   const { exportData, importData, deleteAllData, getLatestSessionStats, rebuildAllData } = createImportExportHandlers(service, db, gameUrlPattern)
 
+  const rejectIfOperationBusy = (action: string, sendResponse: (response: MessageResponse) => void): boolean => {
+    if (isOperationIdle()) return false
+
+    console.warn(`[${action}] Blocked: operation already in progress (${getOperationState().type})`)
+    sendResponse({ success: false, error: '別の処理が実行中です' })
+    return true
+  }
+
   chrome.runtime.onMessage.addListener((request: ChromeMessage, sender: chrome.runtime.MessageSender, sendResponse: (response: MessageResponse) => void) => {
     if (request.action === 'exportData') {
       // Block concurrent operations
-      if (!isOperationIdle()) {
-        console.warn(`[exportData] Blocked: operation already in progress (${getOperationState().type})`)
-        sendResponse({ success: false, error: '別の処理が実行中です' })
-        return true
-      }
+      if (rejectIfOperationBusy('exportData', sendResponse)) return true
       exportData(request.format)
         .then(() => sendResponse({ success: true }))
         .catch(error => {
@@ -74,6 +78,7 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
         })
       return true // 非同期レスポンスを示す
     } else if (request.action === 'importData') {
+      if (rejectIfOperationBusy('importData', sendResponse)) return true
       importData(request.data)
         .then((result) => {
           chrome.runtime.sendMessage<ImportStatusMessage>({
@@ -92,6 +97,7 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
         })
       return true // 非同期レスポンスを示す
     } else if (request.action === 'importDataInit') {
+      if (rejectIfOperationBusy('importDataInit', sendResponse)) return true
       startImportSession(request.totalChunks, request.fileName)
       sendResponse({ success: true })
       return true
@@ -111,6 +117,8 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
         sendResponse({ success: false, error: 'Import session incomplete' })
         return true
       }
+
+      if (rejectIfOperationBusy('importDataProcess', sendResponse)) return true
 
       // すべてのチャンクを結合
       const completeData = currentImportSession.chunks.join('')


### PR DESCRIPTION
## Summary

- Reject direct imports while another long-running operation is active.
- Reject chunk-session initialization while busy.
- Preserve completed chunk sessions when processing is blocked so callers can retry.

## Validation

- npm run typecheck
- npm test -- --runInBand (89 suites, 833 tests)
- npm run build

Head SHA: e92c496880c27f4649663b6b45ce0ee6275dbb9d