### PR TITLE
fix(content): restore background port after disconnect

### DIFF
--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -13,6 +13,7 @@ import App from './components/App'
 import type { ChromeMessage } from './types/messages'
 import { MESSAGE_ACTIONS as EVENTS } from './types/messages'
 import type { AllPlayersRealTimeStats } from './realtime-stats/realtime-stats-service'
+import { RuntimePortManager } from './utils/runtime-port-manager'
 /** !!! BACKGROUND、WEB_ACCESSIBLE_RESOURCES からインポートしないこと !!! */
 
 const RECONNECT_DELAY_MS = 500
@@ -33,41 +34,6 @@ declare global {
     [POKER_CHASE_SERVICE_EVENT]: CustomEvent<StatsData>
   }
 }
-
-const connectToBackgroundService = () => {
-  try {
-    const port = chrome.runtime.connect({ name: POKER_CHASE_SERVICE_EVENT })
-
-    // 接続成功時、ゲーム中ならキープアライブを開始
-    if (isGameActive) {
-      startKeepalive(port)
-    }
-
-    port.onMessage.addListener((message: { stats: PlayerStats[], evtDeal?: ApiEvent<ApiType.EVT_DEAL>, realTimeStats?: AllPlayersRealTimeStats } | string) => {
-      if (typeof message === 'object' && message !== null && 'stats' in message) {
-        console.time('[content_script] Dispatching stats event')
-        window.dispatchEvent(new CustomEvent(POKER_CHASE_SERVICE_EVENT, { detail: message }))
-        console.timeEnd('[content_script] Dispatching stats event')
-        if (message.realTimeStats) {
-          console.log('[content_script] Real-time stats received:', Object.keys(message.realTimeStats))
-        }
-      }
-    })
-    port.onDisconnect.addListener(() => {
-      // 切断時にキープアライブを停止
-      stopKeepalive()
-      // 再接続を試みる
-      setTimeout(connectToBackgroundService, RECONNECT_DELAY_MS)
-    })
-    return port
-  } catch (e) {
-    // 拡張機能のコンテキストが無効な場合は、少し待ってから再試行
-    setTimeout(connectToBackgroundService, RECONNECT_DELAY_MS)
-    return null as any
-  }
-}
-
-let port = connectToBackgroundService()
 
 // キープアライブ管理
 const startKeepalive = (port: chrome.runtime.Port | null) => {
@@ -97,6 +63,37 @@ const stopKeepalive = () => {
   }
 }
 
+const portManager = new RuntimePortManager({
+  connect: () => chrome.runtime.connect({ name: POKER_CHASE_SERVICE_EVENT }),
+  reconnectDelayMs: RECONNECT_DELAY_MS,
+  onConnected: port => {
+    if (isGameActive) startKeepalive(port)
+  },
+  onDisconnected: stopKeepalive,
+  onMessage: message => {
+    if (typeof message === 'object' && message !== null && 'stats' in message) {
+      const statsMessage = message as {
+        stats: PlayerStats[]
+        evtDeal?: ApiEvent<ApiType.EVT_DEAL>
+        realTimeStats?: AllPlayersRealTimeStats
+      }
+      console.time('[content_script] Dispatching stats event')
+      window.dispatchEvent(new CustomEvent(POKER_CHASE_SERVICE_EVENT, { detail: statsMessage }))
+      console.timeEnd('[content_script] Dispatching stats event')
+      if (statsMessage.realTimeStats) {
+        console.log('[content_script] Real-time stats received:', Object.keys(statsMessage.realTimeStats))
+      }
+    }
+  },
+  onSendError: error => {
+    if (error instanceof Error && error.message === 'Extension context invalidated.') {
+      window.location.reload()
+    }
+  }
+})
+
+portManager.connect()
+
 // window.postMessageはさまざまなソースからのメッセージを受信する可能性がある
 window.addEventListener('message', (event: MessageEvent<unknown>) => {
   // 全ての条件を統合してチェック
@@ -119,7 +116,7 @@ window.addEventListener('message', (event: MessageEvent<unknown>) => {
       // セッション開始
       if (!isGameActive) {
         isGameActive = true
-        startKeepalive(port)
+        startKeepalive(portManager.port)
       }
       break
 
@@ -132,30 +129,16 @@ window.addEventListener('message', (event: MessageEvent<unknown>) => {
       break
   }
 
-  if (!port) {
-    // ポートが無効な場合は再接続を試みる
-    port = connectToBackgroundService()
-    return
-  }
-
-  try {
-    port.postMessage(event.data)
-  } catch (error: unknown) {
-    if (error instanceof Error && error.message === 'Extension context invalidated.') {
-      // 拡張機能が更新または無効化された場合は静かにリロード
-      window.location.reload()
-    }
-    // その他のエラーも静かに処理（コンソールに出力しない）
-  }
+  portManager.send(event.data)
 })
 
 // Cleanup on window unload
 window.addEventListener('beforeunload', () => {
   stopKeepalive()
   // Disconnect port gracefully
-  if (port) {
+  if (portManager.port) {
     try {
-      port.disconnect()
+      portManager.disconnect()
     } catch (e) {
       // ポートが既に切断されている可能性があるため、エラーは静かに無視
     }
@@ -167,9 +150,9 @@ document.addEventListener('visibilitychange', () => {
   if (document.hidden) {
     // Tab is hidden, stop keepalive to save resources
     stopKeepalive()
-  } else if (isGameActive && port) {
+  } else if (isGameActive && portManager.port) {
     // Tab is visible again and game is active, restart keepalive
-    startKeepalive(port)
+    startKeepalive(portManager.port)
   }
 })
 

--- a/src/utils/runtime-port-manager.test.ts
+++ b/src/utils/runtime-port-manager.test.ts
@@ -1,0 +1,72 @@
+import { RuntimePortManager } from './runtime-port-manager'
+
+const createPort = () => {
+  let disconnectListener: (() => void) | undefined
+  const port = {
+    onMessage: { addListener: jest.fn() },
+    onDisconnect: {
+      addListener: jest.fn((listener: () => void) => {
+        disconnectListener = listener
+      })
+    },
+    postMessage: jest.fn(),
+    disconnect: jest.fn()
+  } as unknown as chrome.runtime.Port
+
+  return {
+    port,
+    disconnect: () => disconnectListener?.()
+  }
+}
+
+describe('RuntimePortManager', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  test('stores the replacement Port after a disconnect', () => {
+    const first = createPort()
+    const second = createPort()
+    const connect = jest.fn()
+      .mockReturnValueOnce(first.port)
+      .mockReturnValueOnce(second.port)
+    const manager = new RuntimePortManager({ connect, reconnectDelayMs: 500 })
+
+    manager.connect()
+    first.disconnect()
+    jest.advanceTimersByTime(500)
+    manager.send({ ApiTypeId: 1 })
+
+    expect(connect).toHaveBeenCalledTimes(2)
+    expect(first.port.postMessage).not.toHaveBeenCalled()
+    expect(second.port.postMessage).toHaveBeenCalledWith({ ApiTypeId: 1 })
+  })
+
+  test('connects and forwards the triggering message when no Port is active', () => {
+    const replacement = createPort()
+    const manager = new RuntimePortManager({
+      connect: () => replacement.port,
+      reconnectDelayMs: 500
+    })
+
+    expect(manager.send({ ApiTypeId: 2 })).toBe(true)
+    expect(replacement.port.postMessage).toHaveBeenCalledWith({ ApiTypeId: 2 })
+  })
+
+  test('does not reconnect after an intentional disconnect', () => {
+    const current = createPort()
+    const connect = jest.fn(() => current.port)
+    const manager = new RuntimePortManager({ connect, reconnectDelayMs: 500 })
+
+    manager.connect()
+    manager.disconnect()
+    current.disconnect()
+    jest.advanceTimersByTime(500)
+
+    expect(connect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/utils/runtime-port-manager.ts
+++ b/src/utils/runtime-port-manager.ts
@@ -1,0 +1,89 @@
+interface RuntimePortManagerOptions {
+  connect: () => chrome.runtime.Port
+  reconnectDelayMs: number
+  onConnected?: (port: chrome.runtime.Port) => void
+  onDisconnected?: () => void
+  onMessage?: (message: unknown) => void
+  onSendError?: (error: unknown) => void
+}
+
+/**
+ * Owns a runtime Port across service-worker restarts.
+ *
+ * The manager, rather than a caller-local callback, stores every replacement
+ * Port so future messages never keep targeting a disconnected instance.
+ */
+export class RuntimePortManager {
+  private activePort: chrome.runtime.Port | null = null
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+
+  constructor(private readonly options: RuntimePortManagerOptions) {}
+
+  get port(): chrome.runtime.Port | null {
+    return this.activePort
+  }
+
+  connect(): chrome.runtime.Port | null {
+    if (this.activePort) return this.activePort
+
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+
+    try {
+      const port = this.options.connect()
+      this.activePort = port
+
+      port.onMessage.addListener(message => this.options.onMessage?.(message))
+      port.onDisconnect.addListener(() => this.handleDisconnect(port))
+      this.options.onConnected?.(port)
+      return port
+    } catch {
+      this.scheduleReconnect()
+      return null
+    }
+  }
+
+  send(message: unknown): boolean {
+    const port = this.activePort ?? this.connect()
+    if (!port) return false
+
+    try {
+      port.postMessage(message)
+      return true
+    } catch (error) {
+      this.handleDisconnect(port)
+      this.options.onSendError?.(error)
+      return false
+    }
+  }
+
+  disconnect(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+
+    const port = this.activePort
+    this.activePort = null
+    if (port) port.disconnect()
+  }
+
+  private handleDisconnect(port: chrome.runtime.Port): void {
+    if (this.activePort !== port) return
+
+    this.activePort = null
+    this.options.onDisconnected?.()
+    this.scheduleReconnect()
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimer) return
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      this.connect()
+    }, this.options.reconnectDelayMs)
+  }
+}


### PR DESCRIPTION
## Summary

- Store replacement runtime Ports in a dedicated connection manager.
- Reconnect after service-worker disconnects without retaining the stale Port.
- Forward the event that triggered an on-demand reconnect.

## Validation

- npm run typecheck
- npm test -- --runInBand (89 suites, 833 tests)
- npm run build

Head SHA: 457042177e5875db15e2d641222a592fd8bc8802