### PR TITLE
fix(export): replace inert offscreen keepalive

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,6 @@
     "tabs",
     "notifications",
     "identity",
-    "offscreen",
     "alarms"
   ],
   "host_permissions": [

--- a/offscreen.html
+++ b/offscreen.html
@@ -1,1 +1,0 @@
-<!-- Keep service worker alive during batch export -->

--- a/src/background/import-export.keepalive.test.ts
+++ b/src/background/import-export.keepalive.test.ts
@@ -1,0 +1,23 @@
+import { startKeepAlive } from './import-export'
+
+describe('export service-worker keepalive', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    chrome.runtime.getPlatformInfo = jest.fn().mockResolvedValue({})
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  test('calls an Extension API before the 30-second idle timeout and stops cleanly', async () => {
+    const stop = await startKeepAlive()
+
+    jest.advanceTimersByTime(25000)
+    expect(chrome.runtime.getPlatformInfo).toHaveBeenCalledTimes(1)
+
+    stop()
+    jest.advanceTimersByTime(50000)
+    expect(chrome.runtime.getPlatformInfo).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -460,6 +460,7 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
 
       if (!handHistory) {
         console.error('No hands found to export')
+        stopKeepAlive()
         setOperationState({ type: 'idle' })
         chrome.runtime.sendMessage<ExportProgressMessage>({
           action: 'exportProgress',
@@ -788,30 +789,12 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
 /**
  * Service Worker のアイドル停止を防止するキープアライブを開始する。
  * Chrome MV3 では 30 秒のアイドル後に Worker が停止されるため、
- * 長時間のバッチ処理中は chrome.offscreen API でオフスクリーン
- * ドキュメントを作成して Worker を維持する。
- *
- * offscreen ドキュメントが存在する間、Worker は停止されない。
+ * 長時間のバッチ処理中は30秒未満の間隔でExtension APIを呼び出す。
+ * Chrome 110以降はExtension API呼び出しがService Workerのアイドル
+ * タイマーをリセットする。manifestのminimum_chrome_versionは120。
  * @returns クリーンアップ関数
  */
-const startKeepAlive = async (): Promise<() => void> => {
-  // offscreen API が利用可能な場合はそれを使用（Chrome 109+）
-  if (chrome.offscreen) {
-    try {
-      await chrome.offscreen.createDocument({
-        url: 'offscreen.html',
-        reasons: [chrome.offscreen.Reason.BLOBS],
-        justification: 'Keep service worker alive during batch export'
-      })
-    } catch (e) {
-      // 既に存在する場合は無視
-    }
-    return () => {
-      chrome.offscreen.closeDocument().catch(() => {})
-    }
-  }
-
-  // フォールバック: setInterval + getPlatformInfo
+export const startKeepAlive = async (): Promise<() => void> => {
   const id = setInterval(() => {
     chrome.runtime.getPlatformInfo().catch(() => {})
   }, 25000)


### PR DESCRIPTION
## Summary

- Replace the inert offscreen document with periodic Extension API calls supported by Chrome 120.
- Remove the unused offscreen permission and unbundled HTML file.
- Stop the keepalive timer when PokerStars export has no hands.

## Validation

- npm run typecheck
- npm test -- --runInBand (89 suites, 831 tests)
- npm run build
- Inspected extension.zip contents

Head SHA: d299029398f34520a96064a4ae151cf20eae2461