### PR TITLE
fix(import): always exit batch mode

### DIFF
--- a/src/background/import-export.cleanup.test.ts
+++ b/src/background/import-export.cleanup.test.ts
@@ -1,0 +1,36 @@
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { createImportExportHandlers } from './import-export'
+import { getOperationState, setOperationState } from './operation-state'
+
+describe('importData cleanup', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    service = new PokerChaseService({ db })
+    await service.ready
+    setOperationState({ type: 'idle' })
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    db.close()
+    await db.delete()
+  })
+
+  test('disables batch mode before returning to idle when an import fails', async () => {
+    const setBatchMode = jest.spyOn(service, 'setBatchMode')
+    ;(chrome.runtime.sendMessage as jest.Mock).mockImplementation(() => {
+      throw new Error('runtime unavailable')
+    })
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+
+    await expect(handlers.importData('not-json')).rejects.toThrow('runtime unavailable')
+
+    expect(setBatchMode.mock.calls).toEqual([[true], [false]])
+    expect(getOperationState()).toEqual({ type: 'idle' })
+  })
+})

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -70,6 +70,7 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
    * @returns Object containing import statistics
    */
   const importData = async (jsonlData: string): Promise<{ successCount: number, totalLines: number, duplicateCount: number }> => {
+    let batchModeEnabled = false
     try {
       setOperationState({ type: 'import', progress: 0 })
       console.log('[importData] Starting optimized import process with direct entity generation')
@@ -95,6 +96,7 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
 
       // バッチモードを有効化
       service.setBatchMode(true)
+      batchModeEnabled = true
 
       // 直接エンティティ生成用のイベントを収集
       const allNewEvents: ApiEvent[] = []
@@ -293,9 +295,6 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
         console.log('[importData] No new events to process')
       }
 
-      // バッチモードを無効化
-      service.setBatchMode(false)
-
       // インポート後に統計を強制的に更新
       // 最新のEVT_DEALを取得して統計計算をトリガー
       const latestDealEvent = await findLatestPlayerDealEvent(db)
@@ -329,13 +328,15 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
         }
       }
 
-      setOperationState({ type: 'idle' })
       return { successCount, totalLines: lines.length, duplicateCount }
 
     } catch (error) {
-      setOperationState({ type: 'idle' })
       console.error('Import error:', error)
       throw error
+    } finally {
+      // Every exit path must restore live processing before advertising idle.
+      if (batchModeEnabled) service.setBatchMode(false)
+      setOperationState({ type: 'idle' })
     }
   }
 


### PR DESCRIPTION
## Summary

- Restore batch mode in finally for every import exit path.
- Restore live processing before publishing the idle operation state.
- Cover a runtime failure after batch mode is enabled.

## Validation

- npm run typecheck
- npm test -- --runInBand (89 suites, 831 tests)
- npm run build

Head SHA: ccfd73db32d1d9ef771540e6d09889923d8ae11b