### PR TITLE
fix(sync): per-account bookkeeping integrity across account switches

### DIFF
--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -1373,4 +1373,26 @@ describe('AutoSyncService cloud downloads', () => {
     // never synced).
     expect(performSyncSpy).toHaveBeenCalledTimes(1)
   })
+
+  test('clears the in-memory lastSyncTime as soon as firebaseAuthService notifies an auth state change -- one layer earlier than initialize()\'s own window fix (P2, codex review r3615952256)', async () => {
+    // Simulates account A having a real, recent lastSyncTime already in
+    // memory, as a prior successful sync would leave.
+    const service = new AutoSyncService(db)
+    ;(service as any).syncState.lastSyncTime = new Date('2026-07-20T00:00:00.000Z')
+
+    // firebaseAuthService.signInWithGoogle()/signOut() now notify
+    // listeners SYNCHRONOUSLY as part of exposing a new identity -- before
+    // their own persistAuthState()/storage-removal await, and well before
+    // message-router.ts's explicit onAuthStateChanged(user) call (which is
+    // what initialize()'s own r3615781411 fix guards) even runs.
+    // AutoSyncService registers exactly such a listener in its constructor
+    // -- invoke the notification directly here, the same way
+    // notifyAuthStateListeners() does internally, to prove the registered
+    // callback clears the stale value the instant it fires, independent of
+    // whether onAuthStateChanged()/initialize() has run yet.
+    const userB = { uid: 'user-b', email: 'b@example.com' } as any
+    ;(firebaseAuthService as any).notifyAuthStateListeners(userB)
+
+    expect((service as any).syncState.lastSyncTime).toBeUndefined()
+  })
 })

--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -1326,4 +1326,51 @@ describe('AutoSyncService cloud downloads', () => {
     expect((await chrome.storage.local.get('autoSyncLastTime:user-a'))['autoSyncLastTime:user-a']).toBe(legacyIso)
     expect(performSyncSpy).not.toHaveBeenCalled()
   })
+
+  test('clears the previous account\'s in-memory lastSyncTime immediately (before any awaits), so a session trigger firing during a direct A -> B sign-in cannot undercount B\'s backlog against A\'s stale value (P2, codex review r3615781411)', async () => {
+    await chrome.storage.local.remove(['autoSyncLastTime:user-a', 'autoSyncLastTime:user-b'])
+
+    const userB = { uid: 'user-b', email: 'b@example.com' } as any
+
+    const service = new AutoSyncService(db)
+    // Simulate account A's PREVIOUS successful sync having left a RECENT
+    // lastSyncTime in the shared in-memory syncState -- exactly what a
+    // real prior performSync() call for A would have set.
+    ;(service as any).syncState.lastSyncTime = new Date('2026-07-20T00:00:00.000Z')
+
+    jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue(userB)
+    jest.spyOn(firebaseAuthService, 'getAuthGeneration').mockReturnValue(1)
+    jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockResolvedValue(null)
+
+    // Capture syncState.lastSyncTime at the exact moment initialize()'s
+    // storage read (scoped + legacy keys) is issued -- this is the window
+    // the finding describes: a session-end/start trigger firing here would
+    // read whatever is current.
+    let lastSyncTimeDuringAwait: Date | undefined | 'not-observed' = 'not-observed'
+    const originalGet = (chrome.storage.local.get as jest.Mock).getMockImplementation()!
+    jest.spyOn(chrome.storage.local, 'get').mockImplementation((keys: any) => {
+      if (lastSyncTimeDuringAwait === 'not-observed') {
+        lastSyncTimeDuringAwait = (service as any).syncState.lastSyncTime
+      }
+      return originalGet(keys)
+    })
+
+    // Simulate a successful sync (sets lastSyncTime) -- a plain no-op mock
+    // would leave lastSyncTime unset, triggering initialize()'s
+    // retry-on-incomplete-first-sync logic (invariant (2b), its own
+    // dedicated test elsewhere) and inflating the call count asserted below.
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockImplementation(async () => {
+      (service as any).syncState.lastSyncTime = new Date()
+    })
+
+    await service.initialize()
+
+    // Must already be cleared BEFORE the storage read below -- not A's
+    // stale, more-recent value, which would otherwise make a concurrent
+    // syncIfBacklogExceedsThreshold() undercount B's real backlog.
+    expect(lastSyncTimeDuringAwait).toBeUndefined()
+    // Sanity: B correctly triggers its own first sync afterward (B has
+    // never synced).
+    expect(performSyncSpy).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -1234,4 +1234,96 @@ describe('AutoSyncService cloud downloads', () => {
     // (wrongly) shrink its own upload backlog.
     expect(service.getSyncState().lastSyncTime).toBeUndefined()
   })
+
+  test('waits for an in-flight sync from a DIFFERENT pass to settle before retrying initialization, instead of burning through all retry attempts immediately (P2, codex review r3615664890)', async () => {
+    await chrome.storage.local.remove(['autoSyncLastTime:user-b'])
+
+    const userB = { uid: 'user-b', email: 'b@example.com' } as any
+    jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue(userB)
+    jest.spyOn(firebaseAuthService, 'getAuthGeneration').mockReturnValue(1)
+    jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockResolvedValue(null)
+    // initialize()'s own performSync() call defaults to direction 'both' --
+    // mock the download leg too (the mocked `userB` has no real
+    // getIdToken(), so the REAL firestoreBackupService.syncFromCloud()
+    // would fail authentication and mask this test's actual concern).
+    jest.spyOn(firestoreBackupService, 'syncFromCloud').mockResolvedValue(0)
+
+    const service = new AutoSyncService(db)
+
+    // Simulate a DIFFERENT pass (e.g. account A's) already genuinely
+    // holding the sync latch when initialize() is called for B -- mirrors
+    // exactly what performSync() itself sets up at its own entry.
+    let resolveOtherPass: (() => void) | undefined
+    ;(service as any)._isSyncing = true
+    ;(service as any).inFlightSyncPromise = new Promise<void>(resolve => { resolveOtherPass = resolve })
+
+    const initializePromise = service.initialize()
+
+    // Flush the microtask queue (a macrotask boundary drains it completely)
+    // so initialize()'s first attempt actually reaches the "wait for the
+    // in-flight pass" branch and is blocked on `await this.inFlightSyncPromise`
+    // -- not still spinning through immediate, doomed retries.
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // Release the OTHER pass, exactly as performSync()'s own `finally`
+    // block would once that pass actually completes.
+    ;(service as any)._isSyncing = false
+    ;(service as any).inFlightSyncPromise = null
+    resolveOtherPass?.()
+
+    await initializePromise
+
+    // B's own first sync succeeded once the latch was actually free -- not
+    // abandoned after 3 immediate, doomed retries that all short-circuited
+    // on the same still-held latch.
+    expect((await chrome.storage.local.get('autoSyncLastTime:user-b'))['autoSyncLastTime:user-b']).toBeDefined()
+  })
+
+  test('removes the legacy autoSyncLastTime key BEFORE writing the scoped copy during migration, so a crash between them cannot leave it available for a different account to inherit (P2, codex review r3615664896)', async () => {
+    await chrome.storage.local.remove(['autoSyncLastTime', 'autoSyncLastTime:user-a'])
+
+    const userA = { uid: 'user-a', email: 'a@example.com' } as any
+    jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue(userA)
+    jest.spyOn(firebaseAuthService, 'getAuthGeneration').mockReturnValue(1)
+    jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockResolvedValue(null)
+
+    const legacyIso = new Date('2026-01-01T00:00:00.000Z').toISOString()
+    await chrome.storage.local.set({ autoSyncLastTime: legacyIso })
+
+    // Track call order exactly like the existing r3614064524 crash-window
+    // regression test does for the sync-floor commit -- capture the
+    // CURRENT mock implementations (not just the mutable property
+    // references) before overriding them, same fix as the earlier
+    // recursive-mock issue in the "blocks the legacy migration/clear
+    // write" test above.
+    const callOrder: string[] = []
+    const originalSet = (chrome.storage.local.set as jest.Mock).getMockImplementation()!
+    const originalRemove = (chrome.storage.local.remove as jest.Mock).getMockImplementation()!
+    jest.spyOn(chrome.storage.local, 'set').mockImplementation((items: any) => {
+      callOrder.push(`set:${Object.keys(items).join(',')}`)
+      return originalSet(items)
+    })
+    jest.spyOn(chrome.storage.local, 'remove').mockImplementation((keys: any) => {
+      callOrder.push(`remove:${Array.isArray(keys) ? keys.join(',') : keys}`)
+      return originalRemove(keys)
+    })
+
+    const service = new AutoSyncService(db)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue(undefined)
+
+    await service.initialize()
+
+    const removeIndex = callOrder.findIndex(entry => entry === 'remove:autoSyncLastTime')
+    const setIndex = callOrder.findIndex(entry => entry === 'set:autoSyncLastTime:user-a')
+    expect(removeIndex).toBeGreaterThanOrEqual(0)
+    expect(setIndex).toBeGreaterThanOrEqual(0)
+    // happens-before: the legacy key must already be gone before the
+    // scoped copy is written, so a crash in between leaves no legacy value
+    // for a later, different account to wrongly inherit.
+    expect(removeIndex).toBeLessThan(setIndex)
+
+    // Sanity: the migration still landed correctly for A.
+    expect((await chrome.storage.local.get('autoSyncLastTime:user-a'))['autoSyncLastTime:user-a']).toBe(legacyIso)
+    expect(performSyncSpy).not.toHaveBeenCalled()
+  })
 })

--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -751,10 +751,19 @@ describe('AutoSyncService cloud downloads', () => {
 
     // By the time both calls have been issued (synchronously, before the
     // gate promise resolves), the latch must already be set -- proving the
-    // first call set it before yielding at the `await` for the gate.
+    // first call set it before yielding at its first await.
     expect((service as any)._isSyncing).toBe(true)
 
-    resolveGate?.(false) // gate: not blocked
+    // Flush microtasks until the first call's execution actually reaches
+    // the gate check and `resolveGate` is captured -- performSync() now has
+    // an earlier `await firebaseAuthService.ready()` ahead of the gate
+    // check (r3615553034), so reaching it can take more than one microtask
+    // hop; polling (rather than assuming a fixed hop count) keeps this
+    // test robust to that either way.
+    while (!resolveGate) {
+      await Promise.resolve()
+    }
+    resolveGate(false) // gate: not blocked
     await firstSync
     await secondSync
 
@@ -1132,5 +1141,97 @@ describe('AutoSyncService cloud downloads', () => {
     expect(await chrome.storage.local.get('autoSyncLastTime')).toEqual({ autoSyncLastTime: legacyIso })
     expect(await chrome.storage.local.get('autoSyncLastTime:user-a')).toEqual({ 'autoSyncLastTime:user-a': undefined })
     expect(performSyncSpy).not.toHaveBeenCalled()
+  })
+
+  test('awaits auth restore before snapshotting identity, so a pass starting during Service Worker startup does not snapshot a pre-restore identity (P2, codex review r3615553034)', async () => {
+    await chrome.storage.local.remove(['autoSyncLastTime:user-a'])
+
+    const userA = { uid: 'user-a', email: 'a@example.com' } as any
+    // Simulates firebaseAuthService's own constructor-kicked-off
+    // restoreAuthState() not having resolved yet: getCurrentUser()/
+    // getAuthGeneration() report "nobody signed in yet, generation 0" until
+    // `restored` flips, mirroring how the real service looks before vs.
+    // after its restorePromise settles.
+    let restored = false
+    let resolveReady: (() => void) | undefined
+    jest.spyOn(firebaseAuthService, 'ready').mockImplementation(() => new Promise<void>(resolve => { resolveReady = resolve }))
+    jest.spyOn(firebaseAuthService, 'getCurrentUser').mockImplementation(() => restored ? userA : null)
+    jest.spyOn(firebaseAuthService, 'getAuthGeneration').mockImplementation(() => restored ? 1 : 0)
+
+    jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockResolvedValue(null)
+    jest.spyOn(firestoreBackupService, 'syncToCloudBatch')
+      .mockResolvedValue({ totalEvents: 0, syncedEvents: 0, lastSyncTime: new Date() })
+
+    const service = new AutoSyncService(db)
+    const syncPromise = service.performSync('upload')
+
+    // Restore "completes" while performSync() is awaiting
+    // firebaseAuthService.ready() -- exactly the startup race the finding
+    // describes. If the identity snapshot were taken BEFORE this await
+    // (the bug), it would have already captured `{ uid: undefined,
+    // generation: 0 }` synchronously, before this line ever runs.
+    restored = true
+    resolveReady?.()
+
+    await syncPromise
+
+    // Must have succeeded under the RESTORED identity's own scoped key --
+    // not the bare/unscoped key a pre-restore `{ uid: undefined }` snapshot
+    // would have written to, and not aborted by a later commit-point check
+    // wrongly seeing "generation changed" relative to a stale pre-restore
+    // snapshot.
+    expect(service.getSyncState().status).toBe('success')
+    expect((await chrome.storage.local.get('autoSyncLastTime:user-a'))['autoSyncLastTime:user-a']).toBeDefined()
+    expect(await chrome.storage.local.get('autoSyncLastTime')).toEqual({ autoSyncLastTime: undefined })
+  })
+
+  test('re-checks the generation before publishing sync success into the shared syncState, closing the gap during updateTimestamps() (P2, codex review r3615553045)', async () => {
+    await chrome.storage.local.remove(['autoSyncLastTime:user-a', 'autoSyncLastTime:user-b'])
+
+    const userA = { uid: 'user-a', email: 'a@example.com' } as any
+    const userB = { uid: 'user-b', email: 'b@example.com' } as any
+    const getCurrentUserSpy = jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue(userA)
+    let generation = 1
+    jest.spyOn(firebaseAuthService, 'getAuthGeneration').mockImplementation(() => generation)
+
+    const validRow = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO,
+      Id: 'x', IsRetire: false, timestamp: 100
+    } as ApiEvent
+    await db.apiEvents.add(validRow)
+
+    jest.spyOn(firestoreBackupService, 'syncToCloudBatch')
+      .mockResolvedValue({ totalEvents: 1, syncedEvents: 1, lastSyncTime: new Date() })
+
+    let cloudMaxCalls = 0
+    jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockImplementation(async () => {
+      cloudMaxCalls++
+      // Call #1 is syncToCloud()'s own watermark read (before any
+      // bookkeeping write). Call #2 is updateTimestamps()'s own read,
+      // which runs AFTER the scoped autoSyncLastTime write below has
+      // already landed -- switch accounts exactly there, simulating the
+      // account changing during that specific gap.
+      if (cloudMaxCalls === 2) {
+        generation++
+        getCurrentUserSpy.mockReturnValue(userB)
+      }
+      return null
+    })
+
+    const service = new AutoSyncService(db)
+    await service.performSync('upload')
+
+    expect(service.getSyncState().status).toBe('error')
+    expect(service.getSyncState().error).toContain('before publishing sync success')
+
+    // The scoped bookkeeping WRITE already landed under A -- legitimate,
+    // made while A was still live (before the switch inside updateTimestamps()).
+    expect((await chrome.storage.local.get('autoSyncLastTime:user-a'))['autoSyncLastTime:user-a']).toBeDefined()
+
+    // But the SHARED in-memory syncState.lastSyncTime was never published --
+    // this is exactly what a newly-signed-in B's own
+    // syncIfBacklogExceedsThreshold() would otherwise read and use to
+    // (wrongly) shrink its own upload backlog.
+    expect(service.getSyncState().lastSyncTime).toBeUndefined()
   })
 })

--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -800,7 +800,14 @@ describe('AutoSyncService cloud downloads', () => {
     await chrome.storage.local.set({ autoSyncLastTime: legacyIso })
 
     const service = new AutoSyncService(db)
-    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue(undefined)
+    // Simulate a successful sync (sets lastSyncTime) -- a plain no-op mock
+    // would leave lastSyncTime unset, which now triggers initialize()'s
+    // retry-on-incomplete-first-sync logic (invariant (2b)) and inflates
+    // the call count this test asserts on; that retry behavior has its own
+    // dedicated test below.
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockImplementation(async () => {
+      (service as any).syncState.lastSyncTime = new Date()
+    })
 
     // --- Account A is the first to sign in after upgrade -------------------
     getCurrentUserSpy.mockReturnValue(userA)
@@ -830,6 +837,15 @@ describe('AutoSyncService cloud downloads', () => {
     const userA = { uid: 'user-a', email: 'a@example.com' } as any
     const userB = { uid: 'user-b', email: 'b@example.com' } as any
     const getCurrentUserSpy = jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue(userA)
+    // Real account switches always bump firebase-auth-service's own auth
+    // generation counter (see its doc comment) -- mocking getCurrentUser()
+    // alone does NOT, since the real signInWithGoogle()/signOut() methods
+    // that own that counter are never called here. Mock getAuthGeneration()
+    // too, with its own local counter incremented in lockstep with every
+    // simulated account switch, so assertGenerationUnchanged() sees exactly
+    // what it would in production.
+    let generation = 1
+    jest.spyOn(firebaseAuthService, 'getAuthGeneration').mockImplementation(() => generation)
 
     // An unparseable row (forces a mid-pass EAGER floor persist under A's
     // scope, BEFORE the account switch below -- this write is legitimate,
@@ -854,6 +870,7 @@ describe('AutoSyncService cloud downloads', () => {
     // (accepted risk) -- what must NOT happen is committing bookkeeping
     // under the wrong account afterward.
     jest.spyOn(firestoreBackupService, 'syncToCloudBatch').mockImplementation(async (chunk: ApiEvent[]) => {
+      generation++
       getCurrentUserSpy.mockReturnValue(userB)
       return { totalEvents: chunk.length, syncedEvents: chunk.length, lastSyncTime: new Date() }
     })
@@ -952,5 +969,168 @@ describe('AutoSyncService cloud downloads', () => {
     expect(service.getSyncState().status).toBe('success')
     // A's bookkeeping is intact and correctly advances -- no permanent gap.
     expect((await chrome.storage.local.get('autoSyncLastTime:user-a'))['autoSyncLastTime:user-a']).not.toBe(aLastSyncAfterPhase1)
+  })
+
+  test('detects an A -> B -> A round trip and aborts with zero bookkeeping writes, even though the live uid matches the snapshot again by the final commit (P1, ABA, codex review r3615389112)', async () => {
+    await chrome.storage.local.remove(['autoSyncLastTime:user-a', 'autoSyncLastTime:user-b'])
+
+    const userA = { uid: 'user-a', email: 'a@example.com' } as any
+    const userB = { uid: 'user-b', email: 'b@example.com' } as any
+    const getCurrentUserSpy = jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue(userA)
+    // A uid-string-only check would be fooled here: by the time
+    // performSync()'s final commit assert runs, getCurrentUser() is back to
+    // returning userA, string-equal to the pass-start snapshot. The auth
+    // generation counter is not fooled -- two real transitions (A->B, B->A)
+    // happened in between, advancing it by 2.
+    let generation = 1
+    jest.spyOn(firebaseAuthService, 'getAuthGeneration').mockImplementation(() => generation)
+
+    const validRow = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO,
+      Id: 'aba-row', IsRetire: false, timestamp: 100
+    } as ApiEvent
+    await db.apiEvents.add(validRow)
+
+    jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockResolvedValue(null)
+    // direction: 'download' below, so syncToCloud() (and its own internal
+    // sync-floor commit-point assert, already covered by a separate test)
+    // never runs -- this isolates performSync()'s OWN final
+    // `autoSyncLastTime` commit-point assert as the thing that must catch
+    // the ABA round trip.
+    jest.spyOn(firestoreBackupService, 'syncFromCloud').mockImplementation(async () => {
+      generation++
+      getCurrentUserSpy.mockReturnValue(userB)
+      generation++
+      getCurrentUserSpy.mockReturnValue(userA)
+      return 0
+    })
+
+    const service = new AutoSyncService(db)
+    await service.performSync('download')
+
+    expect(service.getSyncState().status).toBe('error')
+    expect(service.getSyncState().error).toContain('final lastSyncTime commit')
+    expect(await chrome.storage.local.get('autoSyncLastTime:user-a')).toEqual({ 'autoSyncLastTime:user-a': undefined })
+    expect(await chrome.storage.local.get('autoSyncLastTime:user-b')).toEqual({ 'autoSyncLastTime:user-b': undefined })
+  })
+
+  test('re-runs initialize() fresh (does not publish a stale result) if the SAME account signs out and back in mid-computation (invariant (2b), codex review r3615389139/r3615389133)', async () => {
+    await chrome.storage.local.remove(['autoSyncLastTime:user-a'])
+
+    const userA = { uid: 'user-a', email: 'a@example.com' } as any
+    jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue(userA)
+    let generation = 1
+    jest.spyOn(firebaseAuthService, 'getAuthGeneration').mockImplementation(() => generation)
+
+    // A sign-out+sign-in of the SAME account (uid unchanged) still advances
+    // the generation by 2 -- simulated as a side effect of the FIRST
+    // updateTimestamps() call's own getCloudMaxTimestamp() read, landing in
+    // the gap between initialize()'s identity snapshot and its
+    // result-application check.
+    let cloudMaxCalls = 0
+    jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockImplementation(async () => {
+      cloudMaxCalls++
+      if (cloudMaxCalls === 1) generation += 2
+      return null
+    })
+
+    const service = new AutoSyncService(db)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockImplementation(async () => {
+      (service as any).syncState.lastSyncTime = new Date()
+    })
+
+    await service.initialize()
+
+    // The FIRST attempt's computation (generation 1) was discarded once the
+    // mismatch was detected; initialize() re-ran fresh under generation 3
+    // and correctly triggered exactly one first sync from THAT attempt --
+    // not zero (silently abandoned) and not two (the stale attempt also
+    // publishing/triggering before being caught).
+    expect(performSyncSpy).toHaveBeenCalledTimes(1)
+    expect(cloudMaxCalls).toBe(2) // one per attempt (first discarded, second applied)
+  })
+
+  test('discards a stale initialize() result and never publishes it into syncState when the account changes mid-computation to a genuinely DIFFERENT account (invariant (2b))', async () => {
+    await chrome.storage.local.remove(['autoSyncLastTime:user-a', 'autoSyncLastTime:user-b'])
+
+    const userA = { uid: 'user-a', email: 'a@example.com' } as any
+    const userB = { uid: 'user-b', email: 'b@example.com' } as any
+    // A already has its OWN real lastSyncTime -- if this were incorrectly
+    // published for whoever ends up live, initialize() would wrongly
+    // conclude "already synced" and skip triggering a first sync.
+    const staleIso = new Date('2020-01-01T00:00:00.000Z').toISOString()
+    await chrome.storage.local.set({ 'autoSyncLastTime:user-a': staleIso })
+
+    const getCurrentUserSpy = jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue(userA)
+    let generation = 1
+    jest.spyOn(firebaseAuthService, 'getAuthGeneration').mockImplementation(() => generation)
+    let cloudMaxCalls = 0
+    jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockImplementation(async () => {
+      cloudMaxCalls++
+      if (cloudMaxCalls === 1) {
+        // Account switches to B (a genuinely different, never-synced
+        // account) while initialize() -- still computing for A -- awaits
+        // this FIRST call inside updateTimestamps(). Only on the first call
+        // -- the retry's own updateTimestamps() call must see a stable
+        // account so the re-run actually converges.
+        generation++
+        getCurrentUserSpy.mockReturnValue(userB)
+      }
+      return null
+    })
+
+    const service = new AutoSyncService(db)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockImplementation(async () => {
+      (service as any).syncState.lastSyncTime = new Date()
+    })
+
+    await service.initialize()
+
+    // A's stale lastSyncTime (2020) was never published -- the re-run
+    // correctly re-evaluates for B (who has no scoped key at all) and
+    // triggers B's own first sync, rather than silently applying A's
+    // "already synced" conclusion to whoever happens to be live afterward.
+    expect(performSyncSpy).toHaveBeenCalledTimes(1)
+  })
+
+  test('blocks the legacy migration/clear write if the account changes mid-computation, leaving the legacy key untouched for a later attempt to retry (invariant (2), codex review r3615389121)', async () => {
+    await chrome.storage.local.remove(['autoSyncLastTime', 'autoSyncLastTime:user-a'])
+
+    const userA = { uid: 'user-a', email: 'a@example.com' } as any
+    const legacyIso = new Date('2026-01-01T00:00:00.000Z').toISOString()
+    await chrome.storage.local.set({ autoSyncLastTime: legacyIso })
+
+    jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue(userA)
+    let generation = 1
+    jest.spyOn(firebaseAuthService, 'getAuthGeneration').mockImplementation(() => generation)
+
+    // Bump the generation as a side effect of the ONE await between
+    // initialize()'s identity snapshot and the legacy-migration commit
+    // point: the chrome.storage.local.get() read of the scoped+legacy keys.
+    // Capture the CURRENT implementation function (not just the mutable
+    // `chrome.storage.local.get` property reference) before overriding it --
+    // `chrome.storage.local.get` is already a jest.fn() from test-setup.ts,
+    // so re-assigning its implementation via mockImplementation() below
+    // would otherwise make a naively-captured "original" reference recurse
+    // into the NEW implementation too (same underlying mock object).
+    const originalStorageGetImpl = (chrome.storage.local.get as jest.Mock).getMockImplementation()!
+    jest.spyOn(chrome.storage.local, 'get').mockImplementation((keys: any) => {
+      const result = originalStorageGetImpl(keys)
+      generation++
+      return result
+    })
+
+    const service = new AutoSyncService(db)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue(undefined)
+
+    await service.initialize()
+
+    // The migration/clear write never happened -- the legacy key survives
+    // untouched (available for a later, non-stale attempt), and no scoped
+    // key was created from a computation already known to be stale. No
+    // first sync was triggered off it either.
+    expect(await chrome.storage.local.get('autoSyncLastTime')).toEqual({ autoSyncLastTime: legacyIso })
+    expect(await chrome.storage.local.get('autoSyncLastTime:user-a')).toEqual({ 'autoSyncLastTime:user-a': undefined })
+    expect(performSyncSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -1395,4 +1395,41 @@ describe('AutoSyncService cloud downloads', () => {
 
     expect((service as any).syncState.lastSyncTime).toBeUndefined()
   })
+
+  test('rechecks the generation before the scoped legacy migration write, so an account switch during the remove() await cannot persist a stale uid\'s scoped key (P2, codex review r3616056817)', async () => {
+    await chrome.storage.local.remove(['autoSyncLastTime', 'autoSyncLastTime:user-a'])
+
+    const userA = { uid: 'user-a', email: 'a@example.com' } as any
+    jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue(userA)
+    let generation = 1
+    jest.spyOn(firebaseAuthService, 'getAuthGeneration').mockImplementation(() => generation)
+
+    const legacyIso = new Date('2026-01-01T00:00:00.000Z').toISOString()
+    await chrome.storage.local.set({ autoSyncLastTime: legacyIso })
+
+    // Bump the generation as a side effect of the remove() call -- the
+    // window BETWEEN the first assert (before remove()) and the scoped
+    // set() that follows it, which is exactly what the finding describes.
+    const originalRemove = (chrome.storage.local.remove as jest.Mock).getMockImplementation()!
+    jest.spyOn(chrome.storage.local, 'remove').mockImplementation((keys: any) => {
+      const result = originalRemove(keys)
+      generation++
+      return result
+    })
+
+    const service = new AutoSyncService(db)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue(undefined)
+
+    await service.initialize()
+
+    // The legacy key IS gone -- removing it is unconditionally safe
+    // regardless of which account ends up live (r3615664896's ordering
+    // fix), so that part still lands.
+    expect(await chrome.storage.local.get('autoSyncLastTime')).toEqual({ autoSyncLastTime: undefined })
+    // But the scoped write for the now-STALE uid never happened -- it
+    // would have durably persisted a value this account never actually
+    // earned, letting it wrongly look "already synced" on a later sign-in.
+    expect(await chrome.storage.local.get('autoSyncLastTime:user-a')).toEqual({ 'autoSyncLastTime:user-a': undefined })
+    expect(performSyncSpy).not.toHaveBeenCalled()
+  })
 })

--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -5,6 +5,7 @@ import type { ApiEvent } from '../types'
 import { DATABASE_CONSTANTS } from '../constants/database'
 import { AutoSyncService } from './auto-sync-service'
 import { firestoreBackupService } from './firestore-backup-service'
+import { firebaseAuthService } from './firebase-auth-service'
 import * as minVersionGate from './min-version-gate'
 
 describe('AutoSyncService cloud downloads', () => {
@@ -781,5 +782,175 @@ describe('AutoSyncService cloud downloads', () => {
     jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockResolvedValue(null)
     await service.performSync('upload')
     expect(service.getSyncState().status).toBe('success')
+  })
+
+  test('migrates the legacy unscoped autoSyncLastTime to whichever account consumes it first, deleting it so a later DIFFERENT account is never granted it (invariant (1))', async () => {
+    // Other tests in this file may leave these scoped keys set (a plain
+    // module-level object in test-setup.ts, not reset per test).
+    await chrome.storage.local.remove(['autoSyncLastTime', 'autoSyncLastTime:user-a', 'autoSyncLastTime:user-b'])
+
+    const userA = { uid: 'user-a', email: 'a@example.com' } as any
+    const userB = { uid: 'user-b', email: 'b@example.com' } as any
+    const getCurrentUserSpy = jest.spyOn(firebaseAuthService, 'getCurrentUser')
+    jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockResolvedValue(null)
+
+    // Simulates an upgraded profile that still has the pre-scoping legacy
+    // value with no account attribution.
+    const legacyIso = new Date('2026-01-01T00:00:00.000Z').toISOString()
+    await chrome.storage.local.set({ autoSyncLastTime: legacyIso })
+
+    const service = new AutoSyncService(db)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue(undefined)
+
+    // --- Account A is the first to sign in after upgrade -------------------
+    getCurrentUserSpy.mockReturnValue(userA)
+    await service.initialize()
+
+    // The legacy value was migrated to A's OWN scoped key and consumed (not
+    // just copied) -- A is treated as already synced (no phantom first sync).
+    expect(performSyncSpy).not.toHaveBeenCalled()
+    const migrated = await chrome.storage.local.get(['autoSyncLastTime:user-a', 'autoSyncLastTime'])
+    expect(migrated['autoSyncLastTime:user-a']).toBe(legacyIso)
+    expect(migrated['autoSyncLastTime']).toBeUndefined()
+
+    // --- Account B signs in afterward on the same device -------------------
+    getCurrentUserSpy.mockReturnValue(userB)
+    await service.initialize()
+
+    // B must NOT inherit A's migrated-and-consumed legacy value -- the
+    // legacy key is gone, so B correctly looks like it has never synced and
+    // gets its own first-time sync.
+    expect(performSyncSpy).toHaveBeenCalledTimes(1)
+    expect(await chrome.storage.local.get('autoSyncLastTime:user-b')).toEqual({ 'autoSyncLastTime:user-b': undefined })
+  })
+
+  test('aborts a sync pass with ZERO bookkeeping writes for the new account if the signed-in account changes mid-pass, before the pass reaches its final commit (invariant (2))', async () => {
+    await chrome.storage.local.remove(['autoSyncLastTime:user-a', 'autoSyncLastTime:user-b'])
+
+    const userA = { uid: 'user-a', email: 'a@example.com' } as any
+    const userB = { uid: 'user-b', email: 'b@example.com' } as any
+    const getCurrentUserSpy = jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue(userA)
+
+    // An unparseable row (forces a mid-pass EAGER floor persist under A's
+    // scope, BEFORE the account switch below -- this write is legitimate,
+    // made while A was still live, and is expected to survive) followed by
+    // a later valid row.
+    const orphan = { ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 200 }
+    const laterValidRow = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Code: 0,
+      BattleType: BattleType.SIT_AND_GO,
+      Id: 'later-valid',
+      IsRetire: false,
+      timestamp: 300
+    } as ApiEvent
+    await db.apiEvents.bulkAdd([orphan, laterValidRow] as any)
+
+    jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockResolvedValue(null)
+    // Simulates the account switching WHILE the upload network request for
+    // this chunk is in flight -- by the time it resolves, a different
+    // account is signed in. Per the owner-decided scope, this upload itself
+    // is allowed to proceed/complete under whichever account ends up live
+    // (accepted risk) -- what must NOT happen is committing bookkeeping
+    // under the wrong account afterward.
+    jest.spyOn(firestoreBackupService, 'syncToCloudBatch').mockImplementation(async (chunk: ApiEvent[]) => {
+      getCurrentUserSpy.mockReturnValue(userB)
+      return { totalEvents: chunk.length, syncedEvents: chunk.length, lastSyncTime: new Date() }
+    })
+
+    const service = new AutoSyncService(db)
+    await service.performSync('upload')
+
+    // The pass aborted with a clear, attributable error -- not a silent
+    // partial success reported as success.
+    expect(service.getSyncState().status).toBe('error')
+    expect(service.getSyncState().error).toContain('sync-floor commit')
+
+    // The EAGER persist from BEFORE the switch is legitimately under A's
+    // scope and stays -- this is not what the fix prevents.
+    expect((await db.meta.get('syncUnparseableFloor:user-a'))?.value).toBe(200)
+
+    // ZERO bookkeeping writes happened under B's scope, and A's final
+    // lastSyncTime commit never ran either (the pass never reached it).
+    expect(await db.meta.get('syncUnparseableFloor:user-b')).toBeUndefined()
+    expect(await chrome.storage.local.get('autoSyncLastTime:user-a')).toEqual({ 'autoSyncLastTime:user-a': undefined })
+    expect(await chrome.storage.local.get('autoSyncLastTime:user-b')).toEqual({ 'autoSyncLastTime:user-b': undefined })
+  })
+
+  test('sign-in-mistake round trip: switching to a different account and back leaves the original account\'s own bookkeeping intact, and its next sync uploads exactly what its own cloud still lacks (owner-decided scope)', async () => {
+    await chrome.storage.local.remove(['autoSyncLastTime:user-a', 'autoSyncLastTime:user-b'])
+
+    const userA = { uid: 'user-a', email: 'a@example.com' } as any
+    const userB = { uid: 'user-b', email: 'b@example.com' } as any
+    const getCurrentUserSpy = jest.spyOn(firebaseAuthService, 'getCurrentUser')
+    const cloudMaxSpy = jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp')
+    const syncBatchSpy = jest.spyOn(firestoreBackupService, 'syncToCloudBatch')
+      .mockImplementation(async (chunk: ApiEvent[]) => ({ totalEvents: chunk.length, syncedEvents: chunk.length, lastSyncTime: new Date() }))
+
+    const rowA1 = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO,
+      Id: 'a1', IsRetire: false, timestamp: 100
+    } as ApiEvent
+    await db.apiEvents.add(rowA1)
+
+    const service = new AutoSyncService(db)
+
+    // --- Phase 1: signed in as A, first-ever sync for A --------------------
+    getCurrentUserSpy.mockReturnValue(userA)
+    cloudMaxSpy.mockResolvedValue(null) // persistent for this phase -- covers both the syncToCloud() call and updateTimestamps()'s own call
+    await service.performSync('upload')
+
+    expect(syncBatchSpy).toHaveBeenCalledTimes(1)
+    expect(syncBatchSpy.mock.calls[0]![0]).toEqual([rowA1])
+    const aLastSyncAfterPhase1 = (await chrome.storage.local.get('autoSyncLastTime:user-a'))['autoSyncLastTime:user-a']
+    expect(aLastSyncAfterPhase1).toBeDefined()
+
+    // --- Sign-in mistake: switch to B. Local capture (the shared, --------
+    // unpartitioned apiEvents Lake) keeps recording regardless of which
+    // account is signed in -- a poker session B plays here adds rowB1.
+    const rowB1 = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO,
+      Id: 'b1', IsRetire: false, timestamp: 200
+    } as ApiEvent
+    await db.apiEvents.add(rowB1)
+
+    getCurrentUserSpy.mockReturnValue(userB)
+    cloudMaxSpy.mockResolvedValue(null) // B's own cloud is empty
+    await service.performSync('upload')
+
+    // Owner-decided scope: this upload IS allowed to send the WHOLE shared
+    // local backlog (including rowA1, which "belongs" to A's session) to
+    // B's Firestore -- accepted data duplication, not blocked.
+    expect(syncBatchSpy).toHaveBeenCalledTimes(2)
+    expect(syncBatchSpy.mock.calls[1]![0]).toEqual([rowA1, rowB1])
+    expect((await chrome.storage.local.get('autoSyncLastTime:user-b'))['autoSyncLastTime:user-b']).toBeDefined()
+
+    // THE CORE INVARIANT: A's own bookkeeping is completely untouched by
+    // B's entire session (both its cloud read and its upload/commit).
+    expect((await chrome.storage.local.get('autoSyncLastTime:user-a'))['autoSyncLastTime:user-a']).toBe(aLastSyncAfterPhase1)
+
+    // --- Sign back into A (the mistake is noticed and corrected) ---------
+    const rowA2 = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO,
+      Id: 'a2', IsRetire: false, timestamp: 300
+    } as ApiEvent
+    await db.apiEvents.add(rowA2)
+
+    getCurrentUserSpy.mockReturnValue(userA)
+    // A's OWN cloud watermark is still only 100 -- B's upload went to B's
+    // Firestore, not A's -- so from A's perspective its cloud still lacks
+    // rowB1 (200) and rowA2 (300). This is the concrete "no permanent
+    // upload gap" assertion: A's bookkeeping survived B's session with
+    // enough fidelity that A's own watermark (100) is still exactly right.
+    cloudMaxSpy.mockResolvedValue(100)
+    await service.performSync('upload')
+
+    // A's next sync uploads EXACTLY what A's own cloud lacks -- not rowA1
+    // (already covered by A's own watermark), but rowB1 and rowA2.
+    expect(syncBatchSpy).toHaveBeenCalledTimes(3)
+    expect(syncBatchSpy.mock.calls[2]![0]).toEqual([rowB1, rowA2])
+    expect(service.getSyncState().status).toBe('success')
+    // A's bookkeeping is intact and correctly advances -- no permanent gap.
+    expect((await chrome.storage.local.get('autoSyncLastTime:user-a'))['autoSyncLastTime:user-a']).not.toBe(aLastSyncAfterPhase1)
   })
 })

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -327,6 +327,29 @@ export class AutoSyncService {
       const identity = this.snapshotIdentity()
       const uid = identity.uid! // definitely defined -- `user` above proves it
 
+      // Clear the (possibly stale, possibly a DIFFERENT account's)
+      // in-memory lastSyncTime IMMEDIATELY, before the awaits below (codex
+      // review r3615781411, P2, "Clear the previous account's sync time
+      // before awaits"): `syncIfBacklogExceedsThreshold()` reads
+      // `this.syncState.lastSyncTime` directly and is not gated by any of
+      // this method's own commit points, so during a direct A -> B sign-in,
+      // a session-end/start trigger firing while the storage read /
+      // `updateTimestamps()` awaits below are still pending would otherwise
+      // see A's stale value under B's live identity. If A synced more
+      // recently than B's real watermark, that undercounts B's backlog and
+      // can skip an upload B actually needs -- and if B already has an
+      // OLDER scoped value of its own, the "perform initial sync only if
+      // never synced before" check further down won't fire to make up for
+      // it either, since B correctly looks "already synced" once its own
+      // value is restored. Clearing to `undefined` here is conservative in
+      // the safe direction -- a trigger firing in this narrow window
+      // computes the backlog as "everything", which can only ever
+      // OVER-count (at worst one redundant sync attempt), never undercount
+      // -- and gets corrected to this account's own real value once the
+      // async work below completes and generation is reconfirmed (see the
+      // COMMIT POINT before the real assignment further down).
+      this.syncState.lastSyncTime = undefined
+
       // Load last sync time from storage, scoped to this account (invariant
       // (1)). If the LEGACY unscoped key is present, consume/delete it
       // unconditionally (codex review r3615389121, P2, "Clear stale legacy
@@ -388,9 +411,10 @@ export class AutoSyncService {
         return this.initialize(attempt + 1)
       }
 
-      // Explicitly reset (not just "leave whatever was there") so a direct
-      // account switch without an intervening sign-out can't leak the
-      // previous account's in-memory lastSyncTime into this one.
+      // Publish this account's REAL value now (already cleared to
+      // `undefined` up front, before the awaits -- see r3615781411 above)
+      // now that the async work is done and the generation is reconfirmed
+      // current.
       this.syncState.lastSyncTime = storedLastSyncTime ? new Date(storedLastSyncTime as string | number) : undefined
 
       // Perform initial sync only if never synced before (invariant (3):

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -401,6 +401,24 @@ export class AutoSyncService {
         // cross-account leak this migration exists to prevent.
         await chrome.storage.local.remove(this.SYNC_STORAGE_KEY)
         if (storedLastSyncTime === undefined) {
+          // COMMIT POINT (invariant (2), codex review r3616056817, P2,
+          // "Recheck auth before writing the scoped legacy time"):
+          // re-check AGAIN, immediately before this scoped write -- the
+          // FIRST assert above only covers up to the `remove()` await
+          // just completed. If the account changed while THAT await was
+          // in flight, this scoped write would otherwise durably persist
+          // the OLD (now-stale) uid's `autoSyncLastTime:<uid>` key from an
+          // `initialize()` attempt whose in-memory result is already known
+          // to be discarded by the later generation-moved check further
+          // down -- but that discard only prevents the STALE attempt from
+          // publishing to `syncState`; it does nothing to undo a durable
+          // storage write that already landed. If that uid signs in again
+          // later, it would wrongly look "already synced" off a value it
+          // never actually earned. Failing closed here (not writing) only
+          // costs that account one extra "first sync" later -- the legacy
+          // key is already gone either way (removed above), so there's no
+          // repeat-migration risk from skipping this write.
+          this.assertGenerationUnchanged(identity.generation, 'before scoped legacy migration write')
           storedLastSyncTime = legacyLastSyncTime
           console.log(`[AutoSync] Migrating legacy unscoped ${this.SYNC_STORAGE_KEY} to this account (${uid})`)
           await chrome.storage.local.set({ [scopedSyncKey]: storedLastSyncTime })

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -17,21 +17,34 @@ import { isCloudSyncBlockedByMinVersionGate } from './min-version-gate'
 export const MIN_VERSION_SYNC_BLOCKED_MESSAGE = 'このバージョンはサポートが終了しました。Chromeを再起動すると更新が適用されます'
 
 /**
- * Thrown internally whenever a bookkeeping write is about to happen under a
- * uid that no longer matches the one signed in live -- i.e. the account
- * changed since this sync pass started. Never thrown for the actual
- * Firestore upload/download calls themselves (accepted risk, see the
- * ACCOUNT-SCOPING INVARIANTS spec below) -- only for this file's own
- * `meta`/`chrome.storage.local` bookkeeping writes. Caught by
- * `performSync()`'s existing catch block, which sets `syncState.status =
- * 'error'` -- the next `performSync()` call retries cleanly under whichever
- * account is signed in by then.
+ * Thrown internally whenever a bookkeeping write is about to happen under an
+ * auth-state generation that no longer matches the one live when this sync
+ * pass started -- i.e. the account changed (possibly more than once) since
+ * the pass began. Never thrown for the actual Firestore upload/download
+ * calls themselves (accepted risk, see the ACCOUNT-SCOPING INVARIANTS spec
+ * below) -- only for this file's own `meta`/`chrome.storage.local`
+ * bookkeeping writes. Caught by `performSync()`'s existing catch block,
+ * which sets `syncState.status = 'error'` -- the next `performSync()` call
+ * retries cleanly under whichever account is signed in by then.
  */
 export class SyncAccountChangedError extends Error {
   constructor(context: string) {
     super(`同期中にサインインアカウントが変更されたため、このアカウント宛の記録を中止しました (${context})`)
     this.name = 'SyncAccountChangedError'
   }
+}
+
+/**
+ * Snapshot of "who is signed in" taken once at the start of a sync pass (or
+ * an `initialize()` call). `uid` is used for BOOKKEEPING KEY DERIVATION
+ * (`scopedMetaKey()`); `generation` is the VALIDITY TOKEN checked at every
+ * commit point (`assertGenerationUnchanged()`) -- see the ACCOUNT-SCOPING
+ * INVARIANTS spec below for why a bare uid-string comparison is insufficient
+ * (the A -> B -> A problem, codex review r3615389112).
+ */
+interface SyncPassIdentity {
+  uid: string | undefined
+  generation: number
 }
 
 export type SyncStatus = 'idle' | 'syncing' | 'error' | 'success'
@@ -88,19 +101,34 @@ export interface SyncState {
  *     that has never synced correctly sees no stored `lastSyncTime` at all,
  *     not a borrowed one.
  *
- * (2) EVERY BOOKKEEPING WRITE IS GATED ON THE PASS-START UID STILL BEING
- *     LIVE: `performSync()` captures `firebaseAuthService.getCurrentUser()?.uid`
- *     once at sync start and threads that same value through the rest of
- *     the pass. `persistUnparseableSyncFloor()` and
- *     `markUnparseableFloorBackfillDone()` -- the ONLY two methods that ever
- *     write floor/backfill-done `meta` bookkeeping -- each re-check the LIVE
- *     signed-in uid against the uid they were called with, immediately
- *     before their own `db.meta` write, and throw `SyncAccountChangedError`
- *     instead of writing if it no longer matches. `performSync()`'s own
- *     final `autoSyncLastTime` write and `initialize()`'s legacy-migration
- *     write get the same inline check. Every bookkeeping write in this file
- *     is gated at its own write site -- not by remembering to guard every
- *     caller.
+ * (2) EVERY BOOKKEEPING WRITE IS GATED ON THE PASS-START AUTH GENERATION
+ *     STILL BEING CURRENT (codex review r3615389112, P1, "Detect ABA account
+ *     switches before committing bookkeeping" -- hardening an earlier
+ *     version of this invariant that compared uid STRINGS instead): a bare
+ *     `liveUid === snapshottedUid` check is blind to an A -> B -> A round
+ *     trip -- by the time the check runs, the live uid is back to "A",
+ *     string-equal to the snapshot, even though account B was live in
+ *     between and may have driven whatever cloud read/write the check was
+ *     meant to guard (e.g. `syncToCloudBatch()` resolving under B while the
+ *     pass believes it's still operating for A). `firebase-auth-service.ts`
+ *     exposes a monotonic `getAuthGeneration()` counter, incremented on
+ *     EVERY auth-state transition (sign-in, sign-out, initial restore) --
+ *     never fooled by a value cycling back, since A -> B -> A still advances
+ *     it by at least 2. `performSync()` captures `{ uid, generation }`
+ *     (`SyncPassIdentity`) once at sync start; `uid` is used for bookkeeping
+ *     KEY DERIVATION (`scopedMetaKey()`) throughout the pass, while
+ *     `generation` is the VALIDITY TOKEN every commit point re-checks.
+ *     `persistUnparseableSyncFloor()` and `markUnparseableFloorBackfillDone()`
+ *     -- the ONLY two methods that ever write floor/backfill-done `meta`
+ *     bookkeeping -- each re-check the CURRENT generation against the one
+ *     they were called with, immediately before their own `db.meta` write,
+ *     and throw `SyncAccountChangedError` instead of writing if it no
+ *     longer matches. `performSync()`'s own final `autoSyncLastTime` write,
+ *     `initialize()`'s legacy-migration/legacy-clear write, and
+ *     `initialize()`'s own result-application step (see invariant (2b)
+ *     below) all get the same generation check. Every bookkeeping write in
+ *     this file is gated at its own write site -- not by remembering to
+ *     guard every caller.
  *
  *     Deliberately NOT gated: the Firestore upload/download calls themselves
  *     (`syncToCloudBatch`/`syncFromCloud`/`getCloudMaxTimestamp`) -- see
@@ -108,15 +136,41 @@ export interface SyncState {
  *     "assert before the network call" guard would still miss:
  *     `getCloudMaxTimestamp()` at the top of `syncToCloud()` can legitimately
  *     reflect a DIFFERENT account's cloud state if the user switched
- *     accounts between `performSync()`'s snapshot and that call, and
+ *     accounts between `performSync()`'s snapshot and that call (including
+ *     switching BACK by the time any later check runs), and
  *     `backfillUnparseableFloorIfNeeded()` downstream still runs against
  *     that (possibly stale-account) value -- but it can never actually
  *     COMMIT `syncUnparseableFloorBackfillDoneV2` or a floor value derived
- *     from it under the SNAPSHOTTED (now wrong) uid's key, because the write
- *     methods themselves refuse once the live uid has moved on. The pass
- *     aborts with `SyncAccountChangedError`, `performSync()`'s catch block
- *     sets `status: 'error'`, and the NEXT sync pass (by either account)
- *     re-derives cleanly from scratch.
+ *     from it, because the write methods themselves refuse once the
+ *     generation has moved on, REGARDLESS of what the uid looks like by
+ *     then. The pass aborts with `SyncAccountChangedError`,
+ *     `performSync()`'s catch block sets `status: 'error'`, and the NEXT
+ *     sync pass (by either account) re-derives cleanly from scratch under a
+ *     fresh generation snapshot.
+ *
+ * (2b) `initialize()` APPLIES ITS OWN RESULT UNDER THE SAME GENERATION GUARD,
+ *     AND RETRIES RATHER THAN SILENTLY ABANDONING ON STALENESS (codex
+ *     reviews r3615389121/r3615389133/r3615389139, P2): `initialize()` also
+ *     snapshots `{ uid, generation }` at its own start (independent of any
+ *     `performSync()` pass it may go on to trigger). Before publishing
+ *     anything it computed (the resolved `lastSyncTime` into the shared
+ *     `syncState`, or the "have I synced before" decision that gates the
+ *     automatic first sync), it re-checks the CURRENT generation against its
+ *     own snapshot. If they differ -- an account switch happened while
+ *     `initialize()` was awaiting `chrome.storage.local`/`updateTimestamps()`
+ *     -- the computed result is discarded (never published into `syncState`,
+ *     never used to decide whether to call `performSync()`) and
+ *     `initialize()` RE-RUNS itself fresh under whatever is live now
+ *     (bounded to `MAX_INITIALIZE_ATTEMPTS` retries), rather than either (a)
+ *     silently publishing a stale result computed for a different account,
+ *     or (b) just giving up and leaving a genuinely-new account stranded
+ *     with no automatic sync ever triggered. The SAME retry also covers the
+ *     narrower race where `performSync()` inside `initialize()` no-ops
+ *     because a DIFFERENT account's pass is still holding the `_isSyncing`
+ *     latch: if this account is still live (generation unchanged) but no
+ *     `lastSyncTime` got recorded, `initialize()` retries rather than
+ *     leaving that account permanently waiting on some later
+ *     threshold/manual trigger.
  *
  * (3) AUTOMATIC SYNC IS NOT GATED ON WHO LAST SYNCED LOCAL DATA: there is
  *     deliberately no "local data owner" marker or any check blocking
@@ -200,17 +254,32 @@ export class AutoSyncService {
   }
 
   /**
-   * Throws `SyncAccountChangedError` if the live signed-in uid no longer
-   * matches `uid` (the value snapshotted at this sync pass's start). Called
-   * ONLY from the bookkeeping write choke points (`persistUnparseableSyncFloor`,
-   * `markUnparseableFloorBackfillDone`, `performSync()`'s final
-   * `autoSyncLastTime` write, `initialize()`'s legacy-migration write) --
-   * never around the Firestore network calls themselves. See invariant (2)
-   * in the ACCOUNT-SCOPING INVARIANTS spec above.
+   * Snapshots "who is signed in" right now -- `uid` for key derivation,
+   * `generation` for the validity check. See `SyncPassIdentity`'s doc
+   * comment and invariant (2) in the ACCOUNT-SCOPING INVARIANTS spec above.
    */
-  private assertUidUnchanged(uid: string | undefined, context: string): void {
-    const liveUid = firebaseAuthService.getCurrentUser()?.uid
-    if (liveUid !== uid) {
+  private snapshotIdentity(): SyncPassIdentity {
+    return {
+      uid: firebaseAuthService.getCurrentUser()?.uid,
+      generation: firebaseAuthService.getAuthGeneration()
+    }
+  }
+
+  /**
+   * Throws `SyncAccountChangedError` if the CURRENT auth-state generation no
+   * longer matches `generation` (the value snapshotted at this sync pass's
+   * start) -- deliberately a generation-counter comparison, NOT a uid-string
+   * comparison, so an A -> B -> A round trip is still caught even though the
+   * live uid is back to matching the snapshot by the time this runs (see
+   * invariant (2)'s "ABA" rationale above). Called ONLY from the bookkeeping
+   * write choke points (`persistUnparseableSyncFloor`,
+   * `markUnparseableFloorBackfillDone`, `performSync()`'s final
+   * `autoSyncLastTime` write, `initialize()`'s legacy-migration/legacy-clear
+   * write and result-application step) -- never around the Firestore
+   * network calls themselves.
+   */
+  private assertGenerationUnchanged(generation: number, context: string): void {
+    if (firebaseAuthService.getAuthGeneration() !== generation) {
       throw new SyncAccountChangedError(context)
     }
   }
@@ -218,43 +287,74 @@ export class AutoSyncService {
   /**
    * Initialize auto sync service
    */
-  async initialize(): Promise<void> {
+  async initialize(attempt = 0): Promise<void> {
+    // Bounded retry (invariant (2b) above) -- a genuine account-change storm
+    // is implausible in practice (each attempt does real async work), but
+    // this caps the recursion so a pathological case can't loop forever.
+    const MAX_INITIALIZE_ATTEMPTS = 3
     try {
       // Check who is signed in FIRST -- everything below needs a
-      // snapshotted uid (invariant (2)).
+      // snapshotted identity (invariant (2)).
       const user = firebaseAuthService.getCurrentUser()
       if (!user) {
         console.log('[AutoSync] User not authenticated, skipping initialization')
         return
       }
-      const uid = user.uid
+      const identity = this.snapshotIdentity()
+      const uid = identity.uid! // definitely defined -- `user` above proves it
 
       // Load last sync time from storage, scoped to this account (invariant
-      // (1)). If this account's scoped key doesn't exist yet but the LEGACY
-      // unscoped key does, migrate it: this account is whoever happens to be
-      // signed in the first time this runs post-upgrade, so it's the only
-      // reasonable owner to attribute an unattributed legacy value to.
-      // Migration deletes the legacy key in the same step, so it is consumed
-      // exactly once and can never later be read by (or granted to) a
-      // DIFFERENT uid.
+      // (1)). If the LEGACY unscoped key is present, consume/delete it
+      // unconditionally (codex review r3615389121, P2, "Clear stale legacy
+      // sync times even after scoped writes"): if this account has no
+      // scoped value of its own yet, genuinely migrate the legacy value to
+      // it (this account is whoever happens to be signed in the first time
+      // this runs post-upgrade, the only reasonable owner to attribute an
+      // unattributed legacy value to); if this account ALREADY has its own
+      // scoped value (e.g. a manual sync already wrote one, bypassing this
+      // migration path entirely), don't overwrite it -- but STILL delete
+      // the orphaned legacy key so it can never later be inherited by a
+      // DIFFERENT account. Either way the legacy key is consumed exactly
+      // once and never read again.
       const scopedSyncKey = this.scopedMetaKey(this.SYNC_STORAGE_KEY, uid)
       const stored = await chrome.storage.local.get([scopedSyncKey, this.SYNC_STORAGE_KEY]) as Record<string, any>
       let storedLastSyncTime = stored[scopedSyncKey]
-      if (storedLastSyncTime === undefined && stored[this.SYNC_STORAGE_KEY] !== undefined) {
-        storedLastSyncTime = stored[this.SYNC_STORAGE_KEY]
-        // COMMIT POINT (invariant (2)): re-check before this migration write.
-        this.assertUidUnchanged(uid, 'before legacy autoSyncLastTime migration')
-        console.log(`[AutoSync] Migrating legacy unscoped ${this.SYNC_STORAGE_KEY} to this account (${uid}) and clearing it`)
-        await chrome.storage.local.set({ [scopedSyncKey]: storedLastSyncTime })
+      const legacyLastSyncTime = stored[this.SYNC_STORAGE_KEY]
+      if (legacyLastSyncTime !== undefined) {
+        // COMMIT POINT (invariant (2)): re-check before this migration/
+        // clear write.
+        this.assertGenerationUnchanged(identity.generation, 'before legacy autoSyncLastTime migration/clear')
+        if (storedLastSyncTime === undefined) {
+          storedLastSyncTime = legacyLastSyncTime
+          console.log(`[AutoSync] Migrating legacy unscoped ${this.SYNC_STORAGE_KEY} to this account (${uid})`)
+          await chrome.storage.local.set({ [scopedSyncKey]: storedLastSyncTime })
+        } else {
+          console.log(`[AutoSync] Clearing orphaned legacy unscoped ${this.SYNC_STORAGE_KEY} (this account already has its own scoped value)`)
+        }
         await chrome.storage.local.remove(this.SYNC_STORAGE_KEY)
       }
+
+      // Update timestamps
+      await this.updateTimestamps()
+
+      // COMMIT POINT (invariant (2b)): don't publish anything computed above
+      // (storedLastSyncTime, the migration decision) if the account changed
+      // mid-computation -- discard and re-run fresh under whatever is live
+      // now, rather than either publishing a stale result or silently
+      // stranding a new account.
+      if (firebaseAuthService.getAuthGeneration() !== identity.generation) {
+        if (attempt + 1 >= MAX_INITIALIZE_ATTEMPTS) {
+          console.error('[AutoSync] initialize(): giving up after repeated account changes mid-computation')
+          return
+        }
+        console.warn('[AutoSync] initialize(): account changed mid-computation, discarding this result and re-running')
+        return this.initialize(attempt + 1)
+      }
+
       // Explicitly reset (not just "leave whatever was there") so a direct
       // account switch without an intervening sign-out can't leak the
       // previous account's in-memory lastSyncTime into this one.
       this.syncState.lastSyncTime = storedLastSyncTime ? new Date(storedLastSyncTime as string | number) : undefined
-
-      // Update timestamps
-      await this.updateTimestamps()
 
       // Perform initial sync only if never synced before (invariant (3):
       // no cross-account ownership check here -- automatic sync for a
@@ -262,6 +362,19 @@ export class AutoSyncService {
       if (!this.syncState.lastSyncTime) {
         console.log('[AutoSync] First time sync, performing initial sync...')
         await this.performSync()
+        // codex review r3615389133, P2, "Retry first sync after an in-flight
+        // account switch": performSync() may have silently no-op'd (e.g.
+        // `_isSyncing` was still held by a DIFFERENT account's in-flight
+        // pass, or the min-version gate blocked it) -- if this account is
+        // STILL live (generation unchanged) but still has no recorded
+        // lastSyncTime, retry rather than leaving it permanently stranded
+        // until some later threshold/manual trigger.
+        if (!this.syncState.lastSyncTime &&
+          firebaseAuthService.getAuthGeneration() === identity.generation &&
+          attempt + 1 < MAX_INITIALIZE_ATTEMPTS) {
+          console.warn('[AutoSync] initialize(): first sync did not complete (likely a concurrent sync elsewhere), retrying')
+          return this.initialize(attempt + 1)
+        }
       } else {
         console.log('[AutoSync] Last sync was at:', this.syncState.lastSyncTime)
       }
@@ -297,11 +410,12 @@ export class AutoSyncService {
     // path (gate-blocked or sync completed/failed) releases the latch.
     this._isSyncing = true
 
-    // SNAPSHOT the uid ONCE for this entire pass (invariant (2) in the
-    // ACCOUNT-SCOPING INVARIANTS spec above). `syncToCloud`/`syncFromCloud`
-    // and their bookkeeping helpers all use THIS value, never a freshly
-    // re-resolved `getCurrentUser()`. `undefined` when signed out.
-    const uid = firebaseAuthService.getCurrentUser()?.uid
+    // SNAPSHOT identity ONCE for this entire pass (invariant (2) in the
+    // ACCOUNT-SCOPING INVARIANTS spec above). `syncToCloud()` and its
+    // bookkeeping helpers all use THIS snapshot -- `uid` for key
+    // derivation, `generation` for the ABA-proof validity check -- never a
+    // freshly re-resolved `getCurrentUser()`/`getAuthGeneration()`.
+    const identity = this.snapshotIdentity()
 
     try {
       // Remote min-version gate (kill switch, #forced-update): every sync entry
@@ -322,22 +436,31 @@ export class AutoSyncService {
       try {
         // Perform sync based on direction
         if (direction === 'upload' || direction === 'both') {
-          await this.syncToCloud(uid)
+          await this.syncToCloud(identity)
         }
 
         if (direction === 'download' || direction === 'both') {
           await this.syncFromCloud()
         }
 
-        // COMMIT POINT (invariant (2)): the live uid must still match the
-        // snapshot before writing the final success bookkeeping below.
-        this.assertUidUnchanged(uid, 'before final lastSyncTime commit')
+        // COMMIT POINT (invariant (2)): the auth generation must still match
+        // the snapshot before writing the final success bookkeeping below.
+        this.assertGenerationUnchanged(identity.generation, 'before final lastSyncTime commit')
 
         // Update success state
         this.syncState.lastSyncTime = new Date()
-        await chrome.storage.local.set({
-          [this.scopedMetaKey(this.SYNC_STORAGE_KEY, uid)]: this.syncState.lastSyncTime.toISOString()
-        })
+        const scopedSyncKey = this.scopedMetaKey(this.SYNC_STORAGE_KEY, identity.uid)
+        await chrome.storage.local.set({ [scopedSyncKey]: this.syncState.lastSyncTime.toISOString() })
+        // Opportunistically clear an orphaned legacy key here too (codex
+        // review r3615389121): `initialize()` is the primary migration
+        // path, but a manual sync (bypassing `initialize()` entirely, e.g.
+        // right after upgrade) can also be the first write for this
+        // account, and without this the legacy key would linger forever,
+        // available for a later different account to inherit. Only when
+        // signed in -- if `identity.uid` is undefined, `scopedSyncKey`
+        // already equals the bare legacy key itself (see `scopedMetaKey()`),
+        // and removing it here would just delete what was just written.
+        if (identity.uid) await chrome.storage.local.remove(this.SYNC_STORAGE_KEY)
 
         // Update timestamps after sync
         await this.updateTimestamps()
@@ -364,7 +487,7 @@ export class AutoSyncService {
   /**
    * Sync local events to cloud
    */
-  private async syncToCloud(uid: string | undefined): Promise<void> {
+  private async syncToCloud(identity: SyncPassIdentity): Promise<void> {
     console.log('[AutoSync] Starting upload to cloud...')
 
     // Get the latest timestamp from cloud first
@@ -483,9 +606,9 @@ export class AutoSyncService {
     //   application-typed rows below the watermark -- that's tens of
     //   thousands of extra reads (recurring cost risk, not a bounded
     //   one-time migration) versus the near-O(1) local lookup this fix uses.
-    await this.backfillUnparseableFloorIfNeeded(cloudMaxTimestamp, uid)
+    await this.backfillUnparseableFloorIfNeeded(cloudMaxTimestamp, identity)
 
-    const pendingUnparseableTimestamp = await this.getUnparseableSyncFloor(uid)
+    const pendingUnparseableTimestamp = await this.getUnparseableSyncFloor(identity.uid)
     const scanFloor = pendingUnparseableTimestamp !== null && cloudMaxTimestamp !== null
       ? Math.min(cloudMaxTimestamp, pendingUnparseableTimestamp - 1)
       : cloudMaxTimestamp
@@ -505,7 +628,7 @@ export class AutoSyncService {
       // recover, so clear the stale marker rather than rewinding forever.
       // (No upload happened in this branch, so there's nothing for the floor
       // to have advanced past -- clearing here is always safe.)
-      if (pendingUnparseableTimestamp !== null) await this.persistUnparseableSyncFloor(null, uid)
+      if (pendingUnparseableTimestamp !== null) await this.persistUnparseableSyncFloor(null, identity)
       return
     }
 
@@ -587,7 +710,7 @@ export class AutoSyncService {
         // after confirmed upload" rule applies to RAISING/clearing, not to
         // lowering).
         if (persistedFloorValue === null || earliestUnparseableThisPass < persistedFloorValue) {
-          await this.persistUnparseableSyncFloor(earliestUnparseableThisPass, uid)
+          await this.persistUnparseableSyncFloor(earliestUnparseableThisPass, identity)
           persistedFloorValue = earliestUnparseableThisPass
         }
         // else: the durable floor is already <= earliestUnparseableThisPass
@@ -647,7 +770,7 @@ export class AutoSyncService {
     // account-switch assert needed at this specific call site -- it's
     // built into `persistUnparseableSyncFloor()` itself, see the
     // ACCOUNT-SCOPING INVARIANTS spec's invariant (2).)
-    await this.persistUnparseableSyncFloor(earliestUnparseableThisPass, uid)
+    await this.persistUnparseableSyncFloor(earliestUnparseableThisPass, identity)
 
     console.log(`[AutoSync] Uploaded ${synced} new events to cloud`)
   }
@@ -736,8 +859,8 @@ export class AutoSyncService {
    * empty". Do not add a try/catch around that call site that would
    * reintroduce the ambiguity.
    */
-  private async backfillUnparseableFloorIfNeeded(cloudMaxTimestamp: number | null, uid: string | undefined): Promise<void> {
-    const doneKey = this.scopedMetaKey(this.SYNC_UNPARSEABLE_BACKFILL_DONE_KEY, uid)
+  private async backfillUnparseableFloorIfNeeded(cloudMaxTimestamp: number | null, identity: SyncPassIdentity): Promise<void> {
+    const doneKey = this.scopedMetaKey(this.SYNC_UNPARSEABLE_BACKFILL_DONE_KEY, identity.uid)
     const alreadyDone = await this.db.meta.get(doneKey)
     if (alreadyDone) return
 
@@ -745,7 +868,7 @@ export class AutoSyncService {
       // Proven empty (see PROVEN-STATE REQUIREMENT above) -- nothing has
       // ever been uploaded, so there is no "already past the watermark"
       // region below which a pre-existing orphan could be hiding.
-      await this.markUnparseableFloorBackfillDone(uid)
+      await this.markUnparseableFloorBackfillDone(identity)
       return
     }
 
@@ -799,35 +922,37 @@ export class AutoSyncService {
       // chance to run), it already protects at least as much history, so
       // leave it alone rather than risk moving it later (see invariant spec
       // in syncToCloud() above).
-      const existing = await this.getUnparseableSyncFloor(uid)
+      const existing = await this.getUnparseableSyncFloor(identity.uid)
       if (existing === null || existing > earliestAppRow.timestamp) {
         console.log(`[AutoSync] Backfill: earliest local application row (${earliestAppRow.timestamp}) is at or below the cloud watermark (${cloudMaxTimestamp}); seeding sync floor to force a one-time full reconciliation re-offer`)
-        await this.persistUnparseableSyncFloor(earliestAppRow.timestamp, uid)
+        await this.persistUnparseableSyncFloor(earliestAppRow.timestamp, identity)
       }
     }
 
-    await this.markUnparseableFloorBackfillDone(uid)
+    await this.markUnparseableFloorBackfillDone(identity)
   }
 
   /**
-   * Marks the one-time backfill done for `uid`. One of the two bookkeeping
-   * WRITE CHOKE POINTS for this floor mechanism (invariant (2) in the
-   * ACCOUNT-SCOPING INVARIANTS spec above) -- asserts the live signed-in uid
-   * still matches `uid` immediately before the `db.meta` write, so a mid-pass
-   * account switch can never commit this marker under the wrong (stale,
-   * snapshotted) account's key, regardless of which account's cloud state
-   * `cloudMaxTimestamp` (read earlier in `syncToCloud()`) actually reflected.
+   * Marks the one-time backfill done for `identity.uid`. One of the two
+   * bookkeeping WRITE CHOKE POINTS for this floor mechanism (invariant (2)
+   * in the ACCOUNT-SCOPING INVARIANTS spec above) -- asserts the CURRENT
+   * auth generation still matches `identity.generation` immediately before
+   * the `db.meta` write, so a mid-pass account switch (including an A -> B
+   * -> A round trip, which a uid-string check alone would miss) can never
+   * commit this marker under the wrong (stale, snapshotted) account's key,
+   * regardless of which account's cloud state `cloudMaxTimestamp` (read
+   * earlier in `syncToCloud()`) actually reflected.
    */
-  private async markUnparseableFloorBackfillDone(uid: string | undefined): Promise<void> {
-    this.assertUidUnchanged(uid, 'before backfill-done commit')
+  private async markUnparseableFloorBackfillDone(identity: SyncPassIdentity): Promise<void> {
+    this.assertGenerationUnchanged(identity.generation, 'before backfill-done commit')
     await this.db.meta.put({
-      id: this.scopedMetaKey(this.SYNC_UNPARSEABLE_BACKFILL_DONE_KEY, uid),
+      id: this.scopedMetaKey(this.SYNC_UNPARSEABLE_BACKFILL_DONE_KEY, identity.uid),
       value: true,
       updatedAt: Date.now()
     })
   }
 
-  /** Read the persisted unparseable-row sync floor for `uid` (see `syncToCloud()`). */
+  /** Read the persisted unparseable-row sync floor for `uid` (see `syncToCloud()`). Read-only -- no generation check needed. */
   private async getUnparseableSyncFloor(uid: string | undefined): Promise<number | null> {
     const record = await this.db.meta.get(this.scopedMetaKey(this.SYNC_UNPARSEABLE_FLOOR_KEY, uid))
     const value = record?.value
@@ -836,14 +961,15 @@ export class AutoSyncService {
 
   /**
    * Persist (or clear, when `timestamp` is `null`) the unparseable-row sync
-   * floor for `uid`. The OTHER bookkeeping WRITE CHOKE POINT (invariant (2)
-   * above, alongside `markUnparseableFloorBackfillDone()`) -- same
-   * assert-before-write guarantee, for every floor set/lower/raise/clear in
-   * this file (there is no other place that writes `SYNC_UNPARSEABLE_FLOOR_KEY`).
+   * floor for `identity.uid`. The OTHER bookkeeping WRITE CHOKE POINT
+   * (invariant (2) above, alongside `markUnparseableFloorBackfillDone()`) --
+   * same assert-before-write guarantee, for every floor set/lower/raise/
+   * clear in this file (there is no other place that writes
+   * `SYNC_UNPARSEABLE_FLOOR_KEY`).
    */
-  private async persistUnparseableSyncFloor(timestamp: number | null, uid: string | undefined): Promise<void> {
-    this.assertUidUnchanged(uid, 'before sync-floor commit')
-    const key = this.scopedMetaKey(this.SYNC_UNPARSEABLE_FLOOR_KEY, uid)
+  private async persistUnparseableSyncFloor(timestamp: number | null, identity: SyncPassIdentity): Promise<void> {
+    this.assertGenerationUnchanged(identity.generation, 'before sync-floor commit')
+    const key = this.scopedMetaKey(this.SYNC_UNPARSEABLE_FLOOR_KEY, identity.uid)
     if (timestamp === null) {
       await this.db.meta.delete(key)
       return

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -293,6 +293,18 @@ export class AutoSyncService {
     // this caps the recursion so a pathological case can't loop forever.
     const MAX_INITIALIZE_ATTEMPTS = 3
     try {
+      // Wait for auth state to settle BEFORE reading it (codex review
+      // r3615553034, P2, "Await auth restore before snapshotting identity"):
+      // firebaseAuthService's constructor kicks off an async
+      // restoreAuthState() that has not necessarily resolved yet on a fresh
+      // Service Worker start. Reading getCurrentUser() before it resolves
+      // could see "signed out" for an already-signed-in user, or -- once
+      // snapshotIdentity() exists -- capture a stale generation right
+      // before the restore bumps it. Reuses the SAME readiness barrier
+      // `firestore-backup-service.ts` already awaits internally
+      // (`requireUser()`'s `await firebaseAuthService.ready()`).
+      await firebaseAuthService.ready()
+
       // Check who is signed in FIRST -- everything below needs a
       // snapshotted identity (invariant (2)).
       const user = firebaseAuthService.getCurrentUser()
@@ -410,14 +422,31 @@ export class AutoSyncService {
     // path (gate-blocked or sync completed/failed) releases the latch.
     this._isSyncing = true
 
-    // SNAPSHOT identity ONCE for this entire pass (invariant (2) in the
-    // ACCOUNT-SCOPING INVARIANTS spec above). `syncToCloud()` and its
-    // bookkeeping helpers all use THIS snapshot -- `uid` for key
-    // derivation, `generation` for the ABA-proof validity check -- never a
-    // freshly re-resolved `getCurrentUser()`/`getAuthGeneration()`.
-    const identity = this.snapshotIdentity()
-
     try {
+      // Wait for auth state to settle BEFORE snapshotting it (codex review
+      // r3615553034, P2, "Await auth restore before snapshotting identity"):
+      // on a fresh Service Worker start, firebaseAuthService's constructor
+      // kicks off an async restoreAuthState() that has not necessarily
+      // resolved yet. Snapshotting before it resolves could capture
+      // `{ uid: undefined, generation: 0 }` even for an already-signed-in
+      // user -- the FIRST firestoreBackupService call downstream (via
+      // `requireUser()`'s own `await ready()`) would then complete the
+      // restore and bump the generation, making every later commit-point
+      // assert see a false account switch and abort a sync that should
+      // have succeeded. Placed INSIDE the try (after the `_isSyncing`
+      // latch, matching the existing min-version-gate await below) so this
+      // await can't reopen the double-sync race the latch exists to
+      // prevent, and so `finally` still releases the latch if `ready()`
+      // itself ever rejected.
+      await firebaseAuthService.ready()
+
+      // SNAPSHOT identity ONCE for this entire pass (invariant (2) in the
+      // ACCOUNT-SCOPING INVARIANTS spec above). `syncToCloud()` and its
+      // bookkeeping helpers all use THIS snapshot -- `uid` for key
+      // derivation, `generation` for the ABA-proof validity check -- never a
+      // freshly re-resolved `getCurrentUser()`/`getAuthGeneration()`.
+      const identity = this.snapshotIdentity()
+
       // Remote min-version gate (kill switch, #forced-update): every sync entry
       // point funnels through performSync(), so a single guard here covers
       // manual sync, auto sync (session end/start triggers), and initialize()'s
@@ -447,10 +476,12 @@ export class AutoSyncService {
         // the snapshot before writing the final success bookkeeping below.
         this.assertGenerationUnchanged(identity.generation, 'before final lastSyncTime commit')
 
-        // Update success state
-        this.syncState.lastSyncTime = new Date()
+        // Update success state -- computed as a LOCAL value here, not yet
+        // assigned into the shared `this.syncState` (see the second
+        // COMMIT POINT below for why that assignment is deferred).
+        const syncCompletedAt = new Date()
         const scopedSyncKey = this.scopedMetaKey(this.SYNC_STORAGE_KEY, identity.uid)
-        await chrome.storage.local.set({ [scopedSyncKey]: this.syncState.lastSyncTime.toISOString() })
+        await chrome.storage.local.set({ [scopedSyncKey]: syncCompletedAt.toISOString() })
         // Opportunistically clear an orphaned legacy key here too (codex
         // review r3615389121): `initialize()` is the primary migration
         // path, but a manual sync (bypassing `initialize()` entirely, e.g.
@@ -464,6 +495,25 @@ export class AutoSyncService {
 
         // Update timestamps after sync
         await this.updateTimestamps()
+
+        // COMMIT POINT (invariant (2), codex review r3615553045, P2,
+        // "Recheck before publishing sync success"): re-check AGAIN,
+        // immediately before publishing into the shared (unscoped,
+        // cross-account-visible) in-memory `syncState` -- `updateTimestamps()`
+        // above is itself an async gap (it makes its own
+        // `getCloudMaxTimestamp()` call) during which the account could have
+        // changed again, even though the scoped bookkeeping WRITES above
+        // already landed safely under a validated generation. This is why
+        // `syncState.lastSyncTime` is assigned HERE, at the very last
+        // possible moment, rather than right after the first assert above:
+        // `syncIfBacklogExceedsThreshold()` and other readers see this
+        // in-memory value change the instant it's assigned (a direct field
+        // read, not gated by `updateSyncState()`'s broadcast), so if it were
+        // set earlier and the account changed during `updateTimestamps()`,
+        // a newly-signed-in account could transiently compute its own
+        // upload backlog against the PREVIOUS account's completion time.
+        this.assertGenerationUnchanged(identity.generation, 'before publishing sync success')
+        this.syncState.lastSyncTime = syncCompletedAt
 
         this.updateSyncState({
           status: 'success',

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -243,6 +243,21 @@ export class AutoSyncService {
 
   constructor(db?: PokerChaseDB) {
     this.db = db ?? new PokerChaseDB(self.indexedDB, self.IDBKeyRange)
+    // codex review r3615952256, P2, "Clear stale sync state when exposing
+    // the new user": firebaseAuthService.signInWithGoogle()/signOut() now
+    // notify this listener SYNCHRONOUSLY, in the same step as their own
+    // currentState/authGeneration mutation -- before their own
+    // persistAuthState()/storage-removal await, and well before
+    // message-router.ts's explicit `autoSyncService.onAuthStateChanged(user)`
+    // call even runs. This closes the gap one layer earlier than
+    // `initialize()`'s own window fix (r3615781411): during a direct A->B
+    // sign-in, a session-end/start trigger firing between "B is live per
+    // firebaseAuthService" and "onAuthStateChanged(B) has run" would
+    // otherwise still read A's stale in-memory `syncState.lastSyncTime`
+    // under B's now-live identity.
+    firebaseAuthService.onAuthStateChange(() => {
+      this.syncState.lastSyncTime = undefined
+    })
   }
 
   /**

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -16,6 +16,24 @@ import { isCloudSyncBlockedByMinVersionGate } from './min-version-gate'
 /** Shown in the popup and logged when the min-version gate stops cloud sync (#forced-update). */
 export const MIN_VERSION_SYNC_BLOCKED_MESSAGE = 'このバージョンはサポートが終了しました。Chromeを再起動すると更新が適用されます'
 
+/**
+ * Thrown internally whenever a bookkeeping write is about to happen under a
+ * uid that no longer matches the one signed in live -- i.e. the account
+ * changed since this sync pass started. Never thrown for the actual
+ * Firestore upload/download calls themselves (accepted risk, see the
+ * ACCOUNT-SCOPING INVARIANTS spec below) -- only for this file's own
+ * `meta`/`chrome.storage.local` bookkeeping writes. Caught by
+ * `performSync()`'s existing catch block, which sets `syncState.status =
+ * 'error'` -- the next `performSync()` call retries cleanly under whichever
+ * account is signed in by then.
+ */
+export class SyncAccountChangedError extends Error {
+  constructor(context: string) {
+    super(`同期中にサインインアカウントが変更されたため、このアカウント宛の記録を中止しました (${context})`)
+    this.name = 'SyncAccountChangedError'
+  }
+}
+
 export type SyncStatus = 'idle' | 'syncing' | 'error' | 'success'
 export type SyncDirection = 'upload' | 'download' | 'both'
 
@@ -32,6 +50,102 @@ export interface SyncState {
   }
 }
 
+/**
+ * ==============================================================================
+ * ACCOUNT-SCOPING INVARIANTS (owner-decided scope, sola, 2026-07-20/21 --
+ * post-merge diversity reviews on #182 and #192)
+ * ==============================================================================
+ *
+ * A same-device account switch (sign-in mistake, shared device, etc.) is a
+ * realistic case that must be handled -- but the owner-decided requirement
+ * is narrower than "prevent cross-account uploads entirely":
+ *
+ * EXPLICITLY ACCEPTED: local storage (`apiEvents`/`hands`/... in Dexie) is a
+ * single unpartitioned store per browser profile, and an in-flight sync pass
+ * can legitimately end up reading from or writing to whichever Firebase
+ * account is live at the moment `firestore-backup-service.ts` makes its own
+ * internal `requireUser()`/`getIdToken()` calls -- this file does NOT try to
+ * pin those network calls to a snapshotted identity (see ACCEPTED RESIDUAL
+ * RISK below). The worst case is data ending up duplicated in the wrong
+ * account's Firestore. Accepted, not fixed here (an earlier draft of this
+ * fix added a `localDataOwnerUid` ownership guard blocking automatic
+ * cross-account uploads entirely -- removed per this decision).
+ *
+ * WHAT MUST HOLD: bookkeeping integrity per account. After a user signs back
+ * into the correct account (following a sign-in mistake), THAT account's own
+ * sync state (watermark/floor/backfill markers, `lastSyncTime`) must be
+ * intact and correct -- no permanent gap, no marker silently advanced or
+ * cleared by a DIFFERENT account's session in between.
+ *
+ * (1) LEGACY VALUES MIGRATE ONCE, TO WHOEVER IS SIGNED IN, NEVER INHERITED BY
+ *     A DIFFERENT UID: an upgraded profile can have an old unscoped
+ *     `autoSyncLastTime` value with no account attribution at all. The first
+ *     `initialize()` call after upgrade migrates it to that specific uid's
+ *     scoped key AND DELETES the unscoped key in the same step -- so it is
+ *     consumed exactly once, by whichever account happens to be signed in
+ *     the first time this code runs, and can never be read by (or
+ *     accidentally granted to) a later, different uid. A subsequent account
+ *     that has never synced correctly sees no stored `lastSyncTime` at all,
+ *     not a borrowed one.
+ *
+ * (2) EVERY BOOKKEEPING WRITE IS GATED ON THE PASS-START UID STILL BEING
+ *     LIVE: `performSync()` captures `firebaseAuthService.getCurrentUser()?.uid`
+ *     once at sync start and threads that same value through the rest of
+ *     the pass. `persistUnparseableSyncFloor()` and
+ *     `markUnparseableFloorBackfillDone()` -- the ONLY two methods that ever
+ *     write floor/backfill-done `meta` bookkeeping -- each re-check the LIVE
+ *     signed-in uid against the uid they were called with, immediately
+ *     before their own `db.meta` write, and throw `SyncAccountChangedError`
+ *     instead of writing if it no longer matches. `performSync()`'s own
+ *     final `autoSyncLastTime` write and `initialize()`'s legacy-migration
+ *     write get the same inline check. Every bookkeeping write in this file
+ *     is gated at its own write site -- not by remembering to guard every
+ *     caller.
+ *
+ *     Deliberately NOT gated: the Firestore upload/download calls themselves
+ *     (`syncToCloudBatch`/`syncFromCloud`/`getCloudMaxTimestamp`) -- see
+ *     ACCEPTED RESIDUAL RISK. This is what closes the scenario that a naive
+ *     "assert before the network call" guard would still miss:
+ *     `getCloudMaxTimestamp()` at the top of `syncToCloud()` can legitimately
+ *     reflect a DIFFERENT account's cloud state if the user switched
+ *     accounts between `performSync()`'s snapshot and that call, and
+ *     `backfillUnparseableFloorIfNeeded()` downstream still runs against
+ *     that (possibly stale-account) value -- but it can never actually
+ *     COMMIT `syncUnparseableFloorBackfillDoneV2` or a floor value derived
+ *     from it under the SNAPSHOTTED (now wrong) uid's key, because the write
+ *     methods themselves refuse once the live uid has moved on. The pass
+ *     aborts with `SyncAccountChangedError`, `performSync()`'s catch block
+ *     sets `status: 'error'`, and the NEXT sync pass (by either account)
+ *     re-derives cleanly from scratch.
+ *
+ * (3) AUTOMATIC SYNC IS NOT GATED ON WHO LAST SYNCED LOCAL DATA: there is
+ *     deliberately no "local data owner" marker or any check blocking
+ *     automatic sync when local data may belong to a different account --
+ *     the owner confirmed cross-account uploads are acceptable.
+ *     `initialize()`'s first-sync trigger and `syncIfBacklogExceedsThreshold()`
+ *     (backing `onGameSessionEnd`/`onNewSessionStart`) behave exactly as
+ *     they did before any account-scoping work in that respect; only the
+ *     per-account BOOKKEEPING they read/write is scoped and write-gated per
+ *     (1)/(2) above.
+ *
+ * ACCEPTED RESIDUAL RISK (`firestore-backup-service.ts`, deliberately
+ * untouched by this fix): every public method there (`getCloudMaxTimestamp`,
+ * `syncToCloudBatch`, `syncFromCloud`, ...) independently calls its own
+ * `requireUser()`, re-resolving `firebaseAuthService.getCurrentUser()` live
+ * at call time regardless of what this file snapshotted -- so the actual
+ * Firestore document path a given network call targets is decided at the
+ * last possible moment, not pinned to `performSync()`'s snapshot.
+ * 簿記はpass開始時のuidの下でのみ、そのuidが依然liveである時のみ前進する。
+ * アップロード先の誤りはデータ重複に留まり、復帰したアカウントの簿記は
+ * 常に正しい。
+ *
+ * Sign-out/sign-in transitions do not touch any OTHER account's scoped keys
+ * (`onAuthStateChanged(null)` only resets in-memory `syncState`, never
+ * deletes `meta`/`chrome.storage.local` entries) -- each account's
+ * bookkeeping survives a sign-out/sign-in cycle for a different account
+ * untouched, satisfying the isolation half of these invariants together with
+ * (1)/(2) above.
+ */
 export class AutoSyncService {
   private db: PokerChaseDB
   private syncState: SyncState = { status: 'idle' }
@@ -44,17 +158,20 @@ export class AutoSyncService {
    * `meta`テーブルのキー。`syncToCloud()`のwatermarkガード（下記コメント参照）が
    * 「アプリケーション種別だが現在パースできない生行のうち、最も古いタイムスタンプ」
    * を永続化する場所。存在する限り、以降の全`syncToCloud()`呼び出しはこの値の
-   * 直前までスキャン開始点を巻き戻す。
+   * 直前までスキャン開始点を巻き戻す。実際のキーは`scopedMetaKey()`でサインイン中の
+   * uidにスコープされる（上記 ACCOUNT-SCOPING INVARIANTS 参照）。
    */
   private readonly SYNC_UNPARSEABLE_FLOOR_KEY = 'syncUnparseableFloor'
   /**
    * `meta`テーブルのキー。一度だけ実行するバックフィルスキャン
    * （`backfillUnparseableFloorIfNeeded`、下記の invariant spec 参照）が
    * 完了したかどうかを記録する。存在する限り、以降の`syncToCloud()`は
-   * バックフィルスキャンを二度と実行しない。定数の文字列自体を`V2`に
-   * リネームしてある: 旧ロジック（現在パースできない行だけを探す）で既に
-   * done=trueを記録済みのインストールに、修正後のロジック（P1 fix、下記
-   * `backfillUnparseableFloorIfNeeded`参照）を確実に一度だけ再実行させるため。
+   * バックフィルスキャンを二度と実行しない。実際のキーは`scopedMetaKey()`で
+   * uidスコープされる。定数の文字列自体も`V2`にリネームしてある: 旧ロジック
+   * （現在パースできない行だけを探す、かつuidスコープなし）で既にdone=trueを
+   * 記録済みのインストールに、修正後のロジック（P1 fix、下記
+   * `backfillUnparseableFloorIfNeeded`参照）とuidスコープを確実に一度だけ
+   * 適用させるため。
    */
   private readonly SYNC_UNPARSEABLE_BACKFILL_DONE_KEY = 'syncUnparseableFloorBackfillDoneV2'
 
@@ -73,27 +190,75 @@ export class AutoSyncService {
   }
 
   /**
+   * Scopes a local sync-bookkeeping key to a specific Firebase account.
+   * Returns `${baseKey}:${uid}` when `uid` is provided, else the bare
+   * `baseKey` (signed-out fallback -- defensive only, see invariant (2)
+   * above; every real call site passes the pass-start snapshot).
+   */
+  private scopedMetaKey(baseKey: string, uid: string | undefined): string {
+    return uid ? `${baseKey}:${uid}` : baseKey
+  }
+
+  /**
+   * Throws `SyncAccountChangedError` if the live signed-in uid no longer
+   * matches `uid` (the value snapshotted at this sync pass's start). Called
+   * ONLY from the bookkeeping write choke points (`persistUnparseableSyncFloor`,
+   * `markUnparseableFloorBackfillDone`, `performSync()`'s final
+   * `autoSyncLastTime` write, `initialize()`'s legacy-migration write) --
+   * never around the Firestore network calls themselves. See invariant (2)
+   * in the ACCOUNT-SCOPING INVARIANTS spec above.
+   */
+  private assertUidUnchanged(uid: string | undefined, context: string): void {
+    const liveUid = firebaseAuthService.getCurrentUser()?.uid
+    if (liveUid !== uid) {
+      throw new SyncAccountChangedError(context)
+    }
+  }
+
+  /**
    * Initialize auto sync service
    */
   async initialize(): Promise<void> {
     try {
-      // Load last sync time from storage
-      const stored = await chrome.storage.local.get(this.SYNC_STORAGE_KEY) as Record<string, any>
-      if (stored[this.SYNC_STORAGE_KEY]) {
-        this.syncState.lastSyncTime = new Date(stored[this.SYNC_STORAGE_KEY] as string | number)
-      }
-
-      // Update timestamps
-      await this.updateTimestamps()
-
-      // Check if user is authenticated
+      // Check who is signed in FIRST -- everything below needs a
+      // snapshotted uid (invariant (2)).
       const user = firebaseAuthService.getCurrentUser()
       if (!user) {
         console.log('[AutoSync] User not authenticated, skipping initialization')
         return
       }
+      const uid = user.uid
 
-      // Perform initial sync only if never synced before
+      // Load last sync time from storage, scoped to this account (invariant
+      // (1)). If this account's scoped key doesn't exist yet but the LEGACY
+      // unscoped key does, migrate it: this account is whoever happens to be
+      // signed in the first time this runs post-upgrade, so it's the only
+      // reasonable owner to attribute an unattributed legacy value to.
+      // Migration deletes the legacy key in the same step, so it is consumed
+      // exactly once and can never later be read by (or granted to) a
+      // DIFFERENT uid.
+      const scopedSyncKey = this.scopedMetaKey(this.SYNC_STORAGE_KEY, uid)
+      const stored = await chrome.storage.local.get([scopedSyncKey, this.SYNC_STORAGE_KEY]) as Record<string, any>
+      let storedLastSyncTime = stored[scopedSyncKey]
+      if (storedLastSyncTime === undefined && stored[this.SYNC_STORAGE_KEY] !== undefined) {
+        storedLastSyncTime = stored[this.SYNC_STORAGE_KEY]
+        // COMMIT POINT (invariant (2)): re-check before this migration write.
+        this.assertUidUnchanged(uid, 'before legacy autoSyncLastTime migration')
+        console.log(`[AutoSync] Migrating legacy unscoped ${this.SYNC_STORAGE_KEY} to this account (${uid}) and clearing it`)
+        await chrome.storage.local.set({ [scopedSyncKey]: storedLastSyncTime })
+        await chrome.storage.local.remove(this.SYNC_STORAGE_KEY)
+      }
+      // Explicitly reset (not just "leave whatever was there") so a direct
+      // account switch without an intervening sign-out can't leak the
+      // previous account's in-memory lastSyncTime into this one.
+      this.syncState.lastSyncTime = storedLastSyncTime ? new Date(storedLastSyncTime as string | number) : undefined
+
+      // Update timestamps
+      await this.updateTimestamps()
+
+      // Perform initial sync only if never synced before (invariant (3):
+      // no cross-account ownership check here -- automatic sync for a
+      // never-synced account is allowed to proceed, by owner decision).
       if (!this.syncState.lastSyncTime) {
         console.log('[AutoSync] First time sync, performing initial sync...')
         await this.performSync()
@@ -132,6 +297,12 @@ export class AutoSyncService {
     // path (gate-blocked or sync completed/failed) releases the latch.
     this._isSyncing = true
 
+    // SNAPSHOT the uid ONCE for this entire pass (invariant (2) in the
+    // ACCOUNT-SCOPING INVARIANTS spec above). `syncToCloud`/`syncFromCloud`
+    // and their bookkeeping helpers all use THIS value, never a freshly
+    // re-resolved `getCurrentUser()`. `undefined` when signed out.
+    const uid = firebaseAuthService.getCurrentUser()?.uid
+
     try {
       // Remote min-version gate (kill switch, #forced-update): every sync entry
       // point funnels through performSync(), so a single guard here covers
@@ -151,16 +322,22 @@ export class AutoSyncService {
       try {
         // Perform sync based on direction
         if (direction === 'upload' || direction === 'both') {
-          await this.syncToCloud()
+          await this.syncToCloud(uid)
         }
 
         if (direction === 'download' || direction === 'both') {
           await this.syncFromCloud()
         }
 
+        // COMMIT POINT (invariant (2)): the live uid must still match the
+        // snapshot before writing the final success bookkeeping below.
+        this.assertUidUnchanged(uid, 'before final lastSyncTime commit')
+
         // Update success state
         this.syncState.lastSyncTime = new Date()
-        await chrome.storage.local.set({ [this.SYNC_STORAGE_KEY]: this.syncState.lastSyncTime.toISOString() })
+        await chrome.storage.local.set({
+          [this.scopedMetaKey(this.SYNC_STORAGE_KEY, uid)]: this.syncState.lastSyncTime.toISOString()
+        })
 
         // Update timestamps after sync
         await this.updateTimestamps()
@@ -187,7 +364,7 @@ export class AutoSyncService {
   /**
    * Sync local events to cloud
    */
-  private async syncToCloud(): Promise<void> {
+  private async syncToCloud(uid: string | undefined): Promise<void> {
     console.log('[AutoSync] Starting upload to cloud...')
 
     // Get the latest timestamp from cloud first
@@ -306,9 +483,9 @@ export class AutoSyncService {
     //   application-typed rows below the watermark -- that's tens of
     //   thousands of extra reads (recurring cost risk, not a bounded
     //   one-time migration) versus the near-O(1) local lookup this fix uses.
-    await this.backfillUnparseableFloorIfNeeded(cloudMaxTimestamp)
+    await this.backfillUnparseableFloorIfNeeded(cloudMaxTimestamp, uid)
 
-    const pendingUnparseableTimestamp = await this.getUnparseableSyncFloor()
+    const pendingUnparseableTimestamp = await this.getUnparseableSyncFloor(uid)
     const scanFloor = pendingUnparseableTimestamp !== null && cloudMaxTimestamp !== null
       ? Math.min(cloudMaxTimestamp, pendingUnparseableTimestamp - 1)
       : cloudMaxTimestamp
@@ -328,7 +505,7 @@ export class AutoSyncService {
       // recover, so clear the stale marker rather than rewinding forever.
       // (No upload happened in this branch, so there's nothing for the floor
       // to have advanced past -- clearing here is always safe.)
-      if (pendingUnparseableTimestamp !== null) await this.persistUnparseableSyncFloor(null)
+      if (pendingUnparseableTimestamp !== null) await this.persistUnparseableSyncFloor(null, uid)
       return
     }
 
@@ -410,7 +587,7 @@ export class AutoSyncService {
         // after confirmed upload" rule applies to RAISING/clearing, not to
         // lowering).
         if (persistedFloorValue === null || earliestUnparseableThisPass < persistedFloorValue) {
-          await this.persistUnparseableSyncFloor(earliestUnparseableThisPass)
+          await this.persistUnparseableSyncFloor(earliestUnparseableThisPass, uid)
           persistedFloorValue = earliestUnparseableThisPass
         }
         // else: the durable floor is already <= earliestUnparseableThisPass
@@ -466,8 +643,11 @@ export class AutoSyncService {
     // to advance or clear the floor to its final value for this pass. If this
     // commit itself is lost to a crash, the next pass re-derives and
     // re-persists the same value (see invariant spec above) -- not a
-    // correctness gap, just a redundant re-scan/re-upload.
-    await this.persistUnparseableSyncFloor(earliestUnparseableThisPass)
+    // correctness gap, just a redundant re-scan/re-upload. (No explicit
+    // account-switch assert needed at this specific call site -- it's
+    // built into `persistUnparseableSyncFloor()` itself, see the
+    // ACCOUNT-SCOPING INVARIANTS spec's invariant (2).)
+    await this.persistUnparseableSyncFloor(earliestUnparseableThisPass, uid)
 
     console.log(`[AutoSync] Uploaded ${synced} new events to cloud`)
   }
@@ -556,15 +736,16 @@ export class AutoSyncService {
    * empty". Do not add a try/catch around that call site that would
    * reintroduce the ambiguity.
    */
-  private async backfillUnparseableFloorIfNeeded(cloudMaxTimestamp: number | null): Promise<void> {
-    const alreadyDone = await this.db.meta.get(this.SYNC_UNPARSEABLE_BACKFILL_DONE_KEY)
+  private async backfillUnparseableFloorIfNeeded(cloudMaxTimestamp: number | null, uid: string | undefined): Promise<void> {
+    const doneKey = this.scopedMetaKey(this.SYNC_UNPARSEABLE_BACKFILL_DONE_KEY, uid)
+    const alreadyDone = await this.db.meta.get(doneKey)
     if (alreadyDone) return
 
     if (cloudMaxTimestamp === null) {
       // Proven empty (see PROVEN-STATE REQUIREMENT above) -- nothing has
       // ever been uploaded, so there is no "already past the watermark"
       // region below which a pre-existing orphan could be hiding.
-      await this.markUnparseableFloorBackfillDone()
+      await this.markUnparseableFloorBackfillDone(uid)
       return
     }
 
@@ -618,46 +799,70 @@ export class AutoSyncService {
       // chance to run), it already protects at least as much history, so
       // leave it alone rather than risk moving it later (see invariant spec
       // in syncToCloud() above).
-      const existing = await this.getUnparseableSyncFloor()
+      const existing = await this.getUnparseableSyncFloor(uid)
       if (existing === null || existing > earliestAppRow.timestamp) {
         console.log(`[AutoSync] Backfill: earliest local application row (${earliestAppRow.timestamp}) is at or below the cloud watermark (${cloudMaxTimestamp}); seeding sync floor to force a one-time full reconciliation re-offer`)
-        await this.persistUnparseableSyncFloor(earliestAppRow.timestamp)
+        await this.persistUnparseableSyncFloor(earliestAppRow.timestamp, uid)
       }
     }
 
-    await this.markUnparseableFloorBackfillDone()
+    await this.markUnparseableFloorBackfillDone(uid)
   }
 
-  private async markUnparseableFloorBackfillDone(): Promise<void> {
+  /**
+   * Marks the one-time backfill done for `uid`. One of the two bookkeeping
+   * WRITE CHOKE POINTS for this floor mechanism (invariant (2) in the
+   * ACCOUNT-SCOPING INVARIANTS spec above) -- asserts the live signed-in uid
+   * still matches `uid` immediately before the `db.meta` write, so a mid-pass
+   * account switch can never commit this marker under the wrong (stale,
+   * snapshotted) account's key, regardless of which account's cloud state
+   * `cloudMaxTimestamp` (read earlier in `syncToCloud()`) actually reflected.
+   */
+  private async markUnparseableFloorBackfillDone(uid: string | undefined): Promise<void> {
+    this.assertUidUnchanged(uid, 'before backfill-done commit')
     await this.db.meta.put({
-      id: this.SYNC_UNPARSEABLE_BACKFILL_DONE_KEY,
+      id: this.scopedMetaKey(this.SYNC_UNPARSEABLE_BACKFILL_DONE_KEY, uid),
       value: true,
       updatedAt: Date.now()
     })
   }
 
-  /** Read the persisted unparseable-row sync floor (see `syncToCloud()`). */
-  private async getUnparseableSyncFloor(): Promise<number | null> {
-    const record = await this.db.meta.get(this.SYNC_UNPARSEABLE_FLOOR_KEY)
+  /** Read the persisted unparseable-row sync floor for `uid` (see `syncToCloud()`). */
+  private async getUnparseableSyncFloor(uid: string | undefined): Promise<number | null> {
+    const record = await this.db.meta.get(this.scopedMetaKey(this.SYNC_UNPARSEABLE_FLOOR_KEY, uid))
     const value = record?.value
     return typeof value === 'number' ? value : null
   }
 
-  /** Persist (or clear, when `timestamp` is `null`) the unparseable-row sync floor. */
-  private async persistUnparseableSyncFloor(timestamp: number | null): Promise<void> {
+  /**
+   * Persist (or clear, when `timestamp` is `null`) the unparseable-row sync
+   * floor for `uid`. The OTHER bookkeeping WRITE CHOKE POINT (invariant (2)
+   * above, alongside `markUnparseableFloorBackfillDone()`) -- same
+   * assert-before-write guarantee, for every floor set/lower/raise/clear in
+   * this file (there is no other place that writes `SYNC_UNPARSEABLE_FLOOR_KEY`).
+   */
+  private async persistUnparseableSyncFloor(timestamp: number | null, uid: string | undefined): Promise<void> {
+    this.assertUidUnchanged(uid, 'before sync-floor commit')
+    const key = this.scopedMetaKey(this.SYNC_UNPARSEABLE_FLOOR_KEY, uid)
     if (timestamp === null) {
-      await this.db.meta.delete(this.SYNC_UNPARSEABLE_FLOOR_KEY)
+      await this.db.meta.delete(key)
       return
     }
     await this.db.meta.put({
-      id: this.SYNC_UNPARSEABLE_FLOOR_KEY,
+      id: key,
       value: timestamp,
       updatedAt: Date.now()
     })
   }
 
   /**
-   * Sync cloud events to local (cloud as source of truth)
+   * Sync cloud events to local (cloud as source of truth). No `uid` parameter
+   * -- unlike `syncToCloud()`, this method never writes account-scoped
+   * bookkeeping (it only merges raw events into the shared local Lake and
+   * rebuilds derived entities, both of which are already unpartitioned by
+   * design). Which account's cloud data actually lands here is exactly the
+   * ACCEPTED RESIDUAL RISK described in the ACCOUNT-SCOPING INVARIANTS spec
+   * above -- deliberately not gated here.
    */
   private async syncFromCloud(): Promise<void> {
     console.log('[AutoSync] Starting complete download from cloud...')

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -204,6 +204,18 @@ export class AutoSyncService {
   private db: PokerChaseDB
   private syncState: SyncState = { status: 'idle' }
   private _isSyncing = false
+  /**
+   * Resolves when the CURRENT in-flight `performSync()` call's `finally`
+   * block runs (`null` when nothing is in flight). Lets `initialize()`'s
+   * retry (invariant (2b)) wait for a DIFFERENT pass holding `_isSyncing` to
+   * settle instead of immediately re-recursing into a `performSync()` call
+   * that would just short-circuit again (codex review r3615664890, P2,
+   * "Wait for the in-flight sync before retrying initialization") --
+   * without this, all `MAX_INITIALIZE_ATTEMPTS` retries could burn through
+   * before the other pass ever releases the latch, permanently stranding
+   * this account.
+   */
+  private inFlightSyncPromise: Promise<void> | null = null
   private lastSyncAttempt = 0
   private readonly MIN_SYNC_INTERVAL_MS = 0 // No minimum interval restriction
   private readonly SYNC_STORAGE_KEY = 'autoSyncLastTime'
@@ -336,14 +348,27 @@ export class AutoSyncService {
         // COMMIT POINT (invariant (2)): re-check before this migration/
         // clear write.
         this.assertGenerationUnchanged(identity.generation, 'before legacy autoSyncLastTime migration/clear')
+        // Consume (delete) the legacy key BEFORE writing the scoped copy
+        // (codex review r3615664896, P2, "Consume the legacy sync key
+        // before writing the scoped copy"): if the MV3 worker/browser stops
+        // in the gap between these two writes, this ordering guarantees the
+        // legacy key is already gone -- worst case THIS account's own
+        // scoped value fails to land and it simply re-derives "first sync"
+        // on the next `initialize()` call (one extra sync attempt). The
+        // opposite ordering (write-scoped-then-remove-legacy) risks worse:
+        // if the crash lands AFTER the scoped write already durable but
+        // BEFORE the legacy removal, the legacy key survives, remaining
+        // available for a completely DIFFERENT account's later
+        // `initialize()` call to wrongly inherit -- exactly the
+        // cross-account leak this migration exists to prevent.
+        await chrome.storage.local.remove(this.SYNC_STORAGE_KEY)
         if (storedLastSyncTime === undefined) {
           storedLastSyncTime = legacyLastSyncTime
           console.log(`[AutoSync] Migrating legacy unscoped ${this.SYNC_STORAGE_KEY} to this account (${uid})`)
           await chrome.storage.local.set({ [scopedSyncKey]: storedLastSyncTime })
         } else {
-          console.log(`[AutoSync] Clearing orphaned legacy unscoped ${this.SYNC_STORAGE_KEY} (this account already has its own scoped value)`)
+          console.log(`[AutoSync] Cleared orphaned legacy unscoped ${this.SYNC_STORAGE_KEY} (this account already has its own scoped value)`)
         }
-        await chrome.storage.local.remove(this.SYNC_STORAGE_KEY)
       }
 
       // Update timestamps
@@ -384,7 +409,19 @@ export class AutoSyncService {
         if (!this.syncState.lastSyncTime &&
           firebaseAuthService.getAuthGeneration() === identity.generation &&
           attempt + 1 < MAX_INITIALIZE_ATTEMPTS) {
-          console.warn('[AutoSync] initialize(): first sync did not complete (likely a concurrent sync elsewhere), retrying')
+          // codex review r3615664890, P2, "Wait for the in-flight sync
+          // before retrying initialization": if a DIFFERENT pass is still
+          // holding `_isSyncing`, immediately recursing would just call
+          // performSync() again, which short-circuits instantly on the same
+          // latch -- all `MAX_INITIALIZE_ATTEMPTS` retries could burn
+          // through before that other pass ever releases it, permanently
+          // stranding this account. Wait for it to actually settle first.
+          if (this.isSyncing && this.inFlightSyncPromise) {
+            console.warn('[AutoSync] initialize(): first sync did not run because a different pass is still in flight, waiting for it to settle before retrying')
+            await this.inFlightSyncPromise
+          } else {
+            console.warn('[AutoSync] initialize(): first sync did not complete, retrying')
+          }
           return this.initialize(attempt + 1)
         }
       } else {
@@ -421,6 +458,8 @@ export class AutoSyncService {
     // race this flag exists to prevent. Reset in `finally` so every return
     // path (gate-blocked or sync completed/failed) releases the latch.
     this._isSyncing = true
+    let resolveInFlightSyncPromise: (() => void) | undefined
+    this.inFlightSyncPromise = new Promise<void>(resolve => { resolveInFlightSyncPromise = resolve })
 
     try {
       // Wait for auth state to settle BEFORE snapshotting it (codex review
@@ -481,7 +520,6 @@ export class AutoSyncService {
         // COMMIT POINT below for why that assignment is deferred).
         const syncCompletedAt = new Date()
         const scopedSyncKey = this.scopedMetaKey(this.SYNC_STORAGE_KEY, identity.uid)
-        await chrome.storage.local.set({ [scopedSyncKey]: syncCompletedAt.toISOString() })
         // Opportunistically clear an orphaned legacy key here too (codex
         // review r3615389121): `initialize()` is the primary migration
         // path, but a manual sync (bypassing `initialize()` entirely, e.g.
@@ -490,8 +528,15 @@ export class AutoSyncService {
         // available for a later different account to inherit. Only when
         // signed in -- if `identity.uid` is undefined, `scopedSyncKey`
         // already equals the bare legacy key itself (see `scopedMetaKey()`),
-        // and removing it here would just delete what was just written.
+        // and removing it here would delete what's about to be written, so
+        // skip it in that case. Removed BEFORE the scoped write lands (codex
+        // review r3615664896, P2, same ordering rationale as
+        // `initialize()`'s migration): a crash between the two writes then
+        // leaves the legacy key already gone (worst case just an extra
+        // sync attempt) rather than surviving for a different account to
+        // inherit later.
         if (identity.uid) await chrome.storage.local.remove(this.SYNC_STORAGE_KEY)
+        await chrome.storage.local.set({ [scopedSyncKey]: syncCompletedAt.toISOString() })
 
         // Update timestamps after sync
         await this.updateTimestamps()
@@ -531,6 +576,8 @@ export class AutoSyncService {
       }
     } finally {
       this._isSyncing = false
+      this.inFlightSyncPromise = null
+      resolveInFlightSyncPromise?.()
     }
   }
 

--- a/src/services/firebase-auth-service.test.ts
+++ b/src/services/firebase-auth-service.test.ts
@@ -1,0 +1,144 @@
+/**
+ * FirebaseAuthService.getIdToken() -- stale token-refresh handling.
+ *
+ * codex post-merge review on #192, r3616116753, P1, "Count stale refreshes
+ * as auth transitions": if an ID-token refresh for account A is still in
+ * flight when the user signs into account B, applying the refresh response
+ * back into the shared `currentState` unconditionally corrupts it (mixing
+ * B's other fields with A's refreshed uid/token/refreshToken) and silently
+ * resurrects A's uid into `getCurrentUser()` -- without ever advancing
+ * `authGeneration`, defeating every `assertGenerationUnchanged()`
+ * commit-point check built on top of it elsewhere in this codebase.
+ */
+import { FirebaseAuthService } from './firebase-auth-service'
+
+describe('FirebaseAuthService.getIdToken -- stale refresh handling', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('discards a token refresh response for an account that is no longer current, without corrupting currentState or resurrecting the old uid (P1, codex review r3616116753)', async () => {
+    const stateA = {
+      uid: 'user-a',
+      email: 'a@example.com',
+      displayName: null,
+      photoURL: null,
+      idToken: 'a-old-token',
+      refreshToken: 'a-refresh-token',
+      // Already expired -- forces getIdToken() to actually refresh.
+      expiresAt: Date.now() - 1000
+    }
+    // Pre-seed storage so the service's own constructor-kicked-off restore
+    // naturally loads this state -- avoids racing a manual currentState
+    // assignment against that same async restore.
+    await chrome.storage.local.set({ firebaseRestAuthState: stateA })
+
+    const service = new FirebaseAuthService()
+    await service.ready()
+    expect(service.getCurrentUser()?.uid).toBe('user-a')
+
+    const generationBeforeRefresh = (service as any).authGeneration
+
+    const stateB = {
+      uid: 'user-b',
+      email: 'b@example.com',
+      displayName: null,
+      photoURL: null,
+      idToken: 'b-token',
+      refreshToken: 'b-refresh-token',
+      expiresAt: Date.now() + 60 * 60 * 1000
+    }
+
+    let resolveFetch: ((value: any) => void) | undefined
+    // Switch to account B as a side effect of fetch() actually being
+    // called -- guarantees the switch happens exactly once getIdToken()
+    // has progressed past its early-return check and captured A's
+    // refreshingUid/refreshToken, i.e. while A's refresh is genuinely "in
+    // flight" (simulates exactly what signInWithGoogle() does
+    // synchronously: currentState reassignment + authGeneration bump).
+    const fetchMock = jest.fn().mockImplementation(() => {
+      ;(service as any).currentState = stateB
+      ;(service as any).authGeneration = generationBeforeRefresh + 1
+      return new Promise(resolve => { resolveFetch = resolve })
+    })
+    const originalFetch = global.fetch
+    global.fetch = fetchMock as any
+
+    const tokenPromise = service.getIdToken()
+
+    // Flush microtasks until getIdToken() has actually progressed past its
+    // own `await this.ready()` and early-return check and reached the
+    // fetch() call (which is what triggers the account switch above and
+    // captures `resolveFetch`) -- `ready()` being already-resolved still
+    // costs at least one microtask hop before the continuation runs.
+    while (!resolveFetch) {
+      await Promise.resolve()
+    }
+
+    // A's refresh now resolves.
+    resolveFetch({
+      ok: true,
+      json: async () => ({
+        id_token: 'a-refreshed-token',
+        refresh_token: 'a-new-refresh-token',
+        expires_in: '3600',
+        user_id: 'user-a'
+      })
+    })
+
+    const token = await tokenPromise
+    global.fetch = originalFetch
+
+    // The caller that started this refresh for A still gets A's refreshed
+    // token back -- whatever in-flight operation requested it can still
+    // complete using a valid, unexpired token for the account it actually
+    // started with.
+    expect(token).toBe('a-refreshed-token')
+
+    // But currentState was NOT corrupted -- it still correctly reflects B,
+    // completely untouched by A's stale refresh response. In particular,
+    // getCurrentUser() must NOT have silently flipped back to A.
+    expect(service.getCurrentUser()?.uid).toBe('user-b')
+    expect((service as any).currentState).toEqual(stateB)
+
+    // The discard itself doesn't bump authGeneration further -- nothing
+    // NEW happened identity-wise here; the real transition to B already
+    // bumped it when the switch was simulated above.
+    expect((service as any).authGeneration).toBe(generationBeforeRefresh + 1)
+  })
+
+  test('applies a token refresh normally (persists it) when the account has NOT changed during the refresh', async () => {
+    const stateA = {
+      uid: 'user-a',
+      email: 'a@example.com',
+      displayName: null,
+      photoURL: null,
+      idToken: 'a-old-token',
+      refreshToken: 'a-refresh-token',
+      expiresAt: Date.now() - 1000
+    }
+    await chrome.storage.local.set({ firebaseRestAuthState: stateA })
+
+    const service = new FirebaseAuthService()
+    await service.ready()
+
+    const originalFetch = global.fetch
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id_token: 'a-refreshed-token',
+        refresh_token: 'a-new-refresh-token',
+        expires_in: '3600',
+        user_id: 'user-a'
+      })
+    }) as any
+
+    const token = await service.getIdToken()
+    global.fetch = originalFetch
+
+    expect(token).toBe('a-refreshed-token')
+    expect((service as any).currentState.idToken).toBe('a-refreshed-token')
+    expect((service as any).currentState.refreshToken).toBe('a-new-refresh-token')
+    expect(service.getCurrentUser()?.uid).toBe('user-a')
+  })
+})

--- a/src/services/firebase-auth-service.ts
+++ b/src/services/firebase-auth-service.ts
@@ -195,6 +195,23 @@ export class FirebaseAuthService {
       return this.currentState.idToken
     }
 
+    // Snapshot which identity this refresh is FOR, before the network await
+    // (codex review r3616116753, P1, "Count stale refreshes as auth
+    // transitions"): if the user signs into a DIFFERENT account while this
+    // refresh is in flight, applying the response back into the shared
+    // `currentState` unconditionally would silently corrupt it -- spreading
+    // the NEW account's other fields (`...this.currentState`, which by then
+    // already reflects the NEW account) together with the OLD account's
+    // refreshed uid/token/refreshToken, resurrecting the OLD uid into
+    // `currentState.uid` (and therefore `getCurrentUser()`). Nothing in
+    // this method bumps `authGeneration`, so every commit-point
+    // `assertGenerationUnchanged()` check elsewhere would see "unchanged"
+    // even though the live identity had silently flipped back underneath
+    // them -- defeating the entire generation-gate mechanism this PR
+    // builds on.
+    const refreshingUid = this.currentState.uid
+    const refreshToken = this.currentState.refreshToken
+
     const response = await fetch(
       `https://securetoken.googleapis.com/v1/token?key=${firebaseConfig.apiKey}`,
       {
@@ -202,7 +219,7 @@ export class FirebaseAuthService {
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: new URLSearchParams({
           grant_type: 'refresh_token',
-          refresh_token: this.currentState.refreshToken
+          refresh_token: refreshToken
         }).toString()
       }
     )
@@ -213,6 +230,19 @@ export class FirebaseAuthService {
     }
 
     const result = await response.json() as FirebaseRefreshResponse
+
+    // Discard a stale refresh response: the account live NOW is not the one
+    // this refresh was requested for. Still return the freshly-fetched
+    // token to THIS caller -- whatever in-flight operation asked for it
+    // (e.g. a Firestore call already under way for the OLD account) can
+    // still complete using a valid, unexpired token for the account it
+    // actually started with -- but do NOT let it become the new shared
+    // `currentState`, and do NOT persist it.
+    if (this.currentState?.uid !== refreshingUid) {
+      console.warn('[FirebaseAuth] Discarding a token refresh for a no-longer-current account (the signed-in account changed while the refresh was in flight)')
+      return result.id_token
+    }
+
     this.currentState = {
       ...this.currentState,
       uid: result.user_id,

--- a/src/services/firebase-auth-service.ts
+++ b/src/services/firebase-auth-service.ts
@@ -48,9 +48,40 @@ export class FirebaseAuthService {
   private currentState: StoredAuthState | null = null
   private authStateListeners: ((user: AuthUser | null) => void)[] = []
   private restorePromise: Promise<void>
+  /**
+   * Monotonic counter, incremented on every auth-state TRANSITION (sign-in,
+   * sign-out, or the initial restore-from-storage on startup) -- never on a
+   * same-account token refresh (`getIdToken(forceRefresh)`'s `currentState`
+   * reassignment preserves the same `uid`, so it does NOT bump this).
+   *
+   * WHY (codex post-merge review on #192, r3615389112, P1, "Detect ABA
+   * account switches before committing bookkeeping"): callers used to
+   * compare a snapshotted uid string against `getCurrentUser()?.uid` to
+   * detect a mid-pass account switch. That is blind to an A -> B -> A
+   * round trip: by the time the check runs, the live uid is back to "A",
+   * string-equal to the snapshot, even though a DIFFERENT account (B) was
+   * live in between and may have driven whatever cloud read/write the
+   * check was meant to guard. This counter can't be fooled by a value
+   * cycling back -- an A -> B -> A round trip still advances it by (at
+   * least) 2, so a caller comparing the snapshotted GENERATION (not the
+   * uid) correctly detects that *something* changed in between, regardless
+   * of whether the uid happens to match again afterward.
+   */
+  private authGeneration = 0
 
   constructor() {
     this.restorePromise = this.restoreAuthState()
+  }
+
+  /**
+   * Current auth-state generation. See `authGeneration`'s doc comment.
+   * Callers that need to detect a mid-operation account switch (including
+   * an A -> B -> A round trip) should snapshot this alongside
+   * `getCurrentUser()?.uid` at the start of the operation and compare
+   * generations (not uid strings) before any consequential commit.
+   */
+  getAuthGeneration(): number {
+    return this.authGeneration
   }
 
   async ready(): Promise<void> {
@@ -94,6 +125,7 @@ export class FirebaseAuthService {
         refreshToken: result.refreshToken,
         expiresAt: Date.now() + Number(result.expiresIn) * 1000
       }
+      this.authGeneration++ // sign-in transition -- see authGeneration's doc comment
       await this.persistAuthState()
       this.notifyAuthStateListeners(this.getCurrentUser())
       console.log('[FirebaseAuth] Firebase sign in successful:', this.currentState.email)
@@ -110,6 +142,7 @@ export class FirebaseAuthService {
   async signOut(): Promise<void> {
     const previousToken = await this.getChromeAuthToken(false).catch(() => null)
     this.currentState = null
+    this.authGeneration++ // sign-out transition -- see authGeneration's doc comment
     await chrome.storage.local.remove(FirebaseAuthService.STORAGE_KEY)
     this.notifyAuthStateListeners(null)
 
@@ -235,6 +268,12 @@ export class FirebaseAuthService {
   private async restoreAuthState(): Promise<void> {
     const stored = await chrome.storage.local.get(FirebaseAuthService.STORAGE_KEY) as Record<string, StoredAuthState | undefined>
     this.currentState = stored[FirebaseAuthService.STORAGE_KEY] ?? null
+    // Initial-restore transition -- see authGeneration's doc comment. Every
+    // Service Worker (re)start is a fresh generation baseline, even when it
+    // restores the SAME account: a sync pass whose in-memory snapshot was
+    // taken before an SW restart is not meaningfully "the same pass"
+    // afterward regardless of whether the restored uid matches.
+    this.authGeneration++
     this.notifyAuthStateListeners(this.getCurrentUser())
   }
 

--- a/src/services/firebase-auth-service.ts
+++ b/src/services/firebase-auth-service.ts
@@ -126,8 +126,19 @@ export class FirebaseAuthService {
         expiresAt: Date.now() + Number(result.expiresIn) * 1000
       }
       this.authGeneration++ // sign-in transition -- see authGeneration's doc comment
-      await this.persistAuthState()
+      // Notify listeners SYNCHRONOUSLY, in the same step as the currentState/
+      // authGeneration mutation above -- BEFORE the persistAuthState() await
+      // (codex review r3615952256, P2, "Clear stale sync state when
+      // exposing the new user"). Moving this earlier closes the window
+      // where getCurrentUser()/getAuthGeneration() already report the NEW
+      // account but registered listeners (e.g. AutoSyncService clearing its
+      // own stale in-memory state, see its constructor) hadn't been told
+      // yet -- during a direct A->B sign-in, anything reading auth state in
+      // that gap used to see B live while dependent state still reflected
+      // A. persistAuthState() below is a fire-and-forget durability step
+      // from listeners' perspective; it doesn't need to precede them.
       this.notifyAuthStateListeners(this.getCurrentUser())
+      await this.persistAuthState()
       console.log('[FirebaseAuth] Firebase sign in successful:', this.currentState.email)
       return this.getCurrentUser()!
     } catch (error) {


### PR DESCRIPTION
## Summary

**Rebuilt on top of #194** (merged: floor-seeding for recovered rows + eager earlier-floor persistence are now on `main`). This PR is now scoped to just the account-scoping / multi-account bookkeeping-integrity work, per an explicit owner decision (sola, 2026-07-21) that superseded an earlier, broader draft of this fix.

### Background

Post-merge diversity review on #182 originally found 3 issues on the sync-watermark/floor mechanism (`src/services/auto-sync-service.ts`): a backfill blind spot, a floor-ordering gap (both now on `main` via #194), and unscoped sync-bookkeeping `meta` keys. Fixing the scoping issue surfaced further findings across two more review rounds, converging on a genuine architectural question: **how far should this file go to protect against a same-device account switch?**

### Owner-decided scope

> Wrong-account uploads are **acceptable** ("ローカルデータが別アカウントのFirestoreに上がるのは構わない"). What must hold is **bookkeeping integrity per account** — after re-signing into the correct account, its sync state (watermark/floor/backfill markers) must be intact and correct, with no permanent upload gaps.

An earlier draft of this branch added a `localDataOwnerUid` ownership guard that blocked automatic sync entirely when local data might belong to a different account. **That guard has been removed** — cross-account uploads are accepted behavior, not something to gate.

### What this PR does

1. **Per-account bookkeeping keys + once-only legacy migration**: `syncUnparseableFloor`, `syncUnparseableFloorBackfillDoneV2`, and `autoSyncLastTime` are all scoped by uid. A pre-existing unscoped `autoSyncLastTime` value is migrated to whichever account consumes it first (and the legacy key deleted in the same step), so it can never later be inherited by a different account.

2. **Pass-start uid snapshot with write-gated commit points**: `performSync()` snapshots the signed-in uid once. `persistUnparseableSyncFloor()` and `markUnparseableFloorBackfillDone()` — the only two methods that ever write floor/backfill-done bookkeeping — each assert the live uid still matches that snapshot immediately before their own `db.meta` write, throwing `SyncAccountChangedError` (caught by `performSync()`, surfaced as `status: 'error'`) rather than committing under a stale account. `performSync()`'s final `autoSyncLastTime` write and `initialize()`'s legacy-migration write get the same inline check. This is deliberately a **write-site** guard, not a read-site or upload-site guard — it's what makes a mid-pass account switch die at "no bookkeeping committed" rather than needing to prevent the switch (or the resulting cloud read/upload) from happening at all.

3. **Accepted residual risk, documented**: `firestore-backup-service.ts`'s internal `requireUser()`/`getIdToken()` calls independently re-resolve the live signed-in account on every Firestore REST call, regardless of what this file snapshotted — left untouched. Worst case: data duplicated in the wrong account's Firestore. Never: bookkeeping corruption of the account that comes back. Documented inline in the ACCOUNT-SCOPING INVARIANTS spec comment (top of the class).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — 107 suites / 1022 tests, run twice, both clean (jest ×2 gate)
- [x] `npm run e2e:smoke` — all 6 checks pass
- [x] New regression tests in `src/services/auto-sync-service.test.ts`:
  - **Sign-in-mistake round trip**: account A syncs → account B signs in and runs a full session (upload allowed, per accepted scope) → A signs back in → A's bookkeeping is untouched by B's session, and A's next sync uploads exactly what A's own cloud still lacks (not a re-upload of what A already had, not a gap).
  - **Mid-pass account switch → abort with zero bookkeeping writes**: an account switch mid-upload causes the pass to abort via `SyncAccountChangedError`, with a legitimate pre-switch eager floor write surviving (correct) but the final commit and any writes under the new account's scope never happening.
  - **Legacy migration exactly once**: a pre-existing unscoped `autoSyncLastTime` is migrated to the first account that signs in and consumed/deleted, never inherited by a later different account.

## Review history

Findings resolved as **out-of-scope by owner decision** (the ownership-guard mechanism they critique has been removed): "Prevent cross-account uploads after scoping last sync", "Block unowned legacy data before auto-sync", "Do not mark download-only syncs as upload ownership".

Findings resolved via the **write-gated commit-point invariant** described above: "Recheck the uid before cloud watermark reads", "Use the snapshotted uid for Firestore uploads".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
