### PR TITLE
refactor(build): remove EventEmitter polyfill

### DIFF
--- a/esbuild.config.ts
+++ b/esbuild.config.ts
@@ -1,8 +1,7 @@
 import { build, BuildOptions, Plugin } from 'esbuild'
 import { copyFileSync, mkdirSync } from 'fs'
-import { fileURLToPath } from 'url'
 import { parse } from 'path'
-import { resolve, dirname } from 'path'
+import { resolve } from 'path'
 import manifest from './manifest.json'
 
 const {
@@ -71,15 +70,6 @@ const options: BuildOptions = {
         path: '@mui/material/index.js',
         external: false
       }))
-    }
-  }, {
-    name: 'nodePolyfills',
-    setup(build) {
-      const __filename = fileURLToPath(import.meta.url)
-      const __dirname = dirname(__filename)
-      build.onResolve({ filter: /^events$/ }, () => {
-        return { path: resolve(__dirname, 'node_modules/events/events.js') }
-      })
     }
   },
   ...(e2eManifestPlugin ? [e2eManifestPlugin] : [])]

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "@types/react-dom": "^19.0.0",
         "babel-jest": "^30.4.1",
         "esbuild": "^0.28.0",
-        "events": "^3.3.0",
         "fake-indexeddb": "^6.0.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^30.0.0",
@@ -5943,16 +5942,6 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
       }
     },
     "node_modules/execa": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@types/react-dom": "^19.0.0",
     "babel-jest": "^30.4.1",
     "esbuild": "^0.28.0",
-    "events": "^3.3.0",
     "fake-indexeddb": "^6.0.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^30.0.0",

--- a/src/streams/realtime-stats-stream.test.ts
+++ b/src/streams/realtime-stats-stream.test.ts
@@ -1253,7 +1253,7 @@ describe('SPR (Stack to Pot Ratio) Tracking', () => {
           const potOddsData = data.stats.heroStats.potOdds.value
           // Hero has 12000 chips in second hand, pot is 300
           // SPR should be 12000 / 300 = 40.0
-          expect(potOddsData.spr).toBe(40.0)
+          expect(potOddsData).toMatchObject({ spr: 40.0 })
         }
       }
     })

--- a/src/streams/simple-transform.test.ts
+++ b/src/streams/simple-transform.test.ts
@@ -147,6 +147,31 @@ describe('SimpleTransform', () => {
     expect(stream.transformCallCount).toBe(1)
   })
 
+  test('once(): 最初のdataイベントだけを通知する', async () => {
+    const stream = new CountingStream()
+    const results: number[] = []
+    stream.once('data', (value: number) => results.push(value))
+
+    stream.write(1)
+    stream.write(2)
+    await stream.whenIdle()
+
+    expect(results).toEqual([10])
+  })
+
+  test('off(): 登録済みのdataリスナーを解除する', async () => {
+    const stream = new CountingStream()
+    const results: number[] = []
+    const listener = (value: number) => results.push(value)
+    stream.on('data', listener)
+    stream.off('data', listener)
+
+    stream.write(1)
+    await stream.whenIdle()
+
+    expect(results).toEqual([])
+  })
+
   test('end(): キュー完了後に"end"をemitし、pipe先にend()を伝播する', async () => {
     const upstream = new CountingStream()
     const downstream = new CountingStream()

--- a/src/streams/simple-transform.test.ts
+++ b/src/streams/simple-transform.test.ts
@@ -172,6 +172,19 @@ describe('SimpleTransform', () => {
     expect(results).toEqual([])
   })
 
+  test('off(): once()へ渡した元のdataリスナーを発火前に解除する', async () => {
+    const stream = new CountingStream()
+    const results: number[] = []
+    const listener = (value: number) => results.push(value)
+    stream.once('data', listener)
+    stream.off('data', listener)
+
+    stream.write(1)
+    await stream.whenIdle()
+
+    expect(results).toEqual([])
+  })
+
   test('end(): キュー完了後に"end"をemitし、pipe先にend()を伝播する', async () => {
     const upstream = new CountingStream()
     const downstream = new CountingStream()

--- a/src/streams/simple-transform.ts
+++ b/src/streams/simple-transform.ts
@@ -10,7 +10,7 @@
  * バンドルサイズとSW起動時間を圧迫していた。
  *
  * このクラスは実際に使われている機能（write/push/pipe/データ・エラーイベント）
- * のみを、軽量な`events`ポリフィル上に再実装したものである。
+ * のみを、Promiseチェーンと標準JavaScriptのSetで再実装したものである。
  *
  * ## シリアライゼーション不変条件（重要）
  * Node.jsのTransformは内部的に1度に1つの`_transform`呼び出ししか実行しない
@@ -23,12 +23,13 @@
  * 開始する」という厳密な直列実行を保証する。この直列性は本クラスの中核的な
  * 不変条件であり、変更してはならない。
  */
-import { EventEmitter } from 'events'
-
-export type SimpleTransformTarget = Pick<EventEmitter, 'on' | 'emit' | 'listenerCount'> & {
+export type SimpleTransformTarget = {
   write(chunk: any): void
   end(): void
 }
+
+type SimpleTransformEventName = 'data' | 'error' | 'end'
+type SimpleTransformListener = (...args: any[]) => void
 
 /**
  * エラーハンドラ関数の型。呼び出し側（各Streamサブクラス）が現在のTransform/Callback
@@ -37,7 +38,7 @@ export type SimpleTransformTarget = Pick<EventEmitter, 'on' | 'emit' | 'listener
  */
 export type SimpleTransformErrorHandler = (error: unknown) => void
 
-export abstract class SimpleTransform<In = any, Out = any> extends EventEmitter {
+export abstract class SimpleTransform<In = any, Out = any> {
   /** 直列実行を保証する内部プロミスチェーン */
   private queue: Promise<void> = Promise.resolve()
   /** キューに積まれた（まだ完了していない）チャンク数 */
@@ -46,6 +47,60 @@ export abstract class SimpleTransform<In = any, Out = any> extends EventEmitter 
   private target?: SimpleTransformTarget
   /** end()が呼ばれたかどうか */
   private ended = false
+  /** Node EventEmitterを持ち込まずにdata/error/end購読を提供するリスナー集合 */
+  private readonly listeners: Record<SimpleTransformEventName, Set<SimpleTransformListener>> = {
+    data: new Set(),
+    error: new Set(),
+    end: new Set()
+  }
+
+  /**
+   * Stream群が公開してきた最小イベントAPIを維持する。
+   * 同じリスナーの重複登録はSetにより冪等になる。
+   */
+  on(event: 'data', listener: (data: Out) => void): this
+  on(event: 'error', listener: (error: unknown) => void): this
+  on(event: 'end', listener: () => void): this
+  on(event: SimpleTransformEventName, listener: SimpleTransformListener): this {
+    this.listeners[event].add(listener)
+    return this
+  }
+
+  once(event: 'data', listener: (data: Out) => void): this
+  once(event: 'error', listener: (error: unknown) => void): this
+  once(event: 'end', listener: () => void): this
+  once(event: SimpleTransformEventName, listener: SimpleTransformListener): this {
+    const onceListener: SimpleTransformListener = (...args) => {
+      this.listeners[event].delete(onceListener)
+      listener(...args)
+    }
+    this.listeners[event].add(onceListener)
+    return this
+  }
+
+  off(event: 'data', listener: (data: Out) => void): this
+  off(event: 'error', listener: (error: unknown) => void): this
+  off(event: 'end', listener: () => void): this
+  off(event: SimpleTransformEventName, listener: SimpleTransformListener): this {
+    this.listeners[event].delete(listener)
+    return this
+  }
+
+  protected emit(event: 'data', data: Out): boolean
+  protected emit(event: 'error', error: unknown): boolean
+  protected emit(event: 'end'): boolean
+  protected emit(event: SimpleTransformEventName, ...args: any[]): boolean {
+    const listeners = this.listeners[event]
+    if (listeners.size === 0) return false
+
+    // dispatch中の登録変更が現在の通知順序へ影響しないようスナップショットを使う。
+    for (const listener of [...listeners]) listener(...args)
+    return true
+  }
+
+  protected listenerCount(event: SimpleTransformEventName): number {
+    return this.listeners[event].size
+  }
 
   /**
    * サブクラスが実装する変換処理本体。

--- a/src/streams/simple-transform.ts
+++ b/src/streams/simple-transform.ts
@@ -30,6 +30,9 @@ export type SimpleTransformTarget = {
 
 type SimpleTransformEventName = 'data' | 'error' | 'end'
 type SimpleTransformListener = (...args: any[]) => void
+type SimpleTransformRegisteredListener = SimpleTransformListener & {
+  originalListener?: SimpleTransformListener
+}
 
 /**
  * エラーハンドラ関数の型。呼び出し側（各Streamサブクラス）が現在のTransform/Callback
@@ -48,7 +51,7 @@ export abstract class SimpleTransform<In = any, Out = any> {
   /** end()が呼ばれたかどうか */
   private ended = false
   /** Node EventEmitterを持ち込まずにdata/error/end購読を提供するリスナー集合 */
-  private readonly listeners: Record<SimpleTransformEventName, Set<SimpleTransformListener>> = {
+  private readonly listeners: Record<SimpleTransformEventName, Set<SimpleTransformRegisteredListener>> = {
     data: new Set(),
     error: new Set(),
     end: new Set()
@@ -70,10 +73,11 @@ export abstract class SimpleTransform<In = any, Out = any> {
   once(event: 'error', listener: (error: unknown) => void): this
   once(event: 'end', listener: () => void): this
   once(event: SimpleTransformEventName, listener: SimpleTransformListener): this {
-    const onceListener: SimpleTransformListener = (...args) => {
+    const onceListener: SimpleTransformRegisteredListener = (...args) => {
       this.listeners[event].delete(onceListener)
       listener(...args)
     }
+    onceListener.originalListener = listener
     this.listeners[event].add(onceListener)
     return this
   }
@@ -82,7 +86,12 @@ export abstract class SimpleTransform<In = any, Out = any> {
   off(event: 'error', listener: (error: unknown) => void): this
   off(event: 'end', listener: () => void): this
   off(event: SimpleTransformEventName, listener: SimpleTransformListener): this {
-    this.listeners[event].delete(listener)
+    const listeners = this.listeners[event]
+    // EventEmitter同様、once()へ渡した元のlistenerでも発火前に解除できるようにする。
+    const registeredListener = [...listeners]
+      .reverse()
+      .find(registered => registered === listener || registered.originalListener === listener)
+    if (registeredListener) listeners.delete(registeredListener)
     return this
   }
 


### PR DESCRIPTION
## Summary

- replace `SimpleTransform`'s `EventEmitter` inheritance with a typed `Set`-backed listener registry
- preserve the existing `on` / `once` / `off`, `data` / `error` / `end`, and serialized pipeline behavior
- preserve `off(event, originalListener)` cancellation for pending `once()` listeners
- remove the `events` dependency and the final esbuild Node-polyfill alias
- add focused coverage for one-shot listeners and listener removal
- narrow the pre-existing SPR assertion structurally so current-main type checking can complete

## Why

`events` was the last Node compatibility package in the Chrome MV3 background bundle. `SimpleTransform` only needs a small, fixed event surface, so carrying a Node-style polyfill is unnecessary.

With the same esbuild settings, `dist/background.js` changes from 413,610 bytes to 407,800 bytes (-5,810 bytes, -1.4%). The resulting background dependency graph contains only `dexie` and `zod`.

The current `main` test accessed `.spr` directly through the broad `StatValue` union, causing CI type checking to fail. The structural matcher preserves the same runtime assertion without weakening production types.

## Validation

- `npm ci --ignore-scripts` ✅
- `npm run typecheck` ✅
- `npm test -- --runInBand` ✅ (104 suites, 970 tests)
- `npm test -- --runInBand src/streams/simple-transform.test.ts` ✅ (11 tests)
- `npm test -- --runInBand src/streams/realtime-stats-stream.test.ts` ✅ (12 tests)
- `npm run build` ✅
- production background metafile inspection ✅ (`dexie`, `zod`; no Node compatibility packages)

Head: `f14ccdf2f093f29291446b3c692ddfd3c0a8c589`