### PR TITLE
fix(update): audit findings — raw 309 recheck, export-safe reload, idempotent alarm

### DIFF
--- a/src/background/event-ingestion.auto-sync-trigger.test.ts
+++ b/src/background/event-ingestion.auto-sync-trigger.test.ts
@@ -8,6 +8,12 @@
  *    docs/postmortems/2026-07-session-results-drop.md 再発防止#3, so a
  *    broken 309 doesn't leave sync stuck forever)
  *  - no other application event fires either trigger
+ *  - these triggers are hooked off the RAW ApiTypeId (codex review, PR #150
+ *    audit finding #1), same as update-manager's session-activity tracking:
+ *    onGameSessionEnd()/onNewSessionStart() only read the already-persisted
+ *    raw apiEvents Lake row count and never touch the parsed payload, so a
+ *    parse failure (parseApiEvent() -> null, e.g. a PokerChase payload
+ *    schema change) must not skip them
  */
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
 import PokerChaseService, { PokerChaseDB } from '../app'
@@ -141,13 +147,34 @@ describe('registerEventIngestion (auto-sync triggers)', () => {
     expect(onNewSessionStartSpy).not.toHaveBeenCalled()
   })
 
-  test('a parse-failed EVT_ENTRY_QUEUED (201) does not trigger onNewSessionStart (never reaches the pipeline dispatch)', async () => {
-    // Missing every required field -- fails Zod validation, so this never
-    // reaches the ApiTypeId dispatch below the isApplicationApiEvent gate.
+  test('a parse-failed EVT_ENTRY_QUEUED (201) still triggers onNewSessionStart via the raw ApiTypeId (codex review, PR #150 audit)', async () => {
+    // Missing every required field -- fails Zod validation (parseApiEvent()
+    // returns null), so this never reaches the parsed-data ApiTypeId
+    // dispatch below the isApplicationApiEvent gate. Before this fix the
+    // trigger lived exclusively in that unreachable parsed branch, so a
+    // schema change on 201 would have silently dropped the fallback sync
+    // trigger too (same root cause as the 309 pending-update-recheck bug).
     const brokenEntryQueuedEvent = { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, timestamp: 5000 }
     await onMessageHandler(brokenEntryQueuedEvent)
 
-    expect(onNewSessionStartSpy).not.toHaveBeenCalled()
+    expect(onNewSessionStartSpy).toHaveBeenCalledTimes(1)
     expect(onGameSessionEndSpy).not.toHaveBeenCalled()
+  })
+
+  test('a parse-failed EVT_SESSION_RESULTS (309) still triggers onGameSessionEnd -> recheckPendingUpdate via the raw ApiTypeId (codex review, PR #150 audit finding #1)', async () => {
+    // Simulates the season-3 postmortem scenario: PokerChase changes the 309
+    // payload shape so parseApiEvent() returns null. The raw event is still
+    // persisted to the apiEvents Lake above, and onGameSessionEnd() only
+    // counts raw Lake rows -- it doesn't need the parsed payload -- so there
+    // is no reason for a parse failure to skip it. Before this fix, this
+    // trigger (and the recheckPendingUpdate() chained after it) lived only
+    // in the parsed-data branch, which `return`s early on parse failure, so
+    // a malformed 309 left any pending Forced Update stuck until the *next*
+    // session ended.
+    const brokenSessionResultsEvent = { ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 6000 }
+    await onMessageHandler(brokenSessionResultsEvent)
+
+    expect(onGameSessionEndSpy).toHaveBeenCalledTimes(1)
+    expect(onNewSessionStartSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/background/event-ingestion.ts
+++ b/src/background/event-ingestion.ts
@@ -72,6 +72,46 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
           markSessionInactive()
         }
 
+        // Auto-sync起動・保留中アップデートの安全性再チェックも、上のセッション状態
+        // 追跡と同じ理由で生メッセージの数値ApiTypeIdだけを見て判定する（codexレビュー
+        // 指摘, P2）。autoSyncService.onGameSessionEnd()/onNewSessionStart()は
+        // 生のapiEvents Lake（上で既に保存済み）の件数だけを見るヘルパーで、
+        // パース済みdataには一切依存しない。以前はこのトリガーが後段の
+        // `if (data.ApiTypeId === ...)`（パース成功時のみ到達するブロック）に
+        // ぶら下がっていたため、PokerChase側の309ペイロード破壊的変更で
+        // parseApiEvent()がnullを返すケースでは、下のearly returnによって
+        // recheckPendingUpdate()が一切呼ばれず、保留中アップデートは次の
+        // セッション終了までずっと詰まったままになっていた（309の生データは
+        // 上のRaw Event Lake保存で既に確保済みなので、この再チェック自体を
+        // パース成否に依存させる理由はそもそも無い）。
+        if (rawApiTypeId === ApiType.EVT_SESSION_RESULTS) {
+          // セッション終了は保留中アップデートの安全性再チェック地点の1つ
+          // （src/background/update-manager.ts参照）。recheckPendingUpdate()は
+          // onGameSessionEnd()のPromiseが完了(成功/失敗いずれか)してから
+          // 必ずチェーンして呼ぶ -- 両方を並列で撃つと、performSync()が
+          // `_isSyncing`を立てる前の非同期区間（min-versionゲートのawait等）を
+          // recheckPendingUpdate()がすり抜けて安全と誤判定し、直近セッションの
+          // クラウドバックアップがまだ始まってもいないうちに
+          // chrome.runtime.reload()でService Workerを巻き込んでしまう恐れが
+          // あるため（codexレビュー指摘, P1）
+          autoSyncService.onGameSessionEnd()
+            .catch(err => console.error('[background] Auto sync on game end failed:', err))
+            .finally(() => {
+              recheckPendingUpdate().catch(err =>
+                console.error('[background] Pending update recheck on session end failed:', err)
+              )
+            })
+        } else if (rawApiTypeId === ApiType.EVT_ENTRY_QUEUED || rawApiTypeId === ApiType.EVT_SESSION_DETAILS) {
+          // フォールバックトリガー（docs/postmortems/2026-07-session-results-drop.md
+          // 再発防止#3）: 309単一トリガーのSPOF対策。新セッション開始時点は
+          // 進行中ハンドが存在しない安全なタイミングなので、ここでも同じ閾値判定
+          // でuploadを起動する（309が正常なら直前で既にバックログが閾値未満に
+          // なっているため二重発火しない）
+          autoSyncService.onNewSessionStart().catch(err =>
+            console.error('[background] Auto sync on new session start failed:', err)
+          )
+        }
+
         // 通常のAPIメッセージ処理
         // Zodスキーマでパース（passthrough: 未知プロパティは保持）
         const data = parseApiEvent(message as ApiMessage)
@@ -112,37 +152,9 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
         service.handLogStream.write(data)
         service.handAggregateStream.write(data)
         service.realTimeStatsStream.write(data)
-
-        // Handle game session end for auto sync
-        // （セッション状態[markSessionActive/Inactive]は上の生メッセージ判定で
-        // 追跡済み。ここはパース成功時のみ動く同期トリガー）
-        if (data.ApiTypeId === ApiType.EVT_SESSION_RESULTS) {
-          // セッション終了は保留中アップデートの安全性再チェック地点の1つ
-          // （src/background/update-manager.ts参照）。recheckPendingUpdate()は
-          // onGameSessionEnd()のPromiseが完了(成功/失敗いずれか)してから
-          // 必ずチェーンして呼ぶ -- 両方を並列で撃つと、performSync()が
-          // `_isSyncing`を立てる前の非同期区間（min-versionゲートのawait等）を
-          // recheckPendingUpdate()がすり抜けて安全と誤判定し、直近セッションの
-          // クラウドバックアップがまだ始まってもいないうちに
-          // chrome.runtime.reload()でService Workerを巻き込んでしまう恐れが
-          // あるため（codexレビュー指摘, P1）
-          autoSyncService.onGameSessionEnd()
-            .catch(err => console.error('[background] Auto sync on game end failed:', err))
-            .finally(() => {
-              recheckPendingUpdate().catch(err =>
-                console.error('[background] Pending update recheck on session end failed:', err)
-              )
-            })
-        } else if (data.ApiTypeId === ApiType.EVT_ENTRY_QUEUED || data.ApiTypeId === ApiType.EVT_SESSION_DETAILS) {
-          // フォールバックトリガー（docs/postmortems/2026-07-session-results-drop.md
-          // 再発防止#3）: 309単一トリガーのSPOF対策。新セッション開始時点は
-          // 進行中ハンドが存在しない安全なタイミングなので、ここでも同じ閾値判定
-          // でuploadを起動する（309が正常なら直前で既にバックログが閾値未満に
-          // なっているため二重発火しない）
-          autoSyncService.onNewSessionStart().catch(err =>
-            console.error('[background] Auto sync on new session start failed:', err)
-          )
-        }
+        // Auto-sync起動・pending update再チェック（309/201/308）は上のRaw
+        // Event Lake保存直後に生ApiTypeIdベースで既にトリガー済み（本ブロックの
+        // パース成功はストリーム投入のみが目的）
       })
       const stopPing = startPortPing(port)
 

--- a/src/background/event-ingestion.update-manager-trigger.test.ts
+++ b/src/background/event-ingestion.update-manager-trigger.test.ts
@@ -133,6 +133,30 @@ describe('registerEventIngestion (update-manager triggers)', () => {
     expect(markSessionActiveSpy).not.toHaveBeenCalled()
   })
 
+  test('a malformed EVT_SESSION_RESULTS (309) still runs the pending-update recheck via the raw ApiTypeId (codex review, PR #150 audit finding #1)', async () => {
+    // The companion regression to the test above: it's not enough for
+    // session-activity tracking to survive a malformed 309 -- the actual
+    // recheckPendingUpdate() *call* also has to run, or a pending Forced
+    // Update stays stuck until the next session ends even though the
+    // safety predicate itself would already report inactive/safe. Before
+    // this fix, recheckPendingUpdate() was chained only inside the
+    // `if (data.ApiTypeId === EVT_SESSION_RESULTS)` branch guarded by a
+    // successful `parseApiEvent()`, which this event never reaches (it
+    // `return`s early in the `if (!data)` branch).
+    const brokenSessionResultsEvent = {
+      ApiTypeId: ApiType.EVT_SESSION_RESULTS,
+      timestamp: 6100
+      // every other required field omitted -> parseApiEvent() returns null
+    }
+    await onMessageHandler(brokenSessionResultsEvent)
+
+    // recheckPendingUpdate() is chained after autoSyncService.onGameSessionEnd()
+    // settles (same ordering fix as the well-formed-309 test above) -- flush
+    // the microtask queue for that chain to complete before asserting.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(recheckPendingUpdateSpy).toHaveBeenCalledTimes(1)
+  })
+
   test('a malformed EVT_SESSION_DETAILS (308) still marks the session active via the raw ApiTypeId (codex review, P2)', async () => {
     const brokenSessionDetailsEvent = {
       ApiTypeId: ApiType.EVT_SESSION_DETAILS,

--- a/src/background/import-export.export-handoff.test.ts
+++ b/src/background/import-export.export-handoff.test.ts
@@ -1,0 +1,108 @@
+/**
+ * import-export.ts - export download-handoff completion (codex review, PR #150 audit finding #2)
+ *
+ * `exportJsonData()`/`exportPokerStarsData()` call `downloadFile()`, which
+ * hands the exported content off to the content script via
+ * `chrome.tabs.query()` -> `chrome.tabs.sendMessage()`. `chrome.tabs.query()`
+ * is a genuinely async Chrome extension API (callback-based), so before this
+ * fix `downloadFile()` returned `void` and its caller moved straight on to
+ * `setOperationState({ type: 'idle' })` without waiting for that callback to
+ * fire. `operation-state.ts`'s `onOperationBecameIdle` hook feeds directly
+ * into `update-manager.ts`'s `recheckPendingUpdate()`, which can call
+ * `chrome.runtime.reload()` the instant it observes idle+safe -- reloading
+ * the service worker before the download handoff was ever dispatched, so
+ * the user sees "export complete" while the actual file never arrives.
+ *
+ * These tests assert the fixed ordering: the handoff (`chrome.tabs.sendMessage`)
+ * must fire while operationState is still `'export'`, and `exportData()` must
+ * not resolve until after that handoff was dispatched.
+ */
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { createImportExportHandlers } from './import-export'
+import { getOperationState, setOperationState } from './operation-state'
+
+describe('export download-handoff completion', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    service = new PokerChaseService({ db })
+    await service.ready
+    setOperationState({ type: 'idle' })
+    jest.clearAllMocks()
+    // exportJsonData/exportPokerStarsData chain .catch() off every
+    // chrome.runtime.sendMessage() progress-broadcast call.
+    ;(chrome.runtime.sendMessage as jest.Mock).mockReturnValue(Promise.resolve())
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    db.close()
+    await db.delete()
+  })
+
+  test('NDJSON export (json format) dispatches the tabs.sendMessage handoff before returning to idle', async () => {
+    let operationStateWhenHandoffFired: string | undefined
+    // Simulate a genuinely async chrome.tabs.query completion (a real
+    // extension API call is callback-based and never resolves synchronously)
+    // -- a caller that doesn't await the handoff would already have flipped
+    // operationState back to idle by the time this callback runs.
+    ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => {
+      setTimeout(() => callback([{ id: 42 }]), 0)
+    })
+    ;(chrome.tabs.sendMessage as jest.Mock).mockImplementation(() => {
+      operationStateWhenHandoffFired = getOperationState().type
+    })
+
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+    await handlers.exportData('json')
+
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ action: 'downloadFile' })
+    )
+    // The handoff must be dispatched while the operation is still marked
+    // 'export' -- NOT 'idle' -- or update-manager's operation-idle recheck
+    // could race a reload() in ahead of it.
+    expect(operationStateWhenHandoffFired).toBe('export')
+    expect(getOperationState()).toEqual({ type: 'idle' })
+  })
+
+  test('PokerStars export dispatches the tabs.sendMessage handoff before returning to idle', async () => {
+    jest.spyOn(service, 'exportHandHistory').mockResolvedValue('PokerStars Hand #1: ...')
+
+    let operationStateWhenHandoffFired: string | undefined
+    ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => {
+      setTimeout(() => callback([{ id: 7 }]), 0)
+    })
+    ;(chrome.tabs.sendMessage as jest.Mock).mockImplementation(() => {
+      operationStateWhenHandoffFired = getOperationState().type
+    })
+
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+    await handlers.exportData('pokerstars')
+
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({ action: 'downloadFile' })
+    )
+    expect(operationStateWhenHandoffFired).toBe('export')
+    expect(getOperationState()).toEqual({ type: 'idle' })
+  })
+
+  test('falls back to a data-URL download (and still awaits it) when no game tab is open', async () => {
+    ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => {
+      setTimeout(() => callback([]), 0) // no matching tabs
+    })
+
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+    await handlers.exportData('json')
+
+    expect(chrome.tabs.sendMessage).not.toHaveBeenCalled()
+    expect(chrome.downloads.download).toHaveBeenCalledTimes(1)
+    expect(getOperationState()).toEqual({ type: 'idle' })
+  })
+})

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -400,7 +400,12 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
 
       const jsonlContent = chunks.join('\n')
 
-      downloadFile(
+      // ハンドオフ（chrome.tabs.query/sendMessage）の発行完了を待ってから
+      // `setOperationState({ type: 'idle' })`を呼ぶ（codexレビュー指摘,
+      // PR #150監査#2: 待たずに呼ぶとupdate-managerのoperation-idle
+      // recheckがハンドオフ未発行のままchrome.runtime.reload()し、
+      // ダウンロードが失われるレースがあった -- downloadFile()のコメント参照）
+      await downloadFile(
         jsonlContent,
         'pokerchase_raw_data.ndjson',
         'application/x-ndjson'
@@ -479,7 +484,9 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
         return
       }
 
-      downloadFile(
+      // ハンドオフ発行完了を待ってからidleに戻す（上のexportJsonData内
+      // downloadFile()呼び出しのコメント参照、codexレビュー指摘 PR #150監査#2）
+      await downloadFile(
         handHistory,
         'pokerchase_hand_history.txt',
         'text/plain'
@@ -514,7 +521,25 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
     }
   }
 
-  const downloadFile = (content: string, filename: string, contentType: string) => {
+  /**
+   * コンテンツスクリプトへのダウンロードハンドオフ（chrome.tabs.query→
+   * chrome.tabs.sendMessage）が実際に発行されるまで待てるようPromiseを返す
+   * （codexレビュー指摘, PR #150監査#2）。
+   *
+   * 修正前はこの関数が`void`を返し、`chrome.tabs.query`のコールバックが
+   * 実行される前に呼び出し元へ制御を返していた。呼び出し元（exportJsonData/
+   * exportPokerStarsData）は直後に`setOperationState({ type: 'idle' })`を
+   * 呼んでおり、`operation-state.ts`の`onOperationBecameIdle`購読経由で
+   * `update-manager.ts`の`recheckPendingUpdate()`が即座に発火しうる。
+   * そのタイミングが安全（`isSafeToUpdate()`）と判定されると
+   * `chrome.runtime.reload()`でService Workerごと巻き込まれ、まだ
+   * `chrome.tabs.sendMessage`すら呼ばれていないダウンロードが失われる
+   * （ユーザーには「エクスポート完了」と表示されるのに実際のファイルは
+   * 届かない）。ここでハンドオフの発行完了を待てるようにし、呼び出し元で
+   * `await`してから`setOperationState({ type: 'idle' })`を呼ぶことで、
+   * このレースを解消する。
+   */
+  const downloadFile = (content: string, filename: string, contentType: string): Promise<void> => {
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
 
     const extensionMatch = filename.match(/\.[^.]+$/)
@@ -537,32 +562,36 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
     const finalFilename = getFinalFilename()
 
     // Send to content script for Blob-based download (avoids data URL size limits)
-    chrome.tabs.query({ url: gameUrlPattern }, async tabs => {
-      const tab = tabs.find(t => t.id)
-      if (tab?.id) {
-        const sizeMB = content.length / 1024 / 1024
-        const MAX_CHUNK_MB = 50 // Under Chrome's 64MiB message limit
-        const maxChunkSize = MAX_CHUNK_MB * 1024 * 1024
+    return new Promise<void>(resolve => {
+      chrome.tabs.query({ url: gameUrlPattern }, async tabs => {
+        const tab = tabs.find(t => t.id)
+        if (tab?.id) {
+          const sizeMB = content.length / 1024 / 1024
+          const MAX_CHUNK_MB = 50 // Under Chrome's 64MiB message limit
+          const maxChunkSize = MAX_CHUNK_MB * 1024 * 1024
 
-        if (content.length <= maxChunkSize) {
-          chrome.tabs.sendMessage(tab.id, { action: 'downloadFile', content, filename: finalFilename, contentType })
-        } else {
-          // Split into chunks for large files
-          const totalChunks = Math.ceil(content.length / maxChunkSize)
-          console.log(`[Export] Splitting ${sizeMB.toFixed(1)}MB into ${totalChunks} chunks...`)
-          chrome.tabs.sendMessage(tab.id, { action: 'downloadFileInit', filename: finalFilename, contentType, totalChunks })
-          for (let i = 0; i < totalChunks; i++) {
-            const chunk = content.slice(i * maxChunkSize, (i + 1) * maxChunkSize)
-            chrome.tabs.sendMessage(tab.id, { action: 'downloadFileChunk', chunkIndex: i, chunk, totalChunks })
+          if (content.length <= maxChunkSize) {
+            chrome.tabs.sendMessage(tab.id, { action: 'downloadFile', content, filename: finalFilename, contentType })
+          } else {
+            // Split into chunks for large files
+            const totalChunks = Math.ceil(content.length / maxChunkSize)
+            console.log(`[Export] Splitting ${sizeMB.toFixed(1)}MB into ${totalChunks} chunks...`)
+            chrome.tabs.sendMessage(tab.id, { action: 'downloadFileInit', filename: finalFilename, contentType, totalChunks })
+            for (let i = 0; i < totalChunks; i++) {
+              const chunk = content.slice(i * maxChunkSize, (i + 1) * maxChunkSize)
+              chrome.tabs.sendMessage(tab.id, { action: 'downloadFileChunk', chunkIndex: i, chunk, totalChunks })
+            }
+            chrome.tabs.sendMessage(tab.id, { action: 'downloadFileFinish', filename: finalFilename, contentType })
           }
-          chrome.tabs.sendMessage(tab.id, { action: 'downloadFileFinish', filename: finalFilename, contentType })
+          console.log(`[Export] Download initiated via content script: ${finalFilename} (${sizeMB.toFixed(1)}MB)`)
+          resolve()
+          return
         }
-        console.log(`[Export] Download initiated via content script: ${finalFilename} (${sizeMB.toFixed(1)}MB)`)
-        return
-      }
-      // Fallback: data URL (may fail for large files >2MB)
-      console.warn('[Export] No game tab found, falling back to data URL download')
-      downloadViaDataUrl(content, finalFilename, contentType)
+        // Fallback: data URL (may fail for large files >2MB)
+        console.warn('[Export] No game tab found, falling back to data URL download')
+        downloadViaDataUrl(content, finalFilename, contentType)
+        resolve()
+      })
     })
   }
 

--- a/src/background/update-manager.test.ts
+++ b/src/background/update-manager.test.ts
@@ -255,18 +255,57 @@ describe('update-manager', () => {
   })
 
   describe('initUpdateManager (wiring)', () => {
-    it('registers onUpdateAvailable listener, triggers an update check, and creates the alarm', () => {
+    it('registers onUpdateAvailable listener, triggers an update check, and creates the alarm when none exists yet', async () => {
       markSessionInactive()
+      ;(chrome.alarms.get as jest.Mock).mockResolvedValue(undefined) // no alarm scheduled yet (e.g. first install)
 
       initUpdateManager()
 
       expect(chrome.runtime.onUpdateAvailable.addListener).toHaveBeenCalledTimes(1)
       expect(chrome.runtime.requestUpdateCheck).toHaveBeenCalledTimes(1)
+      // The onAlarm listener registration is synchronous (before the
+      // alarms.get() await), unlike alarm creation below.
+      expect(chrome.alarms.onAlarm.addListener).toHaveBeenCalledTimes(1)
+
+      // setupUpdateCheckAlarm() awaits chrome.alarms.get() before deciding
+      // whether to create -- flush the microtask queue for that to resolve.
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(chrome.alarms.get).toHaveBeenCalledWith('pokerchase-hud-update-check')
       expect(chrome.alarms.create).toHaveBeenCalledWith(
         'pokerchase-hud-update-check',
         { periodInMinutes: 6 * 60 }
       )
+    })
+
+    it('does NOT recreate the update-check alarm on SW startup when one is already scheduled (codex review, PR #150 audit finding #3)', async () => {
+      // Regression for: chrome.alarms.create() with an existing alarm name
+      // cancels and replaces it, resetting its periodInMinutes countdown.
+      // Calling it unconditionally on every initUpdateManager() (i.e. every
+      // SW startup) meant a SW that restarts more often than the 6h period
+      // would keep postponing the periodic check indefinitely, leaving only
+      // the throttled startup requestUpdateCheck() call.
+      markSessionInactive()
+      const scheduledTime = Date.now() + 3 * 60 * 60 * 1000 // 3h from now
+      ;(chrome.alarms.get as jest.Mock).mockResolvedValue({
+        name: 'pokerchase-hud-update-check',
+        scheduledTime,
+        periodInMinutes: 6 * 60,
+      })
+
+      initUpdateManager()
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(chrome.alarms.get).toHaveBeenCalledWith('pokerchase-hud-update-check')
+      expect(chrome.alarms.create).not.toHaveBeenCalled()
+      // The onAlarm listener still gets (re-)registered every startup --
+      // only the schedule-resetting create() call is skipped.
       expect(chrome.alarms.onAlarm.addListener).toHaveBeenCalledTimes(1)
+
+      // Restore the default "no alarm scheduled" resolution for subsequent
+      // tests -- jest.clearAllMocks() (in this file's beforeEach) clears
+      // call history but not a mockResolvedValue override.
+      ;(chrome.alarms.get as jest.Mock).mockResolvedValue(undefined)
     })
 
     it('re-checks (and applies) any pending update left over from before the SW restart', async () => {

--- a/src/background/update-manager.ts
+++ b/src/background/update-manager.ts
@@ -197,9 +197,23 @@ export const applyUpdateNow = async (): Promise<ApplyUpdateResult> => {
   return { applied: true }
 }
 
-const setupUpdateCheckAlarm = (): void => {
+/**
+ * 更新チェックalarmをセットアップする。
+ *
+ * `initUpdateManager()`経由でService Worker起動のたびに呼ばれるが、
+ * alarm自体はSW再起動をまたいで既にChrome側に生き続けている。
+ * `chrome.alarms.create()`は「同名のalarmが既にあればキャンセルして
+ * 置き換える」仕様（https://developer.chrome.com/docs/extensions/reference/api/alarms）
+ * のため、無条件に呼び直すと`periodInMinutes`のカウントダウンがその
+ * 都度リセットされる。SWが6時間より頻繁に再起動する環境（アクティブに
+ * 使われている場合はよくある）では、この定期チェックが実質永遠に
+ * 発火しなくなり、`requestUpdateCheck()`はSW起動時1回のスロットリング
+ * された呼び出しにしか頼れなくなる（codexレビュー指摘, PR #150監査#3）。
+ * `chrome.alarms.get()`で既存のalarmを確認し、無い場合（初回インストール時
+ * や何らかの理由でalarmがクリアされていた場合）のみ`create()`する。
+ */
+const setupUpdateCheckAlarm = async (): Promise<void> => {
   if (!chrome.alarms) return
-  chrome.alarms.create(UPDATE_CHECK_ALARM_NAME, { periodInMinutes: UPDATE_CHECK_PERIOD_MINUTES })
   chrome.alarms.onAlarm.addListener((alarm) => {
     if (alarm.name === UPDATE_CHECK_ALARM_NAME) {
       chrome.runtime.requestUpdateCheck?.().catch((error: unknown) => {
@@ -207,6 +221,13 @@ const setupUpdateCheckAlarm = (): void => {
       })
     }
   })
+
+  const existingAlarm = await chrome.alarms.get(UPDATE_CHECK_ALARM_NAME)
+  if (existingAlarm) {
+    console.log(`[update-manager] Update-check alarm already scheduled (next: ${new Date(existingAlarm.scheduledTime).toISOString()}) -- not recreating`)
+    return
+  }
+  chrome.alarms.create(UPDATE_CHECK_ALARM_NAME, { periodInMinutes: UPDATE_CHECK_PERIOD_MINUTES })
 }
 
 /**
@@ -241,7 +262,9 @@ export const initUpdateManager = (): Promise<void> => {
   chrome.runtime.requestUpdateCheck?.().catch((error: unknown) => {
     console.warn('[update-manager] requestUpdateCheck (startup) failed:', error)
   })
-  setupUpdateCheckAlarm()
+  setupUpdateCheckAlarm().catch(error => {
+    console.error('[update-manager] setupUpdateCheckAlarm failed:', error)
+  })
 
   return recheckPendingUpdate().catch(error => {
     console.error('[update-manager] recheckPendingUpdate (SW startup) failed:', error)

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -45,6 +45,7 @@ global.chrome = {
   alarms: {
     create: jest.fn().mockResolvedValue(undefined),
     clear: jest.fn().mockResolvedValue(true),
+    get: jest.fn().mockResolvedValue(undefined),
     onAlarm: {
       addListener: jest.fn(),
     },
@@ -132,6 +133,16 @@ global.chrome = {
     query: jest.fn(),
     create: jest.fn(),
     update: jest.fn(),
+    sendMessage: jest.fn(),
+  },
+  downloads: {
+    download: jest.fn((_options, callback?) => {
+      if (typeof callback === 'function') {
+        callback(1)
+        return undefined
+      }
+      return Promise.resolve(1)
+    }),
   },
   windows: {
     update: jest.fn(),


### PR DESCRIPTION
## Summary

Three unresolved findings from sola's merged-PR audit of #150, all confirmed live on main and fixed:

- **Malformed 309 skipped the pending-update recheck** (and, it turned out, the auto-sync triggers too): the trigger block was gated on the PARSED event. Moved the whole session-boundary trigger block (309 → sync+recheck chain; 201/308 → fallback sync) to fire off the raw `ApiTypeId` before `parseApiEvent()` — the same raw-first lesson as the session-activity fix. One pre-existing test had asserted the buggy behavior; corrected.
- **Reload could race an in-flight export handoff**: exports flipped to `idle` without awaiting `downloadFile()`'s async `chrome.tabs` handoff — `onOperationBecameIdle → reload()` could kill the SW before the download message was ever sent. `downloadFile()` now returns a Promise resolved inside the callback and both export paths await it before going idle. Tests verified failing without the await.
- **6h update-check alarm reset on every SW startup** (create-with-same-name replaces and restarts the countdown — frequent SW restarts meant it could never fire). Now `alarms.get` first, create only if absent. Test verified failing against unconditional create.

## Verification

typecheck clean; 104 suites / 967 tests ×2; smoke 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)