### PR TITLE
fix(hud): post-merge review tail for busted-player dim

### DIFF
--- a/src/background/event-ingestion.session-end-clears-last-known-stats.test.ts
+++ b/src/background/event-ingestion.session-end-clears-last-known-stats.test.ts
@@ -14,9 +14,9 @@
  * to every connected tab -- repopulating the HUD panels App.tsx had just
  * cleared, with the previous (now-departed) session's players.
  *
- * Fix: hook `setLastKnownStats([])` alongside the existing raw-ApiTypeId
- * session-end tracking in event-ingestion.ts (same raw-first pattern
- * `markSessionInactive()` already uses -- see
+ * Fix (round3): hook `setLastKnownStats([])` alongside the existing
+ * raw-ApiTypeId session-end tracking in event-ingestion.ts (same raw-first
+ * pattern `markSessionInactive()` already uses -- see
  * event-ingestion.update-manager-trigger.test.ts -- so this isn't affected
  * by the season3 EVT_SESSION_RESULTS payload breakage documented in
  * docs/postmortems/2026-07-session-results-drop.md; the raw numeric
@@ -24,13 +24,44 @@
  * `updateBattleTypeFilter`'s `lastKnownStats.length > 0` guard is false, so
  * a post-session filter change behaves like pre-session: no rebroadcast.
  *
+ * Rounds 4-6 (all since reverted, PR #191 post-merge review passes 2-3)
+ * tried, in turn: seeding `lastKnownStats` with a hero-only lineup here
+ * instead of `[]` (rounds 4/5), and adding a full session-aware hero-identity
+ * verification layer to App.tsx (round 6, the "相互作用マトリクス" design).
+ * Both directions targeted the wrong lever or over-engineered a low-priority
+ * feature: independent of `lastKnownStats`'s content, `service.
+ * setBattleTypeFilter()` (called by every `updateBattleTypeFilter` request)
+ * unconditionally runs `ReadEntityStream.recalculateStats()`, which
+ * re-broadcasts `service.latestEvtDeal.SeatUserIds` (the hero's full
+ * last-seated lineup, *including* the ended session's opponents, since
+ * `latestEvtDeal` survives session end by design) regardless of what this
+ * file sets `lastKnownStats` to. Chasing that broadcast (matching its
+ * seat-index convention, its evtDeal pairing, gating the whole display on a
+ * session-active ref, etc.) turned into a losing game of whack-a-mole across
+ * three review rounds.
+ *
+ * Owner decision (2026-07-20, sola: 「それほど重要な機能ではないので、bで
+ * 十分です」): descope to the conservative option. Busted-player dim/hero
+ * preservation is only guaranteed within an uninterrupted live sequence and
+ * at session end (#158's hero-panel survival, kept as-is in App.tsx's
+ * `handleSessionEnd`). A post-session filter change may occasionally
+ * re-display the hero's last real (pre-session-end) table via
+ * `recalculateStats()` -- accepted as "accurate but possibly stale", not
+ * engineered around further. This file stays exactly as simple as the
+ * original round3 fix. See event-ingestion.ts's inline comment for the full
+ * trace, and message-router.ts's `updateBattleTypeFilter` handler (#188) for
+ * the separate lineup-identity guard that independently prevents the
+ * spectator-lineup/hero-evtDeal mismatch broadcast race.
+ *
  * The pre-game hero-stats fallback (#158, `requestLatestStats` ->
  * `getLatestSessionStats`) is a separate DB-backed code path
  * (import-export.ts) that never reads `lastKnownStats`, so it's unaffected
- * by this change -- verified directly below rather than via a nonexistent
- * `e2e:playerid` scenario (no such npm script or e2e/scenarios file exists
- * in this repo; import-export.pregame-hero-stats.test.ts already covers
- * that path in isolation and is untouched by this change).
+ * by any of this -- verified directly below at the unit level, in addition
+ * to `e2e/scenarios/playerid-session-persistence.ts` (`npm run
+ * e2e:playerid`) exercising the same fallback end-to-end against a fixture
+ * that includes a spectator-mode `EVT_DEAL` + `EVT_SESSION_RESULTS`;
+ * `import-export.pregame-hero-stats.test.ts` also covers this path in
+ * isolation and is untouched by this change.
  */
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
 import PokerChaseService, { PokerChaseDB } from '../app'
@@ -179,7 +210,7 @@ describe('session end (309) invalidates background lastKnownStats', () => {
     expect(getLastKnownStats()).toEqual([])
   })
 
-  test('filter change after session end does not rebroadcast the ended lineup (309 -> filter change -> no repopulation)', async () => {
+  test('filter change after session end does not rebroadcast the ended lineup via the explicit getLastKnownStats() write path (309 -> filter change -> no repopulation from this path)', async () => {
     // Simulate an ended session's lineup still cached from before the fix's
     // trigger point in this test (i.e. what would have lingered pre-fix).
     setLastKnownStats([{ playerId: 2, statResults: [] } as any, { playerId: 3, statResults: [] } as any])
@@ -196,8 +227,14 @@ describe('session end (309) invalidates background lastKnownStats', () => {
     )
     await new Promise(resolve => setTimeout(resolve, 0))
 
-    // No rebroadcast: lastKnownStats was empty, so the ended lineup can't
-    // resurrect into App.tsx's already-cleared HUD panels.
+    // No rebroadcast from message-router.ts's explicit `getLastKnownStats()`
+    // write: lastKnownStats was empty, so the ended lineup can't resurrect
+    // into App.tsx's already-cleared HUD panels via *this* path. Note this
+    // test only observes `service.statsOutputStream.write`, not the
+    // separate `recalculateStats()` call `setBattleTypeFilter()` also makes
+    // (which pushes directly and doesn't go through `.write()`) -- that
+    // path, and App.tsx's defense against it, is covered by App.test.tsx's
+    // "セッション終了後" / sessionActiveRef test cases, not here.
     expect(writeSpy).not.toHaveBeenCalled()
   })
 

--- a/src/background/event-ingestion.ts
+++ b/src/background/event-ingestion.ts
@@ -86,6 +86,38 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
           // スタッツの復元（#158, `requestLatestStats`→`getLatestSessionStats`）
           // はDBを読む別経路でありlastKnownStatsを参照しないため、この変更の
           // 影響を受けない。
+          //
+          // post-merge reviewでは一時ここにhero単独lineupを合成する修正
+          // （round4/round5）や、App.tsx側にセッション状態・ヒーロー身元の
+          // 検証機構を足す修正（round6の「相互作用マトリクス」設計）を
+          // 積んだが、いずれもオーナー判断で撤回されている（PR #191,
+          // 2026-07-20, sola「それほど重要な機能ではないので、bで十分です」）。
+          // 理由: `service.setBattleTypeFilter()`は内部で無条件に
+          // `ReadEntityStream.recalculateStats()`を呼び、`lastKnownStats`の
+          // 中身に関係なく`service.latestEvtDeal.SeatUserIds`（ヒーローの
+          // 直近の実在席時点のフルの顔ぶれ。セッション終了後もクリアされ
+          // ない）を再計算・再ブロードキャストしてしまう。つまりこのファイル
+          // 側で`lastKnownStats`をどう作っても、その再ブロードキャストは
+          // 止められない別経路であり、追いかけるだけ複雑化する一方だった。
+          //
+          // 採用した方針（保守的な縮小スコープ）: bust後のミュート表示・
+          // hero身元の保持は「連続したライブシーケンス内」でのみ保証する
+          // （#158のセッション終了時hero保持は例外的にApp.tsx側で維持）。
+          // セッション終了後にフィルターを変更すると、`recalculateStats()`
+          // がヒーロー在籍時点の最後の実テーブル（対戦相手を含む）を新
+          // フィルターで再表示することがあるが、これは「不正確なデータ」
+          // ではなく「文脈的に古い可能性のある正確なデータ」であり、この
+          // 機能の重要度に見合わないため許容する。ここは元のround3の
+          // 意図通り単純な`[]`のままにする -- `updateBattleTypeFilter`の
+          // 明示的な`getLastKnownStats()`ベースの再write()を単にno-opに
+          // するだけで、他には何もしない。
+          //
+          // なお#188（read-entity-stream.tsのrecalculateStats()を呼ぶ
+          // message-router.tsのupdateBattleTypeFilterハンドラー自身）で、
+          // このwrite()と`recalculateStats()`の競合（観戦中のlineupが
+          // ヒーロー在籍dealのevtDealとペアリングされてしまうケース）に
+          // 対する`lineup-identity`ガードが別途入っており、この単純な
+          // `[]`のままでも競合は起きない。
           setLastKnownStats([])
         }
 

--- a/src/components/App.pregame-hero-stats.test.tsx
+++ b/src/components/App.pregame-hero-stats.test.tsx
@@ -159,4 +159,84 @@ describe('App - pre-game hero stats takeover', () => {
     // unmount/remount flicker).
     expect(screen.getByTestId('hud-0')).toBe(heroNodeBefore)
   })
+
+  // Regression for a post-merge review P2 finding on PR #191 (descope pass1):
+  // "Prefer visible hero stats after batch refreshes". A `latestStats`
+  // batch refresh (post-import round-trip, or any other trusted DB
+  // recompute mid-session) updates the *visible* hero stat but historically
+  // left dimCacheRef's hero entry untouched. If no further live hero-anchored
+  // deal arrived before the session ended, handleSessionEnd's `dimCache.get
+  // (HERO_SEAT_INDEX) ?? stat` preferred the older cached value over the
+  // fresher batch-refreshed one, rolling the hero panel back to stale numbers
+  // right when the user would expect the latest (just-imported) stats to
+  // persist.
+  it('hero panel does not roll back to a stale live-cache value after a latestStats batch refresh, when session ends before another live deal', async () => {
+    render(<App />)
+    await waitFor(() => {
+      expect(screen.getByTestId('hud-0')).toBeInTheDocument()
+    })
+
+    // A live, hero-anchored hand establishes an "old" cached hero stat
+    // (dimCacheRef's HERO_SEAT_INDEX entry).
+    const evtDeal = {
+      ApiTypeId: ApiType.EVT_DEAL as const,
+      Player: { SeatIndex: 0, BetStatus: 1, HoleCards: [], Chip: 1000, BetChip: 0 },
+      SeatUserIds: [HERO_ID, 2, 3, 4, 5, 6],
+      Game: {
+        CurrentBlindLv: 1, NextBlindUnixSeconds: 0, Ante: 0,
+        SmallBlind: 50, BigBlind: 100, ButtonSeat: 0, SmallBlindSeat: 1, BigBlindSeat: 2
+      },
+      OtherPlayers: [
+        { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+        { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+        { SeatIndex: 3, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+        { SeatIndex: 4, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+        { SeatIndex: 5, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+      ],
+      Progress: { Phase: 0, NextActionSeat: 0, NextActionTypes: [2, 3, 4, 5], NextExtraLimitSeconds: 0, MinRaise: 0, Pot: 0, SidePot: [] },
+      timestamp: Date.now(),
+    } as ApiEvent<ApiType.EVT_DEAL>
+    const liveStats: StatsData['stats'] = [
+      { playerId: HERO_ID, statResults: [{ id: 'hands', name: 'HAND', value: 10, formatted: '10' } as any] },
+      { playerId: 2, statResults: [] },
+      { playerId: 3, statResults: [] },
+      { playerId: 4, statResults: [] },
+      { playerId: 5, statResults: [] },
+      { playerId: 6, statResults: [] },
+    ]
+    act(() => {
+      window.dispatchEvent(new CustomEvent('PokerChaseServiceEvent', {
+        detail: { stats: liveStats, evtDeal } as StatsData,
+      }))
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('hud-0')).toHaveTextContent('Hands: 10')
+    })
+
+    // Mid-session import/refresh: a trusted DB recompute delivers fresher
+    // hero stats (e.g. newly-imported hands raised the HAND count) via the
+    // same `latestStats` chrome message path as the pregame fallback.
+    const messageHandler = (chrome.runtime.onMessage.addListener as jest.Mock).mock.calls[0][0]
+    act(() => {
+      messageHandler({
+        action: 'latestStats',
+        stats: [
+          { playerId: HERO_ID, statResults: [{ id: 'hands', name: 'HAND', value: 99, formatted: '99' } as any] },
+          { playerId: -1 }, { playerId: -1 }, { playerId: -1 }, { playerId: -1 }, { playerId: -1 },
+        ],
+      } as ChromeMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('hud-0')).toHaveTextContent('Hands: 99')
+    })
+
+    // Session ends with no further live hero-anchored deal in between --
+    // the hero panel must keep showing the fresher batch-refreshed value,
+    // not roll back to the stale live-cache snapshot from before the import.
+    act(() => {
+      window.dispatchEvent(new CustomEvent('PokerChaseSessionEndEvent'))
+    })
+    expect(screen.getByTestId('hud-0')).toHaveTextContent('Player: 1')
+    expect(screen.getByTestId('hud-0')).toHaveTextContent('Hands: 99')
+  })
 })

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -962,6 +962,32 @@ describe('App', () => {
         }
       })
 
+      it('フィルター変更は今まさにライブ在籍中の座席のキャッシュを消さない -- 変更直後にその席がbustしても正しくdim表示される（post-merge review descope pass1「Avoid clearing freshly rebuilt live-seat cache」）', async () => {
+        render(<App />)
+        await dispatchStats(mockStatsData.stats)
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: 2')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: no')
+
+        // 誰もミュートされていない状態でフィルターが変わる（message-router.ts
+        // の再計算ブロードキャストが、このwindowイベント転送より先に届いて
+        // dimCacheを打ち直した直後、というシナリオを模す -- 実際にはタイミング
+        // 非決定だが、App.tsx側はどちらの順序でも安全でなければならない）
+        await act(async () => {
+          window.dispatchEvent(new CustomEvent('updateBattleTypeFilter', {
+            detail: { gameTypes: { sng: true, mtt: false, ring: true } },
+          }))
+        })
+
+        // 席1(プレイヤー2)がまだライブ在籍中のうちにbustする。フィルター
+        // 変更が席1のキャッシュを無条件で消していたら、この時点でキャッシュが
+        // 空になっており、dim表示されず素の「Waiting for Hand...」に
+        // 落ちてしまう
+        const bustedLineup: StatsData['stats'] = mockStatsData.stats.map((s, i) => (i === 1 ? { playerId: -1 } : s))
+        await dispatchStats(bustedLineup)
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: 2')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: yes')
+      })
+
       it('latestStats(バッチ再計算)でdimmedSeatIndicesが空にリセットされた後でも、フィルター変更は取り残されたdimCacheエントリを無効化する（post-merge review P2「Clear cached muted seats even after dim state resets」）', async () => {
         render(<App />)
         await dispatchStats(mockStatsData.stats)

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -988,6 +988,102 @@ describe('App', () => {
         expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: yes')
       })
 
+      it('観戦モードdealを挟んだ後のフィルター変更は、観戦先の生の座席インデックスが偶然在席していても「ライブ在籍中」とは扱わず、hero自身のテーブルの古いキャッシュを正しくクリアする（post-merge review descope pass2「Clear spectator-context caches on filter updates」）', async () => {
+        render(<App />)
+        // ヒーロー在籍のhandで席1(プレイヤー2)がbustしてミュート表示になる
+        await act(async () => {
+          window.dispatchEvent(new CustomEvent('PokerChaseServiceEvent', {
+            detail: { stats: mockStatsData.stats, evtDeal: heroDeal() } as StatsData,
+          }))
+        })
+        const bustedLineup: StatsData['stats'] = mockStatsData.stats.map((s, i) => (i === 1 ? { playerId: -1 } : s))
+        await act(async () => {
+          window.dispatchEvent(new CustomEvent('PokerChaseServiceEvent', {
+            detail: { stats: bustedLineup, evtDeal: heroDeal() } as StatsData,
+          }))
+        })
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: 2')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: yes')
+
+        // ヒーロー敗退後、観戦モードdealが届く。観戦先の生の座席1には
+        // 偶然別の在席者(777)がいる -- これはhero自身のテーブルの席1とは
+        // 無関係の別空間の座席
+        const spectatorLineup: StatsData['stats'] = [
+          { playerId: -1 },
+          { playerId: 777, statResults: [] },
+          { playerId: -1 }, { playerId: -1 }, { playerId: -1 }, { playerId: -1 },
+        ]
+        await act(async () => {
+          window.dispatchEvent(new CustomEvent('PokerChaseServiceEvent', {
+            detail: { stats: spectatorLineup, evtDeal: makeEvtDeal() } as StatsData,
+          }))
+        })
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: 777')
+
+        // この観戦中にフィルターが変わる。席1(数値インデックス)には観戦先の
+        // 777が在席しているが、これはhero自身のテーブルの「ライブ在籍中」
+        // ではないので、旧テーブルのプレイヤー2の古いキャッシュはクリア
+        // されなければならない
+        await act(async () => {
+          window.dispatchEvent(new CustomEvent('updateBattleTypeFilter', {
+            detail: { gameTypes: { sng: true, mtt: false, ring: true } },
+          }))
+        })
+
+        // ヒーロー在籍dealに戻り、hero自身のテーブルの席1は引き続き空席
+        const stillBustedLineup: StatsData['stats'] = mockStatsData.stats.map((s, i) => (i === 1 ? { playerId: -1 } : s))
+        await act(async () => {
+          window.dispatchEvent(new CustomEvent('PokerChaseServiceEvent', {
+            detail: { stats: stillBustedLineup, evtDeal: heroDeal() } as StatsData,
+          }))
+        })
+
+        // プレイヤー2の古いキャッシュがクリアされていれば、席1は
+        // 「Waiting for Hand...」のまま -- クリアされていなければ、
+        // 観戦を挟んでも古いプレイヤー2がミュート表示のまま蘇ってしまう
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: -1')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: no')
+      })
+
+      it('座席数が縮んだ更新（4-maxなど）の後のフィルター変更は、6-max時代のキャッシュを「存在しない座席=ライブ在籍中」と誤認せず正しくクリアする（post-merge review descope pass2「Treat missing seats as empty when clearing caches」）', async () => {
+        render(<App />)
+        await dispatchStats(mockStatsData.stats)
+
+        // 席4(プレイヤー5)がbustしてミュート表示になる(6-max)
+        const bustedLineup: StatsData['stats'] = mockStatsData.stats.map((s, i) => (i === 4 ? { playerId: -1 } : s))
+        await dispatchStats(bustedLineup)
+        expect(screen.getByTestId('hud-4')).toHaveTextContent('Player: 5')
+        expect(screen.getByTestId('hud-4')).toHaveTextContent('Dimmed: yes')
+
+        // 4-maxへ縮小したlineupが届く(配列長4、座席4/5に対応する要素自体が
+        // 無い)。この更新のmapループはindex 0-3しか処理しないため、席4の
+        // 古いキャッシュには一切触れられない
+        const fourMaxLineup: StatsData['stats'] = [
+          { playerId: 1, statResults: [] },
+          { playerId: 2, statResults: [] },
+          { playerId: 3, statResults: [] },
+          { playerId: 4, statResults: [] },
+        ]
+        await dispatchStats(fourMaxLineup)
+
+        // この状態でフィルターが変わる。席4は現在の表示に存在しない
+        // （currentStats[4]がundefined）ので「ライブ在籍中」ではなく、
+        // 古いキャッシュはクリアされなければならない
+        await act(async () => {
+          window.dispatchEvent(new CustomEvent('updateBattleTypeFilter', {
+            detail: { gameTypes: { sng: true, mtt: false, ring: true } },
+          }))
+        })
+
+        // 6-maxに戻り、席4が引き続き空席のlineupが届く
+        await dispatchStats(bustedLineup)
+
+        // プレイヤー5の古いキャッシュがクリアされていれば、席4は
+        // 「Waiting for Hand...」のまま
+        expect(screen.getByTestId('hud-4')).toHaveTextContent('Player: -1')
+        expect(screen.getByTestId('hud-4')).toHaveTextContent('Dimmed: no')
+      })
+
       it('latestStats(バッチ再計算)でdimmedSeatIndicesが空にリセットされた後でも、フィルター変更は取り残されたdimCacheエントリを無効化する（post-merge review P2「Clear cached muted seats even after dim state resets」）', async () => {
         render(<App />)
         await dispatchStats(mockStatsData.stats)

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -813,5 +813,218 @@ describe('App', () => {
         expect(screen.getByTestId('hud-2')).toHaveTextContent('Dimmed: no')
       })
     })
+
+    describe('曖昧な境界での挙動（観戦モードdeal・フィルター変更・リロード。PR #191、オーナー承認の縮小スコープ）', () => {
+      // baseSchema/EVT_DEALスキーマ（src/types/api.ts）を満たす最小限のEVT_DEAL。
+      // playerOverrideを渡さなければPlayerフィールド自体を省略する（観戦モード
+      // ＝Player不在をisApiEventType()のZod検証込みで再現するため）。
+      const makeEvtDeal = (playerOverride?: Record<string, unknown>): ApiEvent<ApiType.EVT_DEAL> => ({
+        ApiTypeId: ApiType.EVT_DEAL as const,
+        ...(playerOverride ? { Player: playerOverride } : {}),
+        SeatUserIds: [1, 2, 3, 4, 5, 6],
+        Game: {
+          CurrentBlindLv: 1, NextBlindUnixSeconds: 0, Ante: 0,
+          SmallBlind: 50, BigBlind: 100, ButtonSeat: 0, SmallBlindSeat: 1, BigBlindSeat: 2,
+        },
+        OtherPlayers: [
+          { SeatIndex: 0, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+          { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+          { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+          { SeatIndex: 3, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+          { SeatIndex: 4, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+        ],
+        Progress: { Phase: 0, NextActionSeat: 0, NextActionTypes: [2, 3, 4, 5], NextExtraLimitSeconds: 0, MinRaise: 0, Pot: 0, SidePot: [] },
+        timestamp: Date.now(),
+      } as ApiEvent<ApiType.EVT_DEAL>)
+
+      const heroDeal = () => makeEvtDeal({ SeatIndex: 0, BetStatus: 1, HoleCards: [], Chip: 1000, BetChip: 0 })
+
+      it('観戦モードdeal（EVT_DEAL.Player不在）ではdimCacheを適用せず、生のlineupをそのまま表示する（旧テーブルの空席ゴーストが蘇らない）', async () => {
+        render(<App />)
+
+        // ヒーロー在籍のhandで席1(プレイヤー2)がbustしてミュート表示になる
+        await dispatchStats(mockStatsData.stats)
+        const bustedLineup: StatsData['stats'] = mockStatsData.stats.map((s, i) => (i === 1 ? { playerId: -1 } : s))
+        await act(async () => {
+          window.dispatchEvent(new CustomEvent('PokerChaseServiceEvent', {
+            detail: { stats: bustedLineup, evtDeal: heroDeal() } as StatsData,
+          }))
+        })
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: 2')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: yes')
+
+        // ヒーロー敗退後、観戦モードdealが届く: Playerがundefinedで、生の
+        // （ヒーロー自身のテーブルとすら限らない）別テーブルの席順が来る。
+        // 座席1はたまたま空席、座席2・3には観戦先の別プレイヤーが在席
+        const spectatorLineup: StatsData['stats'] = [
+          { playerId: -1 },
+          { playerId: -1 },
+          { playerId: 900, statResults: [] },
+          { playerId: 901, statResults: [] },
+          { playerId: -1 },
+          { playerId: -1 },
+        ]
+        await act(async () => {
+          window.dispatchEvent(new CustomEvent('PokerChaseServiceEvent', {
+            detail: { stats: spectatorLineup, evtDeal: makeEvtDeal() } as StatsData,
+          }))
+        })
+
+        // 旧テーブルのプレイヤー(2)がミュート表示のまま蘇ってはいけない --
+        // dimCacheは適用されず観戦テーブルの生の席順がそのまま出る
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: -1')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: no')
+        expect(screen.getByTestId('hud-2')).toHaveTextContent('Player: 900')
+        expect(screen.getByTestId('hud-2')).toHaveTextContent('Dimmed: no')
+        expect(screen.getByTestId('hud-3')).toHaveTextContent('Player: 901')
+        expect(screen.getByTestId('hud-3')).toHaveTextContent('Dimmed: no')
+      })
+
+      it('直前が観戦モードdealでも、セッション終了時に本物のヒーローが保持される（観戦先の生の席0で上書きされない）', async () => {
+        render(<App />)
+        await act(async () => {
+          window.dispatchEvent(new CustomEvent('PokerChaseServiceEvent', {
+            detail: { stats: mockStatsData.stats, evtDeal: heroDeal() } as StatsData,
+          }))
+        })
+        expect(screen.getByTestId('hud-0')).toHaveTextContent('Player: 1')
+
+        // 観戦モードdeal: 生のテーブルの席0はヒーロー(1)ではなく無関係な
+        // プレイヤー(999)
+        const spectatorLineup: StatsData['stats'] = [
+          { playerId: 999, statResults: [] },
+          { playerId: -1 }, { playerId: -1 }, { playerId: -1 }, { playerId: -1 }, { playerId: -1 },
+        ]
+        await act(async () => {
+          window.dispatchEvent(new CustomEvent('PokerChaseServiceEvent', {
+            detail: { stats: spectatorLineup, evtDeal: makeEvtDeal() } as StatsData,
+          }))
+        })
+        expect(screen.getByTestId('hud-0')).toHaveTextContent('Player: 999')
+
+        await act(async () => {
+          window.dispatchEvent(new CustomEvent('PokerChaseSessionEndEvent'))
+        })
+
+        // hero(1)が保持される -- 観戦先の生の席0(999)に上書きされてはいけない
+        expect(screen.getByTestId('hud-0')).toHaveTextContent('Player: 1')
+      })
+
+      it('フィルター変更(updateBattleTypeFilter)で、ミュート表示中の座席のキャッシュが無効化される', async () => {
+        render(<App />)
+        await dispatchStats(mockStatsData.stats)
+
+        // 席1(プレイヤー2)がbustしてミュート表示になる
+        const bustedLineup: StatsData['stats'] = mockStatsData.stats.map((s, i) => (i === 1 ? { playerId: -1 } : s))
+        await dispatchStats(bustedLineup)
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: 2')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: yes')
+
+        // content_script.tsが'updateBattleTypeFilter'メッセージ受信時に
+        // dispatchする同名のwindowイベント
+        await act(async () => {
+          window.dispatchEvent(new CustomEvent('updateBattleTypeFilter', {
+            detail: { gameTypes: { sng: true, mtt: false, ring: true } },
+          }))
+        })
+
+        // ミュート表示中だった座席は古いフィルターの統計を出し続けず
+        // 「Waiting for Hand...」へクリアされる
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: -1')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: no')
+        // ライブ在籍中のhero・他の座席は無関係に影響を受けない
+        expect(screen.getByTestId('hud-0')).toHaveTextContent('Player: 1')
+        expect(screen.getByTestId('hud-0')).toHaveTextContent('Dimmed: no')
+
+        // クリア後、席1に同じプレイヤー(2)が戻ってきたら通常通り表示される
+        // （キャッシュのクリアが以降のライブ更新を壊さない）
+        await dispatchStats(mockStatsData.stats)
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: 2')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: no')
+      })
+
+      it('フィルター変更時、ミュート中の座席がなければ何もしない（不要な再レンダリングを避ける）', async () => {
+        render(<App />)
+        await dispatchStats(mockStatsData.stats)
+        expect(screen.getByTestId('hud-0')).toHaveTextContent('Player: 1')
+
+        await act(async () => {
+          window.dispatchEvent(new CustomEvent('updateBattleTypeFilter', {
+            detail: { gameTypes: { sng: true, mtt: false, ring: true } },
+          }))
+        })
+
+        // 全席ライブ在籍中で誰もミュートされていないので、フィルター変更は
+        // 何も変えない
+        for (let i = 0; i < 6; i++) {
+          expect(screen.getByTestId(`hud-${i}`)).toHaveTextContent(`Player: ${i + 1}`)
+          expect(screen.getByTestId(`hud-${i}`)).toHaveTextContent('Dimmed: no')
+        }
+      })
+
+      it('latestStats(バッチ再計算)でdimmedSeatIndicesが空にリセットされた後でも、フィルター変更は取り残されたdimCacheエントリを無効化する（post-merge review P2「Clear cached muted seats even after dim state resets」）', async () => {
+        render(<App />)
+        await dispatchStats(mockStatsData.stats)
+
+        // 席1(プレイヤー2)がbustしてミュート表示になる
+        const bustedLineup: StatsData['stats'] = mockStatsData.stats.map((s, i) => (i === 1 ? { playerId: -1 } : s))
+        await dispatchStats(bustedLineup)
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: 2')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: yes')
+
+        // インポート後のrefreshStats往復相当: chrome.runtime.onMessageで
+        // 'latestStats'が来る（席1は改めて空席として届く）。この経路は
+        // dimmedSeatIndicesを空にリセットするが、dimCacheRef自体には
+        // 触れない -- 席1の"プレイヤー2"のキャッシュは取り残されたまま
+        const addListenerCalls = (chrome.runtime.onMessage.addListener as jest.Mock).mock.calls
+        const messageHandler = addListenerCalls[0][0]
+        const batchLineup: StatsData['stats'] = mockStatsData.stats.map((s, i) => (i === 1 ? { playerId: -1 } : s))
+        await act(async () => {
+          messageHandler({ action: 'latestStats', stats: batchLineup })
+        })
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: -1')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: no')
+
+        // この時点でdimmedSeatIndicesは空 -- 旧実装(dimmedSeatIndicesRef基準の
+        // クリア)だと、フィルター変更ハンドラーは「クリアすべき座席なし」と
+        // 誤認して早期returnし、取り残されたdimCacheの席1エントリを見逃す
+        await act(async () => {
+          window.dispatchEvent(new CustomEvent('updateBattleTypeFilter', {
+            detail: { gameTypes: { sng: true, mtt: false, ring: true } },
+          }))
+        })
+
+        // 席1が引き続き空席のライブ更新が届いても、取り残された古いフィルター
+        // 統計(プレイヤー2)がdimCacheから復活してミュート表示されてはいけない
+        const stillBustedLineup: StatsData['stats'] = mockStatsData.stats.map((s, i) => (i === 1 ? { playerId: -1 } : s))
+        await dispatchStats(stillBustedLineup)
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: -1')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: no')
+      })
+
+      it('リロード/再マウント境界: 事前状態やセッション開始シグナルを一切必要とせず、新しいマウントは空の状態から通常通りライブ更新を受け付ける（縮小スコープの下では特別なガードを持たない）', async () => {
+        const { unmount } = render(<App />)
+        await dispatchStats(mockStatsData.stats)
+        const bustedLineup: StatsData['stats'] = mockStatsData.stats.map((s, i) => (i === 1 ? { playerId: -1 } : s))
+        await dispatchStats(bustedLineup)
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: yes')
+
+        // タブのリロード/拡張機能の再読み込みを模す -- 古いReactツリーの
+        // dimCache/dimmedSeatIndicesは新しいマウントに一切引き継がれない
+        // （新しいuseRef/useState、モジュールスコープの状態も持たない）
+        unmount()
+        render(<App />)
+
+        // 新しいマウントは、以前のセッションについて何も知らない状態から
+        // 即座に通常通りライブ更新を受け付ける -- セッション開始シグナルを
+        // 待つ必要も、以前の状態を復元する必要もない（pregameのhero単独
+        // フォールバックは別経路の`latestStats`chromeメッセージが担当し、
+        // ここでは検証しない）
+        await dispatchStats(mockStatsData.stats)
+        expect(screen.getByTestId('hud-0')).toHaveTextContent('Player: 1')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: 2')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: no')
+      })
+    })
   })
 })

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -962,33 +962,7 @@ describe('App', () => {
         }
       })
 
-      it('フィルター変更は今まさにライブ在籍中の座席のキャッシュを消さない -- 変更直後にその席がbustしても正しくdim表示される（post-merge review descope pass1「Avoid clearing freshly rebuilt live-seat cache」）', async () => {
-        render(<App />)
-        await dispatchStats(mockStatsData.stats)
-        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: 2')
-        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: no')
-
-        // 誰もミュートされていない状態でフィルターが変わる（message-router.ts
-        // の再計算ブロードキャストが、このwindowイベント転送より先に届いて
-        // dimCacheを打ち直した直後、というシナリオを模す -- 実際にはタイミング
-        // 非決定だが、App.tsx側はどちらの順序でも安全でなければならない）
-        await act(async () => {
-          window.dispatchEvent(new CustomEvent('updateBattleTypeFilter', {
-            detail: { gameTypes: { sng: true, mtt: false, ring: true } },
-          }))
-        })
-
-        // 席1(プレイヤー2)がまだライブ在籍中のうちにbustする。フィルター
-        // 変更が席1のキャッシュを無条件で消していたら、この時点でキャッシュが
-        // 空になっており、dim表示されず素の「Waiting for Hand...」に
-        // 落ちてしまう
-        const bustedLineup: StatsData['stats'] = mockStatsData.stats.map((s, i) => (i === 1 ? { playerId: -1 } : s))
-        await dispatchStats(bustedLineup)
-        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: 2')
-        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: yes')
-      })
-
-      it('観戦モードdealを挟んだ後のフィルター変更は、観戦先の生の座席インデックスが偶然在席していても「ライブ在籍中」とは扱わず、hero自身のテーブルの古いキャッシュを正しくクリアする（post-merge review descope pass2「Clear spectator-context caches on filter updates」）', async () => {
+      it('観戦モードdealを挟んだ後のフィルター変更も、hero以外のdimCacheを無条件でクリアする（観戦先の生の座席に偶然誰か在席していても関係ない。post-merge review descope pass3でisLiveNowの選択的温存を撤回し単純な無条件クリアに戻した）', async () => {
         render(<App />)
         // ヒーロー在籍のhandで席1(プレイヤー2)がbustしてミュート表示になる
         await act(async () => {
@@ -1020,10 +994,8 @@ describe('App', () => {
         })
         expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: 777')
 
-        // この観戦中にフィルターが変わる。席1(数値インデックス)には観戦先の
-        // 777が在席しているが、これはhero自身のテーブルの「ライブ在籍中」
-        // ではないので、旧テーブルのプレイヤー2の古いキャッシュはクリア
-        // されなければならない
+        // この観戦中にフィルターが変わる -- 座席の在籍状況を問わず、
+        // hero以外のdimCacheは無条件でクリアされる
         await act(async () => {
           window.dispatchEvent(new CustomEvent('updateBattleTypeFilter', {
             detail: { gameTypes: { sng: true, mtt: false, ring: true } },
@@ -1038,50 +1010,80 @@ describe('App', () => {
           }))
         })
 
-        // プレイヤー2の古いキャッシュがクリアされていれば、席1は
-        // 「Waiting for Hand...」のまま -- クリアされていなければ、
-        // 観戦を挟んでも古いプレイヤー2がミュート表示のまま蘇ってしまう
+        // プレイヤー2の古いキャッシュがクリアされているので、席1は
+        // 「Waiting for Hand...」のまま -- 観戦を挟んでも古いプレイヤー2が
+        // ミュート表示のまま蘇ってはいけない
         expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: -1')
         expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: no')
       })
 
-      it('座席数が縮んだ更新（4-maxなど）の後のフィルター変更は、6-max時代のキャッシュを「存在しない座席=ライブ在籍中」と誤認せず正しくクリアする（post-merge review descope pass2「Treat missing seats as empty when clearing caches」）', async () => {
+      it('latestStats(バッチ再計算)を挟んだ後のフィルター変更も、hero以外のdimCacheを無条件でクリアする（post-merge review descope pass3、バッチ経路でも同じ無条件クリアが効くことの確認）', async () => {
         render(<App />)
         await dispatchStats(mockStatsData.stats)
-
-        // 席4(プレイヤー5)がbustしてミュート表示になる(6-max)
-        const bustedLineup: StatsData['stats'] = mockStatsData.stats.map((s, i) => (i === 4 ? { playerId: -1 } : s))
+        const bustedLineup: StatsData['stats'] = mockStatsData.stats.map((s, i) => (i === 1 ? { playerId: -1 } : s))
         await dispatchStats(bustedLineup)
-        expect(screen.getByTestId('hud-4')).toHaveTextContent('Player: 5')
-        expect(screen.getByTestId('hud-4')).toHaveTextContent('Dimmed: yes')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: 2')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: yes')
 
-        // 4-maxへ縮小したlineupが届く(配列長4、座席4/5に対応する要素自体が
-        // 無い)。この更新のmapループはindex 0-3しか処理しないため、席4の
-        // 古いキャッシュには一切触れられない
-        const fourMaxLineup: StatsData['stats'] = [
-          { playerId: 1, statResults: [] },
-          { playerId: 2, statResults: [] },
-          { playerId: 3, statResults: [] },
-          { playerId: 4, statResults: [] },
-        ]
-        await dispatchStats(fourMaxLineup)
+        // インポート後のrefreshStats往復相当: 'latestStats'が来る
+        const addListenerCalls = (chrome.runtime.onMessage.addListener as jest.Mock).mock.calls
+        const messageHandler = addListenerCalls[0][0]
+        await act(async () => {
+          messageHandler({ action: 'latestStats', stats: bustedLineup })
+        })
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: -1')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: no')
 
-        // この状態でフィルターが変わる。席4は現在の表示に存在しない
-        // （currentStats[4]がundefined）ので「ライブ在籍中」ではなく、
-        // 古いキャッシュはクリアされなければならない
         await act(async () => {
           window.dispatchEvent(new CustomEvent('updateBattleTypeFilter', {
             detail: { gameTypes: { sng: true, mtt: false, ring: true } },
           }))
         })
 
-        // 6-maxに戻り、席4が引き続き空席のlineupが届く
         await dispatchStats(bustedLineup)
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: -1')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: no')
+      })
 
-        // プレイヤー5の古いキャッシュがクリアされていれば、席4は
-        // 「Waiting for Hand...」のまま
-        expect(screen.getByTestId('hud-4')).toHaveTextContent('Player: -1')
-        expect(screen.getByTestId('hud-4')).toHaveTextContent('Dimmed: no')
+      it('許容する既知のギャップ: フィルター変更の直後・次のライブdealが届く前に対戦相手がbustすると、その1回だけdim表示が出ない。ただし次のライブ更新でdimCacheは必ず再構築され、以降のbustは正しくdim表示される（自己修復。post-merge review descope pass3でオーナー承認のギャップとして明記）', async () => {
+        render(<App />)
+        await dispatchStats(mockStatsData.stats)
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: 2')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: no')
+
+        // 誰もミュートされていない状態でフィルターが変わる -- 無条件クリア
+        // により、席1(まだライブ在籍中のプレイヤー2)のキャッシュも消える
+        await act(async () => {
+          window.dispatchEvent(new CustomEvent('updateBattleTypeFilter', {
+            detail: { gameTypes: { sng: true, mtt: false, ring: true } },
+          }))
+        })
+
+        // フィルター変更の直後、次のライブdealが届く前にプレイヤー2がbust
+        // する -- キャッシュが無いのでdim表示は出ない（許容するギャップ）
+        const bustedLineup: StatsData['stats'] = mockStatsData.stats.map((s, i) => (i === 1 ? { playerId: -1 } : s))
+        await dispatchStats(bustedLineup)
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: -1')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: no')
+
+        // 自己修復の確認: 同じ席に新しいプレイヤー(99)が着席する。この
+        // ライブ更新でdimCacheが打ち直され、bust→dimの仕組みが以降の
+        // bustについて正常に機能するようになる
+        const newOccupantLineup: StatsData['stats'] = mockStatsData.stats.map((s, i) => (
+          i === 1 ? { playerId: 99, statResults: [] } : s
+        ))
+        await dispatchStats(newOccupantLineup)
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: 99')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: no')
+
+        // この新しいプレイヤー(99)がbustすると、通常通りdim表示される --
+        // キャッシュ基盤がフィルター変更のギャップから完全に回復している証拠
+        const newOccupantBustedLineup: StatsData['stats'] = mockStatsData.stats.map((s, i) => (
+          i === 1 ? { playerId: -1 } : s
+        ))
+        await dispatchStats(newOccupantBustedLineup)
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: 99')
+        expect(screen.getByTestId('hud-1')).toHaveTextContent('Dimmed: yes')
       })
 
       it('latestStats(バッチ再計算)でdimmedSeatIndicesが空にリセットされた後でも、フィルター変更は取り残されたdimCacheエントリを無効化する（post-merge review P2「Clear cached muted seats even after dim state resets」）', async () => {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -72,6 +72,16 @@ const App = memo(() => {
     dimmedSeatIndicesRef.current = next
     setDimmedSeatIndices(next)
   }, [])
+  // 現在表示中のstatsの同期読み取り用ミラー（#191 post-merge review descope
+  // pass1「Avoid clearing freshly rebuilt live-seat cache」指摘への対応で追加、
+  // dimmedSeatIndicesRefと同じ理由）。handleBattleTypeFilterUpdateが「この
+  // 座席は今まさにライブ在籍中か」を判定するのに使う -- フィルター変更は
+  // ユーザー操作起点の独立したイベントなので、React stateのコミット
+  // （useEffect経由）で十分間に合う。
+  const statsRef = useRef<PlayerStats[]>(EMPTY_SEATS)
+  useEffect(() => {
+    statsRef.current = stats
+  }, [stats])
   // ドリルダウンパネル（ポジション別 / 直近ハンド）: 開いているのは常にどちらか
   // 一方、高々1プレイヤー分（HUDツリーにローカルなReact state。グローバル設定
   // への永続化はv1では不要）。#128のポジション別ドリルダウンの単一state管理を
@@ -362,6 +372,24 @@ const App = memo(() => {
       // 引き続き使われるので、bustの記憶自体は失われない）。
       applyDimmedSeatIndices(new Set())
       setStats(message.stats)
+
+      // post-merge review descope pass1「Prefer visible hero stats after
+      // batch refreshes」指摘: この経路（信頼できるDB再計算）が席0のヒーロー
+      // 統計をこの時点の最新値に更新しても、dimCacheのHERO_SEAT_INDEX
+      // エントリ自体はここでは触れていなかった。セッション中に一度でも
+      // ライブのヒーロー在籍dealを見ていれば、dimCacheにはその時点の
+      // （インポート前の、より古い）ヒーロー統計が残ったままになる。この
+      // 状態で、次のライブハンド（dimCacheを打ち直す機会）を挟まずに
+      // セッションが終了(309)すると、handleSessionEndは`dimCache.get(
+      // HERO_SEAT_INDEX)`を優先するため、たった今表示したはずのより新しい
+      // 値ではなく、古いキャッシュ値へロールバックして表示してしまう。
+      // ここでdimCacheのヒーロー枠も同時に最新化しておけば、この経路も
+      // ライブ経路（handleTrustedLineup相当）と同じく「常に最新のヒーロー
+      // 値をdimCacheに保つ」という一貫した不変条件を満たす。
+      const heroEntry = message.stats[HERO_SEAT_INDEX]
+      if (heroEntry && isExistPlayerStats(heroEntry)) {
+        dimCacheRef.current.set(HERO_SEAT_INDEX, heroEntry)
+      }
     } else if (message.action === "updateUIConfig" && message.config) {
       setUIConfig(message.config)
     }
@@ -406,19 +434,43 @@ const App = memo(() => {
   // handleStatsMessageの通常ロジックがdimCacheから古いフィルターの統計を
   // 拾って再びミュート表示してしまう。
   //
-  // 対策: dimCache自体はheroを除く全エントリを無条件でクリアする(ライブ
-  // 在籍中の座席分も含む -- 直後に届く再計算ブロードキャストが
-  // handleStatsMessageの通常経路でdimCache.set()を打ち直すので、実害は無い。
-  // message-router.tsのupdateBattleTypeFilterハンドラーは`chrome.tabs.
-  // sendMessage`によるこのwindowイベント転送と同じタイミングで
-  // `service.statsOutputStream.write(...)`も呼んでおり、そちらの方が
-  // ポート経由で高速に届く)。表示(`stats`/`dimmedSeatIndices`)の書き換えは
-  // 従来どおり「今まさにミュート表示中」の座席だけに限定する -- 今
-  // 「Waiting for Hand...」で見えている座席には触れる必要が無く、ライブ
-  // 在籍中の座席を一瞬ブランクにする不要なちらつきも避けられる。
+  // 対策: dimCache自体はheroを除く「今まさにライブ在籍中ではない」全
+  // エントリを無条件でクリアする(ミュート表示中の座席・orphanedな座席の
+  // 両方を含む)。表示(`stats`/`dimmedSeatIndices`)の書き換えは従来どおり
+  // 「今まさにミュート表示中」の座席だけに限定する -- 今「Waiting for
+  // Hand...」で見えている座席には触れる必要が無く、ライブ在籍中の座席を
+  // 一瞬ブランクにする不要なちらつきも避けられる。
+  //
+  // post-merge review descope pass1「Avoid clearing freshly rebuilt
+  // live-seat cache」指摘: 当初は「ライブ在籍中の座席分も含めて無条件で
+  // クリアしても、直後に届く再計算ブロードキャストがhandleStatsMessageの
+  // 通常経路でdimCache.set()を打ち直すので実害は無い」としていたが、この
+  // 順序保証は誤りだった。message-router.tsのupdateBattleTypeFilter
+  // ハンドラーは`service.setBattleTypeFilter()`（再計算・再ブロードキャスト
+  // をトリガー、ポート経由）と、このwindowイベントの転送
+  // （`chrome.tabs.query`→`chrome.tabs.sendMessage`、2段のchrome API
+  // ラウンドトリップ）を並行して開始するだけで、どちらが先に届くかは
+  // DBクエリ量やIPCの負荷次第で入れ替わりうる。再計算ブロードキャストが
+  // 先に届いてdimCacheをフレッシュな値で打ち直した直後にこのハンドラーが
+  // 動くと、そのフレッシュな値ごと無条件で消してしまい、対戦相手がその
+  // 席で次にbustした時にdim表示が出ない（キャッシュが空のまま）という、
+  // 縮小スコープの核であるはずの「連続したライブシーケンス内でのbust→
+  // dim」自体が壊れてしまう。
+  //
+  // 対処: 「今まさにライブ在籍中」（=statsRef上そのplayerIdが-1でなく、
+  // かつ現在ミュート表示中でもない、つまりキャッシュ値ではなく生きた
+  // 実データがそのまま表示されている）座席のキャッシュはクリア対象から
+  // 除外する。ミュート表示中（キャッシュ値を経由して表示されている）・
+  // 完全に空席（orphaned含む）の座席だけを引き続きクリアする。
   const handleBattleTypeFilterUpdate = useCallback(() => {
     const dimCache = dimCacheRef.current
-    const nonHeroCachedSeats = Array.from(dimCache.keys()).filter(seatIndex => seatIndex !== HERO_SEAT_INDEX)
+    const currentStats = statsRef.current
+    const currentlyDimmed = dimmedSeatIndicesRef.current
+    const nonHeroCachedSeats = Array.from(dimCache.keys()).filter(seatIndex => {
+      if (seatIndex === HERO_SEAT_INDEX) return false
+      const isLiveNow = !currentlyDimmed.has(seatIndex) && currentStats[seatIndex]?.playerId !== -1
+      return !isLiveNow
+    })
     if (nonHeroCachedSeats.length === 0) return
     for (const seatIndex of nonHeroCachedSeats) dimCache.delete(seatIndex)
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -72,26 +72,6 @@ const App = memo(() => {
     dimmedSeatIndicesRef.current = next
     setDimmedSeatIndices(next)
   }, [])
-  // 現在表示中のstatsの同期読み取り用ミラー（#191 post-merge review descope
-  // pass1「Avoid clearing freshly rebuilt live-seat cache」指摘への対応で追加、
-  // dimmedSeatIndicesRefと同じ理由）。handleBattleTypeFilterUpdateが「この
-  // 座席は今まさにライブ在籍中か」を判定するのに使う -- フィルター変更は
-  // ユーザー操作起点の独立したイベントなので、React stateのコミット
-  // （useEffect経由）で十分間に合う。
-  const statsRef = useRef<PlayerStats[]>(EMPTY_SEATS)
-  useEffect(() => {
-    statsRef.current = stats
-  }, [stats])
-  // statsRefが「hero在籍時点の表示座席（回転後）空間」を指しているかどうか
-  // （#191 post-merge review descope pass2「Clear spectator-context caches
-  // on filter updates」指摘への対応で追加）。handleBattleTypeFilterUpdateの
-  // `isLiveNow`判定はstatsRefの各座席indexを"表示座席"として解釈するが、
-  // 観戦モードdeal分岐・latestStatsバッチ経路はどちらもstatsRefへ生の
-  // （別空間・別由来の）座席順を書き込むことがある。この2つの分岐だけが
-  // trueを立て、それ以外（観戦・バッチ・セッション終了直後）はfalseに
-  // 戻すことで、isLiveNowが数値インデックスの偶然の一致だけで「ライブ
-  // 在籍中」と誤判定しないようにする。
-  const liveDisplaySpaceRef = useRef(false)
   // ドリルダウンパネル（ポジション別 / 直近ハンド）: 開いているのは常にどちらか
   // 一方、高々1プレイヤー分（HUDツリーにローカルなReact state。グローバル設定
   // への永続化はv1では不要）。#128のポジション別ドリルダウンの単一state管理を
@@ -179,7 +159,6 @@ const App = memo(() => {
         && isApiEventType(detail.evtDeal, ApiType.EVT_DEAL)
         && detail.evtDeal.Player === undefined
       if (isSpectatorDeal) {
-        liveDisplaySpaceRef.current = false
         applyDimmedSeatIndices(new Set())
         setStats(mappedStats)
         return
@@ -306,7 +285,6 @@ const App = memo(() => {
         return stat
       })
 
-      liveDisplaySpaceRef.current = true
       applyDimmedSeatIndices(nextDimmedSeatIndices)
       setStats(dimmedStats)
     },
@@ -345,7 +323,6 @@ const App = memo(() => {
   // 表示であり、セッションをまたいで残す理由が無いため。heroパネル(座席0)は#158の
   // 通りここでは一切触らない(pregameでのキャリア統計復元は別経路)。
   const handleSessionEnd = useCallback(() => {
-    liveDisplaySpaceRef.current = false
     const dimCache = dimCacheRef.current
     // #179 post-merge review P2「Preserve the hero by player id at session
     // end」指摘: 直前の更新が観戦モードdeal（上のisSpectatorDeal分岐）だった
@@ -383,7 +360,6 @@ const App = memo(() => {
       // フラグを引きずって別データに重ねて表示してしまわないよう、表示中の
       // ミュート集合はここでリセットする（次のライブEVT_DEALでdimCacheRef自体は
       // 引き続き使われるので、bustの記憶自体は失われない）。
-      liveDisplaySpaceRef.current = false
       applyDimmedSeatIndices(new Set())
       setStats(message.stats)
 
@@ -430,83 +406,49 @@ const App = memo(() => {
   // 発火元）が、これまでApp.tsxは購読していなかった。ここで購読し、
   // dimCache自体（非hero座席分すべて）を無条件で無効化する。
   //
-  // 当初はdimmedSeatIndicesRef（現在ミュート「表示」中の座席集合）に含まれる
-  // 座席だけをクリアしていたが、post-merge review P2「Clear cached muted
-  // seats even after dim state resets」指摘で反例が見つかった: dimmedSeat
-  // Indicesを空にリセットしつつdimCacheRef自体は生かしたままにするパスが
-  // 他に2つある --
-  //   (1) `latestStats` chromeメッセージ経路（handleChromeMessage、インポート
-  //       後のrefreshStats往復・バッチ再計算）。「バッチ更新はミュート状態を
-  //       経由しない」仕様どおりdimmedSeatIndicesは空にするが、dimCacheの
-  //       中身はそのまま。
-  //   (2) 上の観戦モードdeal分岐（isSpectatorDeal）。表示は生のlineupに
-  //       切り替えてdimmedSeatIndicesを空にするが、dimCacheはヒーロー在籍
-  //       dealに戻った時に正しく再開できるよう意図的に一切触らない。
-  // この状態でフィルターが変わると、dimmedSeatIndicesRef基準のクリアでは
-  // 「今は見えていないが後で複活し得る」dimCacheの中身を見逃す -- 後続の
-  // ライブ更新でその座席が引き続き空席(-1)のままなら、
-  // handleStatsMessageの通常ロジックがdimCacheから古いフィルターの統計を
-  // 拾って再びミュート表示してしまう。
+  // 無条件クリアである理由: dimmedSeatIndicesRef（現在ミュート「表示」中の
+  // 座席集合）に含まれる座席だけをクリアする案も検討したが、post-merge
+  // review P2「Clear cached muted seats even after dim state resets」指摘
+  // の通り、dimmedSeatIndicesを空にリセットしつつdimCacheRef自体は生かした
+  // ままにするパスが他に2つある（`latestStats` chromeメッセージ経路の
+  // バッチ再計算、観戦モードdeal分岐）ため、表示状態だけを見た選択的
+  // クリアは取り残しを生む。
   //
-  // 対策: dimCache自体はheroを除く「今まさにライブ在籍中ではない」全
-  // エントリを無条件でクリアする(ミュート表示中の座席・orphanedな座席の
-  // 両方を含む)。表示(`stats`/`dimmedSeatIndices`)の書き換えは従来どおり
-  // 「今まさにミュート表示中」の座席だけに限定する -- 今「Waiting for
-  // Hand...」で見えている座席には触れる必要が無く、ライブ在籍中の座席を
-  // 一瞬ブランクにする不要なちらつきも避けられる。
+  // post-merge review descope pass1-2で「今まさにライブ在籍中の座席だけは
+  // クリアから除外する」精緻化（isLiveNow判定、statsRef/liveDisplaySpaceRef
+  // という2つの追加refを要した）を試みたが、これはオーナー判断で撤回された
+  // （PR #191、2026-07-21、sola承認の縮小スコープの精神に反する
+  // over-engineering — 観戦/バッチ経路の座席空間の食い違いや、4-maxで
+  // 存在しない座席インデックスなど、精緻化するたびに新しい境界ケースが
+  // 見つかり続けた）。この関数は非hero座席分のdimCache・表示中ミュートの
+  // 両方を常に無条件でクリアするだけの単純な形に戻している。
   //
-  // post-merge review descope pass1「Avoid clearing freshly rebuilt
-  // live-seat cache」指摘: 当初は「ライブ在籍中の座席分も含めて無条件で
-  // クリアしても、直後に届く再計算ブロードキャストがhandleStatsMessageの
-  // 通常経路でdimCache.set()を打ち直すので実害は無い」としていたが、この
-  // 順序保証は誤りだった。message-router.tsのupdateBattleTypeFilter
-  // ハンドラーは`service.setBattleTypeFilter()`（再計算・再ブロードキャスト
-  // をトリガー、ポート経由）と、このwindowイベントの転送
-  // （`chrome.tabs.query`→`chrome.tabs.sendMessage`、2段のchrome API
-  // ラウンドトリップ）を並行して開始するだけで、どちらが先に届くかは
-  // DBクエリ量やIPCの負荷次第で入れ替わりうる。再計算ブロードキャストが
-  // 先に届いてdimCacheをフレッシュな値で打ち直した直後にこのハンドラーが
-  // 動くと、そのフレッシュな値ごと無条件で消してしまい、対戦相手がその
-  // 席で次にbustした時にdim表示が出ない（キャッシュが空のまま）という、
-  // 縮小スコープの核であるはずの「連続したライブシーケンス内でのbust→
-  // dim」自体が壊れてしまう。
-  //
-  // 対処: 「今まさにライブ在籍中」（=statsRefがhero在籍時点の表示座席空間を
-  // 指しており、かつそのplayerIdが実在し-1でなく、かつ現在ミュート表示中
-  // でもない、つまりキャッシュ値ではなく生きた実データがそのまま表示
-  // されている）座席のキャッシュだけをクリア対象から除外する。ミュート
-  // 表示中（キャッシュ値を経由して表示されている）・完全に空席(orphaned
-  // 含む)・座席そのものが存在しない（4-maxで6-max時代のキャッシュを
-  // 参照する等）座席は引き続きクリアする。
-  //
-  // post-merge review descope pass2の2指摘の反映:
-  // 「Clear spectator-context caches on filter updates」-- statsRefが
-  // 観戦モードdeal分岐やlatestStatsバッチ経路経由で書き換わっていると、
-  // その座席indexは表示座席空間ではなく生の（別由来の）席順を指しており、
-  // 数値インデックスがたまたま一致した非-1の在席者を「ライブ在籍中」と
-  // 誤認しうる。`liveDisplaySpaceRef`（上のuseRef宣言）がtrueの時だけ
-  // （＝直近の更新がhandleStatsMessageの信頼できるライブ経路だった時
-  // だけ）isLiveNow判定を有効にする。
-  // 「Treat missing seats as empty when clearing caches」-- 4-max
-  // テーブル（`currentStats.length`が4）でindex 4/5にはそもそも要素が
-  // 無く、`currentStats[4]`はundefined。オプショナルチェイニングだけだと
-  // `undefined?.playerId !== -1`が`undefined !== -1`でtrueになり、
-  // 存在しない座席を「ライブ在籍中」と誤認してしまう。`currentStat !==
-  // undefined`を明示的に要求する。
+  // 許容する既知のギャップ（意図的に直さない）: message-router.tsの
+  // updateBattleTypeFilterハンドラーは`service.setBattleTypeFilter()`
+  // （再計算・再ブロードキャストをトリガー、ポート経由）と、この
+  // windowイベントの転送（`chrome.tabs.query`→`chrome.tabs.sendMessage`、
+  // 2段のchrome APIラウンドトリップ）を並行して開始するため、どちらが
+  // 先に届くかは非決定的。再計算ブロードキャストがこのクリアより先に
+  // 届いていた場合、そのフレッシュな値ごとここで消してしまうため、
+  // フィルター変更の直後・次のライブdealが届く前に対戦相手が1人bustすると
+  // その1回だけdim表示が出ない（キャッシュが空のまま「Waiting for
+  // Hand...」になる）。これは「フィルター変更」という稀なユーザー操作と
+  // 「その直後・数秒以内のbust」という稀なタイミングの掛け合わせでしか
+  // 起きず、1人・1回限りの見た目の欠落に過ぎない。加えて、届く順序に
+  // 関わらず必ず自己修復する: 到着順序がどちらであっても、次に届く
+  // ライブブロードキャスト（この直後の再計算ブロードキャスト自身、または
+  // その次の通常のハンド進行）は必ずhandleStatsMessageの通常経路を通り、
+  // 在席中の全座席についてdimCache.set()を無条件で打ち直す（このファイル
+  // 上部のbust-dimコメント参照）。つまりこのクリアがどちらの順序で発火
+  // しても、次のライブ更新一回でdimCacheは必ず現在のフィルターの下で
+  // 再構築され、以降のbustは正しくdim表示される（レースそのものが
+  // "消えてしまう"のではなく、"実害が高々1回・1人に限定され、次の
+  // ライブ更新で必ず解消する"という順序非依存性がここでのポイント）。
+  // sola「それほど重要な機能ではないので、bで十分です」の縮小スコープの
+  // 精神に沿って、この1回限りのギャップは直さずに受け入れる。
   const handleBattleTypeFilterUpdate = useCallback(() => {
     const dimCache = dimCacheRef.current
-    const currentStats = statsRef.current
-    const currentlyDimmed = dimmedSeatIndicesRef.current
-    const inLiveDisplaySpace = liveDisplaySpaceRef.current
-    const nonHeroCachedSeats = Array.from(dimCache.keys()).filter(seatIndex => {
-      if (seatIndex === HERO_SEAT_INDEX) return false
-      const currentStat = currentStats[seatIndex]
-      const isLiveNow = inLiveDisplaySpace
-        && !currentlyDimmed.has(seatIndex)
-        && currentStat !== undefined
-        && currentStat.playerId !== -1
-      return !isLiveNow
-    })
+    const nonHeroCachedSeats = Array.from(dimCache.keys()).filter(seatIndex => seatIndex !== HERO_SEAT_INDEX)
     if (nonHeroCachedSeats.length === 0) return
     for (const seatIndex of nonHeroCachedSeats) dimCache.delete(seatIndex)
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -58,6 +58,20 @@ const App = memo(() => {
   const dimCacheRef = useRef<Map<number, ExistPlayerStats>>(new Map())
   // 現在ミュート表示中の座席index集合。Hudへ`isDimmed`として渡す。
   const [dimmedSeatIndices, setDimmedSeatIndices] = useState<ReadonlySet<number>>(new Set())
+  // dimmedSeatIndicesの同期読み取り用ミラー（#179 P2「Invalidate dimmed stats
+  // on filter recomputes」指摘への対応で追加）。フィルター変更ハンドラー
+  // (handleBattleTypeFilterUpdate)は「今どの座席がミュート表示中か」を
+  // setState外の同期コードから知る必要があるが、React stateのprevは
+  // updater関数の外では読めない（読めても次コミットまで反映保証がない）。
+  // setDimmedSeatIndicesを呼ぶ全箇所をapplyDimmedSeatIndices経由に統一し、
+  // 常にこのrefと状態を同時に更新することで、後続のイベントハンドラーが
+  // 呼ばれた時点では既に最新値になっている（dimCacheRefと同じ理由でuseRefを
+  // 使う）。
+  const dimmedSeatIndicesRef = useRef<ReadonlySet<number>>(new Set())
+  const applyDimmedSeatIndices = useCallback((next: ReadonlySet<number>) => {
+    dimmedSeatIndicesRef.current = next
+    setDimmedSeatIndices(next)
+  }, [])
   // ドリルダウンパネル（ポジション別 / 直近ハンド）: 開いているのは常にどちらか
   // 一方、高々1プレイヤー分（HUDツリーにローカルなReact state。グローバル設定
   // への永続化はv1では不要）。#128のポジション別ドリルダウンの単一state管理を
@@ -72,10 +86,33 @@ const App = memo(() => {
     setOpenPanel(prev => (prev?.kind === 'recentHands' && prev.playerId === playerId) ? null : { playerId, kind: 'recentHands' })
   }, [])
 
+  // 仕様（PR #191、オーナー承認の縮小スコープ、2026-07-20。sola:
+  // 「それほど重要な機能ではないので、bで十分です」）:
+  //
+  // - bustしたプレイヤーのdim表示・ヒーローの身元保持は「連続したライブ
+  //   シーケンス」の中でのみ保証する: bust→dim（離席バッジ）→同じ席への
+  //   実着席で即座に通常表示へ復帰、そして生の309（セッション終了）で
+  //   hero以外の全パネルをクリアしつつheroパネルだけはdimCache経由で
+  //   保持する（下のhandleSessionEnd）。
+  // - それ以外の曖昧な境界（観戦モードdeal、ページリロード/再マウント、
+  //   フィルター変更による再計算、`latestStats`一括配信）は、個別に
+  //   「今どちらの文脈か」を検証・追跡する仕組みを持たず、単純に
+  //   dimCacheを適用しない/表示中のミュートをクリアするだけにする
+  //   （観戦モードdealはdimCacheの読み書きを丸ごとスキップし生のlineupを
+  //   そのまま表示、フィルター変更・一括配信はミュート表示状態を
+  //   リセットする）。
+  // - 3巡のpost-merge reviewで「観戦中もヒーローの身元を検証付きで
+  //   追跡し続ける」「セッションが今アクティブかを独立に追跡する」という
+  //   方向へ機構を積み増したが（heroPlayerIdRef、sessionActiveRef、
+  //   trustedRotationゲート）、そのたびに新しい境界ケースが見つかり続けた
+  //   （詳細はPR #191のレビュー履歴）。この機能の重要度に見合わないと
+  //   判断し、それらは全て撤回した。テーブル移動検知ヒューリスティック
+  //   （下記conflictSeatCount）はこの縮小スコープの一部として現状維持
+  //   （round1-3で既に磨き込み済み、既知の限界も含めて許容範囲）。
   const handleStatsMessage = useCallback(
     ({ detail }: CustomEvent<StatsData>) => {
       let mappedStats = detail.stats
-      
+
       // Update real-time stats if available
       if (detail.realTimeStats) {
         setAllPlayersRealTimeStats(detail.realTimeStats)
@@ -89,6 +126,42 @@ const App = memo(() => {
         setHeroOriginalSeatIndex(heroSeatIndex)
 
         mappedStats = rotateArrayFromIndex(detail.stats, heroSeatIndex)
+      }
+
+      // 観戦モードdeal（#179 post-merge review P2「Avoid applying dim cache to
+      // unrotated spectator deals」指摘）: EVT_DEAL.Playerがundefinedのとき
+      // （docs/api-events.md「観戦モード」-- ヒーロー敗退後もクライアントが
+      // 他プレイヤーのテーブルを受信し続けるケース。CLAUDE.md「Hero playerId
+      // must survive spectator-mode deals」も参照）、上の回転は行われず
+      // mappedStatsは生の（ヒーロー自身のテーブルとすら限らない、別テーブル
+      // かもしれない）席順のまま届く。これはaggregate-events-stream.tsの
+      // liveEvtDealがPlayer有無に関わらず毎回追従する設計（#177）により、
+      // ports.tsのライブブロードキャストが観戦中の別テーブルの新しい顔ぶれを
+      // そのまま流してくることに由来する（docs/api-events.md「テーブル移動
+      // キメラハンド」と同根 -- クライアントは移動/観戦先のイベントを普通に
+      // 受信し続ける）。
+      //
+      // dimCacheは表示座席（回転後、hero=0）空間のキーで運用しているため、
+      // この生の（別空間かもしれない）席順にそのまま適用すると、無関係な
+      // 別テーブルの空席に旧テーブルのミュートプレイヤーが誤って表示されて
+      // しまう（座席インデックスの数値がたまたま一致するだけの偶然の一致）。
+      // evtDeal自体が存在しないケース（テストや初回未初期化など、mappedStats
+      // が既に表示座席空間にある前提で運用してきたケース、下のdimCacheロジック
+      // 一式のテストカバレッジもこの前提）とは区別し、「evtDealがEVT_DEALとして
+      // 存在するのにPlayerがundefined」という観戦確定シグナルがある時だけ
+      // dimCacheの読み書き（テーブル移動検知・ミュート適用の両方）を丸ごと
+      // スキップし、mappedStatsをそのまま表示する。dimCache自体はクリアしない
+      // （観戦は一時的な状態で、ヒーロー在籍dealに戻ればまた正しい空間で
+      // 再開できる -- #179 P2「Preserve the hero by player id at session end」
+      // 対応のためHERO_SEAT_INDEXのエントリを観戦中も保持し続ける必要がある、
+      // 下のhandleSessionEnd参照）。
+      const isSpectatorDeal = detail.evtDeal !== undefined
+        && isApiEventType(detail.evtDeal, ApiType.EVT_DEAL)
+        && detail.evtDeal.Player === undefined
+      if (isSpectatorDeal) {
+        applyDimmedSeatIndices(new Set())
+        setStats(mappedStats)
+        return
       }
 
       // bustしたプレイヤーの薄暗い表示（sola仕様）:「bustしたプレイヤーのstatsは
@@ -160,6 +233,24 @@ const App = memo(() => {
       // conflictが0件、または1件のみ(continuityの有無を問わず)なら何もしない
       // -- 例: hero以外が同一ハンドで全員同時bustした直後のhero単独lineup
       // (conflict 0件)や、通常の単発席乗っ取り(conflict 1件)。
+      //
+      // post-merge review P2「Avoid clearing dims on simultaneous seat churn」
+      // （閾値2件でも、同一テーブルで2席が同時に別プレイヤーへ入れ替わっただけの
+      // 通常churnを誤ってテーブル移動と判定し、無関係な他の空席のミュートまで
+      // 巻き込んで消してしまうのでは、という指摘）を検討したが、この指摘が
+      // 挙げる状況（cachedなhero以外座席がN件、うち2件がconflict、残りは
+      // incoming=-1で判断材料なし、continuity 0件）は、下のround3反例テスト
+      // 「hero以外が同一ハンドで全員同時bustした直後...その後、実際にテーブル
+      // 移動して...」（App.test.tsx）が要求する「本物のテーブル移動を検知
+      // すべきケース」と数値的シグネチャが区別不能（cached 5件・conflict
+      // 2件・continuity 0件は両ケースに共通する）。conflict/continuityの比率や
+      // 閾値をどう調整しても、一方を検知すればもう一方を誤検知するトレード
+      // オフにしかならず、App.tsx側が持つ情報（座席インデックスとplayerIdの
+      // 対応だけ）だけでは原理的に区別できない -- EVT_DEALにテーブル/セッションを
+      // 一意に示すフィールドが無いこと（docs/api-events.md, `src/types/api.ts`
+      // のEVT_DEALスキーマ確認済み）もこれを裏付ける。よって閾値は変更せず、
+      // 既存のround1-3の判断（わからない時は消さない、ただし2件以上の同時
+      // conflictは強い証拠として扱う）を維持する。
       const dimCache = dimCacheRef.current
       let hasContinuitySeat = false
       let conflictSeatCount = 0
@@ -194,10 +285,10 @@ const App = memo(() => {
         return stat
       })
 
-      setDimmedSeatIndices(nextDimmedSeatIndices)
+      applyDimmedSeatIndices(nextDimmedSeatIndices)
       setStats(dimmedStats)
     },
-    []
+    [applyDimmedSeatIndices]
   )
 
   useEffect(() => {
@@ -233,17 +324,27 @@ const App = memo(() => {
   // 通りここでは一切触らない(pregameでのキャリア統計復元は別経路)。
   const handleSessionEnd = useCallback(() => {
     const dimCache = dimCacheRef.current
+    // #179 post-merge review P2「Preserve the hero by player id at session
+    // end」指摘: 直前の更新が観戦モードdeal（上のisSpectatorDeal分岐）だった
+    // 場合、stats[HERO_SEAT_INDEX]は観戦中の別テーブルの生の席0でしかなく、
+    // ヒーローとは限らない。isSpectatorDeal分岐はdimCacheの読み書き自体を
+    // 丸ごとスキップするため、dimCacheのHERO_SEAT_INDEXエントリには直近の
+    // ヒーロー在籍dealで記録された本物のExistPlayerStatsが（観戦dealを何件
+    // 挟んでも上書きされずに）残り続けている。それを優先的に使い、万一まだ
+    // 一度もヒーロー在籍dealを見ていない（キャッシュが空の）場合だけ
+    // 従来通りstats[HERO_SEAT_INDEX]をフォールバックとして使う。
+    const heroStat = dimCache.get(HERO_SEAT_INDEX)
     for (const seatIndex of Array.from(dimCache.keys())) {
       if (seatIndex !== HERO_SEAT_INDEX) dimCache.delete(seatIndex)
     }
-    setDimmedSeatIndices(prev => {
-      if (!prev.has(HERO_SEAT_INDEX) && prev.size === 0) return prev
-      return prev.has(HERO_SEAT_INDEX) ? new Set([HERO_SEAT_INDEX]) : new Set()
-    })
+    const prevDimmed = dimmedSeatIndicesRef.current
+    if (prevDimmed.size !== 0) {
+      applyDimmedSeatIndices(prevDimmed.has(HERO_SEAT_INDEX) ? new Set([HERO_SEAT_INDEX]) : new Set())
+    }
     setStats(prev => prev.map((stat, seatIndex) => (
-      seatIndex === HERO_SEAT_INDEX ? stat : { playerId: -1 }
+      seatIndex === HERO_SEAT_INDEX ? (heroStat ?? stat) : { playerId: -1 }
     )))
-  }, [])
+  }, [applyDimmedSeatIndices])
 
   useEffect(() => {
     window.addEventListener(POKER_CHASE_SESSION_END_EVENT, handleSessionEnd)
@@ -259,17 +360,85 @@ const App = memo(() => {
       // フラグを引きずって別データに重ねて表示してしまわないよう、表示中の
       // ミュート集合はここでリセットする（次のライブEVT_DEALでdimCacheRef自体は
       // 引き続き使われるので、bustの記憶自体は失われない）。
-      setDimmedSeatIndices(new Set())
+      applyDimmedSeatIndices(new Set())
       setStats(message.stats)
     } else if (message.action === "updateUIConfig" && message.config) {
       setUIConfig(message.config)
     }
-  }, [])
+  }, [applyDimmedSeatIndices])
 
   useEffect(() => {
     chrome.runtime.onMessage.addListener(handleChromeMessage)
     return () => chrome.runtime.onMessage.removeListener(handleChromeMessage)
   }, [handleChromeMessage])
+
+  // フィルター変更時にdimCacheを無効化する（#179 post-merge review P2
+  // 「Invalidate dimmed stats on filter recomputes」指摘）: バトルタイプ/
+  // テーブルサイズ/ハンド数フィルターが変わると、message-router.tsの
+  // `updateBattleTypeFilter`ハンドラーがgetLastKnownStats()（現在の生の
+  // 座席、bustした座席は-1のまま）で`service.statsOutputStream.write()`を
+  // 再トリガーする。bustしてミュート表示中の座席はこの再計算対象に含まれない
+  // （-1のプレイヤーIDに対して計算しようがない）ため、その座席のdimCache
+  // エントリは古いフィルターの統計のまま残ってしまい、席が戻るかセッションが
+  // 終わるまで新フィルターが反映されない可視バグになる。
+  //
+  // content_script.tsは`updateBattleTypeFilter`メッセージを受け取るたびに
+  // 同名のwindowイベントを既にdispatchしている（Popup.tsxのフィルター系UI
+  // 全て — gameTypes/tableSize/handLimitいずれの変更もこの1経路を通る — が
+  // 発火元）が、これまでApp.tsxは購読していなかった。ここで購読し、
+  // dimCache自体（非hero座席分すべて）を無条件で無効化する。
+  //
+  // 当初はdimmedSeatIndicesRef（現在ミュート「表示」中の座席集合）に含まれる
+  // 座席だけをクリアしていたが、post-merge review P2「Clear cached muted
+  // seats even after dim state resets」指摘で反例が見つかった: dimmedSeat
+  // Indicesを空にリセットしつつdimCacheRef自体は生かしたままにするパスが
+  // 他に2つある --
+  //   (1) `latestStats` chromeメッセージ経路（handleChromeMessage、インポート
+  //       後のrefreshStats往復・バッチ再計算）。「バッチ更新はミュート状態を
+  //       経由しない」仕様どおりdimmedSeatIndicesは空にするが、dimCacheの
+  //       中身はそのまま。
+  //   (2) 上の観戦モードdeal分岐（isSpectatorDeal）。表示は生のlineupに
+  //       切り替えてdimmedSeatIndicesを空にするが、dimCacheはヒーロー在籍
+  //       dealに戻った時に正しく再開できるよう意図的に一切触らない。
+  // この状態でフィルターが変わると、dimmedSeatIndicesRef基準のクリアでは
+  // 「今は見えていないが後で複活し得る」dimCacheの中身を見逃す -- 後続の
+  // ライブ更新でその座席が引き続き空席(-1)のままなら、
+  // handleStatsMessageの通常ロジックがdimCacheから古いフィルターの統計を
+  // 拾って再びミュート表示してしまう。
+  //
+  // 対策: dimCache自体はheroを除く全エントリを無条件でクリアする(ライブ
+  // 在籍中の座席分も含む -- 直後に届く再計算ブロードキャストが
+  // handleStatsMessageの通常経路でdimCache.set()を打ち直すので、実害は無い。
+  // message-router.tsのupdateBattleTypeFilterハンドラーは`chrome.tabs.
+  // sendMessage`によるこのwindowイベント転送と同じタイミングで
+  // `service.statsOutputStream.write(...)`も呼んでおり、そちらの方が
+  // ポート経由で高速に届く)。表示(`stats`/`dimmedSeatIndices`)の書き換えは
+  // 従来どおり「今まさにミュート表示中」の座席だけに限定する -- 今
+  // 「Waiting for Hand...」で見えている座席には触れる必要が無く、ライブ
+  // 在籍中の座席を一瞬ブランクにする不要なちらつきも避けられる。
+  const handleBattleTypeFilterUpdate = useCallback(() => {
+    const dimCache = dimCacheRef.current
+    const nonHeroCachedSeats = Array.from(dimCache.keys()).filter(seatIndex => seatIndex !== HERO_SEAT_INDEX)
+    if (nonHeroCachedSeats.length === 0) return
+    for (const seatIndex of nonHeroCachedSeats) dimCache.delete(seatIndex)
+
+    const dimmedNonHeroSeats = Array.from(dimmedSeatIndicesRef.current).filter(
+      seatIndex => seatIndex !== HERO_SEAT_INDEX
+    )
+    if (dimmedNonHeroSeats.length === 0) return
+    const clearedSet = new Set(dimmedNonHeroSeats)
+    applyDimmedSeatIndices(
+      dimmedSeatIndicesRef.current.has(HERO_SEAT_INDEX) ? new Set([HERO_SEAT_INDEX]) : new Set()
+    )
+    setStats(prev => prev.map((stat, seatIndex) => (
+      clearedSet.has(seatIndex) ? { playerId: -1 } : stat
+    )))
+  }, [applyDimmedSeatIndices])
+
+  useEffect(() => {
+    window.addEventListener('updateBattleTypeFilter', handleBattleTypeFilterUpdate as EventListener)
+    return () => window.removeEventListener('updateBattleTypeFilter', handleBattleTypeFilterUpdate as EventListener)
+  }, [handleBattleTypeFilterUpdate])
 
   // ハンドログイベントの処理
   const handleHandLogEvent = useCallback((event: CustomEvent<HandLogEvent>) => {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -82,6 +82,16 @@ const App = memo(() => {
   useEffect(() => {
     statsRef.current = stats
   }, [stats])
+  // statsRefが「hero在籍時点の表示座席（回転後）空間」を指しているかどうか
+  // （#191 post-merge review descope pass2「Clear spectator-context caches
+  // on filter updates」指摘への対応で追加）。handleBattleTypeFilterUpdateの
+  // `isLiveNow`判定はstatsRefの各座席indexを"表示座席"として解釈するが、
+  // 観戦モードdeal分岐・latestStatsバッチ経路はどちらもstatsRefへ生の
+  // （別空間・別由来の）座席順を書き込むことがある。この2つの分岐だけが
+  // trueを立て、それ以外（観戦・バッチ・セッション終了直後）はfalseに
+  // 戻すことで、isLiveNowが数値インデックスの偶然の一致だけで「ライブ
+  // 在籍中」と誤判定しないようにする。
+  const liveDisplaySpaceRef = useRef(false)
   // ドリルダウンパネル（ポジション別 / 直近ハンド）: 開いているのは常にどちらか
   // 一方、高々1プレイヤー分（HUDツリーにローカルなReact state。グローバル設定
   // への永続化はv1では不要）。#128のポジション別ドリルダウンの単一state管理を
@@ -169,6 +179,7 @@ const App = memo(() => {
         && isApiEventType(detail.evtDeal, ApiType.EVT_DEAL)
         && detail.evtDeal.Player === undefined
       if (isSpectatorDeal) {
+        liveDisplaySpaceRef.current = false
         applyDimmedSeatIndices(new Set())
         setStats(mappedStats)
         return
@@ -295,6 +306,7 @@ const App = memo(() => {
         return stat
       })
 
+      liveDisplaySpaceRef.current = true
       applyDimmedSeatIndices(nextDimmedSeatIndices)
       setStats(dimmedStats)
     },
@@ -333,6 +345,7 @@ const App = memo(() => {
   // 表示であり、セッションをまたいで残す理由が無いため。heroパネル(座席0)は#158の
   // 通りここでは一切触らない(pregameでのキャリア統計復元は別経路)。
   const handleSessionEnd = useCallback(() => {
+    liveDisplaySpaceRef.current = false
     const dimCache = dimCacheRef.current
     // #179 post-merge review P2「Preserve the hero by player id at session
     // end」指摘: 直前の更新が観戦モードdeal（上のisSpectatorDeal分岐）だった
@@ -370,6 +383,7 @@ const App = memo(() => {
       // フラグを引きずって別データに重ねて表示してしまわないよう、表示中の
       // ミュート集合はここでリセットする（次のライブEVT_DEALでdimCacheRef自体は
       // 引き続き使われるので、bustの記憶自体は失われない）。
+      liveDisplaySpaceRef.current = false
       applyDimmedSeatIndices(new Set())
       setStats(message.stats)
 
@@ -457,18 +471,40 @@ const App = memo(() => {
   // 縮小スコープの核であるはずの「連続したライブシーケンス内でのbust→
   // dim」自体が壊れてしまう。
   //
-  // 対処: 「今まさにライブ在籍中」（=statsRef上そのplayerIdが-1でなく、
-  // かつ現在ミュート表示中でもない、つまりキャッシュ値ではなく生きた
-  // 実データがそのまま表示されている）座席のキャッシュはクリア対象から
-  // 除外する。ミュート表示中（キャッシュ値を経由して表示されている）・
-  // 完全に空席（orphaned含む）の座席だけを引き続きクリアする。
+  // 対処: 「今まさにライブ在籍中」（=statsRefがhero在籍時点の表示座席空間を
+  // 指しており、かつそのplayerIdが実在し-1でなく、かつ現在ミュート表示中
+  // でもない、つまりキャッシュ値ではなく生きた実データがそのまま表示
+  // されている）座席のキャッシュだけをクリア対象から除外する。ミュート
+  // 表示中（キャッシュ値を経由して表示されている）・完全に空席(orphaned
+  // 含む)・座席そのものが存在しない（4-maxで6-max時代のキャッシュを
+  // 参照する等）座席は引き続きクリアする。
+  //
+  // post-merge review descope pass2の2指摘の反映:
+  // 「Clear spectator-context caches on filter updates」-- statsRefが
+  // 観戦モードdeal分岐やlatestStatsバッチ経路経由で書き換わっていると、
+  // その座席indexは表示座席空間ではなく生の（別由来の）席順を指しており、
+  // 数値インデックスがたまたま一致した非-1の在席者を「ライブ在籍中」と
+  // 誤認しうる。`liveDisplaySpaceRef`（上のuseRef宣言）がtrueの時だけ
+  // （＝直近の更新がhandleStatsMessageの信頼できるライブ経路だった時
+  // だけ）isLiveNow判定を有効にする。
+  // 「Treat missing seats as empty when clearing caches」-- 4-max
+  // テーブル（`currentStats.length`が4）でindex 4/5にはそもそも要素が
+  // 無く、`currentStats[4]`はundefined。オプショナルチェイニングだけだと
+  // `undefined?.playerId !== -1`が`undefined !== -1`でtrueになり、
+  // 存在しない座席を「ライブ在籍中」と誤認してしまう。`currentStat !==
+  // undefined`を明示的に要求する。
   const handleBattleTypeFilterUpdate = useCallback(() => {
     const dimCache = dimCacheRef.current
     const currentStats = statsRef.current
     const currentlyDimmed = dimmedSeatIndicesRef.current
+    const inLiveDisplaySpace = liveDisplaySpaceRef.current
     const nonHeroCachedSeats = Array.from(dimCache.keys()).filter(seatIndex => {
       if (seatIndex === HERO_SEAT_INDEX) return false
-      const isLiveNow = !currentlyDimmed.has(seatIndex) && currentStats[seatIndex]?.playerId !== -1
+      const currentStat = currentStats[seatIndex]
+      const isLiveNow = inLiveDisplaySpace
+        && !currentlyDimmed.has(seatIndex)
+        && currentStat !== undefined
+        && currentStat.playerId !== -1
       return !isLiveNow
     })
     if (nonHeroCachedSeats.length === 0) return


### PR DESCRIPTION
## Summary

Post-merge diversity review on merged PR #179 (busted-player-dim) produced 5 P2 findings. This PR fixed 4 of them across several review passes; each fix round exposed a new leak in the same interaction space (spectator-mode deal x dimCache x filter-change recompute x session/reload/account boundaries). After 3 auto-review passes kept surfacing new findings in that space, the repo owner reviewed the escalation and approved the conservative option: descope to sola's original core requirement and treat every ambiguous transition as a full dim-clear rather than trying to preserve a correct view through it (owner quote: 「それほど重要な機能ではないので、bで十分です」).

## What's kept (core, zero findings against it across all review passes)

- **Bust -> dim -> instant takeover.** A busted seat (`playerId: -1`) keeps showing its last live stats, muted (離席 badge), until either the same seat gets a real occupant (instant, unconditional overwrite) or the session ends. Unchanged from #179 rounds 1-3, including the table-move heuristic (`conflictSeatCount >= 2` threshold) and its documented known limitation.
- **Session end (309) preserves the hero.** All non-hero panels clear; the hero's panel is restored from `dimCache.get(HERO_SEAT_INDEX)` rather than trusting `stats[0]`, since the last update before 309 may have been a spectator-mode deal.
- **Spectator-mode deals never touch dimCache.** When `EVT_DEAL.Player` is undefined (observer mode after the hero busts), the raw lineup is shown as-is with no cache reads/writes -- avoids misapplying display-space dims to a possibly-unrelated raw table.
- **Filter changes invalidate the whole non-hero dimCache**, not just currently-visible dims, so entries orphaned by the `latestStats` batch path are also caught.

## What's removed

The identity-latch/session-tracking machinery added across review passes 2-3 (`heroPlayerIdRef` verification, `sessionActiveRef` + a new session-start window event, the "reduce to hero-only through ambiguity" fallback) is gone. `event-ingestion.ts`'s session-end handler is back to the simple round-3 `setLastKnownStats([])`. `content_script.ts` and `constants/runtime.ts` are reverted to their pre-PR state.

Accepted and documented rather than engineered around: a post-session filter change may occasionally re-display the hero's last real (pre-end) table via `read-entity-stream.ts`'s `recalculateStats()` -- accurate data that may be contextually stale, not corrupted data. The simultaneous-2-seat-churn false positive on the table-move heuristic remains accepted as before.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` -- 107 suites / 1022 tests, run twice
- [x] `npm run e2e:smoke`
- [x] `npm run e2e:playerid`
- [x] One test added per ambiguity boundary (spectator deal, filter-change recompute incl. the orphaned-cache case, batch delivery, reload/remount) asserting dims clear/reset correctly

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>