### PR TITLE
fix(service): seated-deal guard for rebuild; consistent lineup pairing for spectator recalc

### DIFF
--- a/src/background/message-router.spectator-filter-refresh.test.ts
+++ b/src/background/message-router.spectator-filter-refresh.test.ts
@@ -1,0 +1,164 @@
+/**
+ * message-router.ts - updateBattleTypeFilter's lastKnownStats refresh vs.
+ * hero-anchored recalc while spectating
+ *
+ * Regression test for a P2 finding filed on the already-merged #177 (the
+ * two inline review comments posted 2026-07-20T12:39, after #177/#179/#181/
+ * #182/#184/#185 had all landed on main -- NOT covered by #179's
+ * session-end `lastKnownStats` invalidation, since this is a mid-session
+ * spectating state, not a post-309 one).
+ *
+ * `updateBattleTypeFilter`'s handler calls `service.setBattleTypeFilter()`
+ * (which internally awaits `ReadEntityStream.recalculateStats()` --
+ * read-entity-stream.ts -- and, as part of that call's synchronous prefix
+ * before its first `await`, sets `service.liveEvtDeal =
+ * service.latestEvtDeal`, i.e. re-anchors the live-display seat context to
+ * the hero's own last SEATED deal), then immediately (still synchronously,
+ * before that promise settles) reads `getLastKnownStats()` (ports.ts) and
+ * re-triggers `service.statsOutputStream.write(...)` with whatever lineup
+ * was last broadcast live.
+ *
+ * While spectating after busting, `lastKnownStats` holds the *spectator*
+ * table's lineup (a different, non-hero SeatUserIds array than
+ * `service.latestEvtDeal`, which stays pinned to the hero's last seated
+ * deal -- see aggregate-events-stream.ts's EVT_DEAL case). Racing this
+ * `write()` against `recalculateStats()`'s `liveEvtDeal` re-anchor can
+ * broadcast the spectator lineup paired with the hero-anchored `evtDeal`
+ * (or vice versa), causing App.tsx to rotate/display the wrong seats.
+ *
+ * Fix: gate the extra `lastKnownStats` refresh on a lineup-identity check
+ * against `service.latestEvtDeal.SeatUserIds` -- skip it outright when the
+ * two are known to disagree (spectating a different table than the hero's
+ * own last deal). `setBattleTypeFilter()`'s own `recalculateStats()` call
+ * already recomputes and (re)broadcasts the hero-anchored stats correctly,
+ * so nothing is lost by skipping the redundant, racy refresh in that case.
+ * When `service.latestEvtDeal` is unset (never yet known -- a state that
+ * doesn't actually arise once a hero deal has ever landed, but is a
+ * possible synthetic/test state), the mismatch can't be established, so
+ * the refresh still runs as before (safe default: unchanged behavior).
+ */
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { ApiType } from '../types'
+import type { ApiEvent } from '../types'
+import { registerMessageRouter } from './message-router'
+import { registerStreamSubscriptions, setLastKnownStats } from './ports'
+import type { ChromeMessage, MessageResponse } from '../types/messages'
+
+const HERO_ID = 1
+
+const FILTER_OPTIONS = {
+  gameTypes: { sng: true, mtt: true, ring: true }
+}
+
+// Hero's last SEATED deal (persisted context: service.latestEvtDeal).
+const HERO_DEAL: ApiEvent<ApiType.EVT_DEAL> = {
+  ApiTypeId: ApiType.EVT_DEAL,
+  SeatUserIds: [HERO_ID, 2, 3, 4, 5, 6],
+  Game: { CurrentBlindLv: 1, NextBlindUnixSeconds: -1, Ante: 0, SmallBlind: 100, BigBlind: 200, ButtonSeat: 3, SmallBlindSeat: 0, BigBlindSeat: 1 },
+  Player: { SeatIndex: 0, BetStatus: 1, HoleCards: [], Chip: 5000, BetChip: 0 },
+  OtherPlayers: [
+    { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 100, IsSafeLeave: false },
+    { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+    { SeatIndex: 3, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+    { SeatIndex: 4, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+    { SeatIndex: 5, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+  ],
+  Progress: { Phase: 0, NextActionSeat: 2, NextActionTypes: [2, 3, 4, 5], NextExtraLimitSeconds: 1, MinRaise: 400, Pot: 500, SidePot: [] },
+  timestamp: 1000,
+}
+
+describe('message-router updateBattleTypeFilter -- spectator lastKnownStats refresh vs. hero-anchored recalc', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+  let messageListener: (request: ChromeMessage, sender: chrome.runtime.MessageSender, sendResponse: (response: MessageResponse) => void) => boolean | void
+  let writeSpy: jest.SpyInstance
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    service = new PokerChaseService({ db })
+    await service.ready
+    service.playerId = HERO_ID
+
+    ;(global as any).chrome.tabs = {
+      sendMessage: jest.fn(),
+      query: jest.fn((_query, callback) => callback([])),
+    }
+    ;(chrome.runtime.onMessage.addListener as jest.Mock).mockClear()
+
+    registerMessageRouter(service, db, 'https://example.com/*')
+    registerStreamSubscriptions(service, 'https://example.com/*')
+    messageListener = (chrome.runtime.onMessage.addListener as jest.Mock).mock.calls[0][0]
+
+    // write() itself is the message-router-only extra refresh under test --
+    // setBattleTypeFilter()'s own recalculateStats() call pushes via a
+    // different method (this.push(), not write()), so spying on write()
+    // isolates exactly the call site the fix guards.
+    writeSpy = jest.spyOn(service.statsOutputStream, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    delete (global as any).chrome.tabs
+    setLastKnownStats([])
+    db.close()
+    await db.delete()
+  })
+
+  test('spectating a different table than the hero\'s last deal: the extra refresh is skipped (lineup mismatch)', async () => {
+    // Hero's own last seated deal is known...
+    service.latestEvtDeal = HERO_DEAL
+    // ...but the last LIVE broadcast (ports.ts's lastKnownStats) is a
+    // different table's lineup -- the spectator state this bug targets.
+    setLastKnownStats([
+      { playerId: 10, statResults: [] } as any,
+      { playerId: 20, statResults: [] } as any,
+      { playerId: 30, statResults: [] } as any,
+      { playerId: 40, statResults: [] } as any,
+    ])
+
+    const sendResponse = jest.fn()
+    messageListener(
+      { action: 'updateBattleTypeFilter', filterOptions: FILTER_OPTIONS } as unknown as ChromeMessage,
+      {} as chrome.runtime.MessageSender,
+      sendResponse
+    )
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // The mismatched spectator refresh must not fire -- it would race
+    // service.liveEvtDeal's hero-anchored re-sync from recalculateStats()
+    // and risk broadcasting spectator stats paired with the hero's evtDeal.
+    expect(writeSpy).not.toHaveBeenCalled()
+  })
+
+  test('hero still seated (lineup matches latestEvtDeal): the extra refresh still fires as before', async () => {
+    service.latestEvtDeal = HERO_DEAL
+    setLastKnownStats(HERO_DEAL.SeatUserIds.map(playerId => ({ playerId, statResults: [] } as any)))
+
+    const sendResponse = jest.fn()
+    messageListener(
+      { action: 'updateBattleTypeFilter', filterOptions: FILTER_OPTIONS } as unknown as ChromeMessage,
+      {} as chrome.runtime.MessageSender,
+      sendResponse
+    )
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(writeSpy).toHaveBeenCalledWith(HERO_DEAL.SeatUserIds)
+  })
+
+  test('control: latestEvtDeal not yet known -- mismatch cannot be established, refresh still fires (unchanged default behavior)', async () => {
+    // service.latestEvtDeal deliberately left unset.
+    setLastKnownStats([{ playerId: 2, statResults: [] } as any])
+
+    const sendResponse = jest.fn()
+    messageListener(
+      { action: 'updateBattleTypeFilter', filterOptions: FILTER_OPTIONS } as unknown as ChromeMessage,
+      {} as chrome.runtime.MessageSender,
+      sendResponse
+    )
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(writeSpy).toHaveBeenCalledWith([2])
+  })
+})

--- a/src/background/message-router.spectator-filter-refresh.test.ts
+++ b/src/background/message-router.spectator-filter-refresh.test.ts
@@ -161,4 +161,30 @@ describe('message-router updateBattleTypeFilter -- spectator lastKnownStats refr
 
     expect(writeSpy).toHaveBeenCalledWith([2])
   })
+
+  test('playerId unknown even though latestEvtDeal is set (restored/corrupt intermediate state): recalculateStats() cannot run, so the refresh still fires as the only broadcast (codex #188 review)', async () => {
+    // A state read-entity-stream.ts's recalculateStats() can't act on: it
+    // early-returns on `!playerId || !latestEvtDeal` (read-entity-stream.ts),
+    // so if this refresh were skipped too, a filter change would silently
+    // stop updating the visible HUD stats entirely.
+    service.playerId = undefined
+    service.latestEvtDeal = HERO_DEAL
+    // A mismatching lineup by SeatUserIds -- if the mismatch check alone
+    // gated the skip (ignoring whether recalc can actually run), this would
+    // wrongly be dropped.
+    setLastKnownStats([
+      { playerId: 10, statResults: [] } as any,
+      { playerId: 20, statResults: [] } as any,
+    ])
+
+    const sendResponse = jest.fn()
+    messageListener(
+      { action: 'updateBattleTypeFilter', filterOptions: FILTER_OPTIONS } as unknown as ChromeMessage,
+      {} as chrome.runtime.MessageSender,
+      sendResponse
+    )
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(writeSpy).toHaveBeenCalledWith([10, 20])
+  })
 })

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -172,8 +172,44 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
       // 新しいフィルターに基づいてHUD表示を強制更新
       const lastKnownStats = getLastKnownStats()
       if (lastKnownStats.length > 0) {
-        // 現在の席ユーザーIDで計算を再トリガー
-        service.statsOutputStream.write(lastKnownStats.map(stat => stat.playerId))
+        // 上の service.setBattleTypeFilter() は内部で
+        // ReadEntityStream.recalculateStats()（read-entity-stream.ts）を
+        // 呼び、ヒーロー在籍dealの席文脈（service.latestEvtDeal）で
+        // service.liveEvtDealを同期してから再計算・ブロードキャストする
+        // （setBattleTypeFilterはasync関数で、その同期処理は最初のawaitに
+        // 到達する前、つまりこの行に制御が戻る前に完了している）。
+        //
+        // この下のwrite()は歴史的に別経路で存在する「現在ブロードキャスト
+        // 中の顔ぶれ」の強制再計算で、`lastKnownStats`（ports.tsの直近の
+        // ライブブロードキャスト、ヒーロー敗退後は観戦テーブルの顔ぶれの
+        // こともある）を使う。ヒーローが観戦中（lastKnownStatsの顔ぶれが
+        // latestEvtDealのSeatUserIdsと一致しない）場合、この2つの再計算が
+        // 競合すると、write()側のPromiseがrecalculateStats()側より後に
+        // 解決した際、その時点で既にヒーロー在籍dealに向いたservice.
+        // liveEvtDealと、observing側の（顔ぶれの異なる）statsがペアリング
+        // されてブロードキャストされてしまう（App.tsxの座席回転がズレる/
+        // 上書きされる。codex #177マージ後レビュー、2026-07-20指摘）。
+        //
+        // 対処: lastKnownStatsの顔ぶれがヒーロー在籍dealのSeatUserIdsと
+        // 一致しないと判明している場合だけ、この追加リフレッシュを
+        // スキップする（lineup-identityチェック）。setBattleTypeFilter()の
+        // recalculateStats()が別途ヒーロー在籍の統計を正しく再計算・
+        // ブロードキャストするため、スキップしても表示が欠けることはない。
+        // service.latestEvtDealが未設定（この関数のテストのように現実には
+        // 起きない合成状態、または本当にまだ一度もヒーロー在籍dealを見て
+        // いない場合）は「不一致と確定できない」として従来通り実行する
+        // （デフォルトは安全側＝現状維持）。
+        const lastKnownLineup = lastKnownStats.map(stat => stat.playerId)
+        const heroSeatUserIds = service.latestEvtDeal?.SeatUserIds
+        const lineupMismatchesHeroDeal = heroSeatUserIds !== undefined && (
+          lastKnownLineup.length !== heroSeatUserIds.length ||
+          lastKnownLineup.some((playerId, index) => playerId !== heroSeatUserIds[index])
+        )
+
+        if (!lineupMismatchesHeroDeal) {
+          // 現在の席ユーザーIDで計算を再トリガー
+          service.statsOutputStream.write(lastKnownLineup)
+        }
       }
 
       return true // 非同期レスポンスを示す

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -194,14 +194,25 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
         // 一致しないと判明している場合だけ、この追加リフレッシュを
         // スキップする（lineup-identityチェック）。setBattleTypeFilter()の
         // recalculateStats()が別途ヒーロー在籍の統計を正しく再計算・
-        // ブロードキャストするため、スキップしても表示が欠けることはない。
-        // service.latestEvtDealが未設定（この関数のテストのように現実には
-        // 起きない合成状態、または本当にまだ一度もヒーロー在籍dealを見て
-        // いない場合）は「不一致と確定できない」として従来通り実行する
-        // （デフォルトは安全側＝現状維持）。
+        // ブロードキャストするため、スキップしても表示が欠けることはない
+        // -- ただしそれは recalculateStats() が実際に走る場合に限る。
+        // read-entity-stream.ts の recalculateStats() は
+        // `!playerId || !latestEvtDeal` で早期returnするため、
+        // service.latestEvtDealはあるがservice.playerIdがまだ不明な
+        // （復元直後の破損/中間状態）場合、recalculateStats()は何も
+        // ブロードキャストしない。そこでこの追加リフレッシュまでスキップ
+        // すると、フィルター変更がHUDに一切反映されなくなってしまう
+        // （codex #188レビュー、2026-07-20指摘）。そのため「スキップして
+        // 良い」と判定するには、不一致に加えて service.playerId も
+        // 存在する（＝recalculateStats()が実際に代替のブロードキャストを
+        // 行える）ことを要求する。playerId未定義またはlatestEvtDeal未定義
+        // （この関数のテストのように現実には起きない合成状態を含む）の
+        // 場合は「不一致と確定できない／代替を保証できない」として従来通り
+        // 実行する（デフォルトは安全側＝現状維持）。
         const lastKnownLineup = lastKnownStats.map(stat => stat.playerId)
         const heroSeatUserIds = service.latestEvtDeal?.SeatUserIds
-        const lineupMismatchesHeroDeal = heroSeatUserIds !== undefined && (
+        const heroAnchoredRecalcCanRun = service.playerId !== undefined && heroSeatUserIds !== undefined
+        const lineupMismatchesHeroDeal = heroAnchoredRecalcCanRun && (
           lastKnownLineup.length !== heroSeatUserIds.length ||
           lastKnownLineup.some((playerId, index) => playerId !== heroSeatUserIds[index])
         )

--- a/src/services/auto-sync-service.rebuild-spectator-tail.test.ts
+++ b/src/services/auto-sync-service.rebuild-spectator-tail.test.ts
@@ -1,0 +1,139 @@
+/**
+ * AutoSyncService.rebuildLocalEntities() -- seated-deal guard on cloud restore
+ *
+ * Regression test for a P2 finding filed on the already-merged #177 (the
+ * two inline review comments posted 2026-07-20T12:39, after #177/#179/#181/
+ * #182/#184/#185 had all landed on main):
+ *
+ * `rebuildLocalEntities()` (called after `syncFromCloud()` downloads any
+ * events -- see `performSync('download')`/`performSync('both')`) used to
+ * record the LAST EVT_DEAL seen while chunk-scanning the rebuilt history as
+ * `latestDealEvent`, regardless of whether it carried `Player.SeatIndex`.
+ * If a cloud download/restore's raw event history happens to end on a
+ * spectator-mode deal (hero busted mid-session, client kept receiving
+ * another table's deals -- see docs/api-events.md "観戦モード"), that
+ * spectator deal was fed straight into `service.latestEvtDeal`'s setter
+ * (poker-chase-service.ts), which:
+ *   (1) also syncs the live-display `liveEvtDeal` field to the same
+ *       spectator-mode deal, and
+ *   (2) cannot recover `service.playerId` (a spectator deal has no
+ *       `Player.SeatIndex` to read a hero seat from),
+ * recreating on the cloud-restore path exactly the mixed
+ * hero-identity/spectator-context state #177 fixed for the live pipeline --
+ * and doing so on the *recovery* path (a fresh install restoring from
+ * cloud), which is the worst place for it to resurface.
+ *
+ * Fix: `rebuildLocalEntities()`'s per-event loop now only updates
+ * `latestDealEvent` when `event.Player?.SeatIndex !== undefined` -- the
+ * same discrimination `findLatestPlayerDealEvent()` (database-utils.ts)
+ * applies for the equivalent DB-driven recovery paths (import-export.ts,
+ * poker-chase-service.ts's `recalculateAllStats()`). A spectator-mode tail
+ * event is simply ignored during rebuild (not fed to any field, persisted
+ * or otherwise) -- rebuild is not a live-display moment, so there is no
+ * `liveEvtDeal`-equivalent value for it to usefully seed; the next real
+ * live EVT_DEAL will populate `liveEvtDeal` correctly on its own.
+ */
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { ApiType } from '../types'
+import type { ApiEvent } from '../types'
+import { AutoSyncService } from './auto-sync-service'
+import { firestoreBackupService } from './firestore-backup-service'
+
+const HERO_ID = 4
+
+// Hero's last SEATED deal -- Player.SeatIndex present, hero is UserId 4 at
+// seat 1 (SeatUserIds[1]).
+const SEATED_DEAL = {
+  ApiTypeId: ApiType.EVT_DEAL,
+  SeatUserIds: [2, 4, 3, 1],
+  Game: { CurrentBlindLv: 1, NextBlindUnixSeconds: -1, Ante: 0, SmallBlind: 100, BigBlind: 200, ButtonSeat: 3, SmallBlindSeat: 0, BigBlindSeat: 1 },
+  Player: { SeatIndex: 1, BetStatus: 1, HoleCards: [5, 21], Chip: 5750, BetChip: 200 },
+  OtherPlayers: [
+    { SeatIndex: 0, Status: 0, BetStatus: 1, Chip: 5850, BetChip: 100, IsSafeLeave: false },
+    { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 5950, BetChip: 0, IsSafeLeave: false },
+    { SeatIndex: 3, Status: 0, BetStatus: 1, Chip: 5950, BetChip: 0, IsSafeLeave: false },
+  ],
+  Progress: { Phase: 0, NextActionSeat: 2, NextActionTypes: [2, 3, 4, 5], NextExtraLimitSeconds: 1, MinRaise: 400, Pot: 500, SidePot: [] },
+  timestamp: 1000,
+} as unknown as ApiEvent
+
+// Tail of the downloaded history: hero busted, client kept receiving deals
+// for a different table it's now only spectating -- Player is absent.
+const SPECTATOR_DEAL = {
+  ApiTypeId: ApiType.EVT_DEAL,
+  SeatUserIds: [10, 20, 30, 40],
+  Game: { CurrentBlindLv: 2, NextBlindUnixSeconds: -1, Ante: 0, SmallBlind: 200, BigBlind: 400, ButtonSeat: 1, SmallBlindSeat: 2, BigBlindSeat: 3 },
+  OtherPlayers: [
+    { SeatIndex: 0, Status: 0, BetStatus: 1, Chip: 3000, BetChip: 0, IsSafeLeave: false },
+    { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 3000, BetChip: 0, IsSafeLeave: false },
+    { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 3000, BetChip: 200, IsSafeLeave: false },
+    { SeatIndex: 3, Status: 0, BetStatus: 1, Chip: 3000, BetChip: 400, IsSafeLeave: false },
+  ],
+  Progress: { Phase: 0, NextActionSeat: 0, NextActionTypes: [2, 3, 4, 5], NextExtraLimitSeconds: 1, MinRaise: 400, Pot: 600, SidePot: [] },
+  timestamp: 2000,
+} as unknown as ApiEvent
+
+describe('AutoSyncService.rebuildLocalEntities() -- seated-deal guard on cloud restore', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+
+  beforeEach(async () => {
+    const sendMessageMock = chrome.runtime.sendMessage as jest.Mock
+    sendMessageMock.mockResolvedValue(undefined)
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    service = new PokerChaseService({ db })
+    await service.ready
+    // rebuildLocalEntities() reads the live singleton off `self.service`
+    // (see auto-sync-service.ts) -- in a jsdom jest environment `self` is
+    // `globalThis`/`window`, so this is the same object the module reads.
+    ;(globalThis as any).service = service
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    delete (globalThis as any).service
+    db.close()
+    await db.delete()
+  })
+
+  test('a cloud download ending on a spectator-mode deal restores the hero-anchored SEATED deal, not the spectator tail', async () => {
+    jest.spyOn(firestoreBackupService, 'syncFromCloud').mockImplementation(async options => {
+      // Cloud history arrives oldest-first, ending on the spectator tail --
+      // exactly the shape rebuildLocalEntities() chunk-scans in timestamp order.
+      await options.onBatch([SEATED_DEAL, SPECTATOR_DEAL])
+      options.onProgress?.({ current: 2, total: 2 })
+      return 2
+    })
+
+    const autoSyncService = new AutoSyncService(db)
+    await autoSyncService.performSync('download')
+
+    // playerId recovered from the seated deal, not left undefined (a
+    // spectator deal has no Player.SeatIndex to derive it from).
+    expect(service.playerId).toBe(HERO_ID)
+    // latestEvtDeal (persisted, hero-anchored context) is the last SEATED
+    // deal -- the spectator tail never reaches it.
+    expect(service.latestEvtDeal).toEqual(SEATED_DEAL)
+    // The latestEvtDeal setter syncs liveEvtDeal too (poker-chase-service.ts)
+    // -- the spectator tail is ignored outright, not fed to either field.
+    expect(service.liveEvtDeal).toEqual(SEATED_DEAL)
+  })
+
+  test('control: a cloud download ending on a seated deal still restores it as before', async () => {
+    const laterSeatedDeal = { ...SEATED_DEAL, timestamp: 3000, SeatUserIds: [5, 4, 6, 7] } as ApiEvent
+    jest.spyOn(firestoreBackupService, 'syncFromCloud').mockImplementation(async options => {
+      await options.onBatch([SEATED_DEAL, laterSeatedDeal])
+      options.onProgress?.({ current: 2, total: 2 })
+      return 2
+    })
+
+    const autoSyncService = new AutoSyncService(db)
+    await autoSyncService.performSync('download')
+
+    expect(service.playerId).toBe(HERO_ID)
+    expect(service.latestEvtDeal).toEqual(laterSeatedDeal)
+    expect(service.liveEvtDeal).toEqual(laterSeatedDeal)
+  })
+})

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -594,7 +594,23 @@ export class AutoSyncService {
         for (const event of events) {
           lastProcessedTimestamp = Math.max(lastProcessedTimestamp, event.timestamp || 0)
           this.restoreSessionEvent(service, event)
-          if (isApiEventType(event, ApiType.EVT_DEAL)) latestDealEvent = event
+          // 席着席時のみ latestDealEvent を更新する（findLatestPlayerDealEvent()
+          // ／aggregate-events-stream.tsのEVT_DEALケースと同じ判別: event.Player?.
+          // SeatIndex !== undefined）。ダウンロード履歴の末尾が観戦モードのdeal
+          // （ヒーロー敗退後もクライアントが他プレイヤーのテーブルを受信し続ける
+          // ケース）で終わっていた場合、ここで無条件に最後のEVT_DEALを採用すると、
+          // 下のrestoreLatestDeal()がそれを`service.latestEvtDeal`（ヒーロー在籍の
+          // 文脈・setterがliveEvtDealも同期する）に代入してしまい、クラウド復元
+          // 直後にヒーローのplayerIdを再導出できないばかりか、#177が塞いだはずの
+          // 「観戦テーブルの顔ぶれでヒーロー統計が上書きされる」混在状態を
+          // 復元パス（新規インストールでのクラウドDL）自体が再現してしまう
+          // （codex #177マージ後レビュー、2026-07-20指摘）。観戦モードのdealは
+          // ここで単純に無視する（意図的な選択: リビルドはライブ表示の瞬間では
+          // ないため、liveEvtDeal相当の非永続フィールドへ別途フィードする必要は
+          // ない -- 次の本物のライブdealが来ればliveEvtDealは正しく更新される）。
+          if (isApiEventType(event, ApiType.EVT_DEAL) && event.Player?.SeatIndex !== undefined) {
+            latestDealEvent = event
+          }
         }
       }
 
@@ -666,6 +682,10 @@ export class AutoSyncService {
       // spectator-mode liveEvtDeal from before this cloud-sync restore ran)
       // broadcasts paired with this restored hero-anchored deal's seat
       // context, not a leftover one (codex #177 3rd review round P2).
+      // `latestEvtDeal`'s own contract (poker-chase-service.ts) requires
+      // callers to only ever assign a deal with Player.SeatIndex present --
+      // rebuildLocalEntities() above now upholds that (guards latestDealEvent
+      // to seated deals only), so this is never a spectator-mode deal.
       service.latestEvtDeal = latestDealEvent
       const playerSeatIndex = latestDealEvent.Player?.SeatIndex
       if (playerSeatIndex !== undefined && playerSeatIndex >= 0) {


### PR DESCRIPTION
## Summary

Two late codex findings on the already-merged #177 (inline review comments posted 2026-07-20T12:39, filed against main after #177/#179/#181/#182/#184/#185 had all landed) -- the remaining tail of the deal-context consumer sweep.

- **Finding 1** (`src/services/auto-sync-service.ts` `rebuildLocalEntities()`): recorded the rebuild history's LAST `EVT_DEAL` as `latestDealEvent` even when it was spectator-mode (no `Player.SeatIndex`), then persisted it via the hero-anchored `latestEvtDeal` setter -- a cloud download/restore ending in a spectator deal recreated the mixed hero-identity/spectator-context state #177 fixed, on exactly the recovery path (fresh installs restoring from cloud).

  Fix: only track deals with `Player.SeatIndex` present while chunk-scanning (same discrimination `findLatestPlayerDealEvent()` applies elsewhere). A spectator-mode tail event is now simply ignored during rebuild -- not fed to any field, persisted or otherwise, since rebuild isn't a live-display moment; the next real live `EVT_DEAL` populates `liveEvtDeal` correctly on its own.

- **Finding 2** (`src/streams/read-entity-stream.ts` / `src/background/message-router.ts`): `recalculateStats()` (called from `setBattleTypeFilter()`) re-anchors `service.liveEvtDeal` to the hero's deal synchronously, before its first `await`. `message-router.ts`'s `updateBattleTypeFilter` handler separately replays the last known live broadcast (`lastKnownStats`) via `statsOutputStream.write()` right after calling `setBattleTypeFilter()`. While spectating after busting mid-session (pre-309, **not** covered by #179's session-end `lastKnownStats` invalidation), `lastKnownStats` holds the spectator table's lineup -- racing that replay against the hero-anchored `liveEvtDeal` re-sync can broadcast spectator stats paired with the hero's `evtDeal` (or vice versa), rotating/overwriting the wrong seats in `App.tsx`.

  Fix: a lineup-identity check in `message-router.ts` -- skip the extra `lastKnownStats` replay outright when its lineup doesn't match `service.latestEvtDeal.SeatUserIds` (a confirmed mismatch). `setBattleTypeFilter()`'s own `recalculateStats()` already recomputes and broadcasts the hero-anchored stats correctly in that case, so nothing is lost. When `latestEvtDeal` is unset, the mismatch can't be established, so the refresh still runs as before (safe default, matches pre-existing test coverage).

## Test plan
- [x] `npx tsc --noEmit` -- clean
- [x] `npm test` (jest) x2 -- 107 suites / 1015 tests, both runs clean
- [x] `npm run e2e:smoke` -- all 6 checks pass
- [x] `npm run e2e:playerid` -- all 4 checks pass
- [x] New regression tests:
  - `src/services/auto-sync-service.rebuild-spectator-tail.test.ts` -- cloud download ending on a spectator-mode deal restores the last SEATED deal (playerId recovered), not the spectator tail; control case (download ending on a seated deal) unaffected
  - `src/background/message-router.spectator-filter-refresh.test.ts` -- spectating a different table than the hero's last deal skips the extra refresh (lineup mismatch); hero still seated still refreshes as before; `latestEvtDeal` unset falls back to unchanged default behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>