### PR TITLE
fix(import): surface rejected import requests

### DIFF
--- a/src/components/popup/ImportExportSection.test.tsx
+++ b/src/components/popup/ImportExportSection.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useRef, useState } from 'react'
 import userEvent from '@testing-library/user-event'
 import { ImportExportSection } from './ImportExportSection'
 import { REBUILD_ADVISORY_STORAGE_KEY } from '../../background/rebuild-advisory'
@@ -21,6 +22,20 @@ const defaultProps = {
   setImportDuplicates: noop,
   setImportSuccess: noop,
   setImportStartTime: noop,
+}
+
+const ImportStatusHarness = () => {
+  const [importStatus, setImportStatus] = useState('')
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  return (
+    <ImportExportSection
+      {...defaultProps}
+      importStatus={importStatus}
+      fileInputRef={fileInputRef}
+      setImportStatus={setImportStatus}
+    />
+  )
 }
 
 describe('ImportExportSection - rebuild advisory banner', () => {
@@ -121,7 +136,7 @@ describe('ImportExportSection - rebuild advisory banner', () => {
     await screen.findByText(/データ再構築」を実行してください/)
 
     // Simulate resolveAdvisory() writing storage while the popup is open
-    emitStorageChange({ acknowledgedVersion: 1 })
+    act(() => emitStorageChange({ acknowledgedVersion: 1 }))
 
     await waitFor(() => {
       expect(screen.queryByText(/データ再構築」を実行してください/)).not.toBeInTheDocument()
@@ -129,7 +144,6 @@ describe('ImportExportSection - rebuild advisory banner', () => {
   })
 
   it('stops chunk upload and shows the background error when import initialization is rejected', async () => {
-    const setImportStatus = jest.fn()
     mockSendMessage.mockImplementation((message: { action?: string }, callback?: (response: unknown) => void) => {
       if (typeof callback === 'function') {
         callback({})
@@ -141,17 +155,25 @@ describe('ImportExportSection - rebuild advisory banner', () => {
       return Promise.resolve({ success: true })
     })
 
-    const { container } = render(
-      <ImportExportSection {...defaultProps} setImportStatus={setImportStatus} />
-    )
+    const { container } = render(<ImportStatusHarness />)
+    const handleRuntimeMessage = (chrome.runtime.onMessage.addListener as jest.Mock).mock.calls[0][0]
+    act(() => {
+      handleRuntimeMessage({
+        action: 'exportProgress',
+        state: 'completed',
+        format: 'json',
+        message: 'エクスポート完了'
+      })
+    })
+    expect(screen.getByText('エクスポート完了')).toBeInTheDocument()
+
     const input = container.querySelector('input[type="file"]') as HTMLInputElement
     const file = new File(['{}'], 'data.ndjson', { type: 'application/x-ndjson' })
 
     fireEvent.change(input, { target: { files: [file] } })
 
-    await waitFor(() => {
-      expect(setImportStatus).toHaveBeenCalledWith('インポート失敗: 別の処理が実行中です')
-    })
+    expect(await screen.findByText('インポート失敗: 別の処理が実行中です')).toBeInTheDocument()
+    expect(screen.queryByText('エクスポート完了')).not.toBeInTheDocument()
     const actions = mockSendMessage.mock.calls.map(([message]) => message.action)
     expect(actions).toContain('importDataInit')
     expect(actions).not.toContain('importDataChunk')

--- a/src/components/popup/ImportExportSection.test.tsx
+++ b/src/components/popup/ImportExportSection.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ImportExportSection } from './ImportExportSection'
 import { REBUILD_ADVISORY_STORAGE_KEY } from '../../background/rebuild-advisory'
@@ -126,5 +126,35 @@ describe('ImportExportSection - rebuild advisory banner', () => {
     await waitFor(() => {
       expect(screen.queryByText(/データ再構築」を実行してください/)).not.toBeInTheDocument()
     })
+  })
+
+  it('stops chunk upload and shows the background error when import initialization is rejected', async () => {
+    const setImportStatus = jest.fn()
+    mockSendMessage.mockImplementation((message: { action?: string }, callback?: (response: unknown) => void) => {
+      if (typeof callback === 'function') {
+        callback({})
+        return undefined
+      }
+      if (message.action === 'importDataInit') {
+        return Promise.resolve({ success: false, error: '別の処理が実行中です' })
+      }
+      return Promise.resolve({ success: true })
+    })
+
+    const { container } = render(
+      <ImportExportSection {...defaultProps} setImportStatus={setImportStatus} />
+    )
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File(['{}'], 'data.ndjson', { type: 'application/x-ndjson' })
+
+    fireEvent.change(input, { target: { files: [file] } })
+
+    await waitFor(() => {
+      expect(setImportStatus).toHaveBeenCalledWith('インポート失敗: 別の処理が実行中です')
+    })
+    const actions = mockSendMessage.mock.calls.map(([message]) => message.action)
+    expect(actions).toContain('importDataInit')
+    expect(actions).not.toContain('importDataChunk')
+    expect(actions).not.toContain('importDataProcess')
   })
 })

--- a/src/components/popup/ImportExportSection.tsx
+++ b/src/components/popup/ImportExportSection.tsx
@@ -257,6 +257,7 @@ export const ImportExportSection = ({
       setImportTotal(0)
       setImportDuplicates(0)
       setImportSuccess(0)
+      setOperationStatus('')
       setImportStatus('インポート開始...')
       setImportStartTime(Date.now())
 
@@ -308,6 +309,7 @@ export const ImportExportSection = ({
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
+      setOperationStatus('')
       setImportStatus(`インポート失敗: ${message}`)
       setImportProgress(0)
       if (fileInputRef.current) {

--- a/src/components/popup/ImportExportSection.tsx
+++ b/src/components/popup/ImportExportSection.tsx
@@ -13,6 +13,7 @@ import type {
   ImportDataChunkMessage,
   ImportDataInitMessage,
   ImportDataProcessMessage,
+  MessageResponse,
   RebuildProgressMessage,
 } from '../../types/messages'
 import { isExportProgressMessage, isRebuildProgressMessage } from '../../types/messages'
@@ -38,6 +39,15 @@ interface ImportExportSectionProps {
 }
 
 const FILE_CHUNK_SIZE = 5 * 1024 * 1024 // 5MB chunks for file import
+
+const requireSuccessfulResponse = (
+  response: MessageResponse | undefined,
+  fallbackMessage: string
+): void => {
+  if (!response?.success) {
+    throw new Error(response?.error || fallbackMessage)
+  }
+}
 
 type ExportState = 'idle' | 'exporting'
 type RebuildState = 'idle' | 'rebuilding'
@@ -254,11 +264,12 @@ export const ImportExportSection = ({
       const totalChunks = Math.ceil(file.size / FILE_CHUNK_SIZE)
 
       // Initialize import session
-      await chrome.runtime.sendMessage<ImportDataInitMessage>({
+      const initResponse = await chrome.runtime.sendMessage({
         action: 'importDataInit',
         totalChunks: totalChunks,
         fileName: file.name
-      })
+      } satisfies ImportDataInitMessage) as MessageResponse | undefined
+      requireSuccessfulResponse(initResponse, 'インポートを開始できませんでした')
 
       // Read and send file in chunks
       for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
@@ -274,11 +285,12 @@ export const ImportExportSection = ({
         })
 
         // Send chunk to background
-        await chrome.runtime.sendMessage<ImportDataChunkMessage>({
+        const chunkResponse = await chrome.runtime.sendMessage({
           action: 'importDataChunk',
           chunkIndex: chunkIndex,
           chunkData: chunkContent
-        })
+        } satisfies ImportDataChunkMessage) as MessageResponse | undefined
+        requireSuccessfulResponse(chunkResponse, 'インポートデータを送信できませんでした')
 
         // Update progress
         const fileProgress = Math.round(((chunkIndex + 1) / totalChunks) * 100)
@@ -286,15 +298,17 @@ export const ImportExportSection = ({
       }
 
       // Process the complete data
-      await chrome.runtime.sendMessage<ImportDataProcessMessage>({
+      const processResponse = await chrome.runtime.sendMessage({
         action: 'importDataProcess'
-      })
+      } satisfies ImportDataProcessMessage) as MessageResponse | undefined
+      requireSuccessfulResponse(processResponse, 'インポートを処理できませんでした')
 
       if (fileInputRef.current) {
         fileInputRef.current.value = ''
       }
     } catch (error) {
-      setImportStatus(`インポート失敗: ${error}`)
+      const message = error instanceof Error ? error.message : String(error)
+      setImportStatus(`インポート失敗: ${message}`)
       setImportProgress(0)
       if (fileInputRef.current) {
         fileInputRef.current.value = ''


### PR DESCRIPTION
## Summary

- Stop popup imports immediately when init, chunk, or process responses fail.
- Surface the background error to the user and reset upload progress.
- Clear stale export or rebuild status before starting or failing an import.
- Add UI regression coverage for a busy import rejection after a completed export.

## Context

Follow-up to #153, which was merged before its review feedback could be pushed.

## Validation

- npm ci
- npm run typecheck
- npm test -- --runInBand (92 suites, 839 tests)
- npm run build

Head SHA: ee263cefcd59e5248717a2e6b6baf15d05454d8f
