### PR TITLE
fix(e2e): use the standard puppeteer cache dir for Chrome for Testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,8 @@ coverage/
 *.ndjson
 
 # E2E QA harness (see e2e/README.md)
-e2e/.cache/
+# Chrome for Testing downloads live in ~/.cache/puppeteer/ (see BROWSER_CACHE_DIR
+# in e2e/config.ts), not a per-worktree e2e/.cache/, so nothing to ignore here.
 e2e/.build/
 e2e/out/
 # the blanket *.ndjson rule above would also hide our committed, anonymized

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -19,8 +19,10 @@ This builds the e2e extension variant, launches Chrome for Testing headless,
 replays the anonymized fixture over a real WebSocket, and asserts the HUD
 + popup work. Screenshots land in `e2e/out/`.
 
-First run downloads Chrome for Testing (~200MB) into `e2e/.cache/` -- later
-runs reuse the cache and take a few seconds.
+First run downloads Chrome for Testing (~200MB) into `~/.cache/puppeteer/`
+(puppeteer's standard cache location, shared across worktrees -- override
+with `E2E_BROWSER_CACHE_DIR`) -- later runs reuse the cache and take a few
+seconds.
 
 ## How it works: the replay seam
 
@@ -260,9 +262,10 @@ Key methods: `evaluate`, `screenshot`, `domSnapshotText`, `domSnapshotHtml`,
 and `browser` (raw `puppeteer-core` objects) are also exposed for anything
 not covered by the helpers.
 
-`launchHarness` downloads (once, cached under `e2e/.cache/`) and launches
-a pinned Chrome for Testing build (see `CHROME_BUILD_ID` in
-`e2e/config.ts`) with `--load-extension`/`--disable-extensions-except`
+`launchHarness` downloads (once, cached under `~/.cache/puppeteer/`, see
+`BROWSER_CACHE_DIR` in `e2e/config.ts`) and launches a pinned Chrome for
+Testing build (see `CHROME_BUILD_ID` in `e2e/config.ts`) with
+`--load-extension`/`--disable-extensions-except`
 pointed at `e2e/.build/extension/`. Headless was verified to work fine for
 this harness (Chrome for Testing supports extensions in headless mode) and
 is the default; pass `{ headed: true }` to watch it.
@@ -396,7 +399,10 @@ e2e/
     build-e2e.ts               orchestrates the full e2e build
     extract-fixture.ts         CLI to regenerate fixtures from a raw capture
     anonymize.ts / .test.ts    pure UserId/UserName remapping (jest-tested)
-  .cache/    gitignored -- downloaded Chrome for Testing
   .build/    gitignored -- generated manifest + built e2e extension + session.json
   out/       gitignored -- default screenshot/output directory
 ```
+
+Chrome for Testing downloads are *not* under `e2e/`: they live in
+`~/.cache/puppeteer/` (puppeteer's standard, worktree-independent cache
+location; see `BROWSER_CACHE_DIR` in `e2e/config.ts`).

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -8,6 +8,7 @@
  */
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
+import { homedir } from 'node:os'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -32,8 +33,15 @@ export const E2E_MANIFEST_PATH = join(BUILD_DIR, 'manifest.e2e.json')
 export const EXTENSION_DIR = join(BUILD_DIR, 'extension')
 export const EXTENSION_DIST_DIR = join(EXTENSION_DIR, 'dist')
 
-/** Downloaded Chrome for Testing binaries. Gitignored, reused across runs. */
-export const BROWSER_CACHE_DIR = join(E2E_DIR, '.cache')
+/**
+ * Downloaded Chrome for Testing binaries. Uses `@puppeteer/browsers`'
+ * standard cache layout (`~/.cache/puppeteer/chrome/<platform>-<buildId>/`)
+ * rather than a per-worktree `e2e/.cache/` -- that way multiple worktrees
+ * share one download, and outbound-firewall tools (e.g. LuLu) that key on
+ * executable path see one stable path instead of a new one per worktree.
+ * Override with E2E_BROWSER_CACHE_DIR for local debugging only.
+ */
+export const BROWSER_CACHE_DIR = process.env.E2E_BROWSER_CACHE_DIR || join(homedir(), '.cache', 'puppeteer')
 
 /**
  * Chrome for Testing build to install/launch. Pinned (not "stable") so runs


### PR DESCRIPTION
## Summary
- `BROWSER_CACHE_DIR` (`e2e/config.ts`) now defaults to `@puppeteer/browsers`' standard cache layout (`~/.cache/puppeteer/`) instead of a per-worktree `e2e/.cache/`, with an `E2E_BROWSER_CACHE_DIR` override for local/CI flexibility.
- Rationale: per-worktree `e2e/.cache/` extractions of Chrome for Testing give each worktree its own executable path, which makes outbound-firewall tools (e.g. LuLu) prompt per path and accumulate garbage rules over time. `install`/`computeExecutablePath` from `@puppeteer/browsers` (used in `e2e/harness.ts`) take `cacheDir` directly, and the standard layout (`chrome/<platform>-<buildId>/`) is what puppeteer already produces, so existing downloads under `~/.cache/puppeteer/` are reused as-is — no re-download, no migration needed.
- Pruned the now-unused `e2e/.cache/` gitignore entry (left an explanatory comment instead of a bare removal) and updated `e2e/README.md` (intro blurb, `launchHarness` description, file-map tree) to match.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` (jest) — 107 suites / 1016 tests pass
- [x] `npm run e2e:smoke` (1st run, cold): downloaded Chrome for Testing 151.0.7922.34 into `~/.cache/puppeteer/chrome/mac_arm-151.0.7922.34/`; all 6 smoke checks passed
- [x] `npm run e2e:smoke` (2nd run): no download log line, reused the cache, ~5s total; all 6 checks passed again
- [x] Confirmed `e2e/.cache/` was never created across either run (only `e2e/.build/` and `e2e/out/`, both pre-existing gitignored dirs)
- [x] Resolved executable path (`/Users/local/.cache/puppeteer/chrome/mac_arm-151.0.7922.34/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`) falls under the already-allowlisted `~/.cache/puppeteer/*` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)