### PR TITLE
fix(ingestion): raw-write durability barrier; conservative session-activity detection

### DIFF
--- a/src/background/event-ingestion.arrival-ordering.test.ts
+++ b/src/background/event-ingestion.arrival-ordering.test.ts
@@ -1,0 +1,211 @@
+/**
+ * event-ingestion.ts - session-activity arrival-order integrity
+ *
+ * Verifies two pass-2 findings on PR #196 (both created 2026-07-21,
+ * chatgpt-codex-connector, on top of the P2#3 fix that made ACTIVE-marking
+ * synchronous while INACTIVE-marking (309) stays behind the Raw Event Lake
+ * durability barrier -- an intentional asymmetry, see event-ingestion.ts's
+ * markSessionActiveFromRawMessage() docstring):
+ *
+ * P1 "Preserve session activity ordering across queued events": because
+ * ACTIVE-marking (201/303[Player]/308) fires synchronously in
+ * port.onMessage while INACTIVE-marking (309) only settles later, behind
+ * `ingestionQueue`, the raw arrival order [309, 201] could invert: 201's
+ * synchronous ACTIVE mark lands first, then the *older* (but slower to
+ * settle) 309's INACTIVE mark overwrites it, leaving the tri-state
+ * 'inactive' while a brand new hand is actually live. The fix
+ * (update-manager.ts's `arrivalSeq`-gated `markSessionActive`/
+ * `markSessionInactive`) makes only the transition with the *newest*
+ * arrival sequence number win, regardless of which one settles first.
+ *
+ * P2 "Skip duplicate starts before arming activity": a reconnect
+ * resend/duplicate of an already-stored 201/303/308 arms ACTIVE
+ * optimistically (before the queued ConstraintError dedupe check can
+ * identify it as a duplicate and skip it), so a stale resend arriving
+ * after a genuine 309 can flip sessionActivity back to 'active' with no
+ * live hand, blocking pending Forced Updates indefinitely. The fix
+ * (`revertSessionActivityIfStillApplied()`) rolls the optimistic ACTIVE
+ * mark back to whatever it was immediately before, once the duplicate is
+ * confirmed -- but only if nothing newer has applied since.
+ */
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { ApiType } from '../types'
+import { registerEventIngestion } from './event-ingestion'
+import { connectedPorts } from './ports'
+import * as updateManager from './update-manager'
+import { autoSyncService } from '../services/auto-sync-service'
+
+describe('registerEventIngestion (session-activity arrival-order integrity)', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+  let onMessageHandler: (message: any) => Promise<void>
+  let disconnectHandlers: Array<() => void>
+  let mockPort: any
+
+  beforeEach(async () => {
+    // update-manager.ts's session-activity state (sessionActivity,
+    // lastAppliedSeq, etc.) is module-scope and persists across `test()`
+    // blocks within this file (only `registerEventIngestion`'s own
+    // `arrivalSequence` closure is fresh per test) -- reset it so each
+    // test's arrival sequence numbers are compared against a clean
+    // baseline, matching the pattern in update-manager.test.ts /
+    // message-router.forced-update.test.ts.
+    updateManager.__resetUpdateManagerStateForTests()
+
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    service = new PokerChaseService({ db })
+    await service.ready
+
+    ;(chrome.runtime as any).onConnect = { addListener: jest.fn() }
+    registerEventIngestion(service)
+    const connectListener = (chrome.runtime as any).onConnect.addListener.mock.calls[0][0]
+
+    disconnectHandlers = []
+    mockPort = {
+      name: PokerChaseService.POKER_CHASE_SERVICE_EVENT,
+      onMessage: { addListener: jest.fn() },
+      onDisconnect: { addListener: jest.fn((fn: () => void) => disconnectHandlers.push(fn)) },
+      postMessage: jest.fn()
+    }
+    connectListener(mockPort)
+    onMessageHandler = mockPort.onMessage.addListener.mock.calls[0][0]
+
+    // These tests are about session-activity ordering, not the sync
+    // trigger's own (unrelated, auth/network-dependent) behavior -- mock it
+    // out so `isSafeToUpdate()`'s `!autoSyncService.isSyncing` term doesn't
+    // introduce timing noise unrelated to what's under test here.
+    jest.spyOn(autoSyncService, 'onGameSessionEnd').mockResolvedValue(undefined)
+    jest.spyOn(autoSyncService, 'onNewSessionStart').mockResolvedValue(undefined)
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    disconnectHandlers.forEach(fn => fn())
+    connectedPorts.clear()
+    db.close()
+    await db.delete()
+  })
+
+  const entryQueued = (timestamp: number) => ({
+    ApiTypeId: ApiType.EVT_ENTRY_QUEUED, timestamp, Code: 0, BattleType: 0, Id: 'stage000_003', IsRetire: false
+  })
+
+  const sessionResults = (timestamp: number) => ({
+    ApiTypeId: ApiType.EVT_SESSION_RESULTS,
+    timestamp,
+    Ranking: 3,
+    IsLeave: false,
+    IsRebuy: false,
+    TotalMatch: 100,
+    RankReward: {
+      IsSeasonal: true,
+      RankPoint: 10,
+      RankPointDiff: 1,
+      Rank: { RankId: 'gold', RankName: 'ゴールド', RankLvId: 'gold', RankLvName: 'ゴールド' },
+      SeasonalRanking: 0
+    },
+    Rewards: [],
+    EventRewards: [],
+    Charas: [],
+    Costumes: [],
+    Decos: [],
+    Items: [],
+    Money: { FreeMoney: -1, PaidMoney: -1 },
+    Emblems: []
+  })
+
+  test('P1: raw arrival order [309, 201] -- a 309 whose durability write settles AFTER a later 201 must not overwrite that 201\'s ACTIVE mark (audit\'s exact ordering scenario)', async () => {
+    // Make the 309's own apiEvents.add() settle only when we say so, so we
+    // can arrange for the 201 (which arrives *after* the 309 chronologically,
+    // but whose ACTIVE mark is synchronous) to complete first -- reproducing
+    // "session end immediately followed by a new hand, before the 309's raw
+    // write has actually settled".
+    let resolveSessionResultsAdd!: (key: number) => void
+    const realAdd = db.apiEvents.add.bind(db.apiEvents)
+    jest.spyOn(db.apiEvents, 'add').mockImplementation(((event: any) => {
+      if (event.ApiTypeId === ApiType.EVT_SESSION_RESULTS) {
+        return new Promise<number>(resolve => { resolveSessionResultsAdd = resolve })
+      }
+      return realAdd(event)
+    }) as any)
+
+    // 1) The session-end 309 arrives first (true arrival order) -- its
+    // processing is now stuck behind the mocked, unresolved add(). Note:
+    // `ingestionQueue` strictly serializes `processEvent` calls, so this
+    // event's OWN promise won't settle until we release it below -- do not
+    // await it yet.
+    const pendingSessionResults = onMessageHandler(sessionResults(100))
+
+    // 2) A brand new hand's 201 arrives next (true arrival order: AFTER the
+    // 309) -- markSessionActive() fires synchronously in the port.onMessage
+    // listener, before this event is even enqueued, so it has already run
+    // by the time this call returns (regardless of the fact that this
+    // event's own queued processing is stuck behind the still-unresolved
+    // 309 and its returned promise won't settle until that unblocks either
+    // -- captured but deliberately not awaited yet).
+    const pendingEntryQueued = onMessageHandler(entryQueued(200))
+
+    // At this point the newer (201) transition has already applied.
+    expect(updateManager.isSafeToUpdate()).toBe(false) // active -- unsafe, correctly
+
+    // Let the queue actually reach the mocked (still-unresolved) 309 add()
+    // call before releasing it -- `ingestionQueue.then(...)` and the
+    // `await service.ready` / `await apiEvents.add(...)` chain inside
+    // `processEvent` each take a few microtask hops to get there.
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // 3) Now let the 309's raw write settle -- its markSessionInactive()
+    // call finally runs, but carries the OLDER arrival sequence number.
+    resolveSessionResultsAdd(1)
+    await pendingSessionResults
+    await pendingEntryQueued
+
+    // The older (309) transition must NOT have overwritten the newer (201)
+    // one -- the true arrival order says a new hand is live.
+    expect(updateManager.isSafeToUpdate()).toBe(false)
+  })
+
+  test('P1 sanity check: raw arrival order [201, 309] (no inversion) still ends inactive as expected', async () => {
+    await onMessageHandler(entryQueued(300))
+    expect(updateManager.isSafeToUpdate()).toBe(false) // active
+
+    await onMessageHandler(sessionResults(400))
+    expect(updateManager.isSafeToUpdate()).toBe(true) // inactive, and no other unsafe condition
+  })
+
+  test('P2: a reconnect-resend duplicate of an already-processed 201 does not re-arm session activity after a genuine 309 (audit\'s exact duplicate scenario)', async () => {
+    // Genuine session: 201 starts it, 309 ends it.
+    const originalEntryQueued = entryQueued(500)
+    await onMessageHandler(originalEntryQueued)
+    await onMessageHandler(sessionResults(600))
+
+    expect(updateManager.isSafeToUpdate()).toBe(true) // inactive, session truly over
+
+    // A stale reconnect resend of the *exact same* 201 event arrives late
+    // (identical timestamp+ApiTypeId+payload -- e.g. a buffered unacked
+    // message replayed after the port reconnects). It optimistically arms
+    // ACTIVE the instant it arrives (synchronous, fail-closed by design)...
+    await onMessageHandler({ ...originalEntryQueued })
+
+    // ...but once its raw add() rejects with a real ConstraintError and the
+    // payload comparison confirms it's a true duplicate (not a same-ms
+    // collision), the optimistic ACTIVE mark is rolled back to whatever it
+    // was immediately before -- 'inactive', matching reality (no live hand).
+    expect(updateManager.isSafeToUpdate()).toBe(true)
+    expect(await db.apiEvents.count()).toBe(2) // only the two genuine rows, resend added nothing
+  })
+
+  test('P2 control: a genuinely NEW 201 after a 309 (not a duplicate) is NOT reverted -- only true duplicates roll back', async () => {
+    await onMessageHandler(entryQueued(700))
+    await onMessageHandler(sessionResults(800))
+    expect(updateManager.isSafeToUpdate()).toBe(true) // inactive
+
+    // A brand new, distinct 201 (different timestamp -- no key collision at
+    // all, let alone a duplicate) legitimately starts a new session.
+    await onMessageHandler(entryQueued(900))
+
+    expect(updateManager.isSafeToUpdate()).toBe(false) // active, correctly NOT reverted
+  })
+})

--- a/src/background/event-ingestion.arrival-ordering.test.ts
+++ b/src/background/event-ingestion.arrival-ordering.test.ts
@@ -1,32 +1,43 @@
 /**
- * event-ingestion.ts - session-activity arrival-order integrity
+ * event-ingestion.ts - session-activity: strict queue serialization
  *
- * Verifies two pass-2 findings on PR #196 (both created 2026-07-21,
- * chatgpt-codex-connector, on top of the P2#3 fix that made ACTIVE-marking
- * synchronous while INACTIVE-marking (309) stays behind the Raw Event Lake
- * durability barrier -- an intentional asymmetry, see event-ingestion.ts's
- * markSessionActiveFromRawMessage() docstring):
+ * 2026-07-21, pass-3 consolidation. Two earlier rounds of findings against
+ * a design where ACTIVE-marking (201/303[Player]/308) fired synchronously
+ * in port.onMessage while INACTIVE-marking (309/203) settled later, behind
+ * the `ingestionQueue` durability barrier:
+ *   - pass-2 P1 "arrival-order inversion": a slow-to-settle 309 could
+ *     overwrite a chronologically-newer 201's synchronous ACTIVE mark.
+ *     Patched with an `arrivalSeq`-gated ordering scheme.
+ *   - pass-2 P2 "duplicate re-arms activity": a stale resend armed ACTIVE
+ *     optimistically before the dedupe check could identify it. Patched
+ *     with a 1-level rollback.
+ *   - pass-3 P2 "stacked duplicate rollback": the 1-level rollback broke
+ *     when a reconnect resent MORE THAN ONE stale duplicate in a row (the
+ *     second optimistic ACTIVE mark clobbered the rollback slot meant for
+ *     the first).
  *
- * P1 "Preserve session activity ordering across queued events": because
- * ACTIVE-marking (201/303[Player]/308) fires synchronously in
- * port.onMessage while INACTIVE-marking (309) only settles later, behind
- * `ingestionQueue`, the raw arrival order [309, 201] could invert: 201's
- * synchronous ACTIVE mark lands first, then the *older* (but slower to
- * settle) 309's INACTIVE mark overwrites it, leaving the tri-state
- * 'inactive' while a brand new hand is actually live. The fix
- * (update-manager.ts's `arrivalSeq`-gated `markSessionActive`/
- * `markSessionInactive`) makes only the transition with the *newest*
- * arrival sequence number win, regardless of which one settles first.
+ * Each patch fixed the finding that prompted it but created the next one --
+ * the write-side design was fighting itself. The actual fix: move ALL
+ * session-activity transitions inside the same serialized `ingestionQueue`
+ * that already gates the Raw Event Lake durability barrier and the
+ * duplicate/collision dedupe check (see event-ingestion.ts's
+ * `applySessionActivity` docstring):
+ *   - the queue preserves true arrival order by construction, so there is
+ *     no inversion to guard against and no `arrivalSeq` machinery needed
+ *   - the dedupe check runs BEFORE the activity decision, so a duplicate
+ *     (however many are resent in a row) never reaches
+ *     markSessionActive()/markSessionInactive() at all -- nothing to roll
+ *     back, ever
  *
- * P2 "Skip duplicate starts before arming activity": a reconnect
- * resend/duplicate of an already-stored 201/303/308 arms ACTIVE
- * optimistically (before the queued ConstraintError dedupe check can
- * identify it as a duplicate and skip it), so a stale resend arriving
- * after a genuine 309 can flip sessionActivity back to 'active' with no
- * live hand, blocking pending Forced Updates indefinitely. The fix
- * (`revertSessionActivityIfStillApplied()`) rolls the optimistic ACTIVE
- * mark back to whatever it was immediately before, once the duplicate is
- * confirmed -- but only if nothing newer has applied since.
+ * The original motivation for making ACTIVE-marking synchronous in the
+ * first place (a slow/stuck `apiEvents.add()` leaving `sessionActivity`
+ * stale while a safety recheck fires) is now solved on the READ side
+ * instead: `awaitIngestionDrain()` (see
+ * event-ingestion.durability-barrier.test.ts for that test).
+ *
+ * This file keeps the ordering/duplicate *scenarios* from the earlier
+ * rounds (they're still valid regression coverage) and adds the
+ * multi-duplicate-burst case that broke the 1-level rollback.
  */
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
 import PokerChaseService, { PokerChaseDB } from '../app'
@@ -36,7 +47,7 @@ import { connectedPorts } from './ports'
 import * as updateManager from './update-manager'
 import { autoSyncService } from '../services/auto-sync-service'
 
-describe('registerEventIngestion (session-activity arrival-order integrity)', () => {
+describe('registerEventIngestion (session-activity: strict queue serialization)', () => {
   let db: PokerChaseDB
   let service: PokerChaseService
   let onMessageHandler: (message: any) => Promise<void>
@@ -44,12 +55,9 @@ describe('registerEventIngestion (session-activity arrival-order integrity)', ()
   let mockPort: any
 
   beforeEach(async () => {
-    // update-manager.ts's session-activity state (sessionActivity,
-    // lastAppliedSeq, etc.) is module-scope and persists across `test()`
-    // blocks within this file (only `registerEventIngestion`'s own
-    // `arrivalSequence` closure is fresh per test) -- reset it so each
-    // test's arrival sequence numbers are compared against a clean
-    // baseline, matching the pattern in update-manager.test.ts /
+    // update-manager.ts's session-activity state is module-scope and
+    // persists across `test()` blocks within this file -- reset it,
+    // matching the pattern in update-manager.test.ts /
     // message-router.forced-update.test.ts.
     updateManager.__resetUpdateManagerStateForTests()
 
@@ -72,9 +80,9 @@ describe('registerEventIngestion (session-activity arrival-order integrity)', ()
     connectListener(mockPort)
     onMessageHandler = mockPort.onMessage.addListener.mock.calls[0][0]
 
-    // These tests are about session-activity ordering, not the sync
-    // trigger's own (unrelated, auth/network-dependent) behavior -- mock it
-    // out so `isSafeToUpdate()`'s `!autoSyncService.isSyncing` term doesn't
+    // These tests are about session-activity, not the sync trigger's own
+    // (unrelated, auth/network-dependent) behavior -- mock it out so
+    // `isSafeToUpdate()`'s `!autoSyncService.isSyncing` term doesn't
     // introduce timing noise unrelated to what's under test here.
     jest.spyOn(autoSyncService, 'onGameSessionEnd').mockResolvedValue(undefined)
     jest.spyOn(autoSyncService, 'onNewSessionStart').mockResolvedValue(undefined)
@@ -116,67 +124,23 @@ describe('registerEventIngestion (session-activity arrival-order integrity)', ()
     Emblems: []
   })
 
-  test('P1: raw arrival order [309, 201] -- a 309 whose durability write settles AFTER a later 201 must not overwrite that 201\'s ACTIVE mark (audit\'s exact ordering scenario)', async () => {
-    // Make the 309's own apiEvents.add() settle only when we say so, so we
-    // can arrange for the 201 (which arrives *after* the 309 chronologically,
-    // but whose ACTIVE mark is synchronous) to complete first -- reproducing
-    // "session end immediately followed by a new hand, before the 309's raw
-    // write has actually settled".
-    let resolveSessionResultsAdd!: (key: number) => void
-    const realAdd = db.apiEvents.add.bind(db.apiEvents)
-    jest.spyOn(db.apiEvents, 'add').mockImplementation(((event: any) => {
-      if (event.ApiTypeId === ApiType.EVT_SESSION_RESULTS) {
-        return new Promise<number>(resolve => { resolveSessionResultsAdd = resolve })
-      }
-      return realAdd(event)
-    }) as any)
+  test('raw arrival order [309, 201] resolves to ACTIVE (queue serialization preserves true arrival order, no inversion possible)', async () => {
+    await onMessageHandler(sessionResults(100))
+    expect(updateManager.isSafeToUpdate()).toBe(true) // inactive
 
-    // 1) The session-end 309 arrives first (true arrival order) -- its
-    // processing is now stuck behind the mocked, unresolved add(). Note:
-    // `ingestionQueue` strictly serializes `processEvent` calls, so this
-    // event's OWN promise won't settle until we release it below -- do not
-    // await it yet.
-    const pendingSessionResults = onMessageHandler(sessionResults(100))
-
-    // 2) A brand new hand's 201 arrives next (true arrival order: AFTER the
-    // 309) -- markSessionActive() fires synchronously in the port.onMessage
-    // listener, before this event is even enqueued, so it has already run
-    // by the time this call returns (regardless of the fact that this
-    // event's own queued processing is stuck behind the still-unresolved
-    // 309 and its returned promise won't settle until that unblocks either
-    // -- captured but deliberately not awaited yet).
-    const pendingEntryQueued = onMessageHandler(entryQueued(200))
-
-    // At this point the newer (201) transition has already applied.
-    expect(updateManager.isSafeToUpdate()).toBe(false) // active -- unsafe, correctly
-
-    // Let the queue actually reach the mocked (still-unresolved) 309 add()
-    // call before releasing it -- `ingestionQueue.then(...)` and the
-    // `await service.ready` / `await apiEvents.add(...)` chain inside
-    // `processEvent` each take a few microtask hops to get there.
-    await new Promise(resolve => setTimeout(resolve, 0))
-
-    // 3) Now let the 309's raw write settle -- its markSessionInactive()
-    // call finally runs, but carries the OLDER arrival sequence number.
-    resolveSessionResultsAdd(1)
-    await pendingSessionResults
-    await pendingEntryQueued
-
-    // The older (309) transition must NOT have overwritten the newer (201)
-    // one -- the true arrival order says a new hand is live.
-    expect(updateManager.isSafeToUpdate()).toBe(false)
+    await onMessageHandler(entryQueued(200))
+    expect(updateManager.isSafeToUpdate()).toBe(false) // active -- the newer arrival correctly wins
   })
 
-  test('P1 sanity check: raw arrival order [201, 309] (no inversion) still ends inactive as expected', async () => {
+  test('raw arrival order [201, 309] resolves to INACTIVE (the reverse direction, for symmetry)', async () => {
     await onMessageHandler(entryQueued(300))
     expect(updateManager.isSafeToUpdate()).toBe(false) // active
 
     await onMessageHandler(sessionResults(400))
-    expect(updateManager.isSafeToUpdate()).toBe(true) // inactive, and no other unsafe condition
+    expect(updateManager.isSafeToUpdate()).toBe(true) // inactive
   })
 
-  test('P2: a reconnect-resend duplicate of an already-processed 201 does not re-arm session activity after a genuine 309 (audit\'s exact duplicate scenario)', async () => {
-    // Genuine session: 201 starts it, 309 ends it.
+  test('a single reconnect-resend duplicate of an already-processed 201 does not re-arm session activity after a genuine 309', async () => {
     const originalEntryQueued = entryQueued(500)
     await onMessageHandler(originalEntryQueued)
     await onMessageHandler(sessionResults(600))
@@ -184,28 +148,74 @@ describe('registerEventIngestion (session-activity arrival-order integrity)', ()
     expect(updateManager.isSafeToUpdate()).toBe(true) // inactive, session truly over
 
     // A stale reconnect resend of the *exact same* 201 event arrives late
-    // (identical timestamp+ApiTypeId+payload -- e.g. a buffered unacked
-    // message replayed after the port reconnects). It optimistically arms
-    // ACTIVE the instant it arrives (synchronous, fail-closed by design)...
+    // (identical timestamp+ApiTypeId+payload). Its raw add() rejects with a
+    // real ConstraintError, and the dedupe check runs BEFORE the
+    // session-activity decision is ever reached -- the resend never touches
+    // markSessionActive() at all.
     await onMessageHandler({ ...originalEntryQueued })
 
-    // ...but once its raw add() rejects with a real ConstraintError and the
-    // payload comparison confirms it's a true duplicate (not a same-ms
-    // collision), the optimistic ACTIVE mark is rolled back to whatever it
-    // was immediately before -- 'inactive', matching reality (no live hand).
-    expect(updateManager.isSafeToUpdate()).toBe(true)
+    expect(updateManager.isSafeToUpdate()).toBe(true) // unchanged
     expect(await db.apiEvents.count()).toBe(2) // only the two genuine rows, resend added nothing
   })
 
-  test('P2 control: a genuinely NEW 201 after a 309 (not a duplicate) is NOT reverted -- only true duplicates roll back', async () => {
-    await onMessageHandler(entryQueued(700))
+  test('a BURST of multiple stacked reconnect-resend duplicates never re-arms session activity (P2, codex review 2026-07-20 pass-3: this is exactly the case that broke the earlier 1-level rollback design)', async () => {
+    // Genuine session: 201 (via 308 too, to also exercise that trigger),
+    // then a genuine 309 ends it.
+    const originalEntryQueued = entryQueued(700)
+    const sessionDetails = {
+      ApiTypeId: ApiType.EVT_SESSION_DETAILS,
+      timestamp: 701,
+      BlindStructures: [{ ActiveMinutes: 4, Ante: 50, BigBlind: 200, Lv: 1 }],
+      CoinNum: -1,
+      DefaultChip: 20000,
+      IsReplay: false,
+      Items: [],
+      LimitSeconds: 8,
+      MoneyList: [],
+      Name: 'テストセッション',
+      Name2: ''
+    }
+    await onMessageHandler(originalEntryQueued)
+    await onMessageHandler(sessionDetails)
     await onMessageHandler(sessionResults(800))
+
+    expect(updateManager.isSafeToUpdate()).toBe(true) // inactive, session truly over
+
+    // A reconnect replays a BURST of multiple already-processed events in a
+    // row -- e.g. an old 201 immediately followed by the old 308 for the
+    // same (now long-over) session. Under the earlier "optimistic
+    // ACTIVE + 1-level rollback" design, the second optimistic ACTIVE mark
+    // would clobber the rollback slot meant to restore the first, so
+    // deduping the first did nothing and deduping the second restored
+    // 'active' instead of the true prior 'inactive'. With activity
+    // transitions unified inside the queue (after the dedupe check),
+    // NEITHER resend ever reaches markSessionActive() -- there's no
+    // optimistic mark to stack or clobber in the first place.
+    //
+    // Deliberately NOT awaited between the two calls -- the old buggy
+    // design only broke when both resends' synchronous "optimistic ACTIVE"
+    // marks fired back-to-back, before either one's own async dedupe check
+    // (and rollback) had a chance to run. Awaiting each resend fully before
+    // sending the next would fully serialize them and never exercise the
+    // overlap the bug depended on.
+    const pendingResendA = onMessageHandler({ ...originalEntryQueued })
+    const pendingResendB = onMessageHandler({ ...sessionDetails })
+    await pendingResendA
+    await pendingResendB
+
+    expect(updateManager.isSafeToUpdate()).toBe(true) // still inactive -- neither resend moved it
+    expect(await db.apiEvents.count()).toBe(3) // only the three genuine rows
+  })
+
+  test('control: a genuinely NEW 201 after a 309 (not a duplicate) legitimately arms activity', async () => {
+    await onMessageHandler(entryQueued(900))
+    await onMessageHandler(sessionResults(1000))
     expect(updateManager.isSafeToUpdate()).toBe(true) // inactive
 
     // A brand new, distinct 201 (different timestamp -- no key collision at
     // all, let alone a duplicate) legitimately starts a new session.
-    await onMessageHandler(entryQueued(900))
+    await onMessageHandler(entryQueued(1100))
 
-    expect(updateManager.isSafeToUpdate()).toBe(false) // active, correctly NOT reverted
+    expect(updateManager.isSafeToUpdate()).toBe(false) // active, correctly not suppressed
   })
 })

--- a/src/background/event-ingestion.durability-barrier.test.ts
+++ b/src/background/event-ingestion.durability-barrier.test.ts
@@ -1,0 +1,208 @@
+/**
+ * event-ingestion.ts - Raw Event Lake durability barrier
+ *
+ * Verifies the release-blocker audit's finding A fix: `db.apiEvents.add()`
+ * used to be fire-and-forget, so the parse/validation gate, the three live
+ * streams, and the session-end side effects (auto-sync trigger, pending
+ * Forced Update recheck -> possible `chrome.runtime.reload()`) could all run
+ * while the raw write was still in flight or had failed. That could leave
+ * derived stats with no raw recovery row (breaking the Raw Event Lake
+ * invariant -- see CLAUDE.md "Raw Event Lake" / "Storage happens *before*
+ * the validation gate"), double-process a duplicate-key retry, or let a
+ * reload race the in-flight write.
+ *
+ * The fix serializes each event's processing so nothing downstream
+ * (session-activity tracking, the auto-sync trigger, and stream forwarding)
+ * runs until that event's `apiEvents.add()` has settled -- successfully, or
+ * with a *handled* failure (duplicate-key -> skip as already-processed;
+ * any other failure -> drop from the pipeline and surface it via the #141
+ * drop-visibility counter, never forward without a raw row).
+ */
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { ApiType } from '../types'
+import { registerEventIngestion } from './event-ingestion'
+import { connectedPorts } from './ports'
+import * as updateManager from './update-manager'
+import { autoSyncService } from '../services/auto-sync-service'
+import { getUndecodedEventStats, resetUndecodedEventStats, UNDECODED_EVENT_STATS_KEY } from './undecoded-event-tracker'
+
+describe('registerEventIngestion (raw-write durability barrier)', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+  let onMessageHandler: (message: any) => Promise<void>
+  let disconnectHandlers: Array<() => void>
+  let mockPort: any
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    await resetUndecodedEventStats(db)
+    service = new PokerChaseService({ db })
+    await service.ready
+
+    ;(chrome.runtime as any).onConnect = { addListener: jest.fn() }
+    registerEventIngestion(service)
+    const connectListener = (chrome.runtime as any).onConnect.addListener.mock.calls[0][0]
+
+    disconnectHandlers = []
+    mockPort = {
+      name: PokerChaseService.POKER_CHASE_SERVICE_EVENT,
+      onMessage: { addListener: jest.fn() },
+      onDisconnect: { addListener: jest.fn((fn: () => void) => disconnectHandlers.push(fn)) },
+      postMessage: jest.fn()
+    }
+    connectListener(mockPort)
+    onMessageHandler = mockPort.onMessage.addListener.mock.calls[0][0]
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    disconnectHandlers.forEach(fn => fn())
+    connectedPorts.clear()
+    db.close()
+    await db.delete()
+  })
+
+  const entryQueued = (timestamp: number) => ({
+    ApiTypeId: ApiType.EVT_ENTRY_QUEUED, timestamp, Code: 0, BattleType: 0, Id: 'stage000_003', IsRetire: false
+  })
+
+  const sessionResults = (timestamp: number) => ({
+    ApiTypeId: ApiType.EVT_SESSION_RESULTS,
+    timestamp,
+    Ranking: 3,
+    IsLeave: false,
+    IsRebuy: false,
+    TotalMatch: 100,
+    RankReward: {
+      IsSeasonal: true,
+      RankPoint: 10,
+      RankPointDiff: 1,
+      Rank: { RankId: 'gold', RankName: 'ゴールド', RankLvId: 'gold', RankLvName: 'ゴールド' },
+      SeasonalRanking: 0
+    },
+    Rewards: [],
+    EventRewards: [],
+    Charas: [],
+    Costumes: [],
+    Decos: [],
+    Items: [],
+    Money: { FreeMoney: -1, PaidMoney: -1 },
+    Emblems: []
+  })
+
+  test('streams / session-activity tracking / auto-sync trigger do not run before apiEvents.add() resolves, and do run after', async () => {
+    const handLogSpy = jest.spyOn(service.handLogStream, 'write')
+    const markSessionActiveSpy = jest.spyOn(updateManager, 'markSessionActive')
+    const onNewSessionStartSpy = jest.spyOn(autoSyncService, 'onNewSessionStart').mockResolvedValue(undefined)
+
+    let resolveAdd!: (key: number) => void
+    jest.spyOn(db.apiEvents, 'add').mockImplementation(
+      (() => new Promise<number>(resolve => { resolveAdd = resolve })) as any
+    )
+
+    const pending = onMessageHandler(entryQueued(100))
+
+    // Flush the microtask queue repeatedly without resolving add() -- if the
+    // durability barrier is in place, nothing downstream may have run yet.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(handLogSpy).not.toHaveBeenCalled()
+    expect(markSessionActiveSpy).not.toHaveBeenCalled()
+    expect(onNewSessionStartSpy).not.toHaveBeenCalled()
+
+    resolveAdd(1)
+    await pending
+
+    expect(handLogSpy).toHaveBeenCalledTimes(1)
+    expect(markSessionActiveSpy).toHaveBeenCalledTimes(1)
+    expect(onNewSessionStartSpy).toHaveBeenCalledTimes(1)
+  })
+
+  test('on duplicate-key rejection (event already in the Raw Event Lake), all downstream processing is skipped (dedup semantics, no double-processing)', async () => {
+    const event = entryQueued(200)
+    await onMessageHandler(event) // first arrival: stored + processed normally
+
+    const handLogSpy = jest.spyOn(service.handLogStream, 'write')
+    const aggregateSpy = jest.spyOn(service.handAggregateStream, 'write')
+    const realTimeSpy = jest.spyOn(service.realTimeStatsStream, 'write')
+    const markSessionActiveSpy = jest.spyOn(updateManager, 'markSessionActive')
+    const onNewSessionStartSpy = jest.spyOn(autoSyncService, 'onNewSessionStart').mockResolvedValue(undefined)
+
+    // Re-arrival of the exact same (timestamp, ApiTypeId) -- Dexie's add()
+    // throws a real ConstraintError here (ports.ts/import-export.ts resend
+    // scenarios, reconnect replays, etc.)
+    await onMessageHandler({ ...event })
+
+    expect(handLogSpy).not.toHaveBeenCalled()
+    expect(aggregateSpy).not.toHaveBeenCalled()
+    expect(realTimeSpy).not.toHaveBeenCalled()
+    expect(markSessionActiveSpy).not.toHaveBeenCalled()
+    expect(onNewSessionStartSpy).not.toHaveBeenCalled()
+    expect(await db.apiEvents.count()).toBe(1)
+  })
+
+  test('on a non-duplicate raw-write failure (e.g. quota), the event is dropped from the pipeline entirely (Lake invariant: no derived stats without a raw row) and surfaced via the drop-visibility counter', async () => {
+    const handLogSpy = jest.spyOn(service.handLogStream, 'write')
+    const markSessionInactiveSpy = jest.spyOn(updateManager, 'markSessionInactive')
+    const onGameSessionEndSpy = jest.spyOn(autoSyncService, 'onGameSessionEnd').mockResolvedValue(undefined)
+    const recheckPendingUpdateSpy = jest.spyOn(updateManager, 'recheckPendingUpdate').mockResolvedValue(undefined)
+
+    const quotaError = new Error('The quota has been exceeded.')
+    quotaError.name = 'QuotaExceededError'
+    jest.spyOn(db.apiEvents, 'add').mockRejectedValue(quotaError)
+
+    await onMessageHandler(sessionResults(300))
+
+    // Forbidden state check: no raw row exists...
+    expect(await db.apiEvents.count()).toBe(0)
+    // ...so nothing downstream may have run, INCLUDING the reload-capable
+    // pending-update recheck (chained off onGameSessionEnd in the real 309
+    // path) -- a SW reload right now would have nothing to lose, but more
+    // importantly this event's session-end side effects must not fire for
+    // an event that isn't durably recorded.
+    expect(handLogSpy).not.toHaveBeenCalled()
+    expect(markSessionInactiveSpy).not.toHaveBeenCalled()
+    expect(onGameSessionEndSpy).not.toHaveBeenCalled()
+    expect(recheckPendingUpdateSpy).not.toHaveBeenCalled()
+
+    // Drop visibility (#141 mechanism): the failure must not be silent.
+    await new Promise(resolve => setTimeout(resolve, 550)) // flush the tracker's debounce
+    const stats = await getUndecodedEventStats(db)
+    expect(stats.total).toBe(1)
+    expect(stats.perApiTypeId[ApiType.EVT_SESSION_RESULTS]).toEqual({ count: 1, lastSeen: 300 })
+    const persisted = await db.meta.get(UNDECODED_EVENT_STATS_KEY)
+    expect(persisted?.value).toEqual(stats)
+  })
+
+  test('a burst of events preserves stream-write order even though each event awaits its own raw add() (serialization invariant)', async () => {
+    const writeOrder: number[] = []
+    jest.spyOn(service.handLogStream, 'write').mockImplementation((event: any) => {
+      writeOrder.push(event.timestamp)
+      return true as any
+    })
+
+    // Stagger add() latency in *reverse* of arrival order (the earliest
+    // event is the slowest) -- if events weren't serialized, a naive
+    // implementation could let a later event's write resolve before an
+    // earlier one's, reordering what the streams observe.
+    const realAdd = db.apiEvents.add.bind(db.apiEvents)
+    jest.spyOn(db.apiEvents, 'add').mockImplementation(((event: any) => {
+      const index = event.timestamp - 1000
+      const delayMs = (5 - index) * 5
+      return new Promise((resolve, reject) => {
+        setTimeout(() => { realAdd(event).then(resolve, reject) }, delayMs)
+      })
+    }) as any)
+
+    const events = [0, 1, 2, 3, 4].map(i => entryQueued(1000 + i))
+    // Fire the whole burst without awaiting between calls, simulating
+    // messages arriving faster than any single event's DB write settles.
+    const pending = events.map(event => onMessageHandler(event))
+
+    await Promise.all(pending)
+
+    expect(writeOrder).toEqual([1000, 1001, 1002, 1003, 1004])
+  })
+})

--- a/src/background/event-ingestion.durability-barrier.test.ts
+++ b/src/background/event-ingestion.durability-barrier.test.ts
@@ -423,4 +423,55 @@ describe('registerEventIngestion (raw-write durability barrier)', () => {
 
     expect(chrome.runtime.reload).toHaveBeenCalledTimes(1)
   })
+
+  // The companion "an event arrives DURING recheckPendingUpdate()'s own
+  // internal awaits (not just before it starts)" scenario (P1, codex
+  // review 2026-07-21, pass-5, "Guard reload rechecks through the async
+  // path") is covered as a direct, isolated unit test of
+  // recheckPendingUpdate()'s isStillFresh evaluation timing in
+  // update-manager.test.ts, rather than here: reproducing that exact race
+  // through the full event-ingestion.ts integration requires stalling
+  // chrome.storage.local.get() globally, which interacts badly with other
+  // concurrent callers (getRebuildAdvisoryState() inside setBadge()/
+  // clearBadge()) and reliably exhausts the test worker's heap. The
+  // property under test -- that isStillFresh is (re-)evaluated after
+  // recheckPendingUpdate()'s own awaits, not cached from before they
+  // started -- is fully covered without that hazard.
+
+  test('a noise event (202, non-application) queued while onGameSessionEnd() is running does NOT permanently suppress the session-end recheck (P2, codex review 2026-07-21, pass-5: "Don\'t let noise suppress session-end rechecks")', async () => {
+    await chrome.storage.local.set({ pendingUpdate: { pending: true, version: '9.9.9' } })
+
+    let resolveSync!: () => void
+    jest.spyOn(autoSyncService, 'onGameSessionEnd').mockImplementation(
+      () => new Promise<void>(resolve => { resolveSync = resolve })
+    )
+    ;(chrome.runtime.reload as jest.Mock).mockClear()
+
+    const pendingSessionResults = onMessageHandler(sessionResults(2900))
+
+    // Let the queue reach the mocked (still-unresolved) onGameSessionEnd()
+    // call before injecting noise.
+    for (let i = 0; i < 20; i++) {
+      await new Promise(resolve => setTimeout(resolve, 0))
+    }
+
+    // A non-application "noise" event (202) arrives and gets queued while
+    // onGameSessionEnd() is still running. It neither marks the session
+    // active nor triggers any recheck of its own -- under the pre-pass-5
+    // "any newer queued message invalidates freshness" rule, this alone
+    // would have permanently suppressed the 309's recheck this cycle,
+    // leaving the pending update blocked until an unrelated operation
+    // completion or SW restart even though nothing about the session
+    // actually changed.
+    const noiseEvent = { ApiTypeId: 202, timestamp: 2950, Code: 0 }
+    const pendingNoise = onMessageHandler(noiseEvent)
+
+    resolveSync() // let onGameSessionEnd() settle
+    await pendingSessionResults
+    await pendingNoise
+
+    // The recheck must still have applied the (still) safe pending update
+    // -- the noise event must not have counted against freshness.
+    expect(chrome.runtime.reload).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/background/event-ingestion.durability-barrier.test.ts
+++ b/src/background/event-ingestion.durability-barrier.test.ts
@@ -276,6 +276,47 @@ describe('registerEventIngestion (raw-write durability barrier)', () => {
     expect(persisted?.value).toEqual(stats)
   })
 
+  test('a non-duplicate raw-write failure on a session-START event (201) still fails closed to ACTIVE (P2, codex review 2026-07-20 pass-4: "Fail closed on dropped ACTIVE writes")', async () => {
+    // Start from a genuine prior 309 so sessionActivity begins 'inactive'.
+    await onMessageHandler(sessionResults(350))
+
+    const handLogSpy = jest.spyOn(service.handLogStream, 'write')
+    const markSessionActiveSpy = jest.spyOn(updateManager, 'markSessionActive')
+    const onNewSessionStartSpy = jest.spyOn(autoSyncService, 'onNewSessionStart').mockResolvedValue(undefined)
+
+    const quotaError = new Error('The quota has been exceeded.')
+    quotaError.name = 'QuotaExceededError'
+    jest.spyOn(db.apiEvents, 'add').mockRejectedValue(quotaError)
+
+    await onMessageHandler(entryQueued(360))
+
+    // No raw row for this event -- the Lake invariant still holds, and it
+    // still isn't forwarded to streams or the auto-sync trigger.
+    expect(await db.apiEvents.count()).toBe(1) // only the 309 from setup
+    expect(handLogSpy).not.toHaveBeenCalled()
+    expect(onNewSessionStartSpy).not.toHaveBeenCalled()
+    // But the raw message unambiguously shows a new hand starting -- that
+    // fact doesn't depend on whether the write succeeded, so ACTIVE must
+    // still be applied. Without this, sessionActivity would incorrectly
+    // stay 'inactive' (from the prior 309) through an actually-live hand,
+    // and a Forced Update recheck could judge a mid-game reload "safe".
+    expect(markSessionActiveSpy).toHaveBeenCalledTimes(1)
+    expect(updateManager.isSafeToUpdate()).toBe(false)
+  })
+
+  test('control: a non-duplicate raw-write failure on EVT_SESSION_RESULTS (309) does NOT fail open to INACTIVE', async () => {
+    // Mirrors the existing quota-failure test above but asserts the
+    // asymmetry explicitly: ACTIVE-direction failures fail closed (previous
+    // test), INACTIVE-direction failures must NOT fail open, since a
+    // failed 309 write is not confirmation the session actually ended.
+    jest.spyOn(db.apiEvents, 'add').mockRejectedValue(Object.assign(new Error('quota'), { name: 'QuotaExceededError' }))
+    const markSessionInactiveSpy = jest.spyOn(updateManager, 'markSessionInactive')
+
+    await onMessageHandler(sessionResults(370))
+
+    expect(markSessionInactiveSpy).not.toHaveBeenCalled()
+  })
+
   test('a burst of events preserves stream-write order even though each event awaits its own raw add() (serialization invariant)', async () => {
     const writeOrder: number[] = []
     jest.spyOn(service.handLogStream, 'write').mockImplementation((event: any) => {
@@ -306,41 +347,80 @@ describe('registerEventIngestion (raw-write durability barrier)', () => {
     expect(writeOrder).toEqual([1000, 1001, 1002, 1003, 1004])
   })
 
-  test('the session-end pending-update recheck (and any reload it decides on) settles BEFORE the next queued event\'s raw write begins (P2, codex review 2026-07-20 pass-3: "Keep the reload recheck inside the ingestion queue")', async () => {
-    // A pending update exists and becomes safe to apply the instant this
-    // 309 marks the session inactive (sync not in flight, no operation
-    // running -- both hold by default in this harness).
+  test('raw ingestion is NOT blocked behind autoSyncService.onGameSessionEnd() (P2, codex review 2026-07-20 pass-4: "Don\'t block raw ingestion on cloud uploads")', async () => {
+    // Make onGameSessionEnd() (standing in for a real, slow Firestore
+    // upload) stay pending indefinitely. Before this fix, the sync trigger
+    // was awaited inside processEvent, so the entire ingestionQueue --
+    // including apiEvents.add() for the NEXT hand's raw events -- stayed
+    // blocked behind it, freezing the live HUD and risking losing those
+    // events entirely if the Service Worker suspended/reloaded meanwhile.
+    let resolveSync!: () => void
+    jest.spyOn(autoSyncService, 'onGameSessionEnd').mockImplementation(
+      () => new Promise<void>(resolve => { resolveSync = resolve })
+    )
+
+    await onMessageHandler(sessionResults(2200))
+    // The next hand's raw event must reach apiEvents.add() promptly --
+    // NOT stuck waiting behind the still-pending onGameSessionEnd().
+    await onMessageHandler(entryQueued(2300))
+
+    expect(await db.apiEvents.count()).toBe(2)
+
+    resolveSync()
+    await new Promise(resolve => setTimeout(resolve, 0)) // let the deferred sync settle cleanly
+  })
+
+  test('the session-end reload recheck is skipped (not just delayed) when a newer event was already queued while onGameSessionEnd() was running (P1, codex review 2026-07-20 pass-4: "Don\'t reload before queued session starts run")', async () => {
+    // A pending update exists and would become "safe to apply" the instant
+    // this 309 marks the session inactive -- but a new hand's 201 arrives
+    // and gets queued (behind the 309, ahead of having its own ACTIVE
+    // transition applied yet) while the sync trigger is still running.
     await chrome.storage.local.set({ pendingUpdate: { pending: true, version: '9.9.9' } })
 
-    const callOrder: string[] = []
-    const realAdd = db.apiEvents.add.bind(db.apiEvents)
-    jest.spyOn(db.apiEvents, 'add').mockImplementation(((event: any) => {
-      callOrder.push(`add:${event.ApiTypeId}`)
-      return realAdd(event)
-    }) as any)
+    let resolveSync!: () => void
+    jest.spyOn(autoSyncService, 'onGameSessionEnd').mockImplementation(
+      () => new Promise<void>(resolve => { resolveSync = resolve })
+    )
     ;(chrome.runtime.reload as jest.Mock).mockClear()
-    ;(chrome.runtime.reload as jest.Mock).mockImplementation(() => {
-      callOrder.push('reload')
-    })
 
-    // Fire the session-end 309, then immediately (without awaiting)
-    // whatever the next raw event is -- simulating messages arriving
-    // faster than the recheck settles. Before this fix, `processEvent`
-    // fired the sync-trigger + recheck chain without awaiting it, so it
-    // could resolve (letting the queue start the next event's `add()`)
-    // while `recheckPendingUpdate()` was still deciding whether to
-    // `chrome.runtime.reload()` -- a reload right then could abort that
-    // next event's in-flight write despite the durability barrier.
-    const pendingSessionResults = onMessageHandler(sessionResults(2000))
-    const pendingNext = onMessageHandler(entryQueued(2100))
+    const pendingSessionResults = onMessageHandler(sessionResults(2400))
+    const pendingNext = onMessageHandler(entryQueued(2500)) // queued behind the 309, not yet processed
 
+    // Let the queue actually reach the mocked (still-unresolved)
+    // onGameSessionEnd() call before releasing it -- poll rather than a
+    // single fixed tick, since the number of microtask hops through
+    // `service.ready` + `apiEvents.add()` before reaching the sync trigger
+    // isn't guaranteed stable under parallel test-worker load.
+    for (let i = 0; i < 20 && !resolveSync; i++) {
+      await new Promise(resolve => setTimeout(resolve, 0))
+    }
+    resolveSync() // let onGameSessionEnd() settle now that a newer event is already queued
     await pendingSessionResults
     await pendingNext
 
-    expect(callOrder).toEqual([
-      'add:309',
-      'reload',
-      'add:201'
-    ])
+    // The stale-relative-to-arrival recheck must not have reloaded --
+    // reading isSafeToUpdate() at that moment would have seen the 309's
+    // 'inactive' without yet reflecting the queued 201's ACTIVE transition.
+    expect(chrome.runtime.reload).not.toHaveBeenCalled()
+    // The 201 legitimately re-armed the session afterward.
+    expect(updateManager.isSafeToUpdate()).toBe(false)
+    // The pending update is still recorded (deferred to a later recheck
+    // trigger -- the next session end, operation completion, or SW
+    // startup), not silently lost.
+    const state = await chrome.storage.local.get('pendingUpdate')
+    expect((state as any).pendingUpdate?.pending).toBe(true)
+  })
+
+  test('control: the session-end reload recheck still applies a safe pending update when nothing new was queued while onGameSessionEnd() was running', async () => {
+    await chrome.storage.local.set({ pendingUpdate: { pending: true, version: '9.9.9' } })
+    jest.spyOn(autoSyncService, 'onGameSessionEnd').mockResolvedValue(undefined)
+    ;(chrome.runtime.reload as jest.Mock).mockClear()
+
+    await onMessageHandler(sessionResults(2600))
+    // Let the fire-and-forget sync-trigger/recheck chain (unawaited by
+    // processEvent as of the pass-4 decoupling) settle.
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(chrome.runtime.reload).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/background/event-ingestion.durability-barrier.test.ts
+++ b/src/background/event-ingestion.durability-barrier.test.ts
@@ -17,6 +17,18 @@
  * with a *handled* failure (duplicate-key -> skip as already-processed;
  * any other failure -> drop from the pipeline and surface it via the #141
  * drop-visibility counter, never forward without a raw row).
+ *
+ * 2026-07-21 pass-3 consolidation: session-activity tracking
+ * (markSessionActive/markSessionInactive) used to be deliberately EXEMPT
+ * from this barrier (fired synchronously, before the durability await) to
+ * avoid a Forced Update safety recheck reading a stale value. Two more
+ * rounds of findings (arrival-order inversion, stacked-duplicate rollback
+ * corruption) showed that exemption fighting the barrier was the wrong
+ * shape of fix. Session-activity tracking now lives fully INSIDE the
+ * barrier like everything else (see event-ingestion.ts's
+ * `applySessionActivity` docstring) -- the original latency concern is
+ * instead solved on the READ side via update-manager.ts's
+ * `awaitIngestionDrain()` (see the dedicated test below).
  */
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
 import PokerChaseService, { PokerChaseDB } from '../app'
@@ -92,7 +104,7 @@ describe('registerEventIngestion (raw-write durability barrier)', () => {
     Emblems: []
   })
 
-  test('streams / auto-sync trigger do not run before apiEvents.add() resolves, and do run after (session-activity tracking is exempt -- see the dedicated test below)', async () => {
+  test('streams / auto-sync trigger / session-activity tracking all wait behind apiEvents.add(), and all run after it resolves', async () => {
     const handLogSpy = jest.spyOn(service.handLogStream, 'write')
     const markSessionActiveSpy = jest.spyOn(updateManager, 'markSessionActive')
     const onNewSessionStartSpy = jest.spyOn(autoSyncService, 'onNewSessionStart').mockResolvedValue(undefined)
@@ -104,45 +116,61 @@ describe('registerEventIngestion (raw-write durability barrier)', () => {
 
     const pending = onMessageHandler(entryQueued(100))
 
-    // markSessionActive() runs synchronously on message arrival, before any
-    // await -- see the dedicated durability-exemption test below and
-    // markSessionActiveFromRawMessage()'s docstring for why this one is
-    // deliberately NOT gated behind the raw-write barrier.
-    expect(markSessionActiveSpy).toHaveBeenCalledTimes(1)
-
     // Flush the microtask queue repeatedly without resolving add() -- if the
-    // durability barrier is in place, nothing else downstream may have run
-    // yet.
+    // durability barrier is in place, nothing downstream (including
+    // session-activity tracking, unified into the same barrier as of the
+    // pass-3 consolidation) may have run yet.
     await new Promise(resolve => setTimeout(resolve, 0))
     await new Promise(resolve => setTimeout(resolve, 0))
     expect(handLogSpy).not.toHaveBeenCalled()
     expect(onNewSessionStartSpy).not.toHaveBeenCalled()
+    expect(markSessionActiveSpy).not.toHaveBeenCalled()
 
     resolveAdd(1)
     await pending
 
     expect(handLogSpy).toHaveBeenCalledTimes(1)
     expect(onNewSessionStartSpy).toHaveBeenCalledTimes(1)
+    expect(markSessionActiveSpy).toHaveBeenCalledTimes(1)
   })
 
-  test('session-activity tracking (markSessionActive) is exempt from the durability barrier and fires even while apiEvents.add() is still stuck (P2, codex review 2026-07-21)', async () => {
-    // A recheck racing the awaited raw-write window must already observe
-    // ACTIVE -- session-activity is Service Worker memory-only state with no
-    // durability dependency on the raw row, so gating it behind a slow/stuck
-    // add() would reopen exactly the risk finding A closed (a stale
-    // 'inactive' reading permitting a mid-game reload).
-    const markSessionActiveSpy = jest.spyOn(updateManager, 'markSessionActive')
+  test('a reload decision using awaitIngestionDrain() correctly waits out a stuck apiEvents.add() instead of reading stale session-activity state', async () => {
+    // This is the read-side fix for the original "mark-active-latency"
+    // concern (a slow/stuck add() leaving sessionActivity stale while a
+    // safety recheck fires): any reload decision point must await
+    // update-manager.ts's `awaitIngestionDrain()` before consulting
+    // `isSafeToUpdate()`, not just read it directly.
+    let resolveAdd!: (key: number) => void
     jest.spyOn(db.apiEvents, 'add').mockImplementation(
-      (() => new Promise<number>(() => { /* never resolves */ })) as any
+      (() => new Promise<number>(resolve => { resolveAdd = resolve })) as any
     )
 
-    void onMessageHandler(entryQueued(150))
+    const pending = onMessageHandler(entryQueued(105))
+    await new Promise(resolve => setTimeout(resolve, 0))
 
-    expect(markSessionActiveSpy).toHaveBeenCalledTimes(1)
+    // Reading isSafeToUpdate() directly right now would (incorrectly, from
+    // a "is a new hand actually live" standpoint) still see the initial
+    // 'unknown'/unsafe baseline -- which happens to already be unsafe here,
+    // so this assertion alone wouldn't distinguish a real fix from a bug.
+    // The actual guarantee under test is that awaitIngestionDrain() doesn't
+    // resolve until the stuck add() does.
+    let drained = false
+    const drainCheck = updateManager.awaitIngestionDrain().then(() => { drained = true })
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(drained).toBe(false) // still stuck behind the unresolved add()
+
+    resolveAdd(1)
+    await pending
+    await drainCheck
+
+    expect(drained).toBe(true)
+    // Now that the queue has drained, isSafeToUpdate() reflects this
+    // event's fully-applied ACTIVE transition.
     expect(updateManager.isSafeToUpdate()).toBe(false)
   })
 
-  test('on duplicate-key rejection (event already in the Raw Event Lake), all downstream *pipeline* processing is skipped (dedup semantics, no double-processing) -- session-activity still fires (unconditional, see above)', async () => {
+  test('on duplicate-key rejection (event already in the Raw Event Lake), ALL downstream processing is skipped, including session-activity tracking -- duplicates never re-arm', async () => {
     const event = entryQueued(200)
     await onMessageHandler(event) // first arrival: stored + processed normally
 
@@ -157,17 +185,20 @@ describe('registerEventIngestion (raw-write durability barrier)', () => {
     // (ports.ts/import-export.ts resend scenarios, reconnect replays, etc.),
     // and the payload comparison against the existing row confirms it's a
     // true duplicate (not a same-millisecond key collision -- see the
-    // dedicated collision test below).
+    // dedicated collision test below). Since the dedup check now runs
+    // BEFORE the session-activity decision (2026-07-21 pass-3
+    // consolidation), a duplicate never reaches markSessionActive() at
+    // all -- there's no optimistic pre-barrier mark left to roll back, so a
+    // reconnect resending any number of stacked duplicates can never
+    // re-arm activity (see event-ingestion.arrival-ordering.test.ts for the
+    // multi-duplicate-burst regression test).
     await onMessageHandler({ ...event })
 
     expect(handLogSpy).not.toHaveBeenCalled()
     expect(aggregateSpy).not.toHaveBeenCalled()
     expect(realTimeSpy).not.toHaveBeenCalled()
     expect(onNewSessionStartSpy).not.toHaveBeenCalled()
-    // markSessionActive() is unconditional per raw message (see the
-    // dedicated exemption test above) -- it fires again here, harmlessly
-    // (idempotent), even though the *pipeline* re-processing is skipped.
-    expect(markSessionActiveSpy).toHaveBeenCalledTimes(1)
+    expect(markSessionActiveSpy).not.toHaveBeenCalled()
     expect(await db.apiEvents.count()).toBe(1)
   })
 
@@ -273,5 +304,43 @@ describe('registerEventIngestion (raw-write durability barrier)', () => {
     await Promise.all(pending)
 
     expect(writeOrder).toEqual([1000, 1001, 1002, 1003, 1004])
+  })
+
+  test('the session-end pending-update recheck (and any reload it decides on) settles BEFORE the next queued event\'s raw write begins (P2, codex review 2026-07-20 pass-3: "Keep the reload recheck inside the ingestion queue")', async () => {
+    // A pending update exists and becomes safe to apply the instant this
+    // 309 marks the session inactive (sync not in flight, no operation
+    // running -- both hold by default in this harness).
+    await chrome.storage.local.set({ pendingUpdate: { pending: true, version: '9.9.9' } })
+
+    const callOrder: string[] = []
+    const realAdd = db.apiEvents.add.bind(db.apiEvents)
+    jest.spyOn(db.apiEvents, 'add').mockImplementation(((event: any) => {
+      callOrder.push(`add:${event.ApiTypeId}`)
+      return realAdd(event)
+    }) as any)
+    ;(chrome.runtime.reload as jest.Mock).mockClear()
+    ;(chrome.runtime.reload as jest.Mock).mockImplementation(() => {
+      callOrder.push('reload')
+    })
+
+    // Fire the session-end 309, then immediately (without awaiting)
+    // whatever the next raw event is -- simulating messages arriving
+    // faster than the recheck settles. Before this fix, `processEvent`
+    // fired the sync-trigger + recheck chain without awaiting it, so it
+    // could resolve (letting the queue start the next event's `add()`)
+    // while `recheckPendingUpdate()` was still deciding whether to
+    // `chrome.runtime.reload()` -- a reload right then could abort that
+    // next event's in-flight write despite the durability barrier.
+    const pendingSessionResults = onMessageHandler(sessionResults(2000))
+    const pendingNext = onMessageHandler(entryQueued(2100))
+
+    await pendingSessionResults
+    await pendingNext
+
+    expect(callOrder).toEqual([
+      'add:309',
+      'reload',
+      'add:201'
+    ])
   })
 })

--- a/src/background/event-ingestion.durability-barrier.test.ts
+++ b/src/background/event-ingestion.durability-barrier.test.ts
@@ -47,6 +47,7 @@ describe('registerEventIngestion (raw-write durability barrier)', () => {
   let mockPort: any
 
   beforeEach(async () => {
+    updateManager.__resetUpdateManagerStateForTests()
     db = new PokerChaseDB(indexedDB, IDBKeyRange)
     await db.open()
     await resetUndecodedEventStats(db)
@@ -370,7 +371,7 @@ describe('registerEventIngestion (raw-write durability barrier)', () => {
     await new Promise(resolve => setTimeout(resolve, 0)) // let the deferred sync settle cleanly
   })
 
-  test('the session-end reload recheck is skipped (not just delayed) when a newer event was already queued while onGameSessionEnd() was running (P1, codex review 2026-07-20 pass-4: "Don\'t reload before queued session starts run")', async () => {
+  test('the session-end reload recheck drains and observes a newer queued session start before deciding not to reload (P1, codex review 2026-07-20 pass-4: "Don\'t reload before queued session starts run")', async () => {
     // A pending update exists and would become "safe to apply" the instant
     // this 309 marks the session inactive -- but a new hand's 201 arrives
     // and gets queued (behind the 309, ahead of having its own ACTIVE
@@ -398,9 +399,9 @@ describe('registerEventIngestion (raw-write durability barrier)', () => {
     await pendingSessionResults
     await pendingNext
 
-    // The stale-relative-to-arrival recheck must not have reloaded --
-    // reading isSafeToUpdate() at that moment would have seen the 309's
-    // 'inactive' without yet reflecting the queued 201's ACTIVE transition.
+    // The recheck must not have reloaded -- its shared commit point drains
+    // the queued 201 and therefore observes ACTIVE instead of trusting the
+    // 309's stale INACTIVE snapshot.
     expect(chrome.runtime.reload).not.toHaveBeenCalled()
     // The 201 legitimately re-armed the session afterward.
     expect(updateManager.isSafeToUpdate()).toBe(false)
@@ -425,18 +426,10 @@ describe('registerEventIngestion (raw-write durability barrier)', () => {
   })
 
   // The companion "an event arrives DURING recheckPendingUpdate()'s own
-  // internal awaits (not just before it starts)" scenario (P1, codex
-  // review 2026-07-21, pass-5, "Guard reload rechecks through the async
-  // path") is covered as a direct, isolated unit test of
-  // recheckPendingUpdate()'s isStillFresh evaluation timing in
-  // update-manager.test.ts, rather than here: reproducing that exact race
-  // through the full event-ingestion.ts integration requires stalling
-  // chrome.storage.local.get() globally, which interacts badly with other
-  // concurrent callers (getRebuildAdvisoryState() inside setBadge()/
-  // clearBadge()) and reliably exhausts the test worker's heap. The
-  // property under test -- that isStillFresh is (re-)evaluated after
-  // recheckPendingUpdate()'s own awaits, not cached from before they
-  // started -- is fully covered without that hazard.
+  // pending-state await (after an operation-complete/SW-startup pre-drain)"
+  // scenario is covered directly in update-manager.test.ts. That isolated
+  // test verifies the shared commit point re-drains after the storage await,
+  // without globally stalling storage for this integration suite.
 
   test('a noise event (202, non-application) queued while onGameSessionEnd() is running does NOT permanently suppress the session-end recheck (P2, codex review 2026-07-21, pass-5: "Don\'t let noise suppress session-end rechecks")', async () => {
     await chrome.storage.local.set({ pendingUpdate: { pending: true, version: '9.9.9' } })
@@ -469,6 +462,13 @@ describe('registerEventIngestion (raw-write durability barrier)', () => {
     resolveSync() // let onGameSessionEnd() settle
     await pendingSessionResults
     await pendingNoise
+
+    // The recheck is intentionally fire-and-forget from processEvent and
+    // now performs its own stable-tail drain. Wait for that bounded chain
+    // instead of assuming one ingestion promise also represents it.
+    for (let i = 0; i < 20 && !(chrome.runtime.reload as jest.Mock).mock.calls.length; i++) {
+      await new Promise(resolve => setTimeout(resolve, 0))
+    }
 
     // The recheck must still have applied the (still) safe pending update
     // -- the noise event must not have counted against freshness.

--- a/src/background/event-ingestion.durability-barrier.test.ts
+++ b/src/background/event-ingestion.durability-barrier.test.ts
@@ -92,7 +92,7 @@ describe('registerEventIngestion (raw-write durability barrier)', () => {
     Emblems: []
   })
 
-  test('streams / session-activity tracking / auto-sync trigger do not run before apiEvents.add() resolves, and do run after', async () => {
+  test('streams / auto-sync trigger do not run before apiEvents.add() resolves, and do run after (session-activity tracking is exempt -- see the dedicated test below)', async () => {
     const handLogSpy = jest.spyOn(service.handLogStream, 'write')
     const markSessionActiveSpy = jest.spyOn(updateManager, 'markSessionActive')
     const onNewSessionStartSpy = jest.spyOn(autoSyncService, 'onNewSessionStart').mockResolvedValue(undefined)
@@ -104,23 +104,45 @@ describe('registerEventIngestion (raw-write durability barrier)', () => {
 
     const pending = onMessageHandler(entryQueued(100))
 
+    // markSessionActive() runs synchronously on message arrival, before any
+    // await -- see the dedicated durability-exemption test below and
+    // markSessionActiveFromRawMessage()'s docstring for why this one is
+    // deliberately NOT gated behind the raw-write barrier.
+    expect(markSessionActiveSpy).toHaveBeenCalledTimes(1)
+
     // Flush the microtask queue repeatedly without resolving add() -- if the
-    // durability barrier is in place, nothing downstream may have run yet.
+    // durability barrier is in place, nothing else downstream may have run
+    // yet.
     await new Promise(resolve => setTimeout(resolve, 0))
     await new Promise(resolve => setTimeout(resolve, 0))
     expect(handLogSpy).not.toHaveBeenCalled()
-    expect(markSessionActiveSpy).not.toHaveBeenCalled()
     expect(onNewSessionStartSpy).not.toHaveBeenCalled()
 
     resolveAdd(1)
     await pending
 
     expect(handLogSpy).toHaveBeenCalledTimes(1)
-    expect(markSessionActiveSpy).toHaveBeenCalledTimes(1)
     expect(onNewSessionStartSpy).toHaveBeenCalledTimes(1)
   })
 
-  test('on duplicate-key rejection (event already in the Raw Event Lake), all downstream processing is skipped (dedup semantics, no double-processing)', async () => {
+  test('session-activity tracking (markSessionActive) is exempt from the durability barrier and fires even while apiEvents.add() is still stuck (P2, codex review 2026-07-21)', async () => {
+    // A recheck racing the awaited raw-write window must already observe
+    // ACTIVE -- session-activity is Service Worker memory-only state with no
+    // durability dependency on the raw row, so gating it behind a slow/stuck
+    // add() would reopen exactly the risk finding A closed (a stale
+    // 'inactive' reading permitting a mid-game reload).
+    const markSessionActiveSpy = jest.spyOn(updateManager, 'markSessionActive')
+    jest.spyOn(db.apiEvents, 'add').mockImplementation(
+      (() => new Promise<number>(() => { /* never resolves */ })) as any
+    )
+
+    void onMessageHandler(entryQueued(150))
+
+    expect(markSessionActiveSpy).toHaveBeenCalledTimes(1)
+    expect(updateManager.isSafeToUpdate()).toBe(false)
+  })
+
+  test('on duplicate-key rejection (event already in the Raw Event Lake), all downstream *pipeline* processing is skipped (dedup semantics, no double-processing) -- session-activity still fires (unconditional, see above)', async () => {
     const event = entryQueued(200)
     await onMessageHandler(event) // first arrival: stored + processed normally
 
@@ -130,17 +152,64 @@ describe('registerEventIngestion (raw-write durability barrier)', () => {
     const markSessionActiveSpy = jest.spyOn(updateManager, 'markSessionActive')
     const onNewSessionStartSpy = jest.spyOn(autoSyncService, 'onNewSessionStart').mockResolvedValue(undefined)
 
-    // Re-arrival of the exact same (timestamp, ApiTypeId) -- Dexie's add()
-    // throws a real ConstraintError here (ports.ts/import-export.ts resend
-    // scenarios, reconnect replays, etc.)
+    // Re-arrival of the exact same (timestamp, ApiTypeId) AND the exact same
+    // payload -- Dexie's add() throws a real ConstraintError here
+    // (ports.ts/import-export.ts resend scenarios, reconnect replays, etc.),
+    // and the payload comparison against the existing row confirms it's a
+    // true duplicate (not a same-millisecond key collision -- see the
+    // dedicated collision test below).
     await onMessageHandler({ ...event })
 
     expect(handLogSpy).not.toHaveBeenCalled()
     expect(aggregateSpy).not.toHaveBeenCalled()
     expect(realTimeSpy).not.toHaveBeenCalled()
-    expect(markSessionActiveSpy).not.toHaveBeenCalled()
     expect(onNewSessionStartSpy).not.toHaveBeenCalled()
+    // markSessionActive() is unconditional per raw message (see the
+    // dedicated exemption test above) -- it fires again here, harmlessly
+    // (idempotent), even though the *pipeline* re-processing is skipped.
+    expect(markSessionActiveSpy).toHaveBeenCalledTimes(1)
     expect(await db.apiEvents.count()).toBe(1)
+  })
+
+  test('on a primary-key collision (a DIFFERENT event landing on the same [timestamp+ApiTypeId] -- e.g. a same-millisecond burst), the event is still forwarded to the live pipeline and the raw-row gap is surfaced (audit finding 6, P2 codex review 2026-07-21)', async () => {
+    // Two distinct EVT_ENTRY_QUEUED events can share a client timestamp
+    // (Date.now() collision in web_accessible_resource.ts under a fast
+    // burst), colliding on the [timestamp+ApiTypeId] primary key. Treating
+    // this exactly like a true duplicate (skip) would silently drop the
+    // second, DIFFERENT event from streams/session-hooks/sync-trigger --
+    // that's the regression this test guards against. The interim fix
+    // forwards it anyway (the full fix is the wave-3 sequence-key
+    // migration) and surfaces the raw-row gap loudly.
+    const first = entryQueued(400)
+    await onMessageHandler(first)
+
+    const handLogSpy = jest.spyOn(service.handLogStream, 'write')
+    const markSessionActiveSpy = jest.spyOn(updateManager, 'markSessionActive')
+    const onNewSessionStartSpy = jest.spyOn(autoSyncService, 'onNewSessionStart').mockResolvedValue(undefined)
+
+    // Same (timestamp, ApiTypeId) as `first`, but a genuinely different
+    // event (different Id -- a different table/room).
+    const second = { ...entryQueued(400), Id: 'stage000_099' }
+    await onMessageHandler(second)
+
+    // Forwarded to the live pipeline despite having no raw row of its own.
+    expect(handLogSpy).toHaveBeenCalledTimes(1)
+    expect(handLogSpy).toHaveBeenCalledWith(expect.objectContaining({ Id: 'stage000_099' }))
+    expect(onNewSessionStartSpy).toHaveBeenCalledTimes(1)
+    expect(markSessionActiveSpy).toHaveBeenCalledTimes(1)
+
+    // The colliding row was never overwritten -- `first`'s payload is still
+    // the one durably stored under this key.
+    const stored = await db.apiEvents.get([400, ApiType.EVT_ENTRY_QUEUED])
+    expect(stored).toEqual(first)
+    expect(await db.apiEvents.count()).toBe(1)
+
+    // The raw-row gap for `second` is surfaced via the drop-visibility
+    // counter (#141 mechanism), same as any other raw-write failure.
+    await new Promise(resolve => setTimeout(resolve, 550)) // flush the tracker's debounce
+    const stats = await getUndecodedEventStats(db)
+    expect(stats.total).toBe(1)
+    expect(stats.perApiTypeId[ApiType.EVT_ENTRY_QUEUED]).toEqual({ count: 1, lastSeen: 400 })
   })
 
   test('on a non-duplicate raw-write failure (e.g. quota), the event is dropped from the pipeline entirely (Lake invariant: no derived stats without a raw row) and surfaced via the drop-visibility counter', async () => {

--- a/src/background/event-ingestion.ts
+++ b/src/background/event-ingestion.ts
@@ -42,65 +42,6 @@ const EVT_ENTRY_CANCELLED_API_TYPE_ID = 203
 let ingestionQueue: Promise<void> = Promise.resolve()
 
 /**
- * 到着世代カウンタ（P1, codexレビュー指摘 2026-07-21, pass-4,
- * "Don't reload before queued session starts run"）。キューへ積まれる
- * メッセージのうち、セッション状態（ACTIVE/INACTIVE）に影響しうるもの
- * ——`isSessionActivityRelevant()`参照——だけを対象に同期的に
- * インクリメントする。`ingestionQueue`自体の参照比較
- * （`awaitIngestionDrain()`のループ）とは別に、309/203自身の
- * `processEvent`実行の**内側**から「自分の後にセッション状態へ影響しうる
- * イベントが既に積まれていないか」を同期的に確認するために使う——
- * その場所では`awaitIngestionDrain()`（自己参照でデッドロックする）は
- * 使えないため、単調増加のカウンタで代用する。詳細は`processEvent`の
- * 309/203ブロックのコメント参照。
- *
- * セッション状態に無関係なメッセージ（202/205等の非アプリケーション
- * イベント、真の重複と後で判明するイベント等）ではインクリメントしない
- * （P2, codexレビュー指摘 2026-07-21, pass-5, "Don't let noise suppress
- * session-end rechecks"）: このカウンタが「何かキューへ積まれたら
- * 一律インクリメント」だった旧実装では、309/203自身も再チェックできず、
- * かつそのノイズイベント自身も自分のrecheckを一切トリガーしないため、
- * 保留中アップデートが無関係な操作完了・SW再起動まで永遠にブロックされ
- * うる問題があった。ACTIVE/INACTIVEを動かしうるイベントだけを対象に
- * 絞ることで、「本当に安全性判定に影響しうる新しい到着」だけを検知する。
- */
-let activityGeneration = 0
-
-/**
- * 生メッセージが（決着すれば）セッションのACTIVE/INACTIVE状態に影響し
- * うるかどうかを、Zodパース前の数値ApiTypeId・生フィールドだけで判定
- * する。`applySessionActivity()`が実際に扱うトリガー集合と完全に一致
- * させること（判定基準がズレると`activityGeneration`が過大/過小に
- * カウントされ、finding 1/finding 3のどちらかを再発させる）。
- *
- * 保守的に倒す判断（P2, codexレビュー指摘 2026-07-21, pass-5）: この
- * 関数はまだraw書き込み・重複判定の**前**、`port.onMessage`受信直後の
- * 同期的な文脈で呼ぶため、このメッセージが後で真の重複と判明して
- * `applySessionActivity()`まで到達しない可能性がある（`processEvent`の
- * 重複判定コメント参照）。それでもここでは「ApiTypeId/Playerの形」
- * だけで判定し、重複かどうかは考慮しない——真の重複を稀に過大カウント
- * しても、309/203の再チェックが「今回は見送り、次の契機に委ねる」だけで
- * 実害は無い（安全側）。逆に見逃す（過小カウントする）と、決着済みの
- * ACTIVE化がreload判定に反映される前にreloadしてしまう恐れがあり、
- * それは実害があるため、疑わしきは「影響しうる」側に倒す。
- */
-const isSessionActivityRelevant = (rawApiTypeId: unknown, message: ApiMessage | { type: string }): boolean => {
-  if (
-    rawApiTypeId === ApiType.EVT_SESSION_RESULTS ||
-    rawApiTypeId === EVT_ENTRY_CANCELLED_API_TYPE_ID ||
-    rawApiTypeId === ApiType.EVT_ENTRY_QUEUED ||
-    rawApiTypeId === ApiType.EVT_SESSION_DETAILS
-  ) {
-    return true
-  }
-  if (rawApiTypeId === ApiType.EVT_DEAL) {
-    const rawPlayer = (message as { Player?: unknown }).Player
-    return rawPlayer != null
-  }
-  return false
-}
-
-/**
  * `chrome.runtime.onConnect`のハンドラーを登録する。
  * content_scriptからのポート接続を受け取り、APIイベントの検証・DB保存・
  * 各ストリームへの書き込み・自動同期トリガーを行う。
@@ -151,19 +92,13 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
   // サスペンド/リロード・タブクローズが起きればそれらのイベントは失われる。
   // `chrome.runtime.reload()`を呼びうる`recheckPendingUpdate()`だけは
   // 引き続き同期トリガーの決着後にチェーンするが、`processEvent`からawait
-  // せずfire-and-forgetにする。再チェック自体の安全性は、キューを
-  // ブロックする代わりに`recheckPendingUpdate()`の`isStillFresh`
-  // オプション（`activityGeneration`比較を渡す）で担保する——`reload()`
-  // 呼び出し直前まで`await`を挟まず原子的に確認する（詳細は
-  // update-manager.tsの`recheckPendingUpdate()`コメント、および
-  // `processEvent`の309/203ブロックのコメント参照）。これにより、以前の
-  // ラウンドで「reloadが次イベントのin-flightなadd()と競合する」ことを
-  // 防ぐために採用していた「キューをブロックして順序を強制する」戦略
-  // から、「決定の直前に鮮度を確認し、古ければreloadを諦めて次の契機に
-  // 委ねる」戦略へ切り替えている——ブロックしなくても同じ安全性が得られ、
-  // かつスループットを犠牲にしない。
+  // せずfire-and-forgetにする。再チェック側はpending state等のawaitを
+  // 終えた後、全reload経路共通のcommit pointで最新のingestion tailを
+  // 安定するまでdrainし、tail同一性とsessionActivityをreload直前に同期
+  // 確認する（update-manager.tsの`commitReloadIfStillSafe()`参照）。
+  // このため呼び出し元固有のactivity generation plumbingは不要であり、
+  // operation completion/SW startupと同じ安全性機構へ統一されている。
   ingestionQueue = Promise.resolve()
-  activityGeneration = 0
   setIngestionDrainProvider(() => ingestionQueue)
 
   chrome.runtime.onConnect.addListener(port => {
@@ -176,20 +111,11 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
           return
         }
 
-        // このメッセージがセッション状態に影響しうる場合のみ、積まれた
-        // 時点の世代を記録する（上の`activityGeneration`/
-        // `isSessionActivityRelevant`コメント参照）。
-        const rawApiTypeIdForGeneration = (message as { ApiTypeId?: unknown }).ApiTypeId
-        if (isSessionActivityRelevant(rawApiTypeIdForGeneration, message)) {
-          activityGeneration++
-        }
-        const enqueueActivityGeneration = activityGeneration
-
         // このイベントの処理を、直前のイベントの処理（add()の決着含む）の
         // 後ろに連結する。`processEvent`は内部で全エラーを捕捉して素通し
         // させない設計だが、想定外のバグでqueueが壊れて以降のイベントが
         // 永久に詰まることのないよう、キューの継続用チェーンは別途catchする。
-        const task = ingestionQueue.then(() => processEvent(service, message, enqueueActivityGeneration))
+        const task = ingestionQueue.then(() => processEvent(service, message))
         ingestionQueue = task.catch(err => {
           console.error('[background] Unhandled ingestion queue error (fail-safe, queue continues):', err)
         })
@@ -288,17 +214,10 @@ const applySessionActivity = (rawApiTypeId: unknown, message: ApiMessage | { typ
  * セッション状態追跡・自動同期トリガー（raw書き込み決着後のみ）→
  * リアルタイムパイプラインへの投入。
  *
- * `enqueueActivityGeneration`は呼び出し元（`registerEventIngestion()`）が
- * このメッセージをキューへ積んだ時点で採番した`activityGeneration`の値
- * （セッション状態に無関係なメッセージでは単に現在値のスナップショット、
- * 比較には使わない）。309/203ブロックが「自分の到着後にセッション状態へ
- * 影響しうるイベントが既に積まれていないか」を同期的に確認するために使う
- * （詳細は該当ブロックのコメント参照）。
  */
 const processEvent = async (
   service: PokerChaseService,
-  message: ApiMessage | { type: string },
-  enqueueActivityGeneration: number
+  message: ApiMessage | { type: string }
 ): Promise<void> => {
   // Ensure service is ready before processing messages
   try {
@@ -521,49 +440,16 @@ const processEvent = async (
     // （前回の暫定対策——チェーン全体をawaitしてreloadとの競合を防ぐ——は
     // このスループット問題を引き起こしていた）。
     //
-    // reload競合の防止は、キューをブロックする代わりに
-    // `recheckPendingUpdate()`の`isStillFresh`オプション（
-    // `activityGeneration`比較）で行う（P1, codexレビュー指摘
-    // 2026-07-21, pass-4/pass-5, "Don't reload before queued session
-    // starts run" / "Guard reload rechecks through the async path"）。
-    //
-    // pass-4時点では「`onGameSessionEnd()`決着直後、`recheckPendingUpdate()`
-    // を呼ぶ前」の1回だけ`activityGeneration`を比較していたが、
-    // `recheckPendingUpdate()`自身も`getPendingUpdateState()`等の
-    // `await`を複数挟む非同期関数であり、その隙間で新しいイベントが
-    // 到着・キューへ積まれうる（pass-5, codexレビュー指摘: 「事前の
-    // 1回チェック」では不十分で、実際にreloadする直前でもう一度確認
-    // しないと隙間を締め切れない）。そこで比較そのものを
-    // `recheckPendingUpdate()`側へ渡し、`isSafeToUpdate()`と全く同じ
-    // タイミング（`chrome.runtime.reload()`直前、間に`await`を挟まない
-    // 原子的な確認——詳細はupdate-manager.tsの`recheckPendingUpdate()`
-    // コメント参照）で評価させる。
-    //
-    // このメッセージが積まれてから（＝`enqueueActivityGeneration`採番
-    // 時から）`activityGeneration`が進んでいれば、自分の後にセッション
-    // 状態へ影響しうる新しいイベント（次のハンドの201/303等、まだ
-    // `applySessionActivity()`未実行）が既に積まれているということ。
-    // その状態で`isSafeToUpdate()`が真だとしても、それはまだ反映されて
-    // いない古い（309由来の）inactiveを読んでいるだけであり、
-    // 実際にreloadすると次イベントのin-flightな`apiEvents.add()`と
-    // 競合しうる。世代が変わっていなければ（＝自分の後にセッション状態へ
-    // 影響しうるイベントが何も積まれていない）、この時点でのreloadは
-    // 安全——`ingestionQueue`は直列なので、割り込む余地は無い。世代が
-    // 変わっていれば今回のrecheckは諦め、次の自然な契機（次のセッション
-    // 終了・操作完了・SW起動）に委ねる（その新しいイベント自身がいずれ
-    // 309/203に到達すれば、その時点で改めてこの同じチェックが走る）。
-    //
-    // セッション状態に無関係な「ノイズ」イベント（202/205等の非
-    // アプリケーションイベント、真の重複と判明したイベント）は
-    // `activityGeneration`をそもそも進めない（P2, codexレビュー指摘
-    // 2026-07-21, pass-5, "Don't let noise suppress session-end
-    // rechecks"）ため、この鮮度チェックを無用に失敗させて再チェックを
-    // 妨げることはない——詳細は`isSessionActivityRelevant()`のコメント
-    // 参照。
+    // reload競合の防止は、同期処理をブロックする世代カウンタではなく、
+    // `recheckPendingUpdate()`内の共有reload commit pointが担う。sync完了後
+    // またはstorage await中に次の201/303/308が積まれても、その時点の最新
+    // tailまでdrainしてACTIVEを適用してから安全性を最終判定する。202/205等
+    // のノイズが同時に積まれた場合も単に処理完了まで待つだけで、再チェックを
+    // 永続的に捨てない。
     autoSyncService.onGameSessionEnd()
       .catch(err => console.error('[background] Auto sync on game end failed:', err))
       .finally(() => {
-        recheckPendingUpdate({ isStillFresh: () => activityGeneration === enqueueActivityGeneration }).catch(err =>
+        recheckPendingUpdate().catch(err =>
           console.error('[background] Pending update recheck on session end failed:', err)
         )
       })
@@ -576,12 +462,9 @@ const processEvent = async (
     // ちょうど安全になったケースでも別の契機（次のセッション終了・操作
     // 完了・SW起動）が来るまで保留され続けてしまう。203はauto-syncの
     // トリガー対象ではない（バックアップすべきセッションデータが無い）
-    // ため`onGameSessionEnd()`は呼ばず、309と同じ`isStillFresh`ガード
-    // 付きで`recheckPendingUpdate()`だけを呼ぶ（このイベント自体には
-    // `onGameSessionEnd()`のような遅い非同期処理が挟まらないため、実際
-    // にここで世代がずれることは稀だが、同じガードを一貫して適用して
-    // おく）。
-    recheckPendingUpdate({ isStillFresh: () => activityGeneration === enqueueActivityGeneration }).catch(err =>
+    // ため`onGameSessionEnd()`は呼ばず、共有commit pointを持つ
+    // `recheckPendingUpdate()`だけを呼ぶ。
+    recheckPendingUpdate().catch(err =>
       console.error('[background] Pending update recheck on entry cancellation failed:', err)
     )
   } else if (rawApiTypeId === ApiType.EVT_ENTRY_QUEUED || rawApiTypeId === ApiType.EVT_SESSION_DETAILS) {

--- a/src/background/event-ingestion.ts
+++ b/src/background/event-ingestion.ts
@@ -66,6 +66,11 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
           return
         }
 
+        // ACTIVE化は`service.ready`・raw書き込みの耐久性バリアより前に、
+        // 完全に同期的に行う（P2, codexレビュー指摘 2026-07-21）。
+        // 詳細は`markSessionActiveFromRawMessage()`のコメント参照。
+        markSessionActiveFromRawMessage(message)
+
         // このイベントの処理を、直前のイベントの処理（add()の決着含む）の
         // 後ろに連結する。`processEvent`は内部で全エラーを捕捉して素通し
         // させない設計だが、想定外のバグでqueueが壊れて以降のイベントが
@@ -89,9 +94,78 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
 }
 
 /**
+ * 生メッセージだけを見て、セッションをACTIVEとしてマークすべきかを判定し、
+ * 該当すれば即座に`markSessionActive()`を呼ぶ。
+ *
+ * 呼び出しタイミング（P2, codexレビュー 2026-07-21指摘）: `service.ready`や
+ * raw書き込みの耐久性バリア（`processEvent`内の`await service.db.apiEvents.add()`）
+ * より前、`port.onMessage`受信直後の完全に同期的な処理として呼ぶこと。
+ * session-activityはService Worker側のメモリ上の状態でしかなく、Raw Event
+ * Lakeの行に由来する派生統計ではないため、耐久性バリアへの依存が一切無い
+ * （このイベント自身のraw書き込みが後で失敗・重複・衝突になっても、
+ * ACTIVEのままにしておくことは「安全側に倒す」設計方針そのものと矛盾
+ * しない——`processEvent`側で何度呼ばれても`markSessionActive()`は冪等）。
+ * 逆にここを`await`の後ろに置くと、遅い/詰まったadd()の裏で
+ * `onUpdateAvailable`等の再チェック（このイベントの処理とは独立に、任意の
+ * タイミングで発火しうる別経路）が「まだ前回309のまま=inactive=safe」と
+ * 誤認し、Service Workerをゲーム中にreloadしてしまう恐れがある。
+ *
+ * 309(EVT_SESSION_RESULTS)によるinactive化は、意図的にここに含めない
+ * （`processEvent`側で耐久性バリアの後ろに残したまま）: SAFE(=inactive)へ
+ * 倒す方向の遷移は、finding Aが塞いだのと同じリスク（このイベント自身の
+ * raw書き込みが確定する前にreloadでService Workerが巻き込まれ、309が
+ * 失われる）を再度開けてしまうため。ACTIVEへ倒す方向は「より保守的
+ * （unsafe側）」な変更なので即座に反映して問題ないが、INACTIVEへ倒す方向は
+ * 引き続きraw書き込みの決着を待つ必要がある——tri-stateの2つの遷移は
+ * 対称ではない。
+ *
+ * EVT_DEAL(303)は観戦モード（ヒーロー未着席、`Player`フィールド自体が
+ * undefined -- docs/api-events.md「EVT_DEAL: Playerフィールドの欠落」/
+ * aggregate-events-stream.ts参照）ではACTIVEトリガーから除外する
+ * （P2, codexレビュー指摘）: バスト後の観戦中に届く303まで拾うと、以降
+ * 309が来ない限りsessionActivityがactiveに固まり、保留中アップデートが
+ * 無期限にブロックされてしまう。raw-firstパターンに従い、Zodパース前の
+ * 生フィールドの有無だけで判定する（content_script.tsのkeepalive起動条件も
+ * 同じ判定をミラーする）。
+ */
+const markSessionActiveFromRawMessage = (message: ApiMessage | { type: string }): void => {
+  const rawApiTypeId = (message as { ApiTypeId?: unknown }).ApiTypeId
+  if (rawApiTypeId === ApiType.EVT_ENTRY_QUEUED || rawApiTypeId === ApiType.EVT_SESSION_DETAILS) {
+    markSessionActive()
+    return
+  }
+  if (rawApiTypeId === ApiType.EVT_DEAL) {
+    const rawPlayer = (message as { Player?: unknown }).Player
+    if (rawPlayer != null) {
+      markSessionActive()
+    }
+  }
+}
+
+/**
+ * ペイロードが構造的に同一かどうかの簡易比較。生イベントはmsgpackデコード後の
+ * 素朴なJSON互換オブジェクトであり、暗号学的な保証は不要な用途（同一
+ * (timestamp, ApiTypeId)への再到着が「本当に同じイベントの再送か」を見分ける
+ * だけ）のため、JSON.stringifyによる構造比較で十分とする（フィールド順序が
+ * 変わりうる別経路からの再構築物を比較する用途ではないため、キー順序依存の
+ * 弱さは実害にならない）。
+ */
+const isSamePayload = (a: unknown, b: unknown): boolean => {
+  try {
+    return JSON.stringify(a) === JSON.stringify(b)
+  } catch {
+    return false
+  }
+}
+
+/**
  * 1件のAPIイベントを処理する: Raw Event Lakeへの保存（耐久性バリア）→
  * セッション状態追跡・自動同期トリガー（raw書き込み決着後のみ）→
  * リアルタイムパイプラインへの投入。
+ *
+ * ACTIVE化のセッション状態追跡（`markSessionActiveFromRawMessage()`）は
+ * この関数の外（`port.onMessage`受信直後、耐久性バリアより前）で完全に
+ * 同期的に既に処理済み。ここで扱うのはINACTIVE化（309）のみ。
  */
 const processEvent = async (
   service: PokerChaseService,
@@ -123,31 +197,74 @@ const processEvent = async (
     try {
       await service.db.apiEvents.add(message as ApiEvent)
     } catch (err) {
-      const isDuplicateKey = err instanceof Dexie.DexieError && err.name === 'ConstraintError'
-      if (isDuplicateKey) {
-        // 同一(timestamp, ApiTypeId)は既にRaw Event Lakeに存在する = この
-        // イベントは初回受信時に既にセッションフック・同期トリガー・
-        // ストリームを一度通過済みのはず。ここで再度投入すると二重処理
-        // （統計の二重計上等）になるため、dedup semanticsとして以降の
-        // 全処理をスキップする。
-        console.warn('[background] Duplicate event (already in Raw Event Lake), skipping re-processing:', message)
+      const isConstraintError = err instanceof Dexie.DexieError && err.name === 'ConstraintError'
+      if (isConstraintError) {
+        // ConstraintError = 既に同じ[timestamp+ApiTypeId]の行がLakeに存在
+        // する。これは2つの別々のケースを区別する必要がある
+        // （P2, codexレビュー指摘 2026-07-21, 監査finding 6）:
+        //   (a) 真の重複: 同一イベントの再到着（再送・reconnect replay等）
+        //   (b) 真の衝突: 同一ミリ秒バーストで2つの"別々の"生WebSocket
+        //       メッセージが同じApiTypeIdで届き、両方とも同じ
+        //       `Date.now()`由来のtimestamp（web_accessible_resource.ts）を
+        //       持ってしまい[timestamp+ApiTypeId]がぶつかったケース
+        // (b)を(a)と同じ「スキップ」扱いにすると、衝突した方のイベント
+        // （アクション・結果・セッション遷移等）がライブパイプラインから
+        // 静かに消えてしまう（このコメントの直前のレビューで指摘された
+        // リグレッション）。既存行のペイロードと比較して区別する。
+        let existing: ApiEvent | undefined
+        try {
+          existing = await service.db.apiEvents.get([rawTimestamp as number, rawApiTypeId as number])
+        } catch (getErr) {
+          console.error('[background] Failed to read colliding row for dedup comparison (treating as a genuine collision, not a duplicate):', getErr)
+        }
+
+        if (existing !== undefined && isSamePayload(existing, message)) {
+          // (a) 真の重複: このイベントは初回受信時に既にセッションフック・
+          // 同期トリガー・ストリームを一度通過済みのはず。ここで再度投入
+          // すると二重処理（統計の二重計上等）になるため、dedup semantics
+          // として以降の全処理をスキップする。
+          console.warn('[background] Duplicate event (identical payload already in Raw Event Lake), skipping re-processing:', message)
+          return
+        }
+
+        // (b) 真の衝突: 別イベントが同じprimary keyを先取りしていたため、
+        // このイベント自身の生ログはRaw Event Lakeに残せない（add()は
+        // 既存行を上書きしない）。根本修正はwave-3で予定されている
+        // シーケンスキー移行（[timestamp+ApiTypeId]をこの種の衝突が起こら
+        // ないキーへ置き換える）で、それまでの当面の対処として、同一
+        // ミリ秒バーストでアクション・結果・セッション遷移を静かに握り
+        // つぶす方が実害が大きいと判断し、ライブパイプラインへの投入は
+        // 続行する（returnしない）。raw行を持てなかったという事実は
+        // drop可視化カウンタ（#141）で大きく可視化し、運用上気づける
+        // ようにする（quota等の失敗と同じ経路 -- どちらも「raw行が無い
+        // まま素通しした」事実を運用に晒す点は共通）。
+        console.error('[background] Primary-key collision (different event landed on the same [timestamp+ApiTypeId] -- see wave-3 sequence-key migration for the real fix; forwarding to the live pipeline anyway, no raw row persisted for this event):', err, { incoming: message, existing })
+        if (typeof rawApiTypeId === 'number') {
+          const eventTimestamp = typeof rawTimestamp === 'number' ? rawTimestamp : Date.now()
+          recordUndecodedEvent(service.db, rawApiTypeId, eventTimestamp).catch(recordErr =>
+            console.error('[background] Failed to record dropped-event stats:', recordErr)
+          )
+        }
+        // フォールスルー（returnしない）: 以降のセッション状態追跡・
+        // 同期トリガー・ストリーム投入へ進む。
+      } else {
+        // 重複/衝突以外の理由（quota超過等）でraw書き込みが失敗 = この
+        // イベントはLakeに存在しない。「派生統計はraw行があって初めて
+        // 存在してよい」というLakeの不変条件を守るため、ストリーム・
+        // セッションフック（の残り。ACTIVE化は既にこの関数の外で処理
+        // 済み）・同期トリガーのいずれにも投入しない（forward NGが正しい
+        // 判断——「ログだけ出して素通しする」は不変条件違反を積極的に
+        // 作りにいくことになるため選ばない）。#141のdrop可視化カウンタで
+        // 運用上気づけるようにする。
+        console.error('[background] Raw Event Lake write failed -- dropping from pipeline to preserve the Lake invariant (derived stats require a raw row):', err, message)
+        if (typeof rawApiTypeId === 'number') {
+          const eventTimestamp = typeof rawTimestamp === 'number' ? rawTimestamp : Date.now()
+          recordUndecodedEvent(service.db, rawApiTypeId, eventTimestamp).catch(recordErr =>
+            console.error('[background] Failed to record dropped-event stats:', recordErr)
+          )
+        }
         return
       }
-      // 重複以外の理由（quota超過等）でraw書き込みが失敗 = このイベントは
-      // Lakeに存在しない。「派生統計はraw行があって初めて存在してよい」
-      // というLakeの不変条件を守るため、ストリーム・セッションフック・
-      // 同期トリガーのいずれにも投入しない（forward NGが正しい判断——
-      // 「ログだけ出して素通しする」は不変条件違反を積極的に作りにいく
-      // ことになるため選ばない）。#141のdrop可視化カウンタで運用上
-      // 気づけるようにする。
-      console.error('[background] Raw Event Lake write failed -- dropping from pipeline to preserve the Lake invariant (derived stats require a raw row):', err, message)
-      if (typeof rawApiTypeId === 'number') {
-        const eventTimestamp = typeof rawTimestamp === 'number' ? rawTimestamp : Date.now()
-        recordUndecodedEvent(service.db, rawApiTypeId, eventTimestamp).catch(recordErr =>
-          console.error('[background] Failed to record dropped-event stats:', recordErr)
-        )
-      }
-      return
     }
   } else {
     // timestamp/ApiTypeIdが数値でない = キーとして使えないため保存不可。
@@ -156,39 +273,23 @@ const processEvent = async (
     console.warn('[background] Event missing numeric timestamp/ApiTypeId, cannot store:', message)
   }
 
-  // ここから先は、raw書き込みが成功した（または保存不可能で待つべきI/Oが
-  // 無かった）場合にのみ到達する。add()が実際に失敗したケースは上で既に
-  // returnしている。
+  // ここから先は、raw書き込みが成功した・保存不可能で待つべきI/Oが無かった・
+  // または真の衝突でフォールスルーしてきた場合にのみ到達する（上記
+  // いずれか）。add()が実際に失敗した（重複以外の失敗、または真の重複）
+  // ケースは上で既にreturnしている。
 
-  // Forced-update安全性述語（update-manager.ts）のセッション状態追跡:
-  // content_script.tsのkeepaliveゲート（isGameActive）と同じ境界イベントを
-  // Service Worker側で独立に追跡する（SW再起動でリセットされるため
-  // content_script側の状態と厳密に同期している必要はない -- 保守的に
-  // 「unknown = unsafe」から始まり、実イベント観測で確定させるだけでよい）。
-  // 意図的にパース成功後のdata.ApiTypeIdではなく、ここで生メッセージの
-  // 数値ApiTypeIdだけを見て判定する: PokerChase側の309ペイロード破壊的
-  // 変更でparseApiEvent()がnullを返すようになっても、308で一度activeに
-  // なったセッション状態が永久にinactiveへ戻らず、まさにその変更を
-  // 修正する更新の安全性判定がずっとunsafeのまま詰まる、という事態を
-  // 避けるため（codexレビュー指摘）
-  //
-  // ACTIVEトリガーは308(EVT_SESSION_DETAILS)単独に頼らない
-  // （release-blocker監査 finding B）: docs/api-events.md:99が明記する
-  // 通り、308の欠落は正常系のバリアント（観測ギャップ）であり、
-  // 「308が来ない試合開始」は普通に起こる。309でinactiveにした直後、
-  // 308無しで次の試合が201/303から始まると、旧実装ではsession-activityが
-  // inactiveのまま固まり、onUpdateAvailable/operation-complete契機の
-  // 安全性再チェックが「安全」と誤判定してService Workerをゲーム中に
-  // reloadしてしまう。保守的に、以下のいずれかを観測したら即active化する:
-  //   - EVT_ENTRY_QUEUED(201): 着席（新セッション/新テーブルの入口）
-  //   - EVT_DEAL(303): ハンド進行中の最も強いシグナル
-  //   - EVT_SESSION_DETAILS(308): 従来からのシグナル（来れば最速）
-  // いずれも「試合が始まった」ことしか示さず「終わった」ことは示さない
-  // ため、inactiveへ戻すトリガーは引き続き309(EVT_SESSION_RESULTS)のみ
-  // （tri-stateのunknown=unsafeデフォルトは変更しない）。
-  // 同じトリガー集合をcontent_script.tsのkeepalive起動条件にも
-  // ミラーする必要がある（背景・コンテンツスクリプト間でimport不可のため
-  // 手動同期。変更時は両ファイルを揃えること）。
+  // Forced-update安全性述語（update-manager.ts）のセッション状態追跡・
+  // INACTIVE化（309のみ）: ACTIVE化（201/303[Player在席時]/308）はこの
+  // 関数の外（`port.onMessage`受信直後、耐久性バリアより前）で
+  // `markSessionActiveFromRawMessage()`により既に同期的に処理済み
+  // （理由は同関数のコメント参照 -- ACTIVE/INACTIVEの2方向は対称ではなく、
+  // INACTIVE化だけがreloadを許可する方向のため引き続き耐久性バリアの
+  // 後ろに残す）。ここでは意図的にパース成功後のdata.ApiTypeIdではなく、
+  // 生メッセージの数値ApiTypeIdだけを見て判定する: PokerChase側の309
+  // ペイロード破壊的変更でparseApiEvent()がnullを返すようになっても、
+  // セッション状態が永久にinactiveへ戻らず、まさにその変更を修正する
+  // 更新の安全性判定がずっとunsafeのまま詰まる、という事態を避けるため
+  // （codexレビュー指摘）
   if (rawApiTypeId === ApiType.EVT_SESSION_RESULTS) {
     markSessionInactive()
     // #179 round3指摘: セッション終了(EVT_SESSION_RESULTS)によるHUDクリアは
@@ -240,12 +341,6 @@ const processEvent = async (
     // 対する`lineup-identity`ガードが別途入っており、この単純な
     // `[]`のままでも競合は起きない。
     setLastKnownStats([])
-  } else if (
-    rawApiTypeId === ApiType.EVT_ENTRY_QUEUED ||
-    rawApiTypeId === ApiType.EVT_DEAL ||
-    rawApiTypeId === ApiType.EVT_SESSION_DETAILS
-  ) {
-    markSessionActive()
   }
 
   // Auto-sync起動・保留中アップデートの安全性再チェックも、上のセッション状態
@@ -323,7 +418,9 @@ const processEvent = async (
   // ここでdataはApiEvent型（isApplicationApiEventで保証済み）
   service.eventLogger(data, 'info')
 
-  // ストリーム処理（DB保存は上で完了済み・耐久性確定済み）
+  // ストリーム処理（DB保存は上で完了済み・耐久性確定済み -- ただし
+  // primary-key衝突でフォールスルーしてきた場合のみ例外: このイベント
+  // 自身の生ログはRaw Event Lakeに残っていない。上のコメント参照）
   service.handLogStream.write(data)
   service.handAggregateStream.write(data)
   service.realTimeStatsStream.write(data)

--- a/src/background/event-ingestion.ts
+++ b/src/background/event-ingestion.ts
@@ -13,7 +13,33 @@ import type { ApiEvent } from '../app'
 import { autoSyncService } from '../services/auto-sync-service'
 import { connectedPorts, startPortPing, setLastKnownStats } from './ports'
 import { recordUndecodedEvent } from './undecoded-event-tracker'
-import { markSessionActive, markSessionInactive, recheckPendingUpdate, revertSessionActivityIfStillApplied } from './update-manager'
+import { markSessionActive, markSessionInactive, recheckPendingUpdate, setIngestionDrainProvider } from './update-manager'
+
+/**
+ * 参加取消申込（ApiTypeId 203）。`ApiType` enum（アプリケーションで使用する
+ * イベント種別、`isApplicationApiEvent`の判定基準）には意図的に含めない
+ * ——enumに加えると`isApplicationApiEvent`がtrueを返すようになり、
+ * ストリーム（handLogStream等）に本来対象外のイベントが投入されてしまう
+ * ため。ここではセッション状態追跡専用の生ApiTypeId定数として扱う
+ * （201/303/308/309と同じraw-firstパターン）。
+ *
+ * 参加申込(201)後、着席（303/308）に至る前にユーザーが参加をキャンセル
+ * すると、ハンドが一度も始まらないため309も届かない
+ * （P2, codexレビュー指摘 2026-07-21, pass-3）。この203を観測したら309と
+ * 同様にsessionActivityをINACTIVEへ戻す（詳細は`applySessionActivity()`
+ * コメント参照）。content_script.tsのkeepalive解除条件も同じ判定を
+ * ミラーする。
+ */
+const EVT_ENTRY_CANCELLED_API_TYPE_ID = 203
+
+/**
+ * Raw Event Lakeの耐久性バリア（release-blocker監査 finding A）を実現する
+ * ための直列化キュー。モジュールスコープに置くのは、update-manager.tsの
+ * `awaitIngestionDrain()`（キュー・ドレイン・バリア、2026-07-21 pass-3）
+ * から`setIngestionDrainProvider()`経由で参照させるため
+ * （`registerEventIngestion()`のコメント参照）。
+ */
+let ingestionQueue: Promise<void> = Promise.resolve()
 
 /**
  * `chrome.runtime.onConnect`のハンドラーを登録する。
@@ -43,9 +69,22 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
   // 入れ替わらないこと」も保証する——add()を待つ以上、後続イベントのadd()が
   // 先に決着してしまうと素朴な実装では順序が壊れうるため）。
   //
+  // セッション状態追跡（markSessionActive/markSessionInactive）もこの
+  // キューの内側、耐久性バリア・重複排除判定の後で行う（2026-07-21
+  // pass-3で統一。経緯: 過去2ラウンドはACTIVE化だけを同期的に前倒しする
+  // 「楽観的arm」設計を採ったが、到着順序ゲーティング・重複判明時の
+  // ロールバックといった対症療法を重ねるほど設計が自分自身と衝突する
+  // ようになった——詳細はupdate-manager.tsの`markSessionActive`コメント
+  // 参照）。この統一により(a)重複イベントがそもそもACTIVE/INACTIVE判定に
+  // 到達しない（判定より先にreturnする）、(b)キュー自体が到着順序を
+  // 保証するため順序反転が起こりえない、という2点が構造的に保証される。
+  // 残る懸念（rawの書き込みが詰まっている間、reload判定が古い
+  // sessionActivityを読んでしまう）は書く側でなく読む側で解決する——
+  // update-manager.tsの`awaitIngestionDrain()`参照。
+  //
   // なお、`autoSyncService.onGameSessionEnd()`/`onNewSessionStart()`自体は
   // raw Lakeの行数を見るだけの非同期処理で、直接`chrome.runtime.reload()`を
-  // 呼ぶわけではない（reloadを呼びうるのはそこから`.finally()`で連鎖される
+  // 呼ぶわけではない（reloadを呼びうるのはそこから連鎖される
   // `recheckPendingUpdate()`のみ）。そのため理屈の上では同期トリガーの発火
   // 自体はadd()の完了を待たなくても安全ではある。ただし、
   //   - どの内部処理が将来reload隣接になるか将来にわたって保証できない
@@ -54,22 +93,8 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
   // という理由で、本実装では簡潔さと防御的深さを優先し、セッションフック・
   // 同期トリガー・ストリーム書き込みの全てをadd()決着後に統一して実行する
   // （最小要件を満たしつつ上回る、意図的な選択）。
-  let ingestionQueue: Promise<void> = Promise.resolve()
-
-  // 到着シーケンス番号（P1, codexレビュー 2026-07-21指摘）: ACTIVE化は
-  // port.onMessage受信直後に完全に同期的に、INACTIVE化はingestionQueue
-  // 経由でRaw Event Lake耐久性バリアの後ろに非同期に決着する。両者は
-  // タイミングが非対称なため、生の到着順序が[309, 201]（セッション終了の
-  // 直後に次のセッションが201/303から始まる、正常系のバリアント）だと、
-  // 遅れて決着する309のINACTIVE化が、先に決着していた201のACTIVE化を
-  // 後から上書きしてしまい「新しいハンドが進行中なのにinactiveのまま」
-  // という状態反転が起こりうる。この`arrivalSequence`を各メッセージの
-  // 受信直後（同期的に、キューへ積むより前）にインクリメントして
-  // `markSessionActive`/`markSessionInactive`へ明示的に渡すことで、
-  // update-manager.ts側が「真の到着順序」を判定でき、決着が遅れた古い
-  // 遷移が新しい遷移を上書きすることを防げる（詳細は
-  // update-manager.tsの該当コメント参照）。
-  let arrivalSequence = 0
+  ingestionQueue = Promise.resolve()
+  setIngestionDrainProvider(() => ingestionQueue)
 
   chrome.runtime.onConnect.addListener(port => {
     if (port.name === PokerChaseService.POKER_CHASE_SERVICE_EVENT) {
@@ -81,20 +106,11 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
           return
         }
 
-        // このメッセージの到着順序を同期的に記録する（他のどの非同期処理
-        // よりも前に採番することが重要 -- 上のコメント参照）。
-        const arrivalSeq = ++arrivalSequence
-
-        // ACTIVE化は`service.ready`・raw書き込みの耐久性バリアより前に、
-        // 完全に同期的に行う（P2, codexレビュー指摘 2026-07-21）。
-        // 詳細は`markSessionActiveFromRawMessage()`のコメント参照。
-        markSessionActiveFromRawMessage(message, arrivalSeq)
-
         // このイベントの処理を、直前のイベントの処理（add()の決着含む）の
         // 後ろに連結する。`processEvent`は内部で全エラーを捕捉して素通し
         // させない設計だが、想定外のバグでqueueが壊れて以降のイベントが
         // 永久に詰まることのないよう、キューの継続用チェーンは別途catchする。
-        const task = ingestionQueue.then(() => processEvent(service, message, arrivalSeq))
+        const task = ingestionQueue.then(() => processEvent(service, message))
         ingestionQueue = task.catch(err => {
           console.error('[background] Unhandled ingestion queue error (fail-safe, queue continues):', err)
         })
@@ -110,63 +126,6 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
       })
     }
   })
-}
-
-/**
- * 生メッセージだけを見て、セッションをACTIVEとしてマークすべきかを判定し、
- * 該当すれば即座に`markSessionActive()`を呼ぶ。
- *
- * 呼び出しタイミング（P2, codexレビュー 2026-07-21指摘）: `service.ready`や
- * raw書き込みの耐久性バリア（`processEvent`内の`await service.db.apiEvents.add()`）
- * より前、`port.onMessage`受信直後の完全に同期的な処理として呼ぶこと。
- * session-activityはService Worker側のメモリ上の状態でしかなく、Raw Event
- * Lakeの行に由来する派生統計ではないため、耐久性バリアへの依存が一切無い
- * （このイベント自身のraw書き込みが後で失敗・重複・衝突になっても、
- * ACTIVEのままにしておくことは「安全側に倒す」設計方針そのものと矛盾
- * しない——`processEvent`側で何度呼ばれても`markSessionActive()`は冪等）。
- * 逆にここを`await`の後ろに置くと、遅い/詰まったadd()の裏で
- * `onUpdateAvailable`等の再チェック（このイベントの処理とは独立に、任意の
- * タイミングで発火しうる別経路）が「まだ前回309のまま=inactive=safe」と
- * 誤認し、Service Workerをゲーム中にreloadしてしまう恐れがある。
- *
- * 309(EVT_SESSION_RESULTS)によるinactive化は、意図的にここに含めない
- * （`processEvent`側で耐久性バリアの後ろに残したまま）: SAFE(=inactive)へ
- * 倒す方向の遷移は、finding Aが塞いだのと同じリスク（このイベント自身の
- * raw書き込みが確定する前にreloadでService Workerが巻き込まれ、309が
- * 失われる）を再度開けてしまうため。ACTIVEへ倒す方向は「より保守的
- * （unsafe側）」な変更なので即座に反映して問題ないが、INACTIVEへ倒す方向は
- * 引き続きraw書き込みの決着を待つ必要がある——tri-stateの2つの遷移は
- * 対称ではない。
- *
- * EVT_DEAL(303)は観戦モード（ヒーロー未着席、`Player`フィールド自体が
- * undefined -- docs/api-events.md「EVT_DEAL: Playerフィールドの欠落」/
- * aggregate-events-stream.ts参照）ではACTIVEトリガーから除外する
- * （P2, codexレビュー指摘）: バスト後の観戦中に届く303まで拾うと、以降
- * 309が来ない限りsessionActivityがactiveに固まり、保留中アップデートが
- * 無期限にブロックされてしまう。raw-firstパターンに従い、Zodパース前の
- * 生フィールドの有無だけで判定する（content_script.tsのkeepalive起動条件も
- * 同じ判定をミラーする）。
- *
- * `arrivalSeq`はこのメッセージの到着順序（`registerEventIngestion()`の
- * `arrivalSequence`カウンタ参照）。真の到着順序を保つため、以降の
- * `processEvent`内での（決着が遅れうる）INACTIVE化との整合判定に使う
- * （update-manager.tsの`markSessionActive`/`markSessionInactive`コメント
- * 参照）。また、この呼び出しが実は真の重複（reconnect resend等）だったと
- * 後で判明した場合の`revertSessionActivityIfStillApplied(arrivalSeq)`
- * （P2, codexレビュー指摘, processEvent内）にも同じ値を使う。
- */
-const markSessionActiveFromRawMessage = (message: ApiMessage | { type: string }, arrivalSeq: number): void => {
-  const rawApiTypeId = (message as { ApiTypeId?: unknown }).ApiTypeId
-  if (rawApiTypeId === ApiType.EVT_ENTRY_QUEUED || rawApiTypeId === ApiType.EVT_SESSION_DETAILS) {
-    markSessionActive(arrivalSeq)
-    return
-  }
-  if (rawApiTypeId === ApiType.EVT_DEAL) {
-    const rawPlayer = (message as { Player?: unknown }).Player
-    if (rawPlayer != null) {
-      markSessionActive(arrivalSeq)
-    }
-  }
 }
 
 /**
@@ -186,24 +145,59 @@ const isSamePayload = (a: unknown, b: unknown): boolean => {
 }
 
 /**
+ * 生メッセージの数値ApiTypeIdだけを見て、セッションのACTIVE/INACTIVE状態を
+ * 判定し、該当すれば`markSessionActive()`/`markSessionInactive()`を呼ぶ。
+ *
+ * 呼び出しは`processEvent`内、Raw Event Lakeの耐久性バリア（add()の決着）
+ * および重複判定の**後**でのみ行う（真の重複はここに到達する前に
+ * `processEvent`がreturn済み——重複イベントがACTIVE/INACTIVEを動かす
+ * ことは無い。詳細は`processEvent`のコメント参照）。
+ *
+ * ACTIVE化のトリガーは308(EVT_SESSION_DETAILS)単独に頼らない
+ * （release-blocker監査 finding B）: docs/api-events.md:99が明記する
+ * 通り、308の欠落は正常系のバリアント（観測ギャップ）であり、
+ * 「308が来ない試合開始」は普通に起こる。以下のいずれかを観測したら
+ * 即active化する:
+ *   - EVT_ENTRY_QUEUED(201): 着席（新セッション/新テーブルの入口）
+ *   - EVT_DEAL(303, Player在席時のみ): ハンド進行中の最も強いシグナル
+ *     （観戦モード=Playerフィールド自体が無い場合は除外——P2, codex
+ *     レビュー指摘。docs/api-events.md「EVT_DEAL: Playerフィールドの
+ *     欠落」参照）
+ *   - EVT_SESSION_DETAILS(308): 従来からのシグナル（来れば最速）
+ *
+ * INACTIVEへ戻すトリガーはEVT_SESSION_RESULTS(309)と
+ * EVT_ENTRY_CANCELLED(203, 本ファイル冒頭の定数コメント参照)の2つ
+ * （tri-stateのunknown=unsafeデフォルトは変更しない）。
+ *
+ * 同じトリガー集合をcontent_script.tsのkeepalive起動/解除条件にも
+ * ミラーする必要がある（背景・コンテンツスクリプト間でimport不可のため
+ * 手動同期。変更時は両ファイルを揃えること）。
+ */
+const applySessionActivity = (rawApiTypeId: unknown, message: ApiMessage | { type: string }): void => {
+  if (rawApiTypeId === ApiType.EVT_SESSION_RESULTS || rawApiTypeId === EVT_ENTRY_CANCELLED_API_TYPE_ID) {
+    markSessionInactive()
+    return
+  }
+  if (rawApiTypeId === ApiType.EVT_ENTRY_QUEUED || rawApiTypeId === ApiType.EVT_SESSION_DETAILS) {
+    markSessionActive()
+    return
+  }
+  if (rawApiTypeId === ApiType.EVT_DEAL) {
+    const rawPlayer = (message as { Player?: unknown }).Player
+    if (rawPlayer != null) {
+      markSessionActive()
+    }
+  }
+}
+
+/**
  * 1件のAPIイベントを処理する: Raw Event Lakeへの保存（耐久性バリア）→
  * セッション状態追跡・自動同期トリガー（raw書き込み決着後のみ）→
  * リアルタイムパイプラインへの投入。
- *
- * ACTIVE化のセッション状態追跡（`markSessionActiveFromRawMessage()`）は
- * この関数の外（`port.onMessage`受信直後、耐久性バリアより前）で完全に
- * 同期的に既に処理済み。ここで扱うのはINACTIVE化（309）と、真の重複判明時の
- * ACTIVE化ロールバックのみ。
- *
- * `arrivalSeq`は呼び出し元（`registerEventIngestion()`）が同期的に採番した
- * このメッセージの到着順序。`markSessionInactive`/
- * `revertSessionActivityIfStillApplied`へそのまま渡し、決着タイミングが
- * 前後しても真の到着順序で状態が決まるようにする。
  */
 const processEvent = async (
   service: PokerChaseService,
-  message: ApiMessage | { type: string },
-  arrivalSeq: number
+  message: ApiMessage | { type: string }
 ): Promise<void> => {
   // Ensure service is ready before processing messages
   try {
@@ -243,8 +237,7 @@ const processEvent = async (
         //       持ってしまい[timestamp+ApiTypeId]がぶつかったケース
         // (b)を(a)と同じ「スキップ」扱いにすると、衝突した方のイベント
         // （アクション・結果・セッション遷移等）がライブパイプラインから
-        // 静かに消えてしまう（このコメントの直前のレビューで指摘された
-        // リグレッション）。既存行のペイロードと比較して区別する。
+        // 静かに消えてしまう。既存行のペイロードと比較して区別する。
         let existing: ApiEvent | undefined
         try {
           existing = await service.db.apiEvents.get([rawTimestamp as number, rawApiTypeId as number])
@@ -256,21 +249,15 @@ const processEvent = async (
           // (a) 真の重複: このイベントは初回受信時に既にセッションフック・
           // 同期トリガー・ストリームを一度通過済みのはず。ここで再度投入
           // すると二重処理（統計の二重計上等）になるため、dedup semantics
-          // として以降の全処理をスキップする。
+          // として以降の全処理をスキップする——ACTIVE/INACTIVE判定
+          // （`applySessionActivity`）にも到達させない。これにより
+          // reconnectが複数の重複をまとめて再送しても（各イベントごとに
+          // 個別にここで判定・スキップされるだけなので）セッション状態が
+          // 一切動かない（2026-07-21 pass-3, codexレビュー指摘: 過去の
+          // 「楽観的ACTIVE化+ロールバック」設計はスタックした重複バースト
+          // で破綻していたが、判定そのものを重複チェックの後ろに統一した
+          // ことで、そもそも動かすものが無くなり構造的に解消される）。
           console.warn('[background] Duplicate event (identical payload already in Raw Event Lake), skipping re-processing:', message)
-
-          // P2 (codexレビュー指摘 2026-07-21): この生メッセージが201/303
-          // [Player在席]/308形状だった場合、`markSessionActiveFromRawMessage()`
-          // が既にこのイベントの到着時点で楽観的にACTIVE化を試みている
-          // （耐久性バリアより前の同期処理のため、この時点ではまだ重複と
-          // 判明していなかった）。今ここで真の重複と判明したので、その
-          // 楽観的なACTIVE化がまだ現在の状態として有効であれば
-          // （＝それ以降により新しい遷移が適用されていなければ）取り消し、
-          // 直前の状態（例: 309で既にinactiveだった場合はinactive）へ
-          // ロールバックする。stale reconnect resend等が
-          // 「新しいハンドが無いのにsessionActivityをactiveへ戻し、保留中
-          // アップデートを無期限にブロックする」事態を防ぐ。
-          revertSessionActivityIfStillApplied(arrivalSeq)
           return
         }
 
@@ -298,11 +285,10 @@ const processEvent = async (
         // 重複/衝突以外の理由（quota超過等）でraw書き込みが失敗 = この
         // イベントはLakeに存在しない。「派生統計はraw行があって初めて
         // 存在してよい」というLakeの不変条件を守るため、ストリーム・
-        // セッションフック（の残り。ACTIVE化は既にこの関数の外で処理
-        // 済み）・同期トリガーのいずれにも投入しない（forward NGが正しい
-        // 判断——「ログだけ出して素通しする」は不変条件違反を積極的に
-        // 作りにいくことになるため選ばない）。#141のdrop可視化カウンタで
-        // 運用上気づけるようにする。
+        // セッションフック・同期トリガーのいずれにも投入しない
+        // （forward NGが正しい判断——「ログだけ出して素通しする」は
+        // 不変条件違反を積極的に作りにいくことになるため選ばない）。
+        // #141のdrop可視化カウンタで運用上気づけるようにする。
         console.error('[background] Raw Event Lake write failed -- dropping from pipeline to preserve the Lake invariant (derived stats require a raw row):', err, message)
         if (typeof rawApiTypeId === 'number') {
           const eventTimestamp = typeof rawTimestamp === 'number' ? rawTimestamp : Date.now()
@@ -325,24 +311,15 @@ const processEvent = async (
   // いずれか）。add()が実際に失敗した（重複以外の失敗、または真の重複）
   // ケースは上で既にreturnしている。
 
-  // Forced-update安全性述語（update-manager.ts）のセッション状態追跡・
-  // INACTIVE化（309のみ）: ACTIVE化（201/303[Player在席時]/308）はこの
-  // 関数の外（`port.onMessage`受信直後、耐久性バリアより前）で
-  // `markSessionActiveFromRawMessage()`により既に同期的に処理済み
-  // （理由は同関数のコメント参照 -- ACTIVE/INACTIVEの2方向は対称ではなく、
-  // INACTIVE化だけがreloadを許可する方向のため引き続き耐久性バリアの
-  // 後ろに残す）。ここでは意図的にパース成功後のdata.ApiTypeIdではなく、
-  // 生メッセージの数値ApiTypeIdだけを見て判定する: PokerChase側の309
-  // ペイロード破壊的変更でparseApiEvent()がnullを返すようになっても、
-  // セッション状態が永久にinactiveへ戻らず、まさにその変更を修正する
-  // 更新の安全性判定がずっとunsafeのまま詰まる、という事態を避けるため
-  // （codexレビュー指摘）。`arrivalSeq`を渡すのはP1（codexレビュー指摘
-  // 2026-07-21）対応: この309の決着が耐久性バリアの後ろで遅れている間に
-  // より新しいメッセージ（201/303等）が同期的にACTIVE化を先に適用して
-  // いた場合、この（実際には古い）INACTIVE化がそれを上書きしないよう
-  // update-manager.ts側で到着順序を判定させるため。
+  // Forced-update安全性述語（update-manager.ts）のセッション状態追跡。
+  // 意図的にパース成功後のdata.ApiTypeIdではなく、生メッセージの数値
+  // ApiTypeIdだけを見て判定する: PokerChase側のペイロード破壊的変更で
+  // parseApiEvent()がnullを返すようになっても、セッション状態が永久に
+  // 誤った値のまま詰まらないようにするため（codexレビュー指摘）。
+  // 詳細は`applySessionActivity`のコメント参照。
+  applySessionActivity(rawApiTypeId, message)
+
   if (rawApiTypeId === ApiType.EVT_SESSION_RESULTS) {
-    markSessionInactive(arrivalSeq)
     // #179 round3指摘: セッション終了(EVT_SESSION_RESULTS)によるHUDクリアは
     // App.tsx側のReact stateだけで完結しており、background(ports.ts)の
     // `lastKnownStats`はセッションをまたいで残り続ける。この状態で
@@ -391,6 +368,10 @@ const processEvent = async (
     // ヒーロー在籍dealのevtDealとペアリングされてしまうケース）に
     // 対する`lineup-identity`ガードが別途入っており、この単純な
     // `[]`のままでも競合は起きない。
+    //
+    // 203(参加取消申込)はここに含めない: 303/308が一度も届いていない
+    // （ハンドが一度も始まっていない）ため、そもそもクリアすべき
+    // ライブlineupが存在しない。
     setLastKnownStats([])
   }
 
@@ -408,21 +389,38 @@ const processEvent = async (
   // パース成否に依存させる理由はそもそも無い）。
   if (rawApiTypeId === ApiType.EVT_SESSION_RESULTS) {
     // セッション終了は保留中アップデートの安全性再チェック地点の1つ
-    // （src/background/update-manager.ts参照）。recheckPendingUpdate()は
-    // onGameSessionEnd()のPromiseが完了(成功/失敗いずれか)してから
-    // 必ずチェーンして呼ぶ -- 両方を並列で撃つと、performSync()が
+    // （src/background/update-manager.ts参照）。onGameSessionEnd()の
+    // Promiseが完了(成功/失敗いずれか)してから必ずチェーンして
+    // recheckPendingUpdate()を呼ぶ -- 両方を並列で撃つと、performSync()が
     // `_isSyncing`を立てる前の非同期区間（min-versionゲートのawait等）を
     // recheckPendingUpdate()がすり抜けて安全と誤判定し、直近セッションの
     // クラウドバックアップがまだ始まってもいないうちに
     // chrome.runtime.reload()でService Workerを巻き込んでしまう恐れが
-    // あるため（codexレビュー指摘, P1）
-    autoSyncService.onGameSessionEnd()
-      .catch(err => console.error('[background] Auto sync on game end failed:', err))
-      .finally(() => {
-        recheckPendingUpdate().catch(err =>
-          console.error('[background] Pending update recheck on session end failed:', err)
-        )
-      })
+    // あるため（codexレビュー指摘, P1）。
+    //
+    // このチェーン全体を`await`し、`processEvent`自体（延いては
+    // `ingestionQueue`）がこの決着を待ってから次のイベントへ進むように
+    // する（P2, codexレビュー指摘 2026-07-21, pass-3, 「Keep the reload
+    // recheck inside the ingestion queue」）: 以前はfire-and-forgetして
+    // いたため、`processEvent()`がここで即座にresolveしてキューが次の
+    // rawイベントの処理（＝新たな`apiEvents.add()`）を始めてしまう一方、
+    // まだ実行中の`recheckPendingUpdate()`が`chrome.runtime.reload()`を
+    // 呼べる状態のままだった。保留中アップデートがある状態で309の直後に
+    // 非ACTIVEなイベントが1件でも続くと、そのreloadが次イベントの
+    // in-flightな`apiEvents.add()`と競合してabortさせ、耐久性バリアが
+    // あるにもかかわらずraw-Lakeに欠落を作りうる。`await`することで、
+    // この309自身の処理が完全に終わる（＝reloadするかどうかの決着が
+    // 付く）までキューが先に進まなくなり、この競合が構造的に無くなる。
+    try {
+      await autoSyncService.onGameSessionEnd()
+    } catch (err) {
+      console.error('[background] Auto sync on game end failed:', err)
+    }
+    try {
+      await recheckPendingUpdate()
+    } catch (err) {
+      console.error('[background] Pending update recheck on session end failed:', err)
+    }
   } else if (rawApiTypeId === ApiType.EVT_ENTRY_QUEUED || rawApiTypeId === ApiType.EVT_SESSION_DETAILS) {
     // フォールバックトリガー（docs/postmortems/2026-07-session-results-drop.md
     // 再発防止#3): 309単一トリガーのSPOF対策。新セッション開始時点は

--- a/src/background/event-ingestion.ts
+++ b/src/background/event-ingestion.ts
@@ -42,6 +42,19 @@ const EVT_ENTRY_CANCELLED_API_TYPE_ID = 203
 let ingestionQueue: Promise<void> = Promise.resolve()
 
 /**
+ * 到着世代カウンタ（P1, codexレビュー指摘 2026-07-21, pass-4,
+ * "Don't reload before queued session starts run"）。キューへ何か（キープ
+ * アライブ以外のメッセージ）が積まれるたびに同期的にインクリメントする。
+ * `ingestionQueue`自体の参照比較（`awaitIngestionDrain()`のループ）とは
+ * 別に、309/203自身の`processEvent`実行の**内側**から「自分の後に何か
+ * 積まれていないか」を同期的に確認するために使う——その場所では
+ * `awaitIngestionDrain()`（自己参照でデッドロックする）は使えない
+ * ため、単調増加のカウンタで代用する。詳細は`processEvent`の309/203
+ * ブロックのコメント参照。
+ */
+let queueGeneration = 0
+
+/**
  * `chrome.runtime.onConnect`のハンドラーを登録する。
  * content_scriptからのポート接続を受け取り、APIイベントの検証・DB保存・
  * 各ストリームへの書き込み・自動同期トリガーを行う。
@@ -82,18 +95,26 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
   // sessionActivityを読んでしまう）は書く側でなく読む側で解決する——
   // update-manager.tsの`awaitIngestionDrain()`参照。
   //
-  // なお、`autoSyncService.onGameSessionEnd()`/`onNewSessionStart()`自体は
-  // raw Lakeの行数を見るだけの非同期処理で、直接`chrome.runtime.reload()`を
-  // 呼ぶわけではない（reloadを呼びうるのはそこから連鎖される
-  // `recheckPendingUpdate()`のみ）。そのため理屈の上では同期トリガーの発火
-  // 自体はadd()の完了を待たなくても安全ではある。ただし、
-  //   - どの内部処理が将来reload隣接になるか将来にわたって保証できない
-  //   - 直列化を「ストリームだけ」「セッションフックだけ」で線引きすると
-  //     実装・レビューの複雑さが増し、境界の取り違えバグを生みやすい
-  // という理由で、本実装では簡潔さと防御的深さを優先し、セッションフック・
-  // 同期トリガー・ストリーム書き込みの全てをadd()決着後に統一して実行する
-  // （最小要件を満たしつつ上回る、意図的な選択）。
+  // 同期トリガー（`autoSyncService.onGameSessionEnd()`/`onNewSessionStart()`）
+  // は、このキューを塞がない（P2, codexレビュー指摘 2026-07-21, pass-4,
+  // "Don't block raw ingestion on cloud uploads"）。認証済みユーザーで
+  // 未同期行数が閾値を超えていれば`onGameSessionEnd()`は実際の
+  // Firestoreアップロードを走らせうる非同期処理で、これをここでawaitして
+  // キューを塞ぐと、次のハンドの生イベントが`apiEvents.add()`にすら到達
+  // できずメモリ上で滞留し、アップロード完了までライブHUDが凍結し、SW
+  // サスペンド/リロード・タブクローズが起きればそれらのイベントは失われる。
+  // `chrome.runtime.reload()`を呼びうる`recheckPendingUpdate()`だけは
+  // 引き続き同期トリガーの決着後にチェーンするが、`processEvent`からawait
+  // せずfire-and-forgetにし、代わりに呼ぶ直前で`queueGeneration`を確認
+  // する（「自分の到着後に何か新しく積まれていないか」の同期的な
+  // チェック——詳細は`processEvent`の309/203ブロックのコメント参照）。
+  // これにより、以前のラウンドで「reloadが次イベントのin-flightなadd()と
+  // 競合する」ことを防ぐために採用していた「キューをブロックして順序を
+  // 強制する」戦略から、「決定の直前に鮮度を確認し、古ければreloadを
+  // 諦めて次の契機に委ねる」戦略へ切り替えている——ブロックしなくても
+  // 同じ安全性が得られ、かつスループットを犠牲にしない。
   ingestionQueue = Promise.resolve()
+  queueGeneration = 0
   setIngestionDrainProvider(() => ingestionQueue)
 
   chrome.runtime.onConnect.addListener(port => {
@@ -106,11 +127,15 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
           return
         }
 
+        // このメッセージが積まれた時点の世代を記録する（上の
+        // `queueGeneration`コメント参照）。
+        const enqueueGeneration = ++queueGeneration
+
         // このイベントの処理を、直前のイベントの処理（add()の決着含む）の
         // 後ろに連結する。`processEvent`は内部で全エラーを捕捉して素通し
         // させない設計だが、想定外のバグでqueueが壊れて以降のイベントが
         // 永久に詰まることのないよう、キューの継続用チェーンは別途catchする。
-        const task = ingestionQueue.then(() => processEvent(service, message))
+        const task = ingestionQueue.then(() => processEvent(service, message, enqueueGeneration))
         ingestionQueue = task.catch(err => {
           console.error('[background] Unhandled ingestion queue error (fail-safe, queue continues):', err)
         })
@@ -172,9 +197,23 @@ const isSamePayload = (a: unknown, b: unknown): boolean => {
  * 同じトリガー集合をcontent_script.tsのkeepalive起動/解除条件にも
  * ミラーする必要がある（背景・コンテンツスクリプト間でimport不可のため
  * 手動同期。変更時は両ファイルを揃えること）。
+ *
+ * `activeOnly`（P2, codexレビュー指摘 2026-07-21, pass-4, "Fail closed
+ * on dropped ACTIVE writes"）: `true`の場合、INACTIVE化（309/203）を
+ * 一切行わない。raw書き込み自体が失敗した（quota超過等、真の重複でも
+ * 衝突でもない）イベントに対する`processEvent`のfail-closed処理から
+ * 呼ばれる場合に使う。理由: 309/203の永続化に失敗したという事実は
+ * 「本当にセッションが終わった/キャンセルされた」ことの確証にならない
+ * ため、INACTIVE化（＝reload許可という「危険側」の遷移）は生書き込みの
+ * 成功を要求する。一方ACTIVE化（＝reload禁止という「安全側」の遷移）は
+ * 生メッセージから読み取れる限り、書き込みが失敗していても即座に反映
+ * してよい——「不明ならunsafe」という保守的デフォルトの単純な延長。
+ * これを怠ると、直前が309でinactiveのまま、実際には新しいハンドが
+ * 始まっているのに（201/303/308の生書き込みがたまたま失敗しただけで）
+ * reloadが「安全」と誤判定されうる。
  */
-const applySessionActivity = (rawApiTypeId: unknown, message: ApiMessage | { type: string }): void => {
-  if (rawApiTypeId === ApiType.EVT_SESSION_RESULTS || rawApiTypeId === EVT_ENTRY_CANCELLED_API_TYPE_ID) {
+const applySessionActivity = (rawApiTypeId: unknown, message: ApiMessage | { type: string }, activeOnly = false): void => {
+  if (!activeOnly && (rawApiTypeId === ApiType.EVT_SESSION_RESULTS || rawApiTypeId === EVT_ENTRY_CANCELLED_API_TYPE_ID)) {
     markSessionInactive()
     return
   }
@@ -194,10 +233,16 @@ const applySessionActivity = (rawApiTypeId: unknown, message: ApiMessage | { typ
  * 1件のAPIイベントを処理する: Raw Event Lakeへの保存（耐久性バリア）→
  * セッション状態追跡・自動同期トリガー（raw書き込み決着後のみ）→
  * リアルタイムパイプラインへの投入。
+ *
+ * `enqueueGeneration`は呼び出し元（`registerEventIngestion()`）が
+ * このメッセージをキューへ積んだ時点で採番した`queueGeneration`の値。
+ * 309/203ブロックが「自分の到着後に何か新しく積まれていないか」を
+ * 同期的に確認するために使う（詳細は該当ブロックのコメント参照）。
  */
 const processEvent = async (
   service: PokerChaseService,
-  message: ApiMessage | { type: string }
+  message: ApiMessage | { type: string },
+  enqueueGeneration: number
 ): Promise<void> => {
   // Ensure service is ready before processing messages
   try {
@@ -285,10 +330,10 @@ const processEvent = async (
         // 重複/衝突以外の理由（quota超過等）でraw書き込みが失敗 = この
         // イベントはLakeに存在しない。「派生統計はraw行があって初めて
         // 存在してよい」というLakeの不変条件を守るため、ストリーム・
-        // セッションフック・同期トリガーのいずれにも投入しない
-        // （forward NGが正しい判断——「ログだけ出して素通しする」は
-        // 不変条件違反を積極的に作りにいくことになるため選ばない）。
-        // #141のdrop可視化カウンタで運用上気づけるようにする。
+        // 同期トリガーには投入しない（forward NGが正しい判断——
+        // 「ログだけ出して素通しする」は不変条件違反を積極的に作りに
+        // いくことになるため選ばない）。#141のdrop可視化カウンタで
+        // 運用上気づけるようにする。
         console.error('[background] Raw Event Lake write failed -- dropping from pipeline to preserve the Lake invariant (derived stats require a raw row):', err, message)
         if (typeof rawApiTypeId === 'number') {
           const eventTimestamp = typeof rawTimestamp === 'number' ? rawTimestamp : Date.now()
@@ -296,6 +341,17 @@ const processEvent = async (
             console.error('[background] Failed to record dropped-event stats:', recordErr)
           )
         }
+        // 例外: セッション状態のACTIVE化だけはfail-closedで適用する
+        // （P2, codexレビュー指摘 2026-07-21, pass-4, "Fail closed on
+        // dropped ACTIVE writes"）。この生メッセージが201/303[Player
+        // 在席]/308形状であれば、raw書き込みが失敗していても「新しい
+        // ハンドが観測された」という事実そのものは疑いようが無い
+        // （生メッセージは実際に届いている）。ここでACTIVE化を諦めると、
+        // 直前が309でinactiveのまま、実際には新しいハンドが始まって
+        // いるのにreloadが「安全」と誤判定されうる。INACTIVE化
+        // （309/203）は適用しない——理由は`applySessionActivity`の
+        // `activeOnly`引数のコメント参照。
+        applySessionActivity(rawApiTypeId, message, true)
         return
       }
     }
@@ -398,28 +454,65 @@ const processEvent = async (
     // chrome.runtime.reload()でService Workerを巻き込んでしまう恐れが
     // あるため（codexレビュー指摘, P1）。
     //
-    // このチェーン全体を`await`し、`processEvent`自体（延いては
-    // `ingestionQueue`）がこの決着を待ってから次のイベントへ進むように
-    // する（P2, codexレビュー指摘 2026-07-21, pass-3, 「Keep the reload
-    // recheck inside the ingestion queue」）: 以前はfire-and-forgetして
-    // いたため、`processEvent()`がここで即座にresolveしてキューが次の
-    // rawイベントの処理（＝新たな`apiEvents.add()`）を始めてしまう一方、
-    // まだ実行中の`recheckPendingUpdate()`が`chrome.runtime.reload()`を
-    // 呼べる状態のままだった。保留中アップデートがある状態で309の直後に
-    // 非ACTIVEなイベントが1件でも続くと、そのreloadが次イベントの
-    // in-flightな`apiEvents.add()`と競合してabortさせ、耐久性バリアが
-    // あるにもかかわらずraw-Lakeに欠落を作りうる。`await`することで、
-    // この309自身の処理が完全に終わる（＝reloadするかどうかの決着が
-    // 付く）までキューが先に進まなくなり、この競合が構造的に無くなる。
-    try {
-      await autoSyncService.onGameSessionEnd()
-    } catch (err) {
-      console.error('[background] Auto sync on game end failed:', err)
-    }
-    try {
-      await recheckPendingUpdate()
-    } catch (err) {
-      console.error('[background] Pending update recheck on session end failed:', err)
+    // このチェーン全体はfire-and-forgetで、`processEvent`からawaitしない
+    // （P2, codexレビュー指摘 2026-07-21, pass-4, "Don't block raw
+    // ingestion on cloud uploads"）: `onGameSessionEnd()`は認証済み
+    // ユーザーで未同期行数が閾値を超えていれば実際のFirestoreアップロード
+    // を走らせうる非同期処理で、これを`ingestionQueue`内でawaitすると、
+    // 次のハンドの生イベントが`apiEvents.add()`にすら到達できずメモリ上に
+    // 滞留し、アップロード完了までライブHUDが凍結し、SWサスペンド/
+    // リロード・タブクローズが起きればそれらのイベントは失われる
+    // （前回の暫定対策——チェーン全体をawaitしてreloadとの競合を防ぐ——は
+    // このスループット問題を引き起こしていた）。
+    //
+    // reload競合の防止は、キューをブロックする代わりに`queueGeneration`
+    // の比較で行う（P1, codexレビュー指摘 2026-07-21, pass-4, "Don't
+    // reload before queued session starts run"）: `onGameSessionEnd()`
+    // が完了した時点で、このメッセージが積まれてから（＝
+    // `enqueueGeneration`採番時から）`queueGeneration`が進んでいれば、
+    // 自分の後に新しいイベント（次のハンドの201/303等、まだ
+    // `applySessionActivity()`未実行）が既に積まれているということ。
+    // その状態で`recheckPendingUpdate()`を呼ぶと、`isSafeToUpdate()`が
+    // まだ反映されていない古い（309由来の）inactiveを読んで「安全」と
+    // 誤判定し、次イベントのin-flightな`apiEvents.add()`と競合する
+    // reloadを引き起こしうる。世代が変わっていなければ（＝自分の後に
+    // 何も積まれていない）、この時点でのreloadは安全——`ingestionQueue`
+    // は直列なので、自分より後に何も積まれていない限り新しいイベントが
+    // 割り込む余地は無い。世代が変わっていれば今回のrecheckは諦め、次の
+    // 自然な契機（次のセッション終了・操作完了・SW起動）に委ねる
+    // （その新しいイベント自身がいずれ309/203に到達すれば、その時点で
+    // 改めてこの同じチェックが走る）。
+    autoSyncService.onGameSessionEnd()
+      .catch(err => console.error('[background] Auto sync on game end failed:', err))
+      .finally(() => {
+        if (queueGeneration !== enqueueGeneration) {
+          console.log('[background] Skipping pending-update recheck after session end -- a newer event has already been queued, deferring to a later recheck trigger')
+          return
+        }
+        recheckPendingUpdate().catch(err =>
+          console.error('[background] Pending update recheck on session end failed:', err)
+        )
+      })
+  } else if (rawApiTypeId === EVT_ENTRY_CANCELLED_API_TYPE_ID) {
+    // 参加取消申込(203)も保留中アップデートの安全性再チェック地点の1つに
+    // 加える（P2, codexレビュー指摘 2026-07-21, pass-4, "Recheck updates
+    // after entry cancellation"）: `applySessionActivity()`は203を309と
+    // 同様にINACTIVE化トリガーとして扱う（本ファイル冒頭の定数コメント
+    // 参照）が、この再チェック地点が309専用のままだと、参加キャンセルで
+    // ちょうど安全になったケースでも別の契機（次のセッション終了・操作
+    // 完了・SW起動）が来るまで保留され続けてしまう。203はauto-syncの
+    // トリガー対象ではない（バックアップすべきセッションデータが無い）
+    // ため`onGameSessionEnd()`は呼ばず、309と同じ`queueGeneration`鮮度
+    // チェックの後に`recheckPendingUpdate()`だけを呼ぶ（このイベント自体
+    // には`onGameSessionEnd()`のような遅い非同期処理が挟まらないため、
+    // 実際にここで世代がずれることは稀だが、同じガードを一貫して適用
+    // しておく）。
+    if (queueGeneration !== enqueueGeneration) {
+      console.log('[background] Skipping pending-update recheck after entry cancellation -- a newer event has already been queued, deferring to a later recheck trigger')
+    } else {
+      recheckPendingUpdate().catch(err =>
+        console.error('[background] Pending update recheck on entry cancellation failed:', err)
+      )
     }
   } else if (rawApiTypeId === ApiType.EVT_ENTRY_QUEUED || rawApiTypeId === ApiType.EVT_SESSION_DETAILS) {
     // フォールバックトリガー（docs/postmortems/2026-07-session-results-drop.md

--- a/src/background/event-ingestion.ts
+++ b/src/background/event-ingestion.ts
@@ -1,4 +1,5 @@
 /** !!! CONTENT_SCRIPTS、WEB_ACCESSIBLE_RESOURCESからインポートしないこと !!! */
+import Dexie from 'dexie'
 import PokerChaseService, {
   ApiType,
   ApiMessage,
@@ -20,190 +21,60 @@ import { markSessionActive, markSessionInactive, recheckPendingUpdate } from './
  * 各ストリームへの書き込み・自動同期トリガーを行う。
  */
 export const registerEventIngestion = (service: PokerChaseService): void => {
+  // Raw Event Lakeの耐久性バリア（release-blocker監査 finding A）:
+  // `db.apiEvents.add()`を待たずにストリーム書き込みやセッションフックの副作用
+  // （自動同期トリガー、`chrome.runtime.reload()`を呼びうる保留アップデート
+  // 再チェック）を進めると、
+  //   (1) quota超過等でadd()が失敗した場合に「派生統計だけ存在してraw行が
+  //       無い」というRaw Event Lakeの不変条件違反（CLAUDE.md「Raw Event
+  //       Lake」/ "Storage happens *before* the validation gate" 参照）が
+  //       起こりうる
+  //   (2) 重複キー失敗（同一(timestamp, ApiTypeId)が既に保存済み）の場合、
+  //       そのイベントは初回処理時に既にストリーム/セッションフックを一度
+  //       通過済みのはずなのに、ここでも投入してしまうと二重処理になる
+  //   (3) add()のトランザクションが確定する前にreloadでService Workerが
+  //       巻き込まれ、書き込みが失われる恐れがある
+  // という3つの安全性違反を起こしうる。
+  //
+  // 対策として、各イベントの処理を「このイベントのadd()が決着（成功、または
+  // 処理済みの失敗）してから次のイベントの処理を始める」キューで直列化する
+  // （`processEvent`内で全副作用がadd()のawait後に実行されるため、この
+  // キューはあわせて「バーストで来たイベントの観測順序がストリーム側で
+  // 入れ替わらないこと」も保証する——add()を待つ以上、後続イベントのadd()が
+  // 先に決着してしまうと素朴な実装では順序が壊れうるため）。
+  //
+  // なお、`autoSyncService.onGameSessionEnd()`/`onNewSessionStart()`自体は
+  // raw Lakeの行数を見るだけの非同期処理で、直接`chrome.runtime.reload()`を
+  // 呼ぶわけではない（reloadを呼びうるのはそこから`.finally()`で連鎖される
+  // `recheckPendingUpdate()`のみ）。そのため理屈の上では同期トリガーの発火
+  // 自体はadd()の完了を待たなくても安全ではある。ただし、
+  //   - どの内部処理が将来reload隣接になるか将来にわたって保証できない
+  //   - 直列化を「ストリームだけ」「セッションフックだけ」で線引きすると
+  //     実装・レビューの複雑さが増し、境界の取り違えバグを生みやすい
+  // という理由で、本実装では簡潔さと防御的深さを優先し、セッションフック・
+  // 同期トリガー・ストリーム書き込みの全てをadd()決着後に統一して実行する
+  // （最小要件を満たしつつ上回る、意図的な選択）。
+  let ingestionQueue: Promise<void> = Promise.resolve()
+
   chrome.runtime.onConnect.addListener(port => {
     if (port.name === PokerChaseService.POKER_CHASE_SERVICE_EVENT) {
       connectedPorts.add(port)
-      port.onMessage.addListener(async (message: ApiMessage | { type: string }) => {
-        // キープアライブメッセージの処理
+      port.onMessage.addListener((message: ApiMessage | { type: string }) => {
+        // キープアライブメッセージの処理（キュー直列化の対象外 -- 何も
+        // 保存・処理しないため、耐久性バリアの対象になる副作用が無い）
         if (typeof message === 'object' && 'type' in message && message.type === 'keepalive') {
-          return // キープアライブは処理のみで、それ以上何もしない
-        }
-
-        // Ensure service is ready before processing messages
-        try {
-          await service.ready
-        } catch (err) {
-          console.error('[background] Service not ready:', err)
           return
         }
 
-        // Raw Event Lake（docs/architecture.md参照）: timestamp/ApiTypeIdが数値である
-        // 限り、Zodパースの成否・アプリケーションイベントか否かに関わらず生のまま
-        // 保存する。バリデーションは後続のリアルタイム処理パイプライン（ストリーム）
-        // への投入可否のみを左右し、保存の可否は左右しない。これにより将来
-        // PokerChase側のペイロード変更でスキーマ検証が壊れても、修正後のデータ
-        // 再構築で復旧可能になる（2026年シーズン3のEVT_SESSION_RESULTS破壊的変更で
-        // 実際にデータが失われた反省による）。
-        if (validateMessage(message).success) {
-          // Dexieの型はApiEvent（既知スキーマ）を想定しているが、Lakeとして未検証・
-          // 未知のApiTypeIdの生イベントも意図的に保存するためアサーションが必要
-          service.db.apiEvents.add(message as ApiEvent)
-            .catch(err => console.error('[background] Failed to save event:', err))
-        } else {
-          // timestamp/ApiTypeIdが数値でない = キーとして使えないため保存不可
-          console.warn('[background] Event missing numeric timestamp/ApiTypeId, cannot store:', message)
-        }
-
-        // Forced-update安全性述語（update-manager.ts）のセッション状態追跡:
-        // content_script.tsのkeepaliveゲート（isGameActive）と同じ境界イベントを
-        // Service Worker側で独立に追跡する（SW再起動でリセットされるため
-        // content_script側の状態と厳密に同期している必要はない -- 保守的に
-        // 「unknown = unsafe」から始まり、実イベント観測で確定させるだけでよい）。
-        // 意図的にパース成功後のdata.ApiTypeIdではなく、ここで生メッセージの
-        // 数値ApiTypeIdだけを見て判定する: PokerChase側の309ペイロード破壊的
-        // 変更でparseApiEvent()がnullを返すようになっても、308で一度activeに
-        // なったセッション状態が永久にinactiveへ戻らず、まさにその変更を
-        // 修正する更新の安全性判定がずっとunsafeのまま詰まる、という事態を
-        // 避けるため（codexレビュー指摘）
-        const rawApiTypeId = (message as { ApiTypeId?: unknown }).ApiTypeId
-        if (rawApiTypeId === ApiType.EVT_SESSION_DETAILS) {
-          markSessionActive()
-        } else if (rawApiTypeId === ApiType.EVT_SESSION_RESULTS) {
-          markSessionInactive()
-          // #179 round3指摘: セッション終了(EVT_SESSION_RESULTS)によるHUDクリアは
-          // App.tsx側のReact stateだけで完結しており、background(ports.ts)の
-          // `lastKnownStats`はセッションをまたいで残り続ける。この状態で
-          // Popupのバトルタイプフィルターが変更されると、message-router.tsの
-          // `updateBattleTypeFilter`ハンドラーが`getLastKnownStats()`（終了済み
-          // lineupのまま）を使って`service.statsOutputStream.write(...)`を
-          // 再トリガーし、ブロードキャストで終了済みlineupが復活してApp.tsxの
-          // クリア済みパネルへ再度流し込まれてしまう。上と同じ「パース成功後の
-          // data.ApiTypeIdではなく生メッセージの数値ApiTypeIdだけを見る」
-          // raw-firstパターンで（309のペイロード破壊的変更に影響されないよう）
-          // ここでlastKnownStatsを空にしておけば、以降のフィルター変更は
-          // `lastKnownStats.length > 0`のガードに引っかからずセッション開始前と
-          // 同じ「何もブロードキャストしない」挙動になる。プリゲーム・ヒーロー
-          // スタッツの復元（#158, `requestLatestStats`→`getLatestSessionStats`）
-          // はDBを読む別経路でありlastKnownStatsを参照しないため、この変更の
-          // 影響を受けない。
-          //
-          // post-merge reviewでは一時ここにhero単独lineupを合成する修正
-          // （round4/round5）や、App.tsx側にセッション状態・ヒーロー身元の
-          // 検証機構を足す修正（round6の「相互作用マトリクス」設計）を
-          // 積んだが、いずれもオーナー判断で撤回されている（PR #191,
-          // 2026-07-20, sola「それほど重要な機能ではないので、bで十分です」）。
-          // 理由: `service.setBattleTypeFilter()`は内部で無条件に
-          // `ReadEntityStream.recalculateStats()`を呼び、`lastKnownStats`の
-          // 中身に関係なく`service.latestEvtDeal.SeatUserIds`（ヒーローの
-          // 直近の実在席時点のフルの顔ぶれ。セッション終了後もクリアされ
-          // ない）を再計算・再ブロードキャストしてしまう。つまりこのファイル
-          // 側で`lastKnownStats`をどう作っても、その再ブロードキャストは
-          // 止められない別経路であり、追いかけるだけ複雑化する一方だった。
-          //
-          // 採用した方針（保守的な縮小スコープ）: bust後のミュート表示・
-          // hero身元の保持は「連続したライブシーケンス内」でのみ保証する
-          // （#158のセッション終了時hero保持は例外的にApp.tsx側で維持）。
-          // セッション終了後にフィルターを変更すると、`recalculateStats()`
-          // がヒーロー在籍時点の最後の実テーブル（対戦相手を含む）を新
-          // フィルターで再表示することがあるが、これは「不正確なデータ」
-          // ではなく「文脈的に古い可能性のある正確なデータ」であり、この
-          // 機能の重要度に見合わないため許容する。ここは元のround3の
-          // 意図通り単純な`[]`のままにする -- `updateBattleTypeFilter`の
-          // 明示的な`getLastKnownStats()`ベースの再write()を単にno-opに
-          // するだけで、他には何もしない。
-          //
-          // なお#188（read-entity-stream.tsのrecalculateStats()を呼ぶ
-          // message-router.tsのupdateBattleTypeFilterハンドラー自身）で、
-          // このwrite()と`recalculateStats()`の競合（観戦中のlineupが
-          // ヒーロー在籍dealのevtDealとペアリングされてしまうケース）に
-          // 対する`lineup-identity`ガードが別途入っており、この単純な
-          // `[]`のままでも競合は起きない。
-          setLastKnownStats([])
-        }
-
-        // Auto-sync起動・保留中アップデートの安全性再チェックも、上のセッション状態
-        // 追跡と同じ理由で生メッセージの数値ApiTypeIdだけを見て判定する（codexレビュー
-        // 指摘, P2）。autoSyncService.onGameSessionEnd()/onNewSessionStart()は
-        // 生のapiEvents Lake（上で既に保存済み）の件数だけを見るヘルパーで、
-        // パース済みdataには一切依存しない。以前はこのトリガーが後段の
-        // `if (data.ApiTypeId === ...)`（パース成功時のみ到達するブロック）に
-        // ぶら下がっていたため、PokerChase側の309ペイロード破壊的変更で
-        // parseApiEvent()がnullを返すケースでは、下のearly returnによって
-        // recheckPendingUpdate()が一切呼ばれず、保留中アップデートは次の
-        // セッション終了までずっと詰まったままになっていた（309の生データは
-        // 上のRaw Event Lake保存で既に確保済みなので、この再チェック自体を
-        // パース成否に依存させる理由はそもそも無い）。
-        if (rawApiTypeId === ApiType.EVT_SESSION_RESULTS) {
-          // セッション終了は保留中アップデートの安全性再チェック地点の1つ
-          // （src/background/update-manager.ts参照）。recheckPendingUpdate()は
-          // onGameSessionEnd()のPromiseが完了(成功/失敗いずれか)してから
-          // 必ずチェーンして呼ぶ -- 両方を並列で撃つと、performSync()が
-          // `_isSyncing`を立てる前の非同期区間（min-versionゲートのawait等）を
-          // recheckPendingUpdate()がすり抜けて安全と誤判定し、直近セッションの
-          // クラウドバックアップがまだ始まってもいないうちに
-          // chrome.runtime.reload()でService Workerを巻き込んでしまう恐れが
-          // あるため（codexレビュー指摘, P1）
-          autoSyncService.onGameSessionEnd()
-            .catch(err => console.error('[background] Auto sync on game end failed:', err))
-            .finally(() => {
-              recheckPendingUpdate().catch(err =>
-                console.error('[background] Pending update recheck on session end failed:', err)
-              )
-            })
-        } else if (rawApiTypeId === ApiType.EVT_ENTRY_QUEUED || rawApiTypeId === ApiType.EVT_SESSION_DETAILS) {
-          // フォールバックトリガー（docs/postmortems/2026-07-session-results-drop.md
-          // 再発防止#3）: 309単一トリガーのSPOF対策。新セッション開始時点は
-          // 進行中ハンドが存在しない安全なタイミングなので、ここでも同じ閾値判定
-          // でuploadを起動する（309が正常なら直前で既にバックログが閾値未満に
-          // なっているため二重発火しない）
-          autoSyncService.onNewSessionStart().catch(err =>
-            console.error('[background] Auto sync on new session start failed:', err)
-          )
-        }
-
-        // 通常のAPIメッセージ処理
-        // Zodスキーマでパース（passthrough: 未知プロパティは保持）
-        const data = parseApiEvent(message as ApiMessage)
-
-        if (!data) {
-          // パース失敗 = 必須プロパティ欠損など破壊的変更の可能性。生ログは上で
-          // 既に保存済みなので、ここではリアルタイムパイプラインへの投入のみ諦める
-          const validationResult = validateApiEvent(message as ApiMessage)
-          const errorDetails = validationResult.error ? getValidationError(validationResult.error) : null
-          console.warn(`[background] Schema validation failed (stored raw, pipeline skipped):\n  Errors: ${JSON.stringify(errorDetails, null, 2)}\n  Event: ${JSON.stringify(message, null, 2)}`)
-
-          // drop可視化（docs/postmortems/2026-07-session-results-drop.md 再発防止#2）:
-          // 検証失敗イベントの件数をApiTypeIdごとに集計してmetaテーブルへ永続化し、
-          // Popupから可視化できるようにする。309インシデントは半年間これが
-          // console.warnの中にしか無かったために気づけなかった
-          if (typeof rawApiTypeId === 'number') {
-            const rawTimestamp = (message as { timestamp?: unknown }).timestamp
-            const eventTimestamp = typeof rawTimestamp === 'number' ? rawTimestamp : Date.now()
-            recordUndecodedEvent(service.db, rawApiTypeId, eventTimestamp).catch(err =>
-              console.error('[background] Failed to record undecoded event stats:', err)
-            )
-          }
-          return
-        }
-
-        // アプリケーション用のイベントかチェック
-        if (!isApplicationApiEvent(data)) {
-          // アプリケーションで使用しないApiTypeIdのイベントはパイプラインに投入しないが
-          // 内容は記録（生ログとしては上で既に保存済み）
-          console.info(`[background] Non-application event (${data.ApiTypeId}): ${JSON.stringify(data)}`)
-          return
-        }
-
-        // ここでdataはApiEvent型（isApplicationApiEventで保証済み）
-        service.eventLogger(data, 'info')
-
-        // ストリーム処理（DB保存は上で完了済み）
-        service.handLogStream.write(data)
-        service.handAggregateStream.write(data)
-        service.realTimeStatsStream.write(data)
-        // Auto-sync起動・pending update再チェック（309/201/308）は上のRaw
-        // Event Lake保存直後に生ApiTypeIdベースで既にトリガー済み（本ブロックの
-        // パース成功はストリーム投入のみが目的）
+        // このイベントの処理を、直前のイベントの処理（add()の決着含む）の
+        // 後ろに連結する。`processEvent`は内部で全エラーを捕捉して素通し
+        // させない設計だが、想定外のバグでqueueが壊れて以降のイベントが
+        // 永久に詰まることのないよう、キューの継続用チェーンは別途catchする。
+        const task = ingestionQueue.then(() => processEvent(service, message))
+        ingestionQueue = task.catch(err => {
+          console.error('[background] Unhandled ingestion queue error (fail-safe, queue continues):', err)
+        })
+        return task
       })
       const stopPing = startPortPing(port)
 
@@ -215,4 +86,248 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
       })
     }
   })
+}
+
+/**
+ * 1件のAPIイベントを処理する: Raw Event Lakeへの保存（耐久性バリア）→
+ * セッション状態追跡・自動同期トリガー（raw書き込み決着後のみ）→
+ * リアルタイムパイプラインへの投入。
+ */
+const processEvent = async (
+  service: PokerChaseService,
+  message: ApiMessage | { type: string }
+): Promise<void> => {
+  // Ensure service is ready before processing messages
+  try {
+    await service.ready
+  } catch (err) {
+    console.error('[background] Service not ready:', err)
+    return
+  }
+
+  const rawApiTypeId = (message as { ApiTypeId?: unknown }).ApiTypeId
+  const rawTimestamp = (message as { timestamp?: unknown }).timestamp
+
+  // Raw Event Lake（docs/architecture.md参照）: timestamp/ApiTypeIdが数値である
+  // 限り、Zodパースの成否・アプリケーションイベントか否かに関わらず生のまま
+  // 保存する。バリデーションは後続のリアルタイム処理パイプライン（ストリーム）
+  // への投入可否のみを左右し、保存の可否は左右しない。これにより将来
+  // PokerChase側のペイロード変更でスキーマ検証が壊れても、修正後のデータ
+  // 再構築で復旧可能になる（2026年シーズン3のEVT_SESSION_RESULTS破壊的変更で
+  // 実際にデータが失われた反省による）。
+  if (validateMessage(message).success) {
+    // Dexieの型はApiEvent（既知スキーマ）を想定しているが、Lakeとして未検証・
+    // 未知のApiTypeIdの生イベントも意図的に保存するためアサーションが必要。
+    // ここを`await`し、決着（成功/失敗）してから以降の全処理へ進むのが
+    // 今回の耐久性バリア本体（release-blocker監査 finding A）。
+    try {
+      await service.db.apiEvents.add(message as ApiEvent)
+    } catch (err) {
+      const isDuplicateKey = err instanceof Dexie.DexieError && err.name === 'ConstraintError'
+      if (isDuplicateKey) {
+        // 同一(timestamp, ApiTypeId)は既にRaw Event Lakeに存在する = この
+        // イベントは初回受信時に既にセッションフック・同期トリガー・
+        // ストリームを一度通過済みのはず。ここで再度投入すると二重処理
+        // （統計の二重計上等）になるため、dedup semanticsとして以降の
+        // 全処理をスキップする。
+        console.warn('[background] Duplicate event (already in Raw Event Lake), skipping re-processing:', message)
+        return
+      }
+      // 重複以外の理由（quota超過等）でraw書き込みが失敗 = このイベントは
+      // Lakeに存在しない。「派生統計はraw行があって初めて存在してよい」
+      // というLakeの不変条件を守るため、ストリーム・セッションフック・
+      // 同期トリガーのいずれにも投入しない（forward NGが正しい判断——
+      // 「ログだけ出して素通しする」は不変条件違反を積極的に作りにいく
+      // ことになるため選ばない）。#141のdrop可視化カウンタで運用上
+      // 気づけるようにする。
+      console.error('[background] Raw Event Lake write failed -- dropping from pipeline to preserve the Lake invariant (derived stats require a raw row):', err, message)
+      if (typeof rawApiTypeId === 'number') {
+        const eventTimestamp = typeof rawTimestamp === 'number' ? rawTimestamp : Date.now()
+        recordUndecodedEvent(service.db, rawApiTypeId, eventTimestamp).catch(recordErr =>
+          console.error('[background] Failed to record dropped-event stats:', recordErr)
+        )
+      }
+      return
+    }
+  } else {
+    // timestamp/ApiTypeIdが数値でない = キーとして使えないため保存不可。
+    // add()自体を呼んでいないので耐久性バリアの対象外（待つべきI/Oが無い）。
+    // 直後のparseApiEvent()もほぼ確実にnullを返し自然に早期returnする。
+    console.warn('[background] Event missing numeric timestamp/ApiTypeId, cannot store:', message)
+  }
+
+  // ここから先は、raw書き込みが成功した（または保存不可能で待つべきI/Oが
+  // 無かった）場合にのみ到達する。add()が実際に失敗したケースは上で既に
+  // returnしている。
+
+  // Forced-update安全性述語（update-manager.ts）のセッション状態追跡:
+  // content_script.tsのkeepaliveゲート（isGameActive）と同じ境界イベントを
+  // Service Worker側で独立に追跡する（SW再起動でリセットされるため
+  // content_script側の状態と厳密に同期している必要はない -- 保守的に
+  // 「unknown = unsafe」から始まり、実イベント観測で確定させるだけでよい）。
+  // 意図的にパース成功後のdata.ApiTypeIdではなく、ここで生メッセージの
+  // 数値ApiTypeIdだけを見て判定する: PokerChase側の309ペイロード破壊的
+  // 変更でparseApiEvent()がnullを返すようになっても、308で一度activeに
+  // なったセッション状態が永久にinactiveへ戻らず、まさにその変更を
+  // 修正する更新の安全性判定がずっとunsafeのまま詰まる、という事態を
+  // 避けるため（codexレビュー指摘）
+  //
+  // ACTIVEトリガーは308(EVT_SESSION_DETAILS)単独に頼らない
+  // （release-blocker監査 finding B）: docs/api-events.md:99が明記する
+  // 通り、308の欠落は正常系のバリアント（観測ギャップ）であり、
+  // 「308が来ない試合開始」は普通に起こる。309でinactiveにした直後、
+  // 308無しで次の試合が201/303から始まると、旧実装ではsession-activityが
+  // inactiveのまま固まり、onUpdateAvailable/operation-complete契機の
+  // 安全性再チェックが「安全」と誤判定してService Workerをゲーム中に
+  // reloadしてしまう。保守的に、以下のいずれかを観測したら即active化する:
+  //   - EVT_ENTRY_QUEUED(201): 着席（新セッション/新テーブルの入口）
+  //   - EVT_DEAL(303): ハンド進行中の最も強いシグナル
+  //   - EVT_SESSION_DETAILS(308): 従来からのシグナル（来れば最速）
+  // いずれも「試合が始まった」ことしか示さず「終わった」ことは示さない
+  // ため、inactiveへ戻すトリガーは引き続き309(EVT_SESSION_RESULTS)のみ
+  // （tri-stateのunknown=unsafeデフォルトは変更しない）。
+  // 同じトリガー集合をcontent_script.tsのkeepalive起動条件にも
+  // ミラーする必要がある（背景・コンテンツスクリプト間でimport不可のため
+  // 手動同期。変更時は両ファイルを揃えること）。
+  if (rawApiTypeId === ApiType.EVT_SESSION_RESULTS) {
+    markSessionInactive()
+    // #179 round3指摘: セッション終了(EVT_SESSION_RESULTS)によるHUDクリアは
+    // App.tsx側のReact stateだけで完結しており、background(ports.ts)の
+    // `lastKnownStats`はセッションをまたいで残り続ける。この状態で
+    // Popupのバトルタイプフィルターが変更されると、message-router.tsの
+    // `updateBattleTypeFilter`ハンドラーが`getLastKnownStats()`（終了済み
+    // lineupのまま）を使って`service.statsOutputStream.write(...)`を
+    // 再トリガーし、ブロードキャストで終了済みlineupが復活してApp.tsxの
+    // クリア済みパネルへ再度流し込まれてしまう。上と同じ「パース成功後の
+    // data.ApiTypeIdではなく生メッセージの数値ApiTypeIdだけを見る」
+    // raw-firstパターンで（309のペイロード破壊的変更に影響されないよう）
+    // ここでlastKnownStatsを空にしておけば、以降のフィルター変更は
+    // `lastKnownStats.length > 0`のガードに引っかからずセッション開始前と
+    // 同じ「何もブロードキャストしない」挙動になる。プリゲーム・ヒーロー
+    // スタッツの復元（#158, `requestLatestStats`→`getLatestSessionStats`）
+    // はDBを読む別経路でありlastKnownStatsを参照しないため、この変更の
+    // 影響を受けない。
+    //
+    // post-merge reviewでは一時ここにhero単独lineupを合成する修正
+    // （round4/round5）や、App.tsx側にセッション状態・ヒーロー身元の
+    // 検証機構を足す修正（round6の「相互作用マトリクス」設計）を
+    // 積んだが、いずれもオーナー判断で撤回されている（PR #191,
+    // 2026-07-20, sola「それほど重要な機能ではないので、bで十分です」）。
+    // 理由: `service.setBattleTypeFilter()`は内部で無条件に
+    // `ReadEntityStream.recalculateStats()`を呼び、`lastKnownStats`の
+    // 中身に関係なく`service.latestEvtDeal.SeatUserIds`（ヒーローの
+    // 直近の実在席時点のフルの顔ぶれ。セッション終了後もクリアされ
+    // ない）を再計算・再ブロードキャストしてしまう。つまりこのファイル
+    // 側で`lastKnownStats`をどう作っても、その再ブロードキャストは
+    // 止められない別経路であり、追いかけるだけ複雑化する一方だった。
+    //
+    // 採用した方針（保守的な縮小スコープ）: bust後のミュート表示・
+    // hero身元の保持は「連続したライブシーケンス内」でのみ保証する
+    // （#158のセッション終了時hero保持は例外的にApp.tsx側で維持）。
+    // セッション終了後にフィルターを変更すると、`recalculateStats()`
+    // がヒーロー在籍時点の最後の実テーブル（対戦相手を含む）を新
+    // フィルターで再表示することがあるが、これは「不正確なデータ」
+    // ではなく「文脈的に古い可能性のある正確なデータ」であり、この
+    // 機能の重要度に見合わないため許容する。ここは元のround3の
+    // 意図通り単純な`[]`のままにする -- `updateBattleTypeFilter`の
+    // 明示的な`getLastKnownStats()`ベースの再write()を単にno-opに
+    // するだけで、他には何もしない。
+    //
+    // なお#188（read-entity-stream.tsのrecalculateStats()を呼ぶ
+    // message-router.tsのupdateBattleTypeFilterハンドラー自身）で、
+    // このwrite()と`recalculateStats()`の競合（観戦中のlineupが
+    // ヒーロー在籍dealのevtDealとペアリングされてしまうケース）に
+    // 対する`lineup-identity`ガードが別途入っており、この単純な
+    // `[]`のままでも競合は起きない。
+    setLastKnownStats([])
+  } else if (
+    rawApiTypeId === ApiType.EVT_ENTRY_QUEUED ||
+    rawApiTypeId === ApiType.EVT_DEAL ||
+    rawApiTypeId === ApiType.EVT_SESSION_DETAILS
+  ) {
+    markSessionActive()
+  }
+
+  // Auto-sync起動・保留中アップデートの安全性再チェックも、上のセッション状態
+  // 追跡と同じ理由で生メッセージの数値ApiTypeIdだけを見て判定する（codexレビュー
+  // 指摘, P2）。autoSyncService.onGameSessionEnd()/onNewSessionStart()は
+  // 生のapiEvents Lake（上で既に保存済み）の件数だけを見るヘルパーで、
+  // パース済みdataには一切依存しない。以前はこのトリガーが後段の
+  // `if (data.ApiTypeId === ...)`（パース成功時のみ到達するブロック）に
+  // ぶら下がっていたため、PokerChase側の309ペイロード破壊的変更で
+  // parseApiEvent()がnullを返すケースでは、下のearly returnによって
+  // recheckPendingUpdate()が一切呼ばれず、保留中アップデートは次の
+  // セッション終了までずっと詰まったままになっていた（309の生データは
+  // 上のRaw Event Lake保存で既に確保済みなので、この再チェック自体を
+  // パース成否に依存させる理由はそもそも無い）。
+  if (rawApiTypeId === ApiType.EVT_SESSION_RESULTS) {
+    // セッション終了は保留中アップデートの安全性再チェック地点の1つ
+    // （src/background/update-manager.ts参照）。recheckPendingUpdate()は
+    // onGameSessionEnd()のPromiseが完了(成功/失敗いずれか)してから
+    // 必ずチェーンして呼ぶ -- 両方を並列で撃つと、performSync()が
+    // `_isSyncing`を立てる前の非同期区間（min-versionゲートのawait等）を
+    // recheckPendingUpdate()がすり抜けて安全と誤判定し、直近セッションの
+    // クラウドバックアップがまだ始まってもいないうちに
+    // chrome.runtime.reload()でService Workerを巻き込んでしまう恐れが
+    // あるため（codexレビュー指摘, P1）
+    autoSyncService.onGameSessionEnd()
+      .catch(err => console.error('[background] Auto sync on game end failed:', err))
+      .finally(() => {
+        recheckPendingUpdate().catch(err =>
+          console.error('[background] Pending update recheck on session end failed:', err)
+        )
+      })
+  } else if (rawApiTypeId === ApiType.EVT_ENTRY_QUEUED || rawApiTypeId === ApiType.EVT_SESSION_DETAILS) {
+    // フォールバックトリガー（docs/postmortems/2026-07-session-results-drop.md
+    // 再発防止#3): 309単一トリガーのSPOF対策。新セッション開始時点は
+    // 進行中ハンドが存在しない安全なタイミングなので、ここでも同じ閾値判定
+    // でuploadを起動する（309が正常なら直前で既にバックログが閾値未満に
+    // なっているため二重発火しない）
+    autoSyncService.onNewSessionStart().catch(err =>
+      console.error('[background] Auto sync on new session start failed:', err)
+    )
+  }
+
+  // 通常のAPIメッセージ処理
+  // Zodスキーマでパース（passthrough: 未知プロパティは保持）
+  const data = parseApiEvent(message as ApiMessage)
+
+  if (!data) {
+    // パース失敗 = 必須プロパティ欠損など破壊的変更の可能性。生ログは上で
+    // 既に保存済みなので、ここではリアルタイムパイプラインへの投入のみ諦める
+    const validationResult = validateApiEvent(message as ApiMessage)
+    const errorDetails = validationResult.error ? getValidationError(validationResult.error) : null
+    console.warn(`[background] Schema validation failed (stored raw, pipeline skipped):\n  Errors: ${JSON.stringify(errorDetails, null, 2)}\n  Event: ${JSON.stringify(message, null, 2)}`)
+
+    // drop可視化（docs/postmortems/2026-07-session-results-drop.md 再発防止#2）:
+    // 検証失敗イベントの件数をApiTypeIdごとに集計してmetaテーブルへ永続化し、
+    // Popupから可視化できるようにする。309インシデントは半年間これが
+    // console.warnの中にしか無かったために気づけなかった
+    if (typeof rawApiTypeId === 'number') {
+      const eventTimestamp = typeof rawTimestamp === 'number' ? rawTimestamp : Date.now()
+      recordUndecodedEvent(service.db, rawApiTypeId, eventTimestamp).catch(err =>
+        console.error('[background] Failed to record undecoded event stats:', err)
+      )
+    }
+    return
+  }
+
+  // アプリケーション用のイベントかチェック
+  if (!isApplicationApiEvent(data)) {
+    // アプリケーションで使用しないApiTypeIdのイベントはパイプラインに投入しないが
+    // 内容は記録（生ログとしては上で既に保存済み）
+    console.info(`[background] Non-application event (${data.ApiTypeId}): ${JSON.stringify(data)}`)
+    return
+  }
+
+  // ここでdataはApiEvent型（isApplicationApiEventで保証済み）
+  service.eventLogger(data, 'info')
+
+  // ストリーム処理（DB保存は上で完了済み・耐久性確定済み）
+  service.handLogStream.write(data)
+  service.handAggregateStream.write(data)
+  service.realTimeStatsStream.write(data)
+  // Auto-sync起動・pending update再チェック（309/201/308）は上のRaw
+  // Event Lake保存直後に生ApiTypeIdベースで既にトリガー済み（本ブロックの
+  // パース成功はストリーム投入のみが目的）
 }

--- a/src/background/event-ingestion.ts
+++ b/src/background/event-ingestion.ts
@@ -13,7 +13,7 @@ import type { ApiEvent } from '../app'
 import { autoSyncService } from '../services/auto-sync-service'
 import { connectedPorts, startPortPing, setLastKnownStats } from './ports'
 import { recordUndecodedEvent } from './undecoded-event-tracker'
-import { markSessionActive, markSessionInactive, recheckPendingUpdate } from './update-manager'
+import { markSessionActive, markSessionInactive, recheckPendingUpdate, revertSessionActivityIfStillApplied } from './update-manager'
 
 /**
  * `chrome.runtime.onConnect`のハンドラーを登録する。
@@ -56,6 +56,21 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
   // （最小要件を満たしつつ上回る、意図的な選択）。
   let ingestionQueue: Promise<void> = Promise.resolve()
 
+  // 到着シーケンス番号（P1, codexレビュー 2026-07-21指摘）: ACTIVE化は
+  // port.onMessage受信直後に完全に同期的に、INACTIVE化はingestionQueue
+  // 経由でRaw Event Lake耐久性バリアの後ろに非同期に決着する。両者は
+  // タイミングが非対称なため、生の到着順序が[309, 201]（セッション終了の
+  // 直後に次のセッションが201/303から始まる、正常系のバリアント）だと、
+  // 遅れて決着する309のINACTIVE化が、先に決着していた201のACTIVE化を
+  // 後から上書きしてしまい「新しいハンドが進行中なのにinactiveのまま」
+  // という状態反転が起こりうる。この`arrivalSequence`を各メッセージの
+  // 受信直後（同期的に、キューへ積むより前）にインクリメントして
+  // `markSessionActive`/`markSessionInactive`へ明示的に渡すことで、
+  // update-manager.ts側が「真の到着順序」を判定でき、決着が遅れた古い
+  // 遷移が新しい遷移を上書きすることを防げる（詳細は
+  // update-manager.tsの該当コメント参照）。
+  let arrivalSequence = 0
+
   chrome.runtime.onConnect.addListener(port => {
     if (port.name === PokerChaseService.POKER_CHASE_SERVICE_EVENT) {
       connectedPorts.add(port)
@@ -66,16 +81,20 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
           return
         }
 
+        // このメッセージの到着順序を同期的に記録する（他のどの非同期処理
+        // よりも前に採番することが重要 -- 上のコメント参照）。
+        const arrivalSeq = ++arrivalSequence
+
         // ACTIVE化は`service.ready`・raw書き込みの耐久性バリアより前に、
         // 完全に同期的に行う（P2, codexレビュー指摘 2026-07-21）。
         // 詳細は`markSessionActiveFromRawMessage()`のコメント参照。
-        markSessionActiveFromRawMessage(message)
+        markSessionActiveFromRawMessage(message, arrivalSeq)
 
         // このイベントの処理を、直前のイベントの処理（add()の決着含む）の
         // 後ろに連結する。`processEvent`は内部で全エラーを捕捉して素通し
         // させない設計だが、想定外のバグでqueueが壊れて以降のイベントが
         // 永久に詰まることのないよう、キューの継続用チェーンは別途catchする。
-        const task = ingestionQueue.then(() => processEvent(service, message))
+        const task = ingestionQueue.then(() => processEvent(service, message, arrivalSeq))
         ingestionQueue = task.catch(err => {
           console.error('[background] Unhandled ingestion queue error (fail-safe, queue continues):', err)
         })
@@ -127,17 +146,25 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
  * 無期限にブロックされてしまう。raw-firstパターンに従い、Zodパース前の
  * 生フィールドの有無だけで判定する（content_script.tsのkeepalive起動条件も
  * 同じ判定をミラーする）。
+ *
+ * `arrivalSeq`はこのメッセージの到着順序（`registerEventIngestion()`の
+ * `arrivalSequence`カウンタ参照）。真の到着順序を保つため、以降の
+ * `processEvent`内での（決着が遅れうる）INACTIVE化との整合判定に使う
+ * （update-manager.tsの`markSessionActive`/`markSessionInactive`コメント
+ * 参照）。また、この呼び出しが実は真の重複（reconnect resend等）だったと
+ * 後で判明した場合の`revertSessionActivityIfStillApplied(arrivalSeq)`
+ * （P2, codexレビュー指摘, processEvent内）にも同じ値を使う。
  */
-const markSessionActiveFromRawMessage = (message: ApiMessage | { type: string }): void => {
+const markSessionActiveFromRawMessage = (message: ApiMessage | { type: string }, arrivalSeq: number): void => {
   const rawApiTypeId = (message as { ApiTypeId?: unknown }).ApiTypeId
   if (rawApiTypeId === ApiType.EVT_ENTRY_QUEUED || rawApiTypeId === ApiType.EVT_SESSION_DETAILS) {
-    markSessionActive()
+    markSessionActive(arrivalSeq)
     return
   }
   if (rawApiTypeId === ApiType.EVT_DEAL) {
     const rawPlayer = (message as { Player?: unknown }).Player
     if (rawPlayer != null) {
-      markSessionActive()
+      markSessionActive(arrivalSeq)
     }
   }
 }
@@ -165,11 +192,18 @@ const isSamePayload = (a: unknown, b: unknown): boolean => {
  *
  * ACTIVE化のセッション状態追跡（`markSessionActiveFromRawMessage()`）は
  * この関数の外（`port.onMessage`受信直後、耐久性バリアより前）で完全に
- * 同期的に既に処理済み。ここで扱うのはINACTIVE化（309）のみ。
+ * 同期的に既に処理済み。ここで扱うのはINACTIVE化（309）と、真の重複判明時の
+ * ACTIVE化ロールバックのみ。
+ *
+ * `arrivalSeq`は呼び出し元（`registerEventIngestion()`）が同期的に採番した
+ * このメッセージの到着順序。`markSessionInactive`/
+ * `revertSessionActivityIfStillApplied`へそのまま渡し、決着タイミングが
+ * 前後しても真の到着順序で状態が決まるようにする。
  */
 const processEvent = async (
   service: PokerChaseService,
-  message: ApiMessage | { type: string }
+  message: ApiMessage | { type: string },
+  arrivalSeq: number
 ): Promise<void> => {
   // Ensure service is ready before processing messages
   try {
@@ -224,6 +258,19 @@ const processEvent = async (
           // すると二重処理（統計の二重計上等）になるため、dedup semantics
           // として以降の全処理をスキップする。
           console.warn('[background] Duplicate event (identical payload already in Raw Event Lake), skipping re-processing:', message)
+
+          // P2 (codexレビュー指摘 2026-07-21): この生メッセージが201/303
+          // [Player在席]/308形状だった場合、`markSessionActiveFromRawMessage()`
+          // が既にこのイベントの到着時点で楽観的にACTIVE化を試みている
+          // （耐久性バリアより前の同期処理のため、この時点ではまだ重複と
+          // 判明していなかった）。今ここで真の重複と判明したので、その
+          // 楽観的なACTIVE化がまだ現在の状態として有効であれば
+          // （＝それ以降により新しい遷移が適用されていなければ）取り消し、
+          // 直前の状態（例: 309で既にinactiveだった場合はinactive）へ
+          // ロールバックする。stale reconnect resend等が
+          // 「新しいハンドが無いのにsessionActivityをactiveへ戻し、保留中
+          // アップデートを無期限にブロックする」事態を防ぐ。
+          revertSessionActivityIfStillApplied(arrivalSeq)
           return
         }
 
@@ -289,9 +336,13 @@ const processEvent = async (
   // ペイロード破壊的変更でparseApiEvent()がnullを返すようになっても、
   // セッション状態が永久にinactiveへ戻らず、まさにその変更を修正する
   // 更新の安全性判定がずっとunsafeのまま詰まる、という事態を避けるため
-  // （codexレビュー指摘）
+  // （codexレビュー指摘）。`arrivalSeq`を渡すのはP1（codexレビュー指摘
+  // 2026-07-21）対応: この309の決着が耐久性バリアの後ろで遅れている間に
+  // より新しいメッセージ（201/303等）が同期的にACTIVE化を先に適用して
+  // いた場合、この（実際には古い）INACTIVE化がそれを上書きしないよう
+  // update-manager.ts側で到着順序を判定させるため。
   if (rawApiTypeId === ApiType.EVT_SESSION_RESULTS) {
-    markSessionInactive()
+    markSessionInactive(arrivalSeq)
     // #179 round3指摘: セッション終了(EVT_SESSION_RESULTS)によるHUDクリアは
     // App.tsx側のReact stateだけで完結しており、background(ports.ts)の
     // `lastKnownStats`はセッションをまたいで残り続ける。この状態で

--- a/src/background/event-ingestion.ts
+++ b/src/background/event-ingestion.ts
@@ -43,16 +43,62 @@ let ingestionQueue: Promise<void> = Promise.resolve()
 
 /**
  * 到着世代カウンタ（P1, codexレビュー指摘 2026-07-21, pass-4,
- * "Don't reload before queued session starts run"）。キューへ何か（キープ
- * アライブ以外のメッセージ）が積まれるたびに同期的にインクリメントする。
- * `ingestionQueue`自体の参照比較（`awaitIngestionDrain()`のループ）とは
- * 別に、309/203自身の`processEvent`実行の**内側**から「自分の後に何か
- * 積まれていないか」を同期的に確認するために使う——その場所では
- * `awaitIngestionDrain()`（自己参照でデッドロックする）は使えない
- * ため、単調増加のカウンタで代用する。詳細は`processEvent`の309/203
- * ブロックのコメント参照。
+ * "Don't reload before queued session starts run"）。キューへ積まれる
+ * メッセージのうち、セッション状態（ACTIVE/INACTIVE）に影響しうるもの
+ * ——`isSessionActivityRelevant()`参照——だけを対象に同期的に
+ * インクリメントする。`ingestionQueue`自体の参照比較
+ * （`awaitIngestionDrain()`のループ）とは別に、309/203自身の
+ * `processEvent`実行の**内側**から「自分の後にセッション状態へ影響しうる
+ * イベントが既に積まれていないか」を同期的に確認するために使う——
+ * その場所では`awaitIngestionDrain()`（自己参照でデッドロックする）は
+ * 使えないため、単調増加のカウンタで代用する。詳細は`processEvent`の
+ * 309/203ブロックのコメント参照。
+ *
+ * セッション状態に無関係なメッセージ（202/205等の非アプリケーション
+ * イベント、真の重複と後で判明するイベント等）ではインクリメントしない
+ * （P2, codexレビュー指摘 2026-07-21, pass-5, "Don't let noise suppress
+ * session-end rechecks"）: このカウンタが「何かキューへ積まれたら
+ * 一律インクリメント」だった旧実装では、309/203自身も再チェックできず、
+ * かつそのノイズイベント自身も自分のrecheckを一切トリガーしないため、
+ * 保留中アップデートが無関係な操作完了・SW再起動まで永遠にブロックされ
+ * うる問題があった。ACTIVE/INACTIVEを動かしうるイベントだけを対象に
+ * 絞ることで、「本当に安全性判定に影響しうる新しい到着」だけを検知する。
  */
-let queueGeneration = 0
+let activityGeneration = 0
+
+/**
+ * 生メッセージが（決着すれば）セッションのACTIVE/INACTIVE状態に影響し
+ * うるかどうかを、Zodパース前の数値ApiTypeId・生フィールドだけで判定
+ * する。`applySessionActivity()`が実際に扱うトリガー集合と完全に一致
+ * させること（判定基準がズレると`activityGeneration`が過大/過小に
+ * カウントされ、finding 1/finding 3のどちらかを再発させる）。
+ *
+ * 保守的に倒す判断（P2, codexレビュー指摘 2026-07-21, pass-5）: この
+ * 関数はまだraw書き込み・重複判定の**前**、`port.onMessage`受信直後の
+ * 同期的な文脈で呼ぶため、このメッセージが後で真の重複と判明して
+ * `applySessionActivity()`まで到達しない可能性がある（`processEvent`の
+ * 重複判定コメント参照）。それでもここでは「ApiTypeId/Playerの形」
+ * だけで判定し、重複かどうかは考慮しない——真の重複を稀に過大カウント
+ * しても、309/203の再チェックが「今回は見送り、次の契機に委ねる」だけで
+ * 実害は無い（安全側）。逆に見逃す（過小カウントする）と、決着済みの
+ * ACTIVE化がreload判定に反映される前にreloadしてしまう恐れがあり、
+ * それは実害があるため、疑わしきは「影響しうる」側に倒す。
+ */
+const isSessionActivityRelevant = (rawApiTypeId: unknown, message: ApiMessage | { type: string }): boolean => {
+  if (
+    rawApiTypeId === ApiType.EVT_SESSION_RESULTS ||
+    rawApiTypeId === EVT_ENTRY_CANCELLED_API_TYPE_ID ||
+    rawApiTypeId === ApiType.EVT_ENTRY_QUEUED ||
+    rawApiTypeId === ApiType.EVT_SESSION_DETAILS
+  ) {
+    return true
+  }
+  if (rawApiTypeId === ApiType.EVT_DEAL) {
+    const rawPlayer = (message as { Player?: unknown }).Player
+    return rawPlayer != null
+  }
+  return false
+}
 
 /**
  * `chrome.runtime.onConnect`のハンドラーを登録する。
@@ -105,16 +151,19 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
   // サスペンド/リロード・タブクローズが起きればそれらのイベントは失われる。
   // `chrome.runtime.reload()`を呼びうる`recheckPendingUpdate()`だけは
   // 引き続き同期トリガーの決着後にチェーンするが、`processEvent`からawait
-  // せずfire-and-forgetにし、代わりに呼ぶ直前で`queueGeneration`を確認
-  // する（「自分の到着後に何か新しく積まれていないか」の同期的な
-  // チェック——詳細は`processEvent`の309/203ブロックのコメント参照）。
-  // これにより、以前のラウンドで「reloadが次イベントのin-flightなadd()と
-  // 競合する」ことを防ぐために採用していた「キューをブロックして順序を
-  // 強制する」戦略から、「決定の直前に鮮度を確認し、古ければreloadを
-  // 諦めて次の契機に委ねる」戦略へ切り替えている——ブロックしなくても
-  // 同じ安全性が得られ、かつスループットを犠牲にしない。
+  // せずfire-and-forgetにする。再チェック自体の安全性は、キューを
+  // ブロックする代わりに`recheckPendingUpdate()`の`isStillFresh`
+  // オプション（`activityGeneration`比較を渡す）で担保する——`reload()`
+  // 呼び出し直前まで`await`を挟まず原子的に確認する（詳細は
+  // update-manager.tsの`recheckPendingUpdate()`コメント、および
+  // `processEvent`の309/203ブロックのコメント参照）。これにより、以前の
+  // ラウンドで「reloadが次イベントのin-flightなadd()と競合する」ことを
+  // 防ぐために採用していた「キューをブロックして順序を強制する」戦略
+  // から、「決定の直前に鮮度を確認し、古ければreloadを諦めて次の契機に
+  // 委ねる」戦略へ切り替えている——ブロックしなくても同じ安全性が得られ、
+  // かつスループットを犠牲にしない。
   ingestionQueue = Promise.resolve()
-  queueGeneration = 0
+  activityGeneration = 0
   setIngestionDrainProvider(() => ingestionQueue)
 
   chrome.runtime.onConnect.addListener(port => {
@@ -127,15 +176,20 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
           return
         }
 
-        // このメッセージが積まれた時点の世代を記録する（上の
-        // `queueGeneration`コメント参照）。
-        const enqueueGeneration = ++queueGeneration
+        // このメッセージがセッション状態に影響しうる場合のみ、積まれた
+        // 時点の世代を記録する（上の`activityGeneration`/
+        // `isSessionActivityRelevant`コメント参照）。
+        const rawApiTypeIdForGeneration = (message as { ApiTypeId?: unknown }).ApiTypeId
+        if (isSessionActivityRelevant(rawApiTypeIdForGeneration, message)) {
+          activityGeneration++
+        }
+        const enqueueActivityGeneration = activityGeneration
 
         // このイベントの処理を、直前のイベントの処理（add()の決着含む）の
         // 後ろに連結する。`processEvent`は内部で全エラーを捕捉して素通し
         // させない設計だが、想定外のバグでqueueが壊れて以降のイベントが
         // 永久に詰まることのないよう、キューの継続用チェーンは別途catchする。
-        const task = ingestionQueue.then(() => processEvent(service, message, enqueueGeneration))
+        const task = ingestionQueue.then(() => processEvent(service, message, enqueueActivityGeneration))
         ingestionQueue = task.catch(err => {
           console.error('[background] Unhandled ingestion queue error (fail-safe, queue continues):', err)
         })
@@ -234,15 +288,17 @@ const applySessionActivity = (rawApiTypeId: unknown, message: ApiMessage | { typ
  * セッション状態追跡・自動同期トリガー（raw書き込み決着後のみ）→
  * リアルタイムパイプラインへの投入。
  *
- * `enqueueGeneration`は呼び出し元（`registerEventIngestion()`）が
- * このメッセージをキューへ積んだ時点で採番した`queueGeneration`の値。
- * 309/203ブロックが「自分の到着後に何か新しく積まれていないか」を
- * 同期的に確認するために使う（詳細は該当ブロックのコメント参照）。
+ * `enqueueActivityGeneration`は呼び出し元（`registerEventIngestion()`）が
+ * このメッセージをキューへ積んだ時点で採番した`activityGeneration`の値
+ * （セッション状態に無関係なメッセージでは単に現在値のスナップショット、
+ * 比較には使わない）。309/203ブロックが「自分の到着後にセッション状態へ
+ * 影響しうるイベントが既に積まれていないか」を同期的に確認するために使う
+ * （詳細は該当ブロックのコメント参照）。
  */
 const processEvent = async (
   service: PokerChaseService,
   message: ApiMessage | { type: string },
-  enqueueGeneration: number
+  enqueueActivityGeneration: number
 ): Promise<void> => {
   // Ensure service is ready before processing messages
   try {
@@ -465,31 +521,49 @@ const processEvent = async (
     // （前回の暫定対策——チェーン全体をawaitしてreloadとの競合を防ぐ——は
     // このスループット問題を引き起こしていた）。
     //
-    // reload競合の防止は、キューをブロックする代わりに`queueGeneration`
-    // の比較で行う（P1, codexレビュー指摘 2026-07-21, pass-4, "Don't
-    // reload before queued session starts run"）: `onGameSessionEnd()`
-    // が完了した時点で、このメッセージが積まれてから（＝
-    // `enqueueGeneration`採番時から）`queueGeneration`が進んでいれば、
-    // 自分の後に新しいイベント（次のハンドの201/303等、まだ
+    // reload競合の防止は、キューをブロックする代わりに
+    // `recheckPendingUpdate()`の`isStillFresh`オプション（
+    // `activityGeneration`比較）で行う（P1, codexレビュー指摘
+    // 2026-07-21, pass-4/pass-5, "Don't reload before queued session
+    // starts run" / "Guard reload rechecks through the async path"）。
+    //
+    // pass-4時点では「`onGameSessionEnd()`決着直後、`recheckPendingUpdate()`
+    // を呼ぶ前」の1回だけ`activityGeneration`を比較していたが、
+    // `recheckPendingUpdate()`自身も`getPendingUpdateState()`等の
+    // `await`を複数挟む非同期関数であり、その隙間で新しいイベントが
+    // 到着・キューへ積まれうる（pass-5, codexレビュー指摘: 「事前の
+    // 1回チェック」では不十分で、実際にreloadする直前でもう一度確認
+    // しないと隙間を締め切れない）。そこで比較そのものを
+    // `recheckPendingUpdate()`側へ渡し、`isSafeToUpdate()`と全く同じ
+    // タイミング（`chrome.runtime.reload()`直前、間に`await`を挟まない
+    // 原子的な確認——詳細はupdate-manager.tsの`recheckPendingUpdate()`
+    // コメント参照）で評価させる。
+    //
+    // このメッセージが積まれてから（＝`enqueueActivityGeneration`採番
+    // 時から）`activityGeneration`が進んでいれば、自分の後にセッション
+    // 状態へ影響しうる新しいイベント（次のハンドの201/303等、まだ
     // `applySessionActivity()`未実行）が既に積まれているということ。
-    // その状態で`recheckPendingUpdate()`を呼ぶと、`isSafeToUpdate()`が
-    // まだ反映されていない古い（309由来の）inactiveを読んで「安全」と
-    // 誤判定し、次イベントのin-flightな`apiEvents.add()`と競合する
-    // reloadを引き起こしうる。世代が変わっていなければ（＝自分の後に
-    // 何も積まれていない）、この時点でのreloadは安全——`ingestionQueue`
-    // は直列なので、自分より後に何も積まれていない限り新しいイベントが
-    // 割り込む余地は無い。世代が変わっていれば今回のrecheckは諦め、次の
-    // 自然な契機（次のセッション終了・操作完了・SW起動）に委ねる
-    // （その新しいイベント自身がいずれ309/203に到達すれば、その時点で
-    // 改めてこの同じチェックが走る）。
+    // その状態で`isSafeToUpdate()`が真だとしても、それはまだ反映されて
+    // いない古い（309由来の）inactiveを読んでいるだけであり、
+    // 実際にreloadすると次イベントのin-flightな`apiEvents.add()`と
+    // 競合しうる。世代が変わっていなければ（＝自分の後にセッション状態へ
+    // 影響しうるイベントが何も積まれていない）、この時点でのreloadは
+    // 安全——`ingestionQueue`は直列なので、割り込む余地は無い。世代が
+    // 変わっていれば今回のrecheckは諦め、次の自然な契機（次のセッション
+    // 終了・操作完了・SW起動）に委ねる（その新しいイベント自身がいずれ
+    // 309/203に到達すれば、その時点で改めてこの同じチェックが走る）。
+    //
+    // セッション状態に無関係な「ノイズ」イベント（202/205等の非
+    // アプリケーションイベント、真の重複と判明したイベント）は
+    // `activityGeneration`をそもそも進めない（P2, codexレビュー指摘
+    // 2026-07-21, pass-5, "Don't let noise suppress session-end
+    // rechecks"）ため、この鮮度チェックを無用に失敗させて再チェックを
+    // 妨げることはない——詳細は`isSessionActivityRelevant()`のコメント
+    // 参照。
     autoSyncService.onGameSessionEnd()
       .catch(err => console.error('[background] Auto sync on game end failed:', err))
       .finally(() => {
-        if (queueGeneration !== enqueueGeneration) {
-          console.log('[background] Skipping pending-update recheck after session end -- a newer event has already been queued, deferring to a later recheck trigger')
-          return
-        }
-        recheckPendingUpdate().catch(err =>
+        recheckPendingUpdate({ isStillFresh: () => activityGeneration === enqueueActivityGeneration }).catch(err =>
           console.error('[background] Pending update recheck on session end failed:', err)
         )
       })
@@ -502,18 +576,14 @@ const processEvent = async (
     // ちょうど安全になったケースでも別の契機（次のセッション終了・操作
     // 完了・SW起動）が来るまで保留され続けてしまう。203はauto-syncの
     // トリガー対象ではない（バックアップすべきセッションデータが無い）
-    // ため`onGameSessionEnd()`は呼ばず、309と同じ`queueGeneration`鮮度
-    // チェックの後に`recheckPendingUpdate()`だけを呼ぶ（このイベント自体
-    // には`onGameSessionEnd()`のような遅い非同期処理が挟まらないため、
-    // 実際にここで世代がずれることは稀だが、同じガードを一貫して適用
-    // しておく）。
-    if (queueGeneration !== enqueueGeneration) {
-      console.log('[background] Skipping pending-update recheck after entry cancellation -- a newer event has already been queued, deferring to a later recheck trigger')
-    } else {
-      recheckPendingUpdate().catch(err =>
-        console.error('[background] Pending update recheck on entry cancellation failed:', err)
-      )
-    }
+    // ため`onGameSessionEnd()`は呼ばず、309と同じ`isStillFresh`ガード
+    // 付きで`recheckPendingUpdate()`だけを呼ぶ（このイベント自体には
+    // `onGameSessionEnd()`のような遅い非同期処理が挟まらないため、実際
+    // にここで世代がずれることは稀だが、同じガードを一貫して適用して
+    // おく）。
+    recheckPendingUpdate({ isStillFresh: () => activityGeneration === enqueueActivityGeneration }).catch(err =>
+      console.error('[background] Pending update recheck on entry cancellation failed:', err)
+    )
   } else if (rawApiTypeId === ApiType.EVT_ENTRY_QUEUED || rawApiTypeId === ApiType.EVT_SESSION_DETAILS) {
     // フォールバックトリガー（docs/postmortems/2026-07-session-results-drop.md
     // 再発防止#3): 309単一トリガーのSPOF対策。新セッション開始時点は

--- a/src/background/event-ingestion.update-manager-trigger.test.ts
+++ b/src/background/event-ingestion.update-manager-trigger.test.ts
@@ -199,6 +199,64 @@ describe('registerEventIngestion (update-manager triggers)', () => {
     expect(recheckPendingUpdateSpy).not.toHaveBeenCalled()
   })
 
+  test('a spectator-mode EVT_DEAL (303, Player absent) does NOT mark the session active (P2, codex review 2026-07-21)', async () => {
+    // docs/api-events.md "EVT_DEAL: Playerフィールドの欠落" / spectator-mode
+    // deals (e.g. after the hero busts but the client keeps receiving other
+    // players' table) have no `Player` field at all. Treating every 303 as
+    // ACTIVE would keep sessionActivity stuck 'active' through a spectated
+    // session that never gets another 309, blocking pending Forced Updates
+    // indefinitely.
+    const spectatorDealEvent = {
+      ApiTypeId: ApiType.EVT_DEAL,
+      timestamp: 4500,
+      SeatUserIds: [1, 2, 3, 4],
+      Game: { CurrentBlindLv: 1, NextBlindUnixSeconds: 0, Ante: 0, SmallBlind: 100, BigBlind: 200, ButtonSeat: 0, SmallBlindSeat: 1, BigBlindSeat: 2 },
+      // Player omitted entirely -- spectator mode
+      OtherPlayers: [
+        { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 100 },
+        { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 200 }
+      ],
+      Progress: { Phase: 0, NextActionSeat: 0, NextActionTypes: [2, 3, 4, 5], NextExtraLimitSeconds: 1, MinRaise: 400, Pot: 300, SidePot: [] }
+    }
+    await onMessageHandler(spectatorDealEvent)
+
+    expect(markSessionActiveSpy).not.toHaveBeenCalled()
+    expect(markSessionInactiveSpy).not.toHaveBeenCalled()
+  })
+
+  test('markSessionActive() runs synchronously before the raw-write durability await settles (P2, codex review 2026-07-21)', async () => {
+    // The durability barrier (finding A) awaits apiEvents.add() before
+    // forwarding to streams/sync-triggers -- but session-activity tracking
+    // must NOT wait behind that same await, or a safety recheck racing a
+    // slow/stuck add() would still see the stale 'inactive' value from the
+    // previous 309 and judge a mid-game reload "safe". Verify
+    // markSessionActive() has already run before the message handler's
+    // returned promise even settles (i.e. before any awaited work inside
+    // processEvent has had a chance to resolve).
+    let resolveAdd!: (key: number) => void
+    jest.spyOn(db.apiEvents, 'add').mockImplementation(
+      (() => new Promise<number>(resolve => { resolveAdd = resolve })) as any
+    )
+
+    const entryQueuedEvent = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED, timestamp: 9000, Code: 0, BattleType: 0, Id: 'stage000_003', IsRetire: false
+    }
+    // Deliberately not awaited yet -- markSessionActiveSpy must already have
+    // fired by the time this synchronous call returns, well before add()
+    // resolves.
+    void onMessageHandler(entryQueuedEvent)
+
+    expect(markSessionActiveSpy).toHaveBeenCalledTimes(1)
+    expect(updateManager.isSafeToUpdate()).toBe(false)
+
+    // Let the queue actually reach the mocked (still-unresolved) add() call
+    // before releasing it, so the test cleans up without leaking a pending
+    // promise.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    resolveAdd(1)
+    await new Promise(resolve => setTimeout(resolve, 0))
+  })
+
   test('raw sequence 309 -> 201 -> 303 without an intervening 308 does not leave the session stuck inactive (release-blocker audit exact scenario)', async () => {
     // The audit's precise regression scenario: a session ends (309), then a
     // brand-new game starts 201/303-first with no 308 in between (a normal

--- a/src/background/event-ingestion.update-manager-trigger.test.ts
+++ b/src/background/event-ingestion.update-manager-trigger.test.ts
@@ -169,11 +169,18 @@ describe('registerEventIngestion (update-manager triggers)', () => {
     expect(markSessionInactiveSpy).not.toHaveBeenCalled()
   })
 
-  test('an unrelated application event (EVT_DEAL) does not touch session-activity tracking', async () => {
+  test('EVT_DEAL (303, hand-in-flight signal) marks the session active (release-blocker audit finding B: 308 alone is not a reliable ACTIVE trigger)', async () => {
+    // docs/api-events.md:99 documents 308 (EVT_SESSION_DETAILS) absence as a
+    // normal variant (an observation gap), not an anomaly. A new game can
+    // legitimately start 201/303-first with no 308 at all. Before this fix,
+    // session-activity tracking only listened for 308, so a session ending
+    // (309 -> inactive) followed by a 308-less restart left the tri-state
+    // stuck inactive, and the Forced Update safety predicate would judge a
+    // mid-game reload "safe".
     const dealEvent = {
       ApiTypeId: ApiType.EVT_DEAL,
       timestamp: 4000,
-      SeatUserIds: [1, 2, 3],
+      SeatUserIds: [1, 2, 3, 4],
       Game: { CurrentBlindLv: 1, NextBlindUnixSeconds: 0, Ante: 0, SmallBlind: 100, BigBlind: 200, ButtonSeat: 0, SmallBlindSeat: 1, BigBlindSeat: 2 },
       Player: { SeatIndex: 0, BetStatus: 1, HoleCards: [0, 1], Chip: 5000, BetChip: 0 },
       OtherPlayers: [
@@ -184,8 +191,78 @@ describe('registerEventIngestion (update-manager triggers)', () => {
     }
     await onMessageHandler(dealEvent)
 
-    expect(markSessionActiveSpy).not.toHaveBeenCalled()
+    expect(markSessionActiveSpy).toHaveBeenCalledTimes(1)
     expect(markSessionInactiveSpy).not.toHaveBeenCalled()
+    // EVT_DEAL is not a pending-update recheck point (only session end/
+    // operation completion/SW startup are, per update-manager.ts) -- marking
+    // active is not the same as re-checking a *pending* update.
+    expect(recheckPendingUpdateSpy).not.toHaveBeenCalled()
+  })
+
+  test('raw sequence 309 -> 201 -> 303 without an intervening 308 does not leave the session stuck inactive (release-blocker audit exact scenario)', async () => {
+    // The audit's precise regression scenario: a session ends (309), then a
+    // brand-new game starts 201/303-first with no 308 in between (a normal
+    // variant per docs/api-events.md:99, e.g. an observation gap). Only a
+    // real EVT_SESSION_RESULTS (309) may mark the tri-state inactive again --
+    // it must not silently stay 'inactive' (which `isSafeToUpdate()` would
+    // read as SAFE and reload mid-game).
+    const sessionResultsEvent = {
+      ApiTypeId: ApiType.EVT_SESSION_RESULTS,
+      timestamp: 8000,
+      Ranking: 1,
+      IsLeave: false,
+      IsRebuy: false,
+      TotalMatch: 10,
+      RankReward: {
+        IsSeasonal: true,
+        RankPoint: 1,
+        RankPointDiff: 1,
+        Rank: { RankId: 'gold', RankName: 'ゴールド', RankLvId: 'gold', RankLvName: 'ゴールド' },
+        SeasonalRanking: 0
+      },
+      Rewards: [],
+      EventRewards: [],
+      Charas: [],
+      Costumes: [],
+      Decos: [],
+      Items: [],
+      Money: { FreeMoney: -1, PaidMoney: -1 },
+      Emblems: []
+    }
+    const entryQueuedEvent = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      timestamp: 8100,
+      Code: 0,
+      BattleType: 0,
+      Id: 'stage000_003',
+      IsRetire: false
+    }
+    const dealEvent = {
+      ApiTypeId: ApiType.EVT_DEAL,
+      timestamp: 8200,
+      SeatUserIds: [1, 2, 3, 4],
+      Game: { CurrentBlindLv: 1, NextBlindUnixSeconds: 0, Ante: 0, SmallBlind: 100, BigBlind: 200, ButtonSeat: 0, SmallBlindSeat: 1, BigBlindSeat: 2 },
+      Player: { SeatIndex: 0, BetStatus: 1, HoleCards: [0, 1], Chip: 5000, BetChip: 0 },
+      OtherPlayers: [
+        { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 100 },
+        { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 200 }
+      ],
+      Progress: { Phase: 0, NextActionSeat: 0, NextActionTypes: [2, 3, 4, 5], NextExtraLimitSeconds: 1, MinRaise: 400, Pot: 300, SidePot: [] }
+    }
+
+    await onMessageHandler(sessionResultsEvent)
+    await new Promise(resolve => setTimeout(resolve, 0)) // let the 309 recheck chain settle
+    recheckPendingUpdateSpy.mockClear()
+
+    await onMessageHandler(entryQueuedEvent)
+    await onMessageHandler(dealEvent)
+
+    // No 309 has occurred since the deal -- update-manager must still see
+    // the session as active (unsafe to reload), never as stuck 'inactive'.
+    expect(updateManager.isSafeToUpdate()).toBe(false)
+    // Session start (201/308) is a pending-update recheck point, but a plain
+    // EVT_DEAL is not -- confirms the tri-state itself (not just the recheck
+    // call) is what's carrying the fix.
     expect(recheckPendingUpdateSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/background/event-ingestion.update-manager-trigger.test.ts
+++ b/src/background/event-ingestion.update-manager-trigger.test.ts
@@ -363,4 +363,39 @@ describe('registerEventIngestion (update-manager triggers)', () => {
     expect(markSessionInactiveSpy).toHaveBeenCalledTimes(1)
     expect(updateManager.isSafeToUpdate()).toBe(true) // inactive again -- no hand ever started
   })
+
+  test('EVT_ENTRY_CANCELLED (203) also triggers the pending-update recheck, same as EVT_SESSION_RESULTS (309) (P2, codex review 2026-07-20 pass-4: "Recheck updates after entry cancellation")', async () => {
+    // applySessionActivity() treats 203 as an INACTIVE trigger (previous
+    // test), but that alone doesn't help a pending Forced Update: without
+    // also firing recheckPendingUpdate() here, a pending update stays
+    // blocked until some unrelated future trigger (a later session's 309,
+    // operation completion, or a Service Worker restart) happens to poke
+    // it, even though cancelling the entry is itself the exact moment it
+    // became safe to apply.
+    const entryQueuedEvent = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      timestamp: 11000,
+      Code: 0,
+      BattleType: 0,
+      Id: 'stage000_003',
+      IsRetire: false
+    }
+    const entryCancelledEvent = {
+      ApiTypeId: 203,
+      timestamp: 11100,
+      Code: 0
+    }
+
+    await onMessageHandler(entryQueuedEvent)
+    recheckPendingUpdateSpy.mockClear()
+
+    await onMessageHandler(entryCancelledEvent)
+    // event-ingestion.ts's 203 branch is fire-and-forget-free (no slow
+    // upload precedes it) but still routed through the same
+    // queueGeneration freshness check as 309 -- flush microtasks so that
+    // synchronous chain settles before asserting.
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(recheckPendingUpdateSpy).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/background/event-ingestion.update-manager-trigger.test.ts
+++ b/src/background/event-ingestion.update-manager-trigger.test.ts
@@ -390,10 +390,8 @@ describe('registerEventIngestion (update-manager triggers)', () => {
     recheckPendingUpdateSpy.mockClear()
 
     await onMessageHandler(entryCancelledEvent)
-    // event-ingestion.ts's 203 branch is fire-and-forget-free (no slow
-    // upload precedes it) but still routed through the same
-    // queueGeneration freshness check as 309 -- flush microtasks so that
-    // synchronous chain settles before asserting.
+    // event-ingestion.ts's 203 branch has no slow upload before its recheck;
+    // flush microtasks so the fire-and-forget call is observable here.
     await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(recheckPendingUpdateSpy).toHaveBeenCalledTimes(1)

--- a/src/background/event-ingestion.update-manager-trigger.test.ts
+++ b/src/background/event-ingestion.update-manager-trigger.test.ts
@@ -224,15 +224,17 @@ describe('registerEventIngestion (update-manager triggers)', () => {
     expect(markSessionInactiveSpy).not.toHaveBeenCalled()
   })
 
-  test('markSessionActive() runs synchronously before the raw-write durability await settles (P2, codex review 2026-07-21)', async () => {
-    // The durability barrier (finding A) awaits apiEvents.add() before
-    // forwarding to streams/sync-triggers -- but session-activity tracking
-    // must NOT wait behind that same await, or a safety recheck racing a
-    // slow/stuck add() would still see the stale 'inactive' value from the
-    // previous 309 and judge a mid-game reload "safe". Verify
-    // markSessionActive() has already run before the message handler's
-    // returned promise even settles (i.e. before any awaited work inside
-    // processEvent has had a chance to resolve).
+  test('markSessionActive() waits behind the raw-write durability barrier (2026-07-21, pass-3 consolidation)', async () => {
+    // Session-activity tracking now lives entirely inside `processEvent`,
+    // behind the same `ingestionQueue` durability barrier as
+    // streams/sync-triggers (see event-ingestion.ts's `applySessionActivity`
+    // docstring for the pass-3 rationale: an earlier design made
+    // ACTIVE-marking synchronous/pre-barrier specifically to avoid this,
+    // but that created its own class of bugs -- ordering inversions and
+    // stacked-duplicate rollback corruption -- so the write side was
+    // simplified back to "everything happens in arrival order, inside the
+    // queue" and the original latency concern is now handled on the READ
+    // side instead, via `awaitIngestionDrain()`).
     let resolveAdd!: (key: number) => void
     jest.spyOn(db.apiEvents, 'add').mockImplementation(
       (() => new Promise<number>(resolve => { resolveAdd = resolve })) as any
@@ -241,20 +243,22 @@ describe('registerEventIngestion (update-manager triggers)', () => {
     const entryQueuedEvent = {
       ApiTypeId: ApiType.EVT_ENTRY_QUEUED, timestamp: 9000, Code: 0, BattleType: 0, Id: 'stage000_003', IsRetire: false
     }
-    // Deliberately not awaited yet -- markSessionActiveSpy must already have
-    // fired by the time this synchronous call returns, well before add()
-    // resolves.
-    void onMessageHandler(entryQueuedEvent)
+    const pending = onMessageHandler(entryQueuedEvent)
+
+    // While add() is stuck, markSessionActive() must NOT have fired yet --
+    // and a reload decision reading isSafeToUpdate() directly would still
+    // see the previous (here: initial 'unknown') value. This is exactly why
+    // reload decision points must use `awaitIngestionDrain()` instead of
+    // reading `isSafeToUpdate()` directly (see the dedicated drain-barrier
+    // test in event-ingestion.durability-barrier.test.ts).
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(markSessionActiveSpy).not.toHaveBeenCalled()
+
+    resolveAdd(1)
+    await pending
 
     expect(markSessionActiveSpy).toHaveBeenCalledTimes(1)
     expect(updateManager.isSafeToUpdate()).toBe(false)
-
-    // Let the queue actually reach the mocked (still-unresolved) add() call
-    // before releasing it, so the test cleans up without leaking a pending
-    // promise.
-    await new Promise(resolve => setTimeout(resolve, 0))
-    resolveAdd(1)
-    await new Promise(resolve => setTimeout(resolve, 0))
   })
 
   test('raw sequence 309 -> 201 -> 303 without an intervening 308 does not leave the session stuck inactive (release-blocker audit exact scenario)', async () => {
@@ -322,5 +326,41 @@ describe('registerEventIngestion (update-manager triggers)', () => {
     // EVT_DEAL is not -- confirms the tri-state itself (not just the recheck
     // call) is what's carrying the fix.
     expect(recheckPendingUpdateSpy).not.toHaveBeenCalled()
+  })
+
+  test('EVT_ENTRY_CANCELLED (203, 参加取消申込) marks the session inactive when no hand ever started (P2, codex review 2026-07-20 pass-3)', async () => {
+    // src/types/api.ts defines 203 as 参加取消申込 (entry cancellation
+    // request). If a user enters matchmaking (201) and cancels before any
+    // deal/session-result is emitted, the raw sequence is 201 -> 203 --
+    // 309 never arrives, since no hand ever started. Before this fix,
+    // sessionActivity had no INACTIVE trigger other than 309, so it stayed
+    // stuck 'active' (and the mirrored content_script.ts switch kept
+    // keepalive armed) until an unrelated future session's 309, or a
+    // Service Worker restart.
+    const entryQueuedEvent = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      timestamp: 10000,
+      Code: 0,
+      BattleType: 0,
+      Id: 'stage000_003',
+      IsRetire: false
+    }
+    // ApiTypeId 203 is not part of the `ApiType` enum (deliberately, so it
+    // doesn't widen isApplicationApiEvent's scope) -- use the raw literal,
+    // matching event-ingestion.ts's own EVT_ENTRY_CANCELLED_API_TYPE_ID.
+    const entryCancelledEvent = {
+      ApiTypeId: 203,
+      timestamp: 10100,
+      Code: 0
+    }
+
+    await onMessageHandler(entryQueuedEvent)
+    expect(markSessionActiveSpy).toHaveBeenCalledTimes(1)
+    expect(updateManager.isSafeToUpdate()).toBe(false) // active
+
+    await onMessageHandler(entryCancelledEvent)
+
+    expect(markSessionInactiveSpy).toHaveBeenCalledTimes(1)
+    expect(updateManager.isSafeToUpdate()).toBe(true) // inactive again -- no hand ever started
   })
 })

--- a/src/background/update-manager.ingestion-drain.test.ts
+++ b/src/background/update-manager.ingestion-drain.test.ts
@@ -1,0 +1,82 @@
+/**
+ * update-manager.ts - awaitIngestionDrain() loop behavior
+ *
+ * Unit-tests the drain barrier's core algorithm in isolation from
+ * event-ingestion.ts's real queue, using a controllable fake provider.
+ *
+ * P1, codex review 2026-07-20 pass-4, "Wait for tasks appended while
+ * draining": `awaitIngestionDrain()` used to call `ingestionDrainProvider()`
+ * exactly once and await that single snapshot. If a new task got appended
+ * to the real ingestion queue (i.e. `ingestionQueue` got reassigned) while
+ * that snapshot was still settling, the drain resolved without ever
+ * waiting for the newly-appended task -- so even callers using the "drain
+ * barrier" could still read stale session-activity state and reload
+ * mid-hand. The fix re-calls the provider after each snapshot settles and
+ * keeps looping until it returns the same reference twice in a row (i.e.
+ * nothing new was appended between the last resolution and the check),
+ * bounded by a safety cap against a pathological/buggy provider.
+ */
+import { awaitIngestionDrain, setIngestionDrainProvider } from './update-manager'
+
+describe('awaitIngestionDrain (loop-until-stable)', () => {
+  test('follows the queue tail through a task appended WHILE the first snapshot is still settling', async () => {
+    let resolveFirst!: () => void
+    let resolveSecond!: () => void
+    const firstTask = new Promise<void>(resolve => { resolveFirst = resolve })
+    const secondTask = new Promise<void>(resolve => { resolveSecond = resolve })
+
+    let currentTail = firstTask
+    let providerCallCount = 0
+    setIngestionDrainProvider(() => {
+      providerCallCount++
+      return currentTail
+    })
+
+    let drainSettled = false
+    const drainPromise = awaitIngestionDrain().then(() => { drainSettled = true })
+
+    // Let the drain loop make its first call and start awaiting `firstTask`.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(providerCallCount).toBe(1)
+
+    // While the drain is still awaiting the FIRST snapshot, a new task gets
+    // appended -- simulating registerEventIngestion()'s onMessage listener
+    // reassigning `ingestionQueue` to a new tail mid-drain.
+    currentTail = secondTask
+    resolveFirst()
+
+    // Give the drain's `.then()` continuation a chance to run and re-check
+    // the provider -- if it incorrectly resolved after only the first
+    // snapshot (the bug), `drainSettled` would already be true here.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(drainSettled).toBe(false)
+    expect(providerCallCount).toBeGreaterThanOrEqual(2) // re-checked after the first snapshot resolved
+
+    resolveSecond()
+    await drainPromise
+
+    expect(drainSettled).toBe(true)
+  })
+
+  test('resolves immediately (single provider call round-trip) when nothing new is appended', async () => {
+    const task = Promise.resolve()
+    let providerCallCount = 0
+    setIngestionDrainProvider(() => {
+      providerCallCount++
+      return task
+    })
+
+    await awaitIngestionDrain()
+
+    // Exactly 2 calls: one to get the initial snapshot, one more to confirm
+    // nothing new was appended before returning.
+    expect(providerCallCount).toBe(2)
+  })
+
+  test('is a no-op when no provider has been registered', async () => {
+    // Simulates the state before event-ingestion.ts's registerEventIngestion()
+    // has ever run (e.g. very early Service Worker startup) -- must not throw.
+    setIngestionDrainProvider(undefined as unknown as () => Promise<void>)
+    await expect(awaitIngestionDrain()).resolves.toBeUndefined()
+  })
+})

--- a/src/background/update-manager.test.ts
+++ b/src/background/update-manager.test.ts
@@ -14,6 +14,7 @@ import {
   markSessionInactive,
   getPendingUpdateState,
   initUpdateManager,
+  setIngestionDrainProvider,
   PENDING_UPDATE_STORAGE_KEY,
   __resetUpdateManagerStateForTests,
 } from './update-manager'
@@ -27,6 +28,11 @@ describe('update-manager', () => {
     __resetUpdateManagerStateForTests()
     setOperationState({ type: 'idle' })
     ;(autoSyncService as any)._isSyncing = false
+    // No ingestion-drain provider registered by default (mirrors "SW just
+    // started, registerEventIngestion() hasn't run yet") -- awaitIngestionDrain()
+    // must be a no-op in that state. Tests that specifically exercise the
+    // drain barrier register their own provider.
+    setIngestionDrainProvider(undefined as unknown as () => Promise<void>)
     await chrome.storage.local.set({
       [PENDING_UPDATE_STORAGE_KEY]: undefined,
       [REBUILD_ADVISORY_STORAGE_KEY]: undefined,
@@ -203,6 +209,125 @@ describe('update-manager', () => {
 
       await recheckPendingUpdate() // still unsafe (session active) -> stays pending, reasserts badge
       expect(chrome.action.setBadgeText).toHaveBeenCalledWith({ text: 'UPD' })
+    })
+  })
+
+  describe('recheckPendingUpdate isStillFresh option (P1, codex review 2026-07-21, pass-5: "Guard reload rechecks through the async path")', () => {
+    // event-ingestion.ts's 309/203-nested recheck can't use
+    // awaitIngestionDrain() (self-referential deadlock), so it passes an
+    // `isStillFresh` closure instead (an `activityGeneration` comparison).
+    // The critical property under test here is *timing*: recheckPendingUpdate()
+    // is itself async (getPendingUpdateState() awaits chrome.storage.local.get()
+    // before ever reaching isSafeToUpdate()/reload()), so a naive
+    // implementation could evaluate `isStillFresh` once, cache the result,
+    // and use the stale cached value at the actual reload() commit point.
+    // These tests flip the callback's return value via a timer that only
+    // fires once recheckPendingUpdate() has itself yielded (awaited), so a
+    // pass requires the callback to be *called* after that await, not
+    // pre-evaluated before it.
+    it('is evaluated AFTER recheckPendingUpdate()\'s own internal awaits, not cached from before they started', async () => {
+      markSessionActive() // unsafe -- handleUpdateAvailable() must persist as pending, not apply immediately
+      await handleUpdateAvailable({ version: '5.2.0' })
+      jest.clearAllMocks()
+      markSessionInactive() // session ends -- now safe by the time recheckPendingUpdate() runs
+
+      let isFreshValue = true
+      // Queued as a microtask BEFORE calling recheckPendingUpdate() below,
+      // so it's strictly ahead of that call's own internal awaits
+      // (getPendingUpdateState() -> chrome.storage.local.get(), themselves
+      // microtask-based) in FIFO microtask-queue order. It will flip
+      // isFreshValue to false by the time recheckPendingUpdate() resumes
+      // from its first await -- so a pass here requires isStillFresh() to
+      // actually be *called* at that later point, not evaluated/cached
+      // synchronously before recheckPendingUpdate() was even invoked.
+      Promise.resolve().then(() => { isFreshValue = false })
+
+      await recheckPendingUpdate({ isStillFresh: () => isFreshValue })
+
+      expect(chrome.runtime.reload).not.toHaveBeenCalled()
+      const state = await getPendingUpdateState()
+      expect(state.pending).toBe(true) // deferred, not lost
+    })
+
+    it('still applies when isStillFresh stays true throughout (control)', async () => {
+      markSessionActive() // unsafe -- handleUpdateAvailable() must persist as pending, not apply immediately
+      await handleUpdateAvailable({ version: '5.2.0' })
+      jest.clearAllMocks()
+      markSessionInactive() // session ends -- now safe by the time recheckPendingUpdate() runs
+
+      await recheckPendingUpdate({ isStillFresh: () => true })
+
+      expect(chrome.runtime.reload).toHaveBeenCalledTimes(1)
+      const state = await getPendingUpdateState()
+      expect(state.pending).toBe(false)
+    })
+
+    it('behaves exactly as before (no extra gating) when isStillFresh is omitted', async () => {
+      markSessionActive() // unsafe -- handleUpdateAvailable() must persist as pending, not apply immediately
+      await handleUpdateAvailable({ version: '5.2.0' })
+      jest.clearAllMocks()
+      markSessionInactive() // session ends -- now safe by the time recheckPendingUpdate() runs
+
+      await recheckPendingUpdate()
+
+      expect(chrome.runtime.reload).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('handleUpdateAvailable persists BEFORE draining (P2, codex review 2026-07-21, pass-5: "Persist pending updates before draining ingestion")', () => {
+    it('records the pending update in storage (and sets the badge) BEFORE awaitIngestionDrain() resolves, so a SW restart mid-drain would not lose it', async () => {
+      // Return a STABLE promise reference until resolved (mirroring how
+      // event-ingestion.ts's real `ingestionQueue` only changes reference
+      // when a genuinely new message arrives) -- awaitIngestionDrain()'s
+      // loop-until-stable algorithm (previous round's fix) would otherwise
+      // never converge against a provider that hands back a fresh,
+      // never-resolving promise on every call.
+      let resolveDrain!: () => void
+      const stalledTail = new Promise<void>(resolve => { resolveDrain = resolve })
+      setIngestionDrainProvider(() => stalledTail)
+
+      // handleUpdateAvailable() is fire-and-forget from
+      // initUpdateManager()'s onUpdateAvailable listener in production --
+      // if the Service Worker is suspended/killed while the drain below is
+      // still pending, this whole promise chain vanishes with it. The
+      // pending-update record must already be durably written by then.
+      const handlePromise = handleUpdateAvailable({ version: '5.2.0' })
+
+      // Let the call reach (and stall on) the never-resolving drain.
+      for (let i = 0; i < 20; i++) {
+        await new Promise(resolve => setTimeout(resolve, 0))
+      }
+
+      const stateWhileDraining = await getPendingUpdateState()
+      expect(stateWhileDraining.pending).toBe(true)
+      expect(stateWhileDraining.version).toBe('5.2.0')
+      expect(chrome.action.setBadgeText).toHaveBeenCalledWith({ text: 'UPD' })
+      // Must not have reloaded yet either -- the safety check itself is
+      // still gated behind the (still-pending) drain.
+      expect(chrome.runtime.reload).not.toHaveBeenCalled()
+
+      resolveDrain()
+      await handlePromise
+      setIngestionDrainProvider(undefined as unknown as () => Promise<void>)
+    })
+
+    it('still applies immediately once the drain resolves and the session is safe', async () => {
+      markSessionInactive()
+      let resolveDrain!: () => void
+      const stalledTail = new Promise<void>(resolve => { resolveDrain = resolve })
+      setIngestionDrainProvider(() => stalledTail)
+
+      const handlePromise = handleUpdateAvailable({ version: '5.2.0' })
+      for (let i = 0; i < 20; i++) {
+        await new Promise(resolve => setTimeout(resolve, 0))
+      }
+      resolveDrain()
+      await handlePromise
+
+      expect(chrome.runtime.reload).toHaveBeenCalledTimes(1)
+      const state = await getPendingUpdateState()
+      expect(state.pending).toBe(false)
+      setIngestionDrainProvider(undefined as unknown as () => Promise<void>)
     })
   })
 

--- a/src/background/update-manager.test.ts
+++ b/src/background/update-manager.test.ts
@@ -14,6 +14,7 @@ import {
   markSessionInactive,
   getPendingUpdateState,
   initUpdateManager,
+  awaitIngestionDrain,
   setIngestionDrainProvider,
   PENDING_UPDATE_STORAGE_KEY,
   __resetUpdateManagerStateForTests,
@@ -32,13 +33,49 @@ describe('update-manager', () => {
     // started, registerEventIngestion() hasn't run yet") -- awaitIngestionDrain()
     // must be a no-op in that state. Tests that specifically exercise the
     // drain barrier register their own provider.
-    setIngestionDrainProvider(undefined as unknown as () => Promise<void>)
+    setIngestionDrainProvider(undefined)
     await chrome.storage.local.set({
       [PENDING_UPDATE_STORAGE_KEY]: undefined,
       [REBUILD_ADVISORY_STORAGE_KEY]: undefined,
     })
     jest.clearAllMocks()
   })
+
+  /**
+   * Arrange the narrowest possible enqueue race: the drain helper has just
+   * observed the same settled tail twice and is about to return, but a
+   * microtask queued by that final observation replaces the tail before the
+   * reload caller resumes. The replacement tail does not apply ACTIVE until
+   * `settleQueuedActivity()` is called, matching an enqueued-but-unprocessed
+   * 201/303/308 blocked on its raw write.
+   */
+  const queueActivityInDrainReturnGap = () => {
+    let settleQueuedActivity!: () => void
+    const queuedActivityTail = new Promise<void>(resolve => {
+      settleQueuedActivity = () => {
+        markSessionActive()
+        resolve()
+      }
+    })
+    let currentTail = Promise.resolve()
+    let providerCalls = 0
+    let signalEnqueued!: () => void
+    const enqueued = new Promise<void>(resolve => { signalEnqueued = resolve })
+
+    setIngestionDrainProvider(() => {
+      providerCalls++
+      const observedTail = currentTail
+      if (providerCalls === 2) {
+        Promise.resolve().then(() => {
+          currentTail = queuedActivityTail
+          signalEnqueued()
+        })
+      }
+      return observedTail
+    })
+
+    return { enqueued, settleQueuedActivity }
+  }
 
   describe('isSafeToUpdate (safety predicate)', () => {
     it('is unsafe when session activity is unknown (conservative default, e.g. right after SW start)', () => {
@@ -87,6 +124,26 @@ describe('update-manager', () => {
       expect(chrome.runtime.reload).toHaveBeenCalledTimes(1)
       const state = await getPendingUpdateState()
       expect(state.pending).toBe(false)
+    })
+
+    it('does not reload when activity is enqueued in the drain-return microtask gap before the update-available commit', async () => {
+      markSessionInactive()
+      const { enqueued, settleQueuedActivity } = queueActivityInDrainReturnGap()
+
+      const handlePromise = handleUpdateAvailable({ version: '5.2.0' })
+      await enqueued
+      await Promise.resolve()
+
+      // The queued tail has not settled, so ACTIVE is not applied yet. A
+      // caller that trusts the just-returned drain without re-reading its
+      // tail sees the stale INACTIVE value and reloads here.
+      expect(chrome.runtime.reload).not.toHaveBeenCalled()
+
+      settleQueuedActivity()
+      await handlePromise
+
+      expect(chrome.runtime.reload).not.toHaveBeenCalled()
+      expect((await getPendingUpdateState()).pending).toBe(true)
     })
 
     it('records a pending update and sets the badge when unsafe (session active)', async () => {
@@ -212,65 +269,86 @@ describe('update-manager', () => {
     })
   })
 
-  describe('recheckPendingUpdate isStillFresh option (P1, codex review 2026-07-21, pass-5: "Guard reload rechecks through the async path")', () => {
-    // event-ingestion.ts's 309/203-nested recheck can't use
-    // awaitIngestionDrain() (self-referential deadlock), so it passes an
-    // `isStillFresh` closure instead (an `activityGeneration` comparison).
-    // The critical property under test here is *timing*: recheckPendingUpdate()
-    // is itself async (getPendingUpdateState() awaits chrome.storage.local.get()
-    // before ever reaching isSafeToUpdate()/reload()), so a naive
-    // implementation could evaluate `isStillFresh` once, cache the result,
-    // and use the stale cached value at the actual reload() commit point.
-    // These tests flip the callback's return value via a timer that only
-    // fires once recheckPendingUpdate() has itself yielded (awaited), so a
-    // pass requires the callback to be *called* after that await, not
-    // pre-evaluated before it.
-    it('is evaluated AFTER recheckPendingUpdate()\'s own internal awaits, not cached from before they started', async () => {
-      markSessionActive() // unsafe -- handleUpdateAvailable() must persist as pending, not apply immediately
-      await handleUpdateAvailable({ version: '5.2.0' })
-      jest.clearAllMocks()
-      markSessionInactive() // session ends -- now safe by the time recheckPendingUpdate() runs
+  describe('shared reload commit point', () => {
+    it('re-drains after the pending-state await, closing the operation-complete / SW-startup post-drain race', async () => {
+      await chrome.storage.local.set({
+        [PENDING_UPDATE_STORAGE_KEY]: { pending: true, version: '5.2.0' },
+      })
+      markSessionInactive()
 
-      let isFreshValue = true
-      // Queued as a microtask BEFORE calling recheckPendingUpdate() below,
-      // so it's strictly ahead of that call's own internal awaits
-      // (getPendingUpdateState() -> chrome.storage.local.get(), themselves
-      // microtask-based) in FIFO microtask-queue order. It will flip
-      // isFreshValue to false by the time recheckPendingUpdate() resumes
-      // from its first await -- so a pass here requires isStillFresh() to
-      // actually be *called* at that later point, not evaluated/cached
-      // synchronously before recheckPendingUpdate() was even invoked.
-      Promise.resolve().then(() => { isFreshValue = false })
+      // Mirrors the old operation-complete/SW-startup wrapper: it drained
+      // once before entering recheckPendingUpdate(), then the storage read
+      // below opened a new await window.
+      let currentTail = Promise.resolve()
+      setIngestionDrainProvider(() => currentTail)
+      await awaitIngestionDrain()
 
-      await recheckPendingUpdate({ isStillFresh: () => isFreshValue })
+      const originalStorageGet = (chrome.storage.local.get as jest.Mock).getMockImplementation()!
+      let releasePendingRead!: () => void
+      let signalPendingRead!: () => void
+      const pendingReadStarted = new Promise<void>(resolve => { signalPendingRead = resolve })
+      let intercepted = false
+      const storageGetSpy = jest.spyOn(chrome.storage.local, 'get').mockImplementation((keys: any, callback?: any) => {
+        if (!intercepted && keys === PENDING_UPDATE_STORAGE_KEY && callback === undefined) {
+          intercepted = true
+          signalPendingRead()
+          return new Promise(resolve => {
+            releasePendingRead = () => resolve({
+              [PENDING_UPDATE_STORAGE_KEY]: { pending: true, version: '5.2.0' },
+            })
+          })
+        }
+        return originalStorageGet(keys, callback)
+      })
+
+      const recheckPromise = recheckPendingUpdate()
+      await pendingReadStarted
+
+      let settleQueuedActivity!: () => void
+      currentTail = new Promise<void>(resolve => {
+        settleQueuedActivity = () => {
+          markSessionActive()
+          resolve()
+        }
+      })
+      releasePendingRead()
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      // Activity is queued but not processed. The old wrapper trusted its
+      // pre-storage drain and reloaded on the stale INACTIVE state here.
+      expect(chrome.runtime.reload).not.toHaveBeenCalled()
+
+      settleQueuedActivity()
+      await recheckPromise
+      storageGetSpy.mockImplementation(originalStorageGet)
 
       expect(chrome.runtime.reload).not.toHaveBeenCalled()
-      const state = await getPendingUpdateState()
-      expect(state.pending).toBe(true) // deferred, not lost
+      expect((await getPendingUpdateState()).pending).toBe(true)
     })
 
-    it('still applies when isStillFresh stays true throughout (control)', async () => {
-      markSessionActive() // unsafe -- handleUpdateAvailable() must persist as pending, not apply immediately
+    it('fails closed when the ingestion drain hits its safety cap instead of reloading on an unproven snapshot', async () => {
+      markSessionInactive()
+      setIngestionDrainProvider(() => Promise.resolve()) // never the same tail twice
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
       await handleUpdateAvailable({ version: '5.2.0' })
-      jest.clearAllMocks()
-      markSessionInactive() // session ends -- now safe by the time recheckPendingUpdate() runs
 
-      await recheckPendingUpdate({ isStillFresh: () => true })
-
-      expect(chrome.runtime.reload).toHaveBeenCalledTimes(1)
-      const state = await getPendingUpdateState()
-      expect(state.pending).toBe(false)
+      expect(chrome.runtime.reload).not.toHaveBeenCalled()
+      expect((await getPendingUpdateState()).pending).toBe(true)
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('iteration safety cap'))
+      warnSpy.mockRestore()
     })
 
-    it('behaves exactly as before (no extra gating) when isStillFresh is omitted', async () => {
-      markSessionActive() // unsafe -- handleUpdateAvailable() must persist as pending, not apply immediately
-      await handleUpdateAvailable({ version: '5.2.0' })
-      jest.clearAllMocks()
-      markSessionInactive() // session ends -- now safe by the time recheckPendingUpdate() runs
+    it('commits at most one reload when concurrent paths race on the same pending update', async () => {
+      await chrome.storage.local.set({
+        [PENDING_UPDATE_STORAGE_KEY]: { pending: true, version: '5.2.0' },
+      })
+      markSessionInactive()
 
-      await recheckPendingUpdate()
+      await Promise.all([recheckPendingUpdate(), recheckPendingUpdate()])
 
       expect(chrome.runtime.reload).toHaveBeenCalledTimes(1)
+      expect(chrome.action.setBadgeText).not.toHaveBeenCalledWith({ text: 'UPD' })
     })
   })
 
@@ -308,7 +386,7 @@ describe('update-manager', () => {
 
       resolveDrain()
       await handlePromise
-      setIngestionDrainProvider(undefined as unknown as () => Promise<void>)
+      setIngestionDrainProvider(undefined)
     })
 
     it('still applies immediately once the drain resolves and the session is safe', async () => {
@@ -327,7 +405,7 @@ describe('update-manager', () => {
       expect(chrome.runtime.reload).toHaveBeenCalledTimes(1)
       const state = await getPendingUpdateState()
       expect(state.pending).toBe(false)
-      setIngestionDrainProvider(undefined as unknown as () => Promise<void>)
+      setIngestionDrainProvider(undefined)
     })
   })
 
@@ -346,6 +424,24 @@ describe('update-manager', () => {
       expect(chrome.runtime.reload).toHaveBeenCalledTimes(1)
       const state = await getPendingUpdateState()
       expect(state.pending).toBe(false)
+    })
+
+    it('does not reload when activity is enqueued in the drain-return microtask gap before the manual-apply commit', async () => {
+      markSessionInactive()
+      const { enqueued, settleQueuedActivity } = queueActivityInDrainReturnGap()
+
+      const applyPromise = applyUpdateNow()
+      await enqueued
+      await Promise.resolve()
+
+      expect(chrome.runtime.reload).not.toHaveBeenCalled()
+
+      settleQueuedActivity()
+      const result = await applyPromise
+
+      expect(result.applied).toBe(false)
+      expect(result.reason).toBe('ゲームセッション中のため適用できません')
+      expect(chrome.runtime.reload).not.toHaveBeenCalled()
     })
 
     it('returns a reason and keeps pending when unsafe (session active)', async () => {

--- a/src/background/update-manager.ts
+++ b/src/background/update-manager.ts
@@ -24,7 +24,12 @@
  *     inactiveのまま固めてしまうと、この安全性述語がゲーム中に「安全」と
  *     誤判定してService Workerをreloadしてしまう（release-blocker監査
  *     finding B）。ACTIVE化のトリガーを201/303/308の3つに広げても、
- *     INACTIVEへ戻すトリガーは引き続き309のみ）
+ *     INACTIVEへ戻すトリガーは引き続き309のみ。ACTIVE化とINACTIVE化は
+ *     呼ばれるタイミングが非対称（前者は同期、後者はRaw Event Lakeの
+ *     耐久性バリアの後ろ）なため、生の到着順序を保つための`arrivalSeq`
+ *     ゲーティングと、真の重複判明時のロールバックが必要——詳細は
+ *     `markSessionActive`/`markSessionInactive`/
+ *     `revertSessionActivityIfStillApplied`のコメント参照）
  *   - `AutoSyncService.isSyncing`がfalse（同期中でない）
  *   - `currentOperationState.type === 'idle'`（export/import/rebuild中でない）
  * 上記いずれかが「unknown」（SW再起動直後などでセッション状態を未観測）の
@@ -70,22 +75,110 @@ type SessionActivity = 'unknown' | 'active' | 'inactive'
 let sessionActivity: SessionActivity = 'unknown'
 
 /**
- * `event-ingestion.ts`のEVT_ENTRY_QUEUED(201)/EVT_DEAL(303)/
- * EVT_SESSION_DETAILS(308)いずれかの受信時に呼ぶ（308単独に頼らない理由は
- * 本ファイル冒頭のコメント参照）
+ * 到着シーケンス番号ゲーティング（P1, codexレビュー 2026-07-21指摘）:
+ *
+ * ACTIVE化（event-ingestion.tsのport.onMessage受信直後、完全に同期的）と
+ * INACTIVE化（同ファイルのRaw Event Lake耐久性バリアの後ろ、`ingestionQueue`
+ * 経由で非同期に決着）は、意図的に異なるタイミングで呼ばれる（理由は
+ * event-ingestion.tsの`markSessionActiveFromRawMessage()`コメント参照）。
+ * しかし生の到着順序が[309, 201]（セッション終了の直後に次のセッションが
+ * 始まる、docs/api-events.md:99が明記する正常系のバリアント）だった場合、
+ * 309は耐久性バリアの後ろでキューに積まれ決着が遅れる一方、201は同期的に
+ * 即座にACTIVE化する。何もしなければ、後から決着する（が到着順序としては
+ * 古い）309のINACTIVE化が、より新しいはずの201のACTIVE化を上書きしてしまい、
+ * 「新しいハンドが進行中なのにinactiveのまま」という状態反転が起こる。
+ *
+ * 対策として、各呼び出し元（event-ingestion.ts）に、その生メッセージの
+ * *到着*順序を表す単調増加の`arrivalSeq`を明示的に渡させ、
+ * `lastAppliedSeq`より新しい`arrivalSeq`の遷移だけを適用する。これにより
+ * 「後から決着したが、実際は先に到着していた」遷移が「先に決着したが、
+ * 実際は後から到着していた」遷移を上書きすることを防ぐ——真の到着順序
+ * だけが最終状態を決める。
+ *
+ * `arrivalSeq`を省略した呼び出し（既存のテスト等、レガシー用途）は
+ * `internalAutoSeq`による自動採番にフォールバックする。呼び出しごとに
+ * 単調増加する値が振られるため、「直近の呼び出しが常に勝つ」という
+ * 従来通りの単純な挙動が保たれる。
  */
-export const markSessionActive = (): void => {
-  sessionActivity = 'active'
+let lastAppliedSeq = 0
+let previousSessionActivity: SessionActivity = 'unknown'
+let previousAppliedSeq = 0
+let internalAutoSeq = 0
+
+/**
+ * `next`への遷移を、`seq`（省略時は内部自動採番）が現在適用済みの
+ * `lastAppliedSeq`より新しい場合にのみ適用する。適用時は直前の状態を
+ * 1段階分だけ`previousSessionActivity`/`previousAppliedSeq`に退避する
+ * （`revertSessionActivityIfStillApplied()`によるロールバック用）。
+ * 実際に適用したかに関わらず、使用した`effectiveSeq`を返す。
+ */
+const applyActivityTransition = (next: SessionActivity, seq?: number): number => {
+  const effectiveSeq = seq ?? ++internalAutoSeq
+  if (effectiveSeq <= lastAppliedSeq) {
+    // 到着順序としてより新しい遷移が既に適用済み -- 古い遷移は無視する
+    return effectiveSeq
+  }
+  previousSessionActivity = sessionActivity
+  previousAppliedSeq = lastAppliedSeq
+  sessionActivity = next
+  lastAppliedSeq = effectiveSeq
+  return effectiveSeq
 }
 
-/** `event-ingestion.ts`のEVT_SESSION_RESULTS(309)受信時に呼ぶ */
-export const markSessionInactive = (): void => {
-  sessionActivity = 'inactive'
+/**
+ * `event-ingestion.ts`のEVT_ENTRY_QUEUED(201)/EVT_DEAL(303, Player在席時)/
+ * EVT_SESSION_DETAILS(308)いずれかの受信時に呼ぶ（308単独に頼らない理由は
+ * 本ファイル冒頭のコメント参照）。`arrivalSeq`は呼び出し元での生メッセージ
+ * 到着順序（上のコメント参照）。
+ */
+export const markSessionActive = (arrivalSeq?: number): void => {
+  applyActivityTransition('active', arrivalSeq)
+}
+
+/**
+ * `event-ingestion.ts`のEVT_SESSION_RESULTS(309)受信時に呼ぶ。`arrivalSeq`は
+ * 呼び出し元での生メッセージ到着順序（上のコメント参照）。
+ */
+export const markSessionInactive = (arrivalSeq?: number): void => {
+  applyActivityTransition('inactive', arrivalSeq)
+}
+
+/**
+ * 重複検知の取り消し（P2, codexレビュー 2026-07-21指摘）: `arrivalSeq`が
+ * まだ現在適用中の遷移（`lastAppliedSeq === arrivalSeq`）であれば、その
+ * 遷移を取り消して直前の状態へ1段階ロールバックする。
+ *
+ * 想定用途: event-ingestion.tsは201/303[Player在席]/308の受信直後に
+ * `markSessionActive()`を同期的に（raw書き込みの耐久性バリアより前に）
+ * 呼ぶ「楽観的」な設計になっている（P2#3, 2026-07-21の前回修正）。これは
+ * 再チェックとの競合を防ぐために必要な一方、この生メッセージが実は
+ * reconnect resend等による**真の重複**（同一(timestamp, ApiTypeId)・
+ * 同一ペイロードが既にRaw Event Lakeに存在する）だと後から判明した場合、
+ * その楽観的なACTIVE化は本来起こるべきではなかった遷移である。
+ * このケースを放置すると、309で正しくinactive化された後にstaleな
+ * resendが届いただけでsessionActivityがactiveに戻ってしまい、
+ * 新しいハンドが無いのに保留中アップデートが無期限にブロックされ続ける
+ * （このバグはtri-stateを`'unknown'`に一律フォールバックさせるのではなく、
+ * 遷移前の状態へ正しくロールバックすることで、「本当は309で終わっていた」
+ * という正しい状態を復元する——1段階の巻き戻しで十分なのは、この関数は
+ * 「まだ現在の状態として有効な遷移」だけを対象にするため。既に別の新しい
+ * 遷移で上書きされていれば`lastAppliedSeq !== arrivalSeq`となり、
+ * 何もしない[その新しい遷移の方が正しいため]）。
+ */
+export const revertSessionActivityIfStillApplied = (arrivalSeq: number): void => {
+  if (lastAppliedSeq === arrivalSeq) {
+    sessionActivity = previousSessionActivity
+    lastAppliedSeq = previousAppliedSeq
+  }
 }
 
 /** テスト専用: モジュールスコープの状態をリセットする */
 export const __resetUpdateManagerStateForTests = (): void => {
   sessionActivity = 'unknown'
+  lastAppliedSeq = 0
+  previousSessionActivity = 'unknown'
+  previousAppliedSeq = 0
+  internalAutoSeq = 0
 }
 
 /** 保留中アップデートを適用できない理由を日本語で説明する（Popup表示用） */

--- a/src/background/update-manager.ts
+++ b/src/background/update-manager.ts
@@ -128,6 +128,12 @@ export const setIngestionDrainProvider = (provider: IngestionDrainProvider): voi
   ingestionDrainProvider = provider
 }
 
+/** `awaitIngestionDrain()`のループ安全上限。通常は数イテレーションで
+ * 安定するが、プロバイダ実装のバグ等で新しいタスクが積まれ続ける異常系
+ * でも呼び出し元を無期限にブロックしないための保険（P1, codexレビュー
+ * 指摘 2026-07-21, pass-4, "Wait for tasks appended while draining"）。 */
+const MAX_DRAIN_ITERATIONS = 1000
+
 /**
  * reload判定（`isSafeToUpdate()`を使う各エントリーポイント）の直前で待つ
  * 「キュー・ドレイン・バリア」（2026-07-21 pass-3 codexレビュー3件の帰結、
@@ -141,16 +147,39 @@ export const setIngestionDrainProvider = (provider: IngestionDrainProvider): voi
  * しまうことを防ぐ（呼び出し後に新たに到着したイベントは、因果的に
  * この判定より後なので待つ必要が無い）。
  *
- * 例外: `event-ingestion.ts`の`processEvent`が309自身の処理の中から直接
- * 呼ぶ`recheckPendingUpdate()`はこのバリアを使わない——`ingestionQueue`は
- * その309自身の処理が完了するまで解決しないため、その中からこの関数を
- * 呼ぶと自己参照でデッドロックする。その経路は代わりに
- * `processEvent`内で素直に`await`することでキューの直列化にそのまま
- * 乗せている（event-ingestion.tsの309ブロックのコメント参照）。
+ * ループする理由（P1, codexレビュー指摘 2026-07-21, pass-4, "Wait for
+ * tasks appended while draining"）: `ingestionDrainProvider()`は呼んだ
+ * 瞬間のキュー末尾のスナップショットを返すだけなので、そのPromiseの
+ * 決着を待っている間に新しいイベントが到着して`ingestionQueue`が
+ * 再代入されると、待っていたスナップショットは「古い末尾」のまま
+ * 決着してしまい、新しく積まれた分の決着を待たずに戻ってしまう
+ * （ドレインバリアを使っている呼び出し元でも、その僅かな隙間で
+ * mid-hand reloadが起こりうる）。決着後にもう一度プロバイダを呼び直し、
+ * 参照が変わっていれば（＝待っている間に何か新しく積まれた）そちらも
+ * 待つ、を「2回連続で同じ参照が返る」まで繰り返すことで、呼び出し
+ * 時点までに到着した全てのイベントの決着を確実に待つ。
+ *
+ * `event-ingestion.ts`の`processEvent`が309/203自身の処理の中から直接
+ * 呼ぶ`recheckPendingUpdate()`はこのバリアを使わない（使うと自己参照で
+ * デッドロックする——`ingestionQueue`はその309/203自身の処理が完了する
+ * まで解決しないため）。その経路は別の機構（`event-ingestion.ts`の
+ * `queueGeneration`比較）で同種の安全性を確保している——詳細は
+ * event-ingestion.tsの309/203ブロックのコメント参照。
  */
 export const awaitIngestionDrain = async (): Promise<void> => {
-  if (ingestionDrainProvider) {
-    await ingestionDrainProvider()
+  if (!ingestionDrainProvider) return
+
+  let previous: Promise<void> | undefined
+  let current = ingestionDrainProvider()
+  let iterations = 0
+  while (current !== previous && iterations < MAX_DRAIN_ITERATIONS) {
+    previous = current
+    await current
+    current = ingestionDrainProvider()
+    iterations++
+  }
+  if (iterations >= MAX_DRAIN_ITERATIONS) {
+    console.warn('[update-manager] awaitIngestionDrain: hit the iteration safety cap -- the ingestion queue may be receiving new work faster than it can settle')
   }
 }
 

--- a/src/background/update-manager.ts
+++ b/src/background/update-manager.ts
@@ -41,8 +41,10 @@
  *
  *     この直列化の裏で残る唯一の懸念——「rawの書き込みがキューに詰まって
  *     いる間、reload判定がまだ反映されていない古いsessionActivityを
- *     読んでしまう」——は書く側ではなく読む側で解決する:
- *     `awaitIngestionDrain()`を参照。
+ *     読んでしまう」——は書く側ではなく、全reload経路が通る
+ *     `commitReloadIfStillSafe()`で解決する。同関数はキューを安定するまで
+ *     drainしたうえで、drain後にtailが差し替わっていないことと
+ *     `isSafeToUpdate()`を、reloadとの間にawaitを挟まず最終確認する。
  *   - `AutoSyncService.isSyncing`がfalse（同期中でない）
  *   - `currentOperationState.type === 'idle'`（export/import/rebuild中でない）
  * 上記いずれかが「unknown」（SW再起動直後などでセッション状態を未観測）の
@@ -87,6 +89,9 @@ type SessionActivity = 'unknown' | 'active' | 'inactive'
 /** SW再起動のたびに`'unknown'`にリセットされる（保守的なデフォルト = unsafe扱い） */
 let sessionActivity: SessionActivity = 'unknown'
 
+/** 1つのSWインスタンスからreloadを二重commitしないための同期ガード。 */
+let reloadCommitted = false
+
 /**
  * `event-ingestion.ts`のEVT_ENTRY_QUEUED(201)/EVT_DEAL(303, Player在席時)/
  * EVT_SESSION_DETAILS(308)いずれかの受信時に呼ぶ（308単独に頼らない理由は
@@ -124,7 +129,7 @@ let ingestionDrainProvider: IngestionDrainProvider | undefined
  * 待てるようにするための登録フック（circular importを避けるための
  * 依存性逆転——update-manager.tsはevent-ingestion.tsを一切importしない）。
  */
-export const setIngestionDrainProvider = (provider: IngestionDrainProvider): void => {
+export const setIngestionDrainProvider = (provider: IngestionDrainProvider | undefined): void => {
   ingestionDrainProvider = provider
 }
 
@@ -159,34 +164,41 @@ const MAX_DRAIN_ITERATIONS = 1000
  * 待つ、を「2回連続で同じ参照が返る」まで繰り返すことで、呼び出し
  * 時点までに到着した全てのイベントの決着を確実に待つ。
  *
- * `event-ingestion.ts`の`processEvent`が309/203自身の処理の中から直接
- * 呼ぶ`recheckPendingUpdate()`はこのバリアを使わない（使うと自己参照で
- * デッドロックする——`ingestionQueue`はその309/203自身の処理が完了する
- * まで解決しないため）。その経路は別の機構（`event-ingestion.ts`の
- * `activityGeneration`比較、`recheckPendingUpdate()`の`isStillFresh`
- * オプション経由）で同種の安全性を確保している——詳細は
- * event-ingestion.tsの309/203ブロックのコメント参照。
+ * この公開関数は既存のテスト・診断用に「待つ」だけのAPIを保つ。reload
+ * commitでは、安定確認済みtailを返す内部版を使い、async関数から呼び出し元へ
+ * 戻るmicrotask境界で新しいtailが積まれた場合も最終同期チェックで検出する。
  */
-export const awaitIngestionDrain = async (): Promise<void> => {
-  if (!ingestionDrainProvider) return
+interface IngestionDrainCheckpoint {
+  stable: boolean
+  tail: Promise<void> | undefined
+}
 
+const awaitStableIngestionCheckpoint = async (): Promise<IngestionDrainCheckpoint> => {
   let previous: Promise<void> | undefined
-  let current = ingestionDrainProvider()
+  let current = ingestionDrainProvider?.()
   let iterations = 0
   while (current !== previous && iterations < MAX_DRAIN_ITERATIONS) {
     previous = current
     await current
-    current = ingestionDrainProvider()
+    current = ingestionDrainProvider?.()
     iterations++
   }
-  if (iterations >= MAX_DRAIN_ITERATIONS) {
+
+  const stable = current === previous
+  if (!stable) {
     console.warn('[update-manager] awaitIngestionDrain: hit the iteration safety cap -- the ingestion queue may be receiving new work faster than it can settle')
   }
+  return { stable, tail: current }
+}
+
+export const awaitIngestionDrain = async (): Promise<void> => {
+  await awaitStableIngestionCheckpoint()
 }
 
 /** テスト専用: モジュールスコープの状態をリセットする */
 export const __resetUpdateManagerStateForTests = (): void => {
   sessionActivity = 'unknown'
+  reloadCommitted = false
 }
 
 /** 保留中アップデートを適用できない理由を日本語で説明する（Popup表示用） */
@@ -243,6 +255,49 @@ const clearBadge = async (): Promise<void> => {
 }
 
 /**
+ * 全ての`chrome.runtime.reload()`が通る唯一のcommit point。
+ *
+ * 1. 現在のingestion tailを「同じ参照が2回続く」までdrainする。
+ * 2. async関数の復帰microtaskより先に新しいmessageがenqueueされてtailが
+ *    差し替わった場合は、同期比較で検出して1へ戻る。
+ * 3. 安定したtailの同一性・sessionActivity/同期/operationの安全性・
+ *    二重commitガードを、`chrome.runtime.reload()`との間にawaitを挟まず
+ *    確認する。
+ *
+ * これにより、storage/badge await中だけでなく、drain自体が返した直後の
+ * microtask境界で201/303/308等が積まれた場合も、未処理のACTIVE遷移を
+ * 古いINACTIVE状態で追い越してreloadすることはない。drainの安全上限に
+ * 達した場合も「安全」とはみなさず、保留したまま次の再チェックへ委ねる。
+ */
+type ReloadCommitResult = 'committed' | 'already-committed' | 'unsafe'
+
+const commitReloadIfStillSafe = async (commitLog?: string): Promise<ReloadCommitResult> => {
+  for (let attempt = 0; attempt < MAX_DRAIN_ITERATIONS; attempt++) {
+    const checkpoint = await awaitStableIngestionCheckpoint()
+    if (!checkpoint.stable) return 'unsafe'
+
+    // `awaitStableIngestionCheckpoint()`のreturnからこの継続へ移る間にも
+    // microtaskが走りうる。現在tailを同期的に取り直し、変わっていれば
+    // その新tailもdrainする。ここからreloadまではawaitを一切挟まない。
+    if (ingestionDrainProvider?.() !== checkpoint.tail) continue
+    if (reloadCommitted) return 'already-committed'
+    if (!isSafeToUpdate()) return 'unsafe'
+
+    reloadCommitted = true
+    if (commitLog) console.log(commitLog)
+    chrome.runtime.reload()
+    // reload後のクリアはfire-and-forget。SWが即終了して未完了でも、次回
+    // startupのバージョン一致分岐がstale stateを確実に片付ける。
+    clearPendingUpdateState().catch(err => console.error('[update-manager] Failed to clear pending update state after reload:', err))
+    clearBadge().catch(err => console.error('[update-manager] Failed to clear badge after reload:', err))
+    return 'committed'
+  }
+
+  console.warn('[update-manager] Reload commit aborted -- ingestion tail never stayed stable at the commit point')
+  return 'unsafe'
+}
+
+/**
  * `chrome.runtime.onUpdateAvailable`のハンドラー本体。
  * SAFEなら即座に適用、そうでなければ保留状態を記録してバッジを出す。
  */
@@ -261,23 +316,12 @@ export const handleUpdateAvailable = async (details: { version: string }): Promi
   await setPendingUpdateState({ pending: true, version: details.version, detectedAt: Date.now() })
   await setBadge()
 
-  // キュー・ドレイン・バリア（本ファイル冒頭のSAFE定義コメント参照）:
-  // `onUpdateAvailable`はevent-ingestion.tsのキューとは無関係な任意の
-  // タイミングで発火しうるため、判定前に必ず待つ。
-  await awaitIngestionDrain()
-
-  if (!isSafeToUpdate()) {
+  const result = await commitReloadIfStillSafe(
+    `[update-manager] Update ${details.version} available and safe -- applying immediately`
+  )
+  if (result === 'unsafe') {
     console.log(`[update-manager] Update ${details.version} available but unsafe (${describeUnsafeReason()}) -- pending`)
-    return
   }
-
-  // ここから`chrome.runtime.reload()`まで`await`を一切挟まない（P1,
-  // codexレビュー指摘 2026-07-21, pass-5, "Guard reload rechecks through
-  // the async path"）。詳細は`recheckPendingUpdate()`の同種コメント参照。
-  console.log(`[update-manager] Update ${details.version} available and safe -- applying immediately`)
-  chrome.runtime.reload()
-  clearPendingUpdateState().catch(err => console.error('[update-manager] Failed to clear pending update state after reload:', err))
-  clearBadge().catch(err => console.error('[update-manager] Failed to clear badge after reload:', err))
 }
 
 /**
@@ -285,27 +329,14 @@ export const handleUpdateAvailable = async (details: { version: string }): Promi
  * session end / entry cancellation / operation completion / SW startup の
  * 4箇所から呼ばれる。
  *
- * キュー・ドレイン・バリアはこの関数自身の中には置かない（意図的）:
- * event-ingestion.tsの309/203自身の`processEvent`内から直接呼ぶ経路が
- * あり、そこで`awaitIngestionDrain()`を呼ぶとその309/203自身を含む
- * `ingestionQueue`の決着を待つことになり自己参照でデッドロックする。
- * 呼び出し元（operation-complete契機・SW起動時契機）側で個別に
- * `awaitIngestionDrain()`してから呼ぶ（`initUpdateManager()`参照）。
- *
- * `options.isStillFresh`（P1, codexレビュー指摘 2026-07-21, pass-5,
- * "Guard reload rechecks through the async path"）: 呼び出し元固有の
- * 追加鮮度チェック。event-ingestion.tsの309/203自身の処理から呼ぶ場合、
- * 「自分の到着以降にセッション状態へ影響しうる新しいイベントが既に
- * キューへ積まれていないか」（`activityGeneration`比較）を渡す——この
- * 経路は`awaitIngestionDrain()`を使えない（自己参照デッドロック）ため、
- * 同期的な世代比較で代替する。下の「原子的な最終確認」の一部として、
- * `isSafeToUpdate()`と**同じタイミングで**（間に`await`を挟まず）評価する
- * ことが重要——この関数はこの2つのawait（`getPendingUpdateState()`と、
- * バージョン一致チェック内の各種await）自体が「その間に新しいイベントが
- * 到着・処理されうる隙間」であるため、呼び出し前に1回チェックするだけ
- * では不十分（それ自体がこのpass-5指摘の内容）。
+ * pending stateやstale-version cleanupに必要なawaitを全て終えた後、共有の
+ * `commitReloadIfStillSafe()`が改めてdrainと最終tail比較を行う。309/203の
+ * ingestion内呼び出しでも、最初の`getPendingUpdateState()` awaitで現在の
+ * `processEvent`が先にreturnできるため、自己参照デッドロックは起こらない。
+ * 呼び出し元ごとのgeneration callbackは不要で、operation completion・
+ * SW startupを含む全経路が同じcommit保証を得る。
  */
-export const recheckPendingUpdate = async (options?: { isStillFresh?: () => boolean }): Promise<void> => {
+export const recheckPendingUpdate = async (): Promise<void> => {
   const state = await getPendingUpdateState()
   if (!state.pending) return
 
@@ -322,34 +353,15 @@ export const recheckPendingUpdate = async (options?: { isStillFresh?: () => bool
     return
   }
 
-  if (!isSafeToUpdate()) {
-    // まだunsafe: バッジを再アサート（rebuild-advisoryが解消済みなら表示に切り替わる）
+  const result = await commitReloadIfStillSafe(
+    '[update-manager] Pending update is now safe to apply -- applying'
+  )
+  if (result === 'unsafe') {
+    // まだunsafe、またはdrainが上限内で安定しなかった: バッジを再アサート
+    // （rebuild-advisory解消後なら表示）。別経路がreloadをcommit済みなら
+    // 先行経路のclearBadgeと競合するため何もしない。
     await setBadge()
-    return
   }
-
-  // 原子的な最終確認（P1, codexレビュー指摘 2026-07-21, pass-5,
-  // "Guard reload rechecks through the async path"）: ここまでの
-  // `await`（`getPendingUpdateState()`等）は、その間に新しいイベントが
-  // 到着・処理されうる隙間である。この直後から`chrome.runtime.reload()`
-  // までの間に一切`await`を挟まないことで、最終チェックと実際のreloadを
-  // 原子的（隣接）にする——`isSafeToUpdate()`と`options.isStillFresh`を
-  // 同じタイミングで評価するのが肝要。
-  if (options?.isStillFresh && !options.isStillFresh()) {
-    console.log('[update-manager] Pending update recheck aborted -- a newer session-activity-relevant event was already queued, deferring to a later recheck trigger')
-    await setBadge()
-    return
-  }
-
-  console.log('[update-manager] Pending update is now safe to apply -- applying')
-  chrome.runtime.reload()
-  // 状態クリアはreload後にfire-and-forgetする: 上のreload()呼び出し直前に
-  // `await`を挟まないことがこの関数の安全性の核なので、クリア処理は
-  // reload()の後段へ回す。仮にSWがreload()で即座に終了してクリアが
-  // 完了しなくても、SW再起動後の`recheckPendingUpdate()`（起動時契機）が
-  // 上のバージョン一致ブランチで確実に片付けるため実害は無い。
-  clearPendingUpdateState().catch(err => console.error('[update-manager] Failed to clear pending update state after reload:', err))
-  clearBadge().catch(err => console.error('[update-manager] Failed to clear badge after reload:', err))
 }
 
 /**
@@ -357,23 +369,13 @@ export const recheckPendingUpdate = async (options?: { isStillFresh?: () => bool
  * SAFEなら適用、そうでなければ理由を返す（Popupに表示させる）。
  */
 export const applyUpdateNow = async (): Promise<ApplyUpdateResult> => {
-  // キュー・ドレイン・バリア（本ファイル冒頭のSAFE定義コメント参照）:
-  // ユーザー操作起点でevent-ingestion.tsのキューとは無関係なタイミングで
-  // 呼ばれるため、判定前に必ず待つ。
-  await awaitIngestionDrain()
-
-  if (!isSafeToUpdate()) {
+  const result = await commitReloadIfStillSafe()
+  if (result === 'unsafe') {
     const reason = describeUnsafeReason()
     const current = await getPendingUpdateState()
     await setPendingUpdateState({ ...current, pending: true, lastBlockedReason: reason })
     return { applied: false, reason }
   }
-
-  // ここから`chrome.runtime.reload()`まで`await`を一切挟まない（P1,
-  // codexレビュー指摘 2026-07-21, pass-5）。詳細は`recheckPendingUpdate()`
-  // の同種コメント参照。
-  chrome.runtime.reload()
-  clearPendingUpdateState().catch(err => console.error('[update-manager] Failed to clear pending update state after reload:', err))
   return { applied: true }
 }
 
@@ -426,18 +428,6 @@ const setupUpdateCheckAlarm = async (): Promise<void> => {
  * 呼び出しをブロックしない（他のセットアップは同期的に完了する）ので、
  * SW起動を止めたくない呼び出し側はそのままfire-and-forgetしてよい。
  */
-/**
- * `recheckPendingUpdate()`をキュー・ドレイン・バリアの後ろで呼ぶラッパー。
- * event-ingestion.tsの309自身の処理からは呼ばない（そちらは
- * `recheckPendingUpdate()`自身のコメント参照）——operation-complete契機・
- * SW起動時契機はどちらもingestionQueueとは無関係なタイミングで発火しうる
- * ため、両方ともこのラッパー経由で呼ぶ。
- */
-const recheckPendingUpdateAfterDrain = async (): Promise<void> => {
-  await awaitIngestionDrain()
-  await recheckPendingUpdate()
-}
-
 export const initUpdateManager = (): Promise<void> => {
   chrome.runtime.onUpdateAvailable.addListener((details) => {
     handleUpdateAvailable(details).catch(error => {
@@ -446,7 +436,7 @@ export const initUpdateManager = (): Promise<void> => {
   })
 
   onOperationBecameIdle(() => {
-    recheckPendingUpdateAfterDrain().catch(error => {
+    recheckPendingUpdate().catch(error => {
       console.error('[update-manager] recheckPendingUpdate (operation completion) failed:', error)
     })
   })
@@ -458,7 +448,7 @@ export const initUpdateManager = (): Promise<void> => {
     console.error('[update-manager] setupUpdateCheckAlarm failed:', error)
   })
 
-  return recheckPendingUpdateAfterDrain().catch(error => {
+  return recheckPendingUpdate().catch(error => {
     console.error('[update-manager] recheckPendingUpdate (SW startup) failed:', error)
   })
 }

--- a/src/background/update-manager.ts
+++ b/src/background/update-manager.ts
@@ -14,22 +14,35 @@
  *
  * SAFE（安全）の定義（`isSafeToUpdate()`）:
  *   - アクティブなゲームセッションが無い（EVT_ENTRY_QUEUED(201)/EVT_DEAL(303)/
- *     EVT_SESSION_DETAILS(308)のいずれかからEVT_SESSION_RESULTS(309)までの
- *     間はunsafe。content_script.tsのkeepaliveゲート[`isGameActive`]と同じ
- *     境界イベントを、Service Worker側で`markSessionActive()`/
- *     `markSessionInactive()`により独立に追跡する。308単独をACTIVEの
- *     トリガーにしないのは、docs/api-events.md:99が明記する通り308の欠落
- *     （観測ギャップ）が正常系のバリアントとして起こりうるため——309で
- *     inactiveにした直後、308無しで次の試合が201/303から始まるケースを
- *     inactiveのまま固めてしまうと、この安全性述語がゲーム中に「安全」と
- *     誤判定してService Workerをreloadしてしまう（release-blocker監査
- *     finding B）。ACTIVE化のトリガーを201/303/308の3つに広げても、
- *     INACTIVEへ戻すトリガーは引き続き309のみ。ACTIVE化とINACTIVE化は
- *     呼ばれるタイミングが非対称（前者は同期、後者はRaw Event Lakeの
- *     耐久性バリアの後ろ）なため、生の到着順序を保つための`arrivalSeq`
- *     ゲーティングと、真の重複判明時のロールバックが必要——詳細は
- *     `markSessionActive`/`markSessionInactive`/
- *     `revertSessionActivityIfStillApplied`のコメント参照）
+ *     EVT_SESSION_DETAILS(308)のいずれかからEVT_SESSION_RESULTS(309)/
+ *     EVT_ENTRY_CANCELLED(203)までの間はunsafe。content_script.tsの
+ *     keepaliveゲート[`isGameActive`]と同じ境界イベントを、Service Worker
+ *     側で`markSessionActive()`/`markSessionInactive()`により独立に
+ *     追跡する。308単独をACTIVEのトリガーにしないのは、
+ *     docs/api-events.md:99が明記する通り308の欠落（観測ギャップ）が
+ *     正常系のバリアントとして起こりうるため——309でinactiveにした直後、
+ *     308無しで次の試合が201/303から始まるケースをinactiveのまま
+ *     固めてしまうと、この安全性述語がゲーム中に「安全」と誤判定して
+ *     Service Workerをreloadしてしまう（release-blocker監査finding B）。
+ *     203(参加取消申込)もINACTIVEトリガーに加えているのは、参加後・
+ *     着席前にキャンセルするとハンドが一度も始まらず309も届かない
+ *     ケースがあり（2026-07-21 pass-3 codexレビュー指摘）、それを
+ *     放置するとsessionActivityがactiveのまま固まるため。
+ *
+ *     ACTIVE化・INACTIVE化はいずれも`event-ingestion.ts`の
+ *     `ingestionQueue`（Raw Event Lakeの耐久性バリア・重複排除の内側）
+ *     で直列に決着する——キュー自体が真の到着順序を保証するため、
+ *     どちらの遷移も「決着が遅れて古い遷移が新しい遷移を上書きする」
+ *     心配が構造的に無い（2026-07-21 pass-3: 以前は同期的な楽観的ACTIVE
+ *     化+到着シーケンス番号ゲーティング+ロールバックという設計だったが、
+ *     reconnectが複数の重複をまとめて再送するケースでロールバックの
+ *     退避スロットが上書きされる等、対症療法が自分自身と衝突し始めた
+ *     ため、根本的にシンプル化した）。
+ *
+ *     この直列化の裏で残る唯一の懸念——「rawの書き込みがキューに詰まって
+ *     いる間、reload判定がまだ反映されていない古いsessionActivityを
+ *     読んでしまう」——は書く側ではなく読む側で解決する:
+ *     `awaitIngestionDrain()`を参照。
  *   - `AutoSyncService.isSyncing`がfalse（同期中でない）
  *   - `currentOperationState.type === 'idle'`（export/import/rebuild中でない）
  * 上記いずれかが「unknown」（SW再起動直後などでセッション状態を未観測）の
@@ -75,110 +88,75 @@ type SessionActivity = 'unknown' | 'active' | 'inactive'
 let sessionActivity: SessionActivity = 'unknown'
 
 /**
- * 到着シーケンス番号ゲーティング（P1, codexレビュー 2026-07-21指摘）:
- *
- * ACTIVE化（event-ingestion.tsのport.onMessage受信直後、完全に同期的）と
- * INACTIVE化（同ファイルのRaw Event Lake耐久性バリアの後ろ、`ingestionQueue`
- * 経由で非同期に決着）は、意図的に異なるタイミングで呼ばれる（理由は
- * event-ingestion.tsの`markSessionActiveFromRawMessage()`コメント参照）。
- * しかし生の到着順序が[309, 201]（セッション終了の直後に次のセッションが
- * 始まる、docs/api-events.md:99が明記する正常系のバリアント）だった場合、
- * 309は耐久性バリアの後ろでキューに積まれ決着が遅れる一方、201は同期的に
- * 即座にACTIVE化する。何もしなければ、後から決着する（が到着順序としては
- * 古い）309のINACTIVE化が、より新しいはずの201のACTIVE化を上書きしてしまい、
- * 「新しいハンドが進行中なのにinactiveのまま」という状態反転が起こる。
- *
- * 対策として、各呼び出し元（event-ingestion.ts）に、その生メッセージの
- * *到着*順序を表す単調増加の`arrivalSeq`を明示的に渡させ、
- * `lastAppliedSeq`より新しい`arrivalSeq`の遷移だけを適用する。これにより
- * 「後から決着したが、実際は先に到着していた」遷移が「先に決着したが、
- * 実際は後から到着していた」遷移を上書きすることを防ぐ——真の到着順序
- * だけが最終状態を決める。
- *
- * `arrivalSeq`を省略した呼び出し（既存のテスト等、レガシー用途）は
- * `internalAutoSeq`による自動採番にフォールバックする。呼び出しごとに
- * 単調増加する値が振られるため、「直近の呼び出しが常に勝つ」という
- * 従来通りの単純な挙動が保たれる。
- */
-let lastAppliedSeq = 0
-let previousSessionActivity: SessionActivity = 'unknown'
-let previousAppliedSeq = 0
-let internalAutoSeq = 0
-
-/**
- * `next`への遷移を、`seq`（省略時は内部自動採番）が現在適用済みの
- * `lastAppliedSeq`より新しい場合にのみ適用する。適用時は直前の状態を
- * 1段階分だけ`previousSessionActivity`/`previousAppliedSeq`に退避する
- * （`revertSessionActivityIfStillApplied()`によるロールバック用）。
- * 実際に適用したかに関わらず、使用した`effectiveSeq`を返す。
- */
-const applyActivityTransition = (next: SessionActivity, seq?: number): number => {
-  const effectiveSeq = seq ?? ++internalAutoSeq
-  if (effectiveSeq <= lastAppliedSeq) {
-    // 到着順序としてより新しい遷移が既に適用済み -- 古い遷移は無視する
-    return effectiveSeq
-  }
-  previousSessionActivity = sessionActivity
-  previousAppliedSeq = lastAppliedSeq
-  sessionActivity = next
-  lastAppliedSeq = effectiveSeq
-  return effectiveSeq
-}
-
-/**
  * `event-ingestion.ts`のEVT_ENTRY_QUEUED(201)/EVT_DEAL(303, Player在席時)/
  * EVT_SESSION_DETAILS(308)いずれかの受信時に呼ぶ（308単独に頼らない理由は
- * 本ファイル冒頭のコメント参照）。`arrivalSeq`は呼び出し元での生メッセージ
- * 到着順序（上のコメント参照）。
+ * 本ファイル冒頭のコメント参照）。`event-ingestion.ts`の`ingestionQueue`
+ * （Raw Event Lakeの耐久性バリア・重複排除判定の後ろ）から直列に呼ばれる
+ * ため、単純に最新の呼び出しを適用するだけでよい（到着順序はキュー自体が
+ * 保証する）。
  */
-export const markSessionActive = (arrivalSeq?: number): void => {
-  applyActivityTransition('active', arrivalSeq)
+export const markSessionActive = (): void => {
+  sessionActivity = 'active'
 }
 
 /**
- * `event-ingestion.ts`のEVT_SESSION_RESULTS(309)受信時に呼ぶ。`arrivalSeq`は
- * 呼び出し元での生メッセージ到着順序（上のコメント参照）。
+ * `event-ingestion.ts`のEVT_SESSION_RESULTS(309)/EVT_ENTRY_CANCELLED(203)
+ * 受信時に呼ぶ。`markSessionActive()`と同じく`ingestionQueue`から直列に
+ * 呼ばれる。
  */
-export const markSessionInactive = (arrivalSeq?: number): void => {
-  applyActivityTransition('inactive', arrivalSeq)
+export const markSessionInactive = (): void => {
+  sessionActivity = 'inactive'
 }
 
 /**
- * 重複検知の取り消し（P2, codexレビュー 2026-07-21指摘）: `arrivalSeq`が
- * まだ現在適用中の遷移（`lastAppliedSeq === arrivalSeq`）であれば、その
- * 遷移を取り消して直前の状態へ1段階ロールバックする。
+ * `event-ingestion.ts`の`registerEventIngestion()`が登録する、
+ * 「現時点までにキューへ積まれた取り込み処理が全て決着するまで待つ」
+ * プロバイダ。未登録（`registerEventIngestion()`が一度も呼ばれていない
+ * ごく初期のSW起動時など）ならno-op。
+ */
+type IngestionDrainProvider = () => Promise<void>
+
+let ingestionDrainProvider: IngestionDrainProvider | undefined
+
+/**
+ * `event-ingestion.ts`専用: このモジュールの外からsessionActivityの
+ * 「書き込みタイミング」を変えることなく、reload判定地点だけが安全に
+ * 待てるようにするための登録フック（circular importを避けるための
+ * 依存性逆転——update-manager.tsはevent-ingestion.tsを一切importしない）。
+ */
+export const setIngestionDrainProvider = (provider: IngestionDrainProvider): void => {
+  ingestionDrainProvider = provider
+}
+
+/**
+ * reload判定（`isSafeToUpdate()`を使う各エントリーポイント）の直前で待つ
+ * 「キュー・ドレイン・バリア」（2026-07-21 pass-3 codexレビュー3件の帰結、
+ * 詳細は本ファイル冒頭のSAFE定義コメント参照）。
  *
- * 想定用途: event-ingestion.tsは201/303[Player在席]/308の受信直後に
- * `markSessionActive()`を同期的に（raw書き込みの耐久性バリアより前に）
- * 呼ぶ「楽観的」な設計になっている（P2#3, 2026-07-21の前回修正）。これは
- * 再チェックとの競合を防ぐために必要な一方、この生メッセージが実は
- * reconnect resend等による**真の重複**（同一(timestamp, ApiTypeId)・
- * 同一ペイロードが既にRaw Event Lakeに存在する）だと後から判明した場合、
- * その楽観的なACTIVE化は本来起こるべきではなかった遷移である。
- * このケースを放置すると、309で正しくinactive化された後にstaleな
- * resendが届いただけでsessionActivityがactiveに戻ってしまい、
- * 新しいハンドが無いのに保留中アップデートが無期限にブロックされ続ける
- * （このバグはtri-stateを`'unknown'`に一律フォールバックさせるのではなく、
- * 遷移前の状態へ正しくロールバックすることで、「本当は309で終わっていた」
- * という正しい状態を復元する——1段階の巻き戻しで十分なのは、この関数は
- * 「まだ現在の状態として有効な遷移」だけを対象にするため。既に別の新しい
- * 遷移で上書きされていれば`lastAppliedSeq !== arrivalSeq`となり、
- * 何もしない[その新しい遷移の方が正しいため]）。
+ * ACTIVE化・INACTIVE化は`event-ingestion.ts`の`ingestionQueue`内で決着する
+ * ため、そのキューにまだ何か積まれている（rawの書き込みが進行中、または
+ * 重複判定待ち）間は、`sessionActivity`が最新の生イベントを反映していない
+ * 可能性がある。この関数は「呼び出し時点までに到着したイベントの処理が
+ * 全て終わるまで」待つことで、reload判定が古い/遷移途中の状態を読んで
+ * しまうことを防ぐ（呼び出し後に新たに到着したイベントは、因果的に
+ * この判定より後なので待つ必要が無い）。
+ *
+ * 例外: `event-ingestion.ts`の`processEvent`が309自身の処理の中から直接
+ * 呼ぶ`recheckPendingUpdate()`はこのバリアを使わない——`ingestionQueue`は
+ * その309自身の処理が完了するまで解決しないため、その中からこの関数を
+ * 呼ぶと自己参照でデッドロックする。その経路は代わりに
+ * `processEvent`内で素直に`await`することでキューの直列化にそのまま
+ * 乗せている（event-ingestion.tsの309ブロックのコメント参照）。
  */
-export const revertSessionActivityIfStillApplied = (arrivalSeq: number): void => {
-  if (lastAppliedSeq === arrivalSeq) {
-    sessionActivity = previousSessionActivity
-    lastAppliedSeq = previousAppliedSeq
+export const awaitIngestionDrain = async (): Promise<void> => {
+  if (ingestionDrainProvider) {
+    await ingestionDrainProvider()
   }
 }
 
 /** テスト専用: モジュールスコープの状態をリセットする */
 export const __resetUpdateManagerStateForTests = (): void => {
   sessionActivity = 'unknown'
-  lastAppliedSeq = 0
-  previousSessionActivity = 'unknown'
-  previousAppliedSeq = 0
-  internalAutoSeq = 0
 }
 
 /** 保留中アップデートを適用できない理由を日本語で説明する（Popup表示用） */
@@ -239,6 +217,11 @@ const clearBadge = async (): Promise<void> => {
  * SAFEなら即座に適用、そうでなければ保留状態を記録してバッジを出す。
  */
 export const handleUpdateAvailable = async (details: { version: string }): Promise<void> => {
+  // キュー・ドレイン・バリア（本ファイル冒頭のSAFE定義コメント参照）:
+  // `onUpdateAvailable`はevent-ingestion.tsのキューとは無関係な任意の
+  // タイミングで発火しうるため、判定前に必ず待つ。
+  await awaitIngestionDrain()
+
   if (isSafeToUpdate()) {
     console.log(`[update-manager] Update ${details.version} available and safe -- applying immediately`)
     await clearPendingUpdateState()
@@ -255,6 +238,13 @@ export const handleUpdateAvailable = async (details: { version: string }): Promi
 /**
  * 保留中アップデートの安全性を再チェックし、SAFEになっていれば適用する。
  * session end / operation completion / SW startup の3箇所から呼ばれる。
+ *
+ * キュー・ドレイン・バリアはこの関数自身の中には置かない（意図的）:
+ * event-ingestion.tsの309自身の`processEvent`内から直接呼ぶ経路が
+ * あり、そこで`awaitIngestionDrain()`を呼ぶとその309自身を含む
+ * `ingestionQueue`の決着を待つことになり自己参照でデッドロックする。
+ * 呼び出し元（operation-complete契機・SW起動時契機）側で個別に
+ * `awaitIngestionDrain()`してから呼ぶ（`initUpdateManager()`参照）。
  */
 export const recheckPendingUpdate = async (): Promise<void> => {
   const state = await getPendingUpdateState()
@@ -290,6 +280,11 @@ export const recheckPendingUpdate = async (): Promise<void> => {
  * SAFEなら適用、そうでなければ理由を返す（Popupに表示させる）。
  */
 export const applyUpdateNow = async (): Promise<ApplyUpdateResult> => {
+  // キュー・ドレイン・バリア（本ファイル冒頭のSAFE定義コメント参照）:
+  // ユーザー操作起点でevent-ingestion.tsのキューとは無関係なタイミングで
+  // 呼ばれるため、判定前に必ず待つ。
+  await awaitIngestionDrain()
+
   if (!isSafeToUpdate()) {
     const reason = describeUnsafeReason()
     const current = await getPendingUpdateState()
@@ -351,6 +346,18 @@ const setupUpdateCheckAlarm = async (): Promise<void> => {
  * 呼び出しをブロックしない（他のセットアップは同期的に完了する）ので、
  * SW起動を止めたくない呼び出し側はそのままfire-and-forgetしてよい。
  */
+/**
+ * `recheckPendingUpdate()`をキュー・ドレイン・バリアの後ろで呼ぶラッパー。
+ * event-ingestion.tsの309自身の処理からは呼ばない（そちらは
+ * `recheckPendingUpdate()`自身のコメント参照）——operation-complete契機・
+ * SW起動時契機はどちらもingestionQueueとは無関係なタイミングで発火しうる
+ * ため、両方ともこのラッパー経由で呼ぶ。
+ */
+const recheckPendingUpdateAfterDrain = async (): Promise<void> => {
+  await awaitIngestionDrain()
+  await recheckPendingUpdate()
+}
+
 export const initUpdateManager = (): Promise<void> => {
   chrome.runtime.onUpdateAvailable.addListener((details) => {
     handleUpdateAvailable(details).catch(error => {
@@ -359,7 +366,7 @@ export const initUpdateManager = (): Promise<void> => {
   })
 
   onOperationBecameIdle(() => {
-    recheckPendingUpdate().catch(error => {
+    recheckPendingUpdateAfterDrain().catch(error => {
       console.error('[update-manager] recheckPendingUpdate (operation completion) failed:', error)
     })
   })
@@ -371,7 +378,7 @@ export const initUpdateManager = (): Promise<void> => {
     console.error('[update-manager] setupUpdateCheckAlarm failed:', error)
   })
 
-  return recheckPendingUpdate().catch(error => {
+  return recheckPendingUpdateAfterDrain().catch(error => {
     console.error('[update-manager] recheckPendingUpdate (SW startup) failed:', error)
   })
 }

--- a/src/background/update-manager.ts
+++ b/src/background/update-manager.ts
@@ -13,10 +13,18 @@
  *   3. Service Worker起動時（`initUpdateManager()`呼び出し時）
  *
  * SAFE（安全）の定義（`isSafeToUpdate()`）:
- *   - アクティブなゲームセッションが無い（EVT_SESSION_DETAILS〜
- *     EVT_SESSION_RESULTSの間はunsafe。content_script.tsのkeepaliveゲート
- *     [`isGameActive`]と同じ境界イベントを、Service Worker側で
- *     `markSessionActive()`/`markSessionInactive()`により独立に追跡する）
+ *   - アクティブなゲームセッションが無い（EVT_ENTRY_QUEUED(201)/EVT_DEAL(303)/
+ *     EVT_SESSION_DETAILS(308)のいずれかからEVT_SESSION_RESULTS(309)までの
+ *     間はunsafe。content_script.tsのkeepaliveゲート[`isGameActive`]と同じ
+ *     境界イベントを、Service Worker側で`markSessionActive()`/
+ *     `markSessionInactive()`により独立に追跡する。308単独をACTIVEの
+ *     トリガーにしないのは、docs/api-events.md:99が明記する通り308の欠落
+ *     （観測ギャップ）が正常系のバリアントとして起こりうるため——309で
+ *     inactiveにした直後、308無しで次の試合が201/303から始まるケースを
+ *     inactiveのまま固めてしまうと、この安全性述語がゲーム中に「安全」と
+ *     誤判定してService Workerをreloadしてしまう（release-blocker監査
+ *     finding B）。ACTIVE化のトリガーを201/303/308の3つに広げても、
+ *     INACTIVEへ戻すトリガーは引き続き309のみ）
  *   - `AutoSyncService.isSyncing`がfalse（同期中でない）
  *   - `currentOperationState.type === 'idle'`（export/import/rebuild中でない）
  * 上記いずれかが「unknown」（SW再起動直後などでセッション状態を未観測）の
@@ -61,7 +69,11 @@ type SessionActivity = 'unknown' | 'active' | 'inactive'
 /** SW再起動のたびに`'unknown'`にリセットされる（保守的なデフォルト = unsafe扱い） */
 let sessionActivity: SessionActivity = 'unknown'
 
-/** `event-ingestion.ts`のEVT_SESSION_DETAILS(308)受信時に呼ぶ */
+/**
+ * `event-ingestion.ts`のEVT_ENTRY_QUEUED(201)/EVT_DEAL(303)/
+ * EVT_SESSION_DETAILS(308)いずれかの受信時に呼ぶ（308単独に頼らない理由は
+ * 本ファイル冒頭のコメント参照）
+ */
 export const markSessionActive = (): void => {
   sessionActivity = 'active'
 }

--- a/src/background/update-manager.ts
+++ b/src/background/update-manager.ts
@@ -163,7 +163,8 @@ const MAX_DRAIN_ITERATIONS = 1000
  * 呼ぶ`recheckPendingUpdate()`はこのバリアを使わない（使うと自己参照で
  * デッドロックする——`ingestionQueue`はその309/203自身の処理が完了する
  * まで解決しないため）。その経路は別の機構（`event-ingestion.ts`の
- * `queueGeneration`比較）で同種の安全性を確保している——詳細は
+ * `activityGeneration`比較、`recheckPendingUpdate()`の`isStillFresh`
+ * オプション経由）で同種の安全性を確保している——詳細は
  * event-ingestion.tsの309/203ブロックのコメント参照。
  */
 export const awaitIngestionDrain = async (): Promise<void> => {
@@ -246,36 +247,65 @@ const clearBadge = async (): Promise<void> => {
  * SAFEなら即座に適用、そうでなければ保留状態を記録してバッジを出す。
  */
 export const handleUpdateAvailable = async (details: { version: string }): Promise<void> => {
+  // まず保留状態を永続化してからドレインする（P2, codexレビュー指摘
+  // 2026-07-21, pass-5, "Persist pending updates before draining
+  // ingestion"）: この関数は`chrome.runtime.onUpdateAvailable`リスナー
+  // からfire-and-forgetで呼ばれる（`initUpdateManager()`参照）。下の
+  // `awaitIngestionDrain()`はキューが詰まっていれば長時間かかりうるが、
+  // その待機中にService Workerがサスペンド/強制終了されると、この関数
+  // 自体のPromiseチェーンごと消え去り、どこにも保留記録が残らない
+  // （SW再起動時契機の`recheckPendingUpdate()`は`pendingUpdate`が
+  // 無ければ何もすることが無く、ダウンロード済みの更新が事実上失われる）。
+  // 先に「保留中」として記録しておけば、途中でSWが落ちてもSW再起動時に
+  // 必ず拾われる。安全であることが分かった場合のクリアは末尾で行う。
+  await setPendingUpdateState({ pending: true, version: details.version, detectedAt: Date.now() })
+  await setBadge()
+
   // キュー・ドレイン・バリア（本ファイル冒頭のSAFE定義コメント参照）:
   // `onUpdateAvailable`はevent-ingestion.tsのキューとは無関係な任意の
   // タイミングで発火しうるため、判定前に必ず待つ。
   await awaitIngestionDrain()
 
-  if (isSafeToUpdate()) {
-    console.log(`[update-manager] Update ${details.version} available and safe -- applying immediately`)
-    await clearPendingUpdateState()
-    await clearBadge()
-    chrome.runtime.reload()
+  if (!isSafeToUpdate()) {
+    console.log(`[update-manager] Update ${details.version} available but unsafe (${describeUnsafeReason()}) -- pending`)
     return
   }
 
-  console.log(`[update-manager] Update ${details.version} available but unsafe (${describeUnsafeReason()}) -- pending`)
-  await setPendingUpdateState({ pending: true, version: details.version, detectedAt: Date.now() })
-  await setBadge()
+  // ここから`chrome.runtime.reload()`まで`await`を一切挟まない（P1,
+  // codexレビュー指摘 2026-07-21, pass-5, "Guard reload rechecks through
+  // the async path"）。詳細は`recheckPendingUpdate()`の同種コメント参照。
+  console.log(`[update-manager] Update ${details.version} available and safe -- applying immediately`)
+  chrome.runtime.reload()
+  clearPendingUpdateState().catch(err => console.error('[update-manager] Failed to clear pending update state after reload:', err))
+  clearBadge().catch(err => console.error('[update-manager] Failed to clear badge after reload:', err))
 }
 
 /**
  * 保留中アップデートの安全性を再チェックし、SAFEになっていれば適用する。
- * session end / operation completion / SW startup の3箇所から呼ばれる。
+ * session end / entry cancellation / operation completion / SW startup の
+ * 4箇所から呼ばれる。
  *
  * キュー・ドレイン・バリアはこの関数自身の中には置かない（意図的）:
- * event-ingestion.tsの309自身の`processEvent`内から直接呼ぶ経路が
- * あり、そこで`awaitIngestionDrain()`を呼ぶとその309自身を含む
+ * event-ingestion.tsの309/203自身の`processEvent`内から直接呼ぶ経路が
+ * あり、そこで`awaitIngestionDrain()`を呼ぶとその309/203自身を含む
  * `ingestionQueue`の決着を待つことになり自己参照でデッドロックする。
  * 呼び出し元（operation-complete契機・SW起動時契機）側で個別に
  * `awaitIngestionDrain()`してから呼ぶ（`initUpdateManager()`参照）。
+ *
+ * `options.isStillFresh`（P1, codexレビュー指摘 2026-07-21, pass-5,
+ * "Guard reload rechecks through the async path"）: 呼び出し元固有の
+ * 追加鮮度チェック。event-ingestion.tsの309/203自身の処理から呼ぶ場合、
+ * 「自分の到着以降にセッション状態へ影響しうる新しいイベントが既に
+ * キューへ積まれていないか」（`activityGeneration`比較）を渡す——この
+ * 経路は`awaitIngestionDrain()`を使えない（自己参照デッドロック）ため、
+ * 同期的な世代比較で代替する。下の「原子的な最終確認」の一部として、
+ * `isSafeToUpdate()`と**同じタイミングで**（間に`await`を挟まず）評価する
+ * ことが重要——この関数はこの2つのawait（`getPendingUpdateState()`と、
+ * バージョン一致チェック内の各種await）自体が「その間に新しいイベントが
+ * 到着・処理されうる隙間」であるため、呼び出し前に1回チェックするだけ
+ * では不十分（それ自体がこのpass-5指摘の内容）。
  */
-export const recheckPendingUpdate = async (): Promise<void> => {
+export const recheckPendingUpdate = async (options?: { isStillFresh?: () => boolean }): Promise<void> => {
   const state = await getPendingUpdateState()
   if (!state.pending) return
 
@@ -292,16 +322,34 @@ export const recheckPendingUpdate = async (): Promise<void> => {
     return
   }
 
-  if (isSafeToUpdate()) {
-    console.log('[update-manager] Pending update is now safe to apply -- applying')
-    await clearPendingUpdateState()
-    await clearBadge()
-    chrome.runtime.reload()
+  if (!isSafeToUpdate()) {
+    // まだunsafe: バッジを再アサート（rebuild-advisoryが解消済みなら表示に切り替わる）
+    await setBadge()
     return
   }
 
-  // まだunsafe: バッジを再アサート（rebuild-advisoryが解消済みなら表示に切り替わる）
-  await setBadge()
+  // 原子的な最終確認（P1, codexレビュー指摘 2026-07-21, pass-5,
+  // "Guard reload rechecks through the async path"）: ここまでの
+  // `await`（`getPendingUpdateState()`等）は、その間に新しいイベントが
+  // 到着・処理されうる隙間である。この直後から`chrome.runtime.reload()`
+  // までの間に一切`await`を挟まないことで、最終チェックと実際のreloadを
+  // 原子的（隣接）にする——`isSafeToUpdate()`と`options.isStillFresh`を
+  // 同じタイミングで評価するのが肝要。
+  if (options?.isStillFresh && !options.isStillFresh()) {
+    console.log('[update-manager] Pending update recheck aborted -- a newer session-activity-relevant event was already queued, deferring to a later recheck trigger')
+    await setBadge()
+    return
+  }
+
+  console.log('[update-manager] Pending update is now safe to apply -- applying')
+  chrome.runtime.reload()
+  // 状態クリアはreload後にfire-and-forgetする: 上のreload()呼び出し直前に
+  // `await`を挟まないことがこの関数の安全性の核なので、クリア処理は
+  // reload()の後段へ回す。仮にSWがreload()で即座に終了してクリアが
+  // 完了しなくても、SW再起動後の`recheckPendingUpdate()`（起動時契機）が
+  // 上のバージョン一致ブランチで確実に片付けるため実害は無い。
+  clearPendingUpdateState().catch(err => console.error('[update-manager] Failed to clear pending update state after reload:', err))
+  clearBadge().catch(err => console.error('[update-manager] Failed to clear badge after reload:', err))
 }
 
 /**
@@ -321,8 +369,11 @@ export const applyUpdateNow = async (): Promise<ApplyUpdateResult> => {
     return { applied: false, reason }
   }
 
-  await clearPendingUpdateState()
+  // ここから`chrome.runtime.reload()`まで`await`を一切挟まない（P1,
+  // codexレビュー指摘 2026-07-21, pass-5）。詳細は`recheckPendingUpdate()`
+  // の同種コメント参照。
   chrome.runtime.reload()
+  clearPendingUpdateState().catch(err => console.error('[update-manager] Failed to clear pending update state after reload:', err))
   return { applied: true }
 }
 

--- a/src/content_script.session-activity.test.ts
+++ b/src/content_script.session-activity.test.ts
@@ -13,6 +13,13 @@
  *
  * Only EVT_SESSION_RESULTS (309) may disarm it again -- the tri-state stays
  * conservative (inactive only on an explicit session-end signal).
+ *
+ * EVT_DEAL is further gated on the raw `Player` field's presence (P2, codex
+ * review 2026-07-21): docs/api-events.md "EVT_DEAL: Playerフィールドの欠落"
+ * documents spectator-mode deals (hero not seated, e.g. after busting out
+ * but the client keeps receiving another table) as having no `Player` field
+ * at all. Arming keepalive on those would keep it running through a
+ * spectated session that may never see another 309.
  */
 import { ApiType } from './types'
 import { POKER_CHASE_ORIGIN } from './constants/runtime'
@@ -62,22 +69,30 @@ describe('content_script keepalive (session-activity triggers)', () => {
     expect(mockPort.postMessage).toHaveBeenCalledWith({ type: 'keepalive' })
   })
 
-  test('EVT_DEAL (303) alone starts keepalive without a prior 308', () => {
-    dispatchGameMessage({ ApiTypeId: ApiType.EVT_DEAL, timestamp: 2 })
+  test('EVT_DEAL (303) with Player present alone starts keepalive without a prior 308', () => {
+    dispatchGameMessage({ ApiTypeId: ApiType.EVT_DEAL, timestamp: 2, Player: { SeatIndex: 0 } })
 
     jest.advanceTimersByTime(KEEPALIVE_INTERVAL_MS)
 
     expect(mockPort.postMessage).toHaveBeenCalledWith({ type: 'keepalive' })
   })
 
-  test('raw sequence 309 -> 201 -> 303 (no intervening 308) keeps keepalive armed (release-blocker audit exact scenario)', () => {
+  test('EVT_DEAL (303) with Player absent (spectator mode) does NOT start keepalive (P2, codex review 2026-07-21)', () => {
+    dispatchGameMessage({ ApiTypeId: ApiType.EVT_DEAL, timestamp: 2 }) // no Player field
+
+    jest.advanceTimersByTime(KEEPALIVE_INTERVAL_MS)
+
+    expect(mockPort.postMessage).not.toHaveBeenCalledWith({ type: 'keepalive' })
+  })
+
+  test('raw sequence 309 -> 201 -> 303[Player present] (no intervening 308) keeps keepalive armed (release-blocker audit exact scenario)', () => {
     // beforeEach already sent a 309 baseline; repeat explicitly so the
     // scenario reads standalone.
     dispatchGameMessage({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 3 })
     mockPort.postMessage.mockClear()
 
     dispatchGameMessage({ ApiTypeId: ApiType.EVT_ENTRY_QUEUED, timestamp: 4 })
-    dispatchGameMessage({ ApiTypeId: ApiType.EVT_DEAL, timestamp: 5 })
+    dispatchGameMessage({ ApiTypeId: ApiType.EVT_DEAL, timestamp: 5, Player: { SeatIndex: 0 } })
 
     jest.advanceTimersByTime(KEEPALIVE_INTERVAL_MS)
 

--- a/src/content_script.session-activity.test.ts
+++ b/src/content_script.session-activity.test.ts
@@ -20,6 +20,12 @@
  * but the client keeps receiving another table) as having no `Player` field
  * at all. Arming keepalive on those would keep it running through a
  * spectated session that may never see another 309.
+ *
+ * ApiTypeId 203 (参加取消申込, entry cancellation -- see src/types/api.ts)
+ * also disarms keepalive, alongside 309 (P2, codex review 2026-07-20
+ * pass-3): entering matchmaking (201) and cancelling before any hand starts
+ * never produces a 309, so 203 is the only signal that the pending
+ * entry -- and the keepalive it armed -- is moot.
  */
 import { ApiType } from './types'
 import { POKER_CHASE_ORIGIN } from './constants/runtime'
@@ -102,6 +108,18 @@ describe('content_script keepalive (session-activity triggers)', () => {
   test('EVT_SESSION_RESULTS (309) stops keepalive', () => {
     dispatchGameMessage({ ApiTypeId: ApiType.EVT_ENTRY_QUEUED, timestamp: 6 })
     dispatchGameMessage({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 7 })
+    mockPort.postMessage.mockClear()
+
+    jest.advanceTimersByTime(KEEPALIVE_INTERVAL_MS * 2)
+
+    expect(mockPort.postMessage).not.toHaveBeenCalled()
+  })
+
+  test('ApiTypeId 203 (参加取消申込, entry cancellation) stops keepalive when no hand ever started (P2, codex review 2026-07-20 pass-3)', () => {
+    dispatchGameMessage({ ApiTypeId: ApiType.EVT_ENTRY_QUEUED, timestamp: 8 })
+    // 203 is not part of the `ApiType` enum -- use the raw literal, matching
+    // event-ingestion.ts's own EVT_ENTRY_CANCELLED_API_TYPE_ID.
+    dispatchGameMessage({ ApiTypeId: 203, timestamp: 9 })
     mockPort.postMessage.mockClear()
 
     jest.advanceTimersByTime(KEEPALIVE_INTERVAL_MS * 2)

--- a/src/content_script.session-activity.test.ts
+++ b/src/content_script.session-activity.test.ts
@@ -1,0 +1,96 @@
+/**
+ * content_script.ts - keepalive session-activity trigger set
+ *
+ * Mirrors event-ingestion.ts's expanded ACTIVE trigger set (release-blocker
+ * audit finding B): EVT_SESSION_DETAILS (308) alone is not a reliable
+ * "game started" signal -- docs/api-events.md:99 documents its absence as a
+ * normal variant (an observation gap in the capture), so a new game can
+ * legitimately start 201 (EVT_ENTRY_QUEUED)/303 (EVT_DEAL)-first with no 308
+ * at all. Before this fix, content_script's keepalive gate (`isGameActive`)
+ * only armed on 308, so that (normal) scenario left keepalive never
+ * starting, silently increasing the risk of the Service Worker suspending
+ * mid-game (no keepalive pings to keep the port/SW alive).
+ *
+ * Only EVT_SESSION_RESULTS (309) may disarm it again -- the tri-state stays
+ * conservative (inactive only on an explicit session-end signal).
+ */
+import { ApiType } from './types'
+import { POKER_CHASE_ORIGIN } from './constants/runtime'
+
+const KEEPALIVE_INTERVAL_MS = 25000
+
+describe('content_script keepalive (session-activity triggers)', () => {
+  let mockPort: any
+
+  const dispatchGameMessage = (data: unknown) => {
+    window.dispatchEvent(new MessageEvent('message', { data, origin: POKER_CHASE_ORIGIN, source: window }))
+  }
+
+  beforeAll(async () => {
+    mockPort = {
+      onMessage: { addListener: jest.fn() },
+      onDisconnect: { addListener: jest.fn() },
+      postMessage: jest.fn(),
+      disconnect: jest.fn()
+    }
+    ;(chrome.runtime as any).connect = jest.fn(() => mockPort)
+    jest.useFakeTimers()
+    // content_script.ts registers its window/document listeners and connects
+    // its port as *import-time* side effects (no exported init function), so
+    // importing it once here is the only way to exercise this file -- see
+    // module docblock above for why every test in this suite shares that one
+    // import instead of re-importing per test.
+    await import('./content_script')
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
+  beforeEach(() => {
+    // Force a known baseline (session inactive, keepalive stopped) before
+    // each test without re-importing the module.
+    dispatchGameMessage({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 0 })
+    mockPort.postMessage.mockClear()
+  })
+
+  test('EVT_ENTRY_QUEUED (201) alone starts keepalive without a prior 308', () => {
+    dispatchGameMessage({ ApiTypeId: ApiType.EVT_ENTRY_QUEUED, timestamp: 1 })
+
+    jest.advanceTimersByTime(KEEPALIVE_INTERVAL_MS)
+
+    expect(mockPort.postMessage).toHaveBeenCalledWith({ type: 'keepalive' })
+  })
+
+  test('EVT_DEAL (303) alone starts keepalive without a prior 308', () => {
+    dispatchGameMessage({ ApiTypeId: ApiType.EVT_DEAL, timestamp: 2 })
+
+    jest.advanceTimersByTime(KEEPALIVE_INTERVAL_MS)
+
+    expect(mockPort.postMessage).toHaveBeenCalledWith({ type: 'keepalive' })
+  })
+
+  test('raw sequence 309 -> 201 -> 303 (no intervening 308) keeps keepalive armed (release-blocker audit exact scenario)', () => {
+    // beforeEach already sent a 309 baseline; repeat explicitly so the
+    // scenario reads standalone.
+    dispatchGameMessage({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 3 })
+    mockPort.postMessage.mockClear()
+
+    dispatchGameMessage({ ApiTypeId: ApiType.EVT_ENTRY_QUEUED, timestamp: 4 })
+    dispatchGameMessage({ ApiTypeId: ApiType.EVT_DEAL, timestamp: 5 })
+
+    jest.advanceTimersByTime(KEEPALIVE_INTERVAL_MS)
+
+    expect(mockPort.postMessage).toHaveBeenCalledWith({ type: 'keepalive' })
+  })
+
+  test('EVT_SESSION_RESULTS (309) stops keepalive', () => {
+    dispatchGameMessage({ ApiTypeId: ApiType.EVT_ENTRY_QUEUED, timestamp: 6 })
+    dispatchGameMessage({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 7 })
+    mockPort.postMessage.mockClear()
+
+    jest.advanceTimersByTime(KEEPALIVE_INTERVAL_MS * 2)
+
+    expect(mockPort.postMessage).not.toHaveBeenCalled()
+  })
+})

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -134,6 +134,14 @@ window.addEventListener('message', (event: MessageEvent<unknown>) => {
     }
   }
 
+  // 参加取消申込（ApiTypeId 203）。`ApiType` enumには含まれないため生の
+  // 数値リテラルを使う（background/event-ingestion.tsの
+  // `EVT_ENTRY_CANCELLED_API_TYPE_ID`コメント参照）。参加(201)後・着席
+  // (303/308)前にキャンセルするとハンドが一度も始まらず309も来ないため、
+  // これも309と同じくkeepalive解除トリガーとして扱う（P2, codexレビュー
+  // 指摘 2026-07-21, pass-3）。
+  const EVT_ENTRY_CANCELLED_API_TYPE_ID = 203
+
   switch (event.data.ApiTypeId) {
     case ApiType.EVT_ENTRY_QUEUED:
     case ApiType.EVT_SESSION_DETAILS:
@@ -149,7 +157,7 @@ window.addEventListener('message', (event: MessageEvent<unknown>) => {
       // isGameActiveがtrueに固まる（309が来るとは限らない -- 観戦を続けたまま
       // タブを閉じる等）。raw-firstパターンに従い、パース前の生フィールドの
       // 有無だけで判定する（background/event-ingestion.tsの
-      // `markSessionActiveFromRawMessage()`と同じ判定をミラー）。
+      // `applySessionActivity()`と同じ判定をミラー）。
       if ((event.data as { Player?: unknown }).Player != null) {
         armSession()
       }
@@ -165,6 +173,17 @@ window.addEventListener('message', (event: MessageEvent<unknown>) => {
       // hero以外の全HUDパネルをクリアするため）。309はここで生イベントとして
       // 既に観測済みなので、background往復の新チャネルを追加せずその場でdispatchする。
       window.dispatchEvent(new CustomEvent(POKER_CHASE_SESSION_END_EVENT))
+      break
+
+    case EVT_ENTRY_CANCELLED_API_TYPE_ID:
+      // 参加取消: ハンドが一度も始まっていないので、309と違いApp.tsxへの
+      // セッション終了通知（POKER_CHASE_SESSION_END_EVENT）は不要
+      // （そもそもクリアすべきライブHUDが存在しない）。keepaliveの解除
+      // だけ行う。
+      if (isGameActive) {
+        isGameActive = false
+        stopKeepalive()
+      }
       break
   }
 

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -113,7 +113,23 @@ window.addEventListener('message', (event: MessageEvent<unknown>) => {
   }
 
   // ゲーム状態の追跡
+  //
+  // ACTIVE化のトリガーはEVT_SESSION_DETAILS(308)単独に頼らない
+  // （release-blocker監査 finding B。background/update-manager.tsの
+  // `markSessionActive()`呼び出し箇所[background/event-ingestion.ts]と
+  // 同じトリガー集合をここでミラーする -- background/content_script間は
+  // import禁止のため、変更時は両ファイルを手動で揃えること）。
+  // docs/api-events.md:99が明記する通り308の欠落は正常系のバリアント
+  // （観測ギャップ）で、309の後に308無しで次の試合が201/303から始まる
+  // ケースは普通に起こる。308だけを見ているとisGameActiveがfalseのまま
+  // 固まり、keepaliveが起動せずService Workerがゲーム中にサスペンドされ
+  // うる。保守的に、以下のいずれかを観測したら即active化する:
+  //   - EVT_ENTRY_QUEUED(201): 着席（新セッション/新テーブルの入口）
+  //   - EVT_DEAL(303): ハンド進行中の最も強いシグナル
+  //   - EVT_SESSION_DETAILS(308): 従来からのシグナル（来れば最速）
   switch (event.data.ApiTypeId) {
+    case ApiType.EVT_ENTRY_QUEUED:
+    case ApiType.EVT_DEAL:
     case ApiType.EVT_SESSION_DETAILS:
       // セッション開始
       if (!isGameActive) {

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -125,16 +125,33 @@ window.addEventListener('message', (event: MessageEvent<unknown>) => {
   // 固まり、keepaliveが起動せずService Workerがゲーム中にサスペンドされ
   // うる。保守的に、以下のいずれかを観測したら即active化する:
   //   - EVT_ENTRY_QUEUED(201): 着席（新セッション/新テーブルの入口）
-  //   - EVT_DEAL(303): ハンド進行中の最も強いシグナル
+  //   - EVT_DEAL(303, Player在席時のみ): ハンド進行中の最も強いシグナル
   //   - EVT_SESSION_DETAILS(308): 従来からのシグナル（来れば最速）
+  const armSession = () => {
+    if (!isGameActive) {
+      isGameActive = true
+      startKeepalive(portManager.port)
+    }
+  }
+
   switch (event.data.ApiTypeId) {
     case ApiType.EVT_ENTRY_QUEUED:
-    case ApiType.EVT_DEAL:
     case ApiType.EVT_SESSION_DETAILS:
-      // セッション開始
-      if (!isGameActive) {
-        isGameActive = true
-        startKeepalive(portManager.port)
+      armSession()
+      break
+
+    case ApiType.EVT_DEAL:
+      // 観戦モード（ヒーロー未着席）のdealはACTIVEトリガーから除外する
+      // （P2, codexレビュー指摘 2026-07-21）: docs/api-events.md「EVT_DEAL:
+      // Playerフィールドの欠落」の通り、観戦モードでは`Player`フィールド
+      // 自体が無い（undefined）。ここを除外しないと、ヒーローがバストして
+      // 観戦中に届く303までkeepaliveを起動してしまい、以降309が来ない限り
+      // isGameActiveがtrueに固まる（309が来るとは限らない -- 観戦を続けたまま
+      // タブを閉じる等）。raw-firstパターンに従い、パース前の生フィールドの
+      // 有無だけで判定する（background/event-ingestion.tsの
+      // `markSessionActiveFromRawMessage()`と同じ判定をミラー）。
+      if ((event.data as { Player?: unknown }).Player != null) {
+        armSession()
       }
       break
 


### PR DESCRIPTION
## Summary

Two P1 release blockers from an independent audit, both in the shared
`src/background/event-ingestion.ts` critical path (fixed together since
the fixes touch overlapping code).

### A. Raw Event Lake durability ordering

`service.db.apiEvents.add(message)` was fire-and-forget (`.catch()` only,
never `await`ed). Session-activity tracking, the auto-sync trigger (whose
`recheckPendingUpdate()` can call `chrome.runtime.reload()`), and stream
forwarding (`handLogStream`/`handAggregateStream`/`realTimeStatsStream`)
all ran unconditionally, regardless of whether the raw write had actually
settled. Concretely:

- On a quota/other failure, derived stats could be produced with **no raw
  recovery row** -- violating the Raw Event Lake invariant that storage
  happens *before* the pipeline (see CLAUDE.md "Raw Event Lake" / "Storage
  happens *before* the validation gate").
- On a duplicate-key failure (same `[timestamp+ApiTypeId]` re-arriving),
  the pipeline would double-process an event that was already handled the
  first time.
- A reload triggered right after could race the still-in-flight write.

**Fix**: each event's processing is now serialized behind its own
`apiEvents.add()` settling (a per-connection queue chains each event after
the previous one's full processing, so wire order is preserved across a
burst even with the added `await`s):
- success -> proceed as before.
- duplicate-key (`Dexie.DexieError` / `ConstraintError`) -> skip *all*
  downstream re-processing (session hooks, sync trigger, streams) --
  dedup semantics, since this exact event already went through once.
- any other failure -> drop the event from the pipeline entirely (never
  forward without a raw row) and surface it via the existing
  drop-visibility counter (`undecoded-event-tracker.ts`, #141 mechanism)
  instead of only a `console.error`.

Session-activity tracking, the auto-sync trigger, and stream writes are
all gated behind the same barrier for simplicity/defense-in-depth, even
though strictly only the reload-capable recheck (chained off
`onGameSessionEnd()`) needs it -- `onGameSessionEnd()`/`onNewSessionStart()`
themselves only read already-persisted raw-Lake row counts and don't call
`reload()` directly. Reasoning is documented inline in
`registerEventIngestion()`.

### B. Session-activity false-inactive

The Forced Update safety predicate's session-activity tri-state
(`update-manager.ts`) was only marked ACTIVE on `EVT_SESSION_DETAILS`
(308), but `docs/api-events.md:99` documents 308's *absence* as a normal
capture variant, not an anomaly. A session ending (309 -> inactive)
followed by a new game legitimately starting 201/303-first with no 308 in
between left the tri-state stuck `inactive`, so `onUpdateAvailable`
/ operation-complete safety rechecks would judge a mid-game reload "safe"
and kill the Service Worker mid-hand.

**Fix**: ACTIVE is now triggered by any of `EVT_ENTRY_QUEUED` (201),
`EVT_DEAL` (303, the strongest "hand in flight" signal), or
`EVT_SESSION_DETAILS` (308, kept for the cases where it does arrive
first). Only `EVT_SESSION_RESULTS` (309) marks inactive -- the tri-state's
conservative `unknown = unsafe` default is unchanged.
`content_script.ts`'s keepalive gate (`isGameActive`) mirrors the same
trigger set, since `background/`↔content-script imports are disallowed and
the two must be kept manually in sync.

## Test plan

- [x] `npm run typecheck` -- clean
- [x] `npx jest` (full suite) x2 -- 1054/1054 both runs, no flakiness
- [x] New tests, fail-before/pass-after verified via a temporary
      `git checkout HEAD --` revert of the 3 touched source files (not
      `git stash`), confirming these tests catch the original bugs:
  - `src/background/event-ingestion.durability-barrier.test.ts`: deferred
    `add()` gates streams/session-hooks/sync-trigger until it resolves;
    duplicate-key rejection skips all downstream re-processing; a
    non-duplicate rejection (simulated `QuotaExceededError`) drops the
    event and surfaces it via the drop-visibility counter with zero raw
    rows persisted; a staggered-latency burst preserves stream-write order
  - `src/content_script.session-activity.test.ts`: 201/303 alone arm
    keepalive without a prior 308; the exact `309 -> 201 -> 303` sequence
    keeps keepalive armed
  - `src/background/event-ingestion.update-manager-trigger.test.ts`:
    updated for the new ACTIVE trigger set, plus the audit's exact
    `309 -> 201 -> 303 -> isSafeToUpdate() === false` regression scenario
- [x] `npm run e2e:smoke` -- 6/6 checks passed
- [x] `npm run e2e:playerid` -- 4/4 checks passed (session plumbing touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)