### PR TITLE
fix(sync): compound-key upload pagination (release blocker)

### DIFF
--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -1,6 +1,6 @@
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
 import { PokerChaseDB } from '../db/poker-chase-db'
-import { ApiType, ApiTypeValues, BattleType } from '../types'
+import { ApiType, ApiTypeValues, BattleType, BetStatusType } from '../types'
 import type { ApiEvent } from '../types'
 import { DATABASE_CONSTANTS } from '../constants/database'
 import { AutoSyncService } from './auto-sync-service'
@@ -208,8 +208,11 @@ describe('AutoSyncService cloud downloads', () => {
     // Still can't upload the broken row (schema hasn't been fixed), but the
     // scan floor was rewound to just below the pending marker (200 - 1 = 199)
     // instead of trusting the real cloud max (300) -- proving the row is
-    // still being re-scanned, not skipped.
-    expect(secondFloor).toBe(199)
+    // still being re-scanned, not skipped. 198, not 199: the P1 fix
+    // (auto-sync-service.ts) shifts the threshold syncToCloudBatch actually
+    // receives one further millisecond earlier -- see the threshold-shift
+    // comment in the backfill test below.
+    expect(secondFloor).toBe(198)
     // firstEntry (timestamp 100) sits below the rewound floor (199), so it's
     // not re-scanned -- only rows from the broken row's timestamp onward are.
     expect(secondChunk).toEqual([nextSessionEntry])
@@ -324,7 +327,14 @@ describe('AutoSyncService cloud downloads', () => {
     // specific orphan.
     expect(syncBatchSpy).toHaveBeenCalledTimes(1)
     const [uploadedChunk, floor] = syncBatchSpy.mock.calls[0]!
-    expect(floor).toBe(99)
+    // 98, not 99: syncToCloudBatch's own dedup filter is bare-timestamp-only
+    // (`event.timestamp > threshold`), so the P1 compound-key-pagination fix
+    // (auto-sync-service.ts) shifts the threshold it receives one
+    // millisecond earlier than the scan floor itself -- makes that filter
+    // INCLUSIVE of the scan floor's own millisecond, closing the gap where a
+    // not-yet-uploaded row could share that exact millisecond with a
+    // different ApiTypeId than whatever pushed the cloud watermark there.
+    expect(floor).toBe(98)
     expect(uploadedChunk).toEqual([oldValidEntry, newEntryAboveCloudMax])
 
     // --- Second sync: the backfill must not run again (one-time, idempotent) ---
@@ -336,7 +346,7 @@ describe('AutoSyncService cloud downloads', () => {
     // re-uploading the already-reconciled history.
     expect(syncBatchSpy).toHaveBeenCalledTimes(2)
     const [secondChunk, secondFloor] = syncBatchSpy.mock.calls[1]!
-    expect(secondFloor).toBe(199)
+    expect(secondFloor).toBe(198) // 199 - 1, same P1 threshold shift as above
     expect(secondChunk).toEqual([newEntryAboveCloudMax])
   })
 
@@ -393,7 +403,9 @@ describe('AutoSyncService cloud downloads', () => {
     // one (there is none) -- and the pass rewound to re-offer it.
     expect(syncBatchSpy).toHaveBeenCalledTimes(1)
     const [uploadedChunk, floor] = syncBatchSpy.mock.calls[0]!
-    expect(floor).toBe(149)
+    // 148, not 149: see the P1 threshold-shift comment in the backfill test
+    // above.
+    expect(floor).toBe(148)
     // recoveredRow is actually included in the upload -- this is the
     // concrete "rows below watermark, parseable, absent from cloud -> floored
     // -> uploaded on next sync" regression the finding calls for.
@@ -438,9 +450,19 @@ describe('AutoSyncService cloud downloads', () => {
     // ApiTypeIds via the index) before finding a match.
     const indexLookups = whereSpy.mock.calls.filter(([index]) => typeof index === 'string' && index === '[ApiTypeId+timestamp]')
     expect(indexLookups.length).toBe(ApiTypeValues.length)
-    // Never falls back to the old unbounded primary-key cursor pattern.
+    // The backfill scan itself never falls back to an unbounded primary-key
+    // cursor with a `.filter()` predicate (that's the whole point of this
+    // test). `[timestamp+ApiTypeId]` IS legitimately used elsewhere in this
+    // same pass now, though: the P1 fix (compound-key upload pagination,
+    // 2026-07-21) made `syncToCloud()`'s own count and per-chunk cursor key
+    // off this exact primary index (see its doc comment) -- a BOUNDED range
+    // query (`.above([cursor]).count()` / `.above([cursor]).limit(N)`), not
+    // the old unbounded `.filter()`-cursor pattern this test guards against.
+    // Exactly 2 calls are expected here: one for `totalCount`'s `.count()`,
+    // one for the single chunk fetch (this test's Lake has only one row, so
+    // the loop never needs a second page).
     const primaryKeyCursorCalls = whereSpy.mock.calls.filter(([index]) => typeof index === 'string' && index === '[timestamp+ApiTypeId]')
-    expect(primaryKeyCursorCalls.length).toBe(0)
+    expect(primaryKeyCursorCalls.length).toBe(2)
   })
 
   test('lowers an already-persisted LATER floor to a newly discovered EARLIER orphan before that chunk uploads (P2 fix, codex review r3614469176)', async () => {
@@ -508,7 +530,11 @@ describe('AutoSyncService cloud downloads', () => {
     // matching the scenario precondition, and the later row still uploaded.
     const syncBatchSpy = firestoreBackupService.syncToCloudBatch as jest.Mock
     const [uploadedChunk, floor] = syncBatchSpy.mock.calls[0]!
-    expect(floor).toBe(300)
+    // 299, not 300: see the P1 threshold-shift comment in the backfill test
+    // above -- this pass's scanFloor happens to land exactly on
+    // cloudMaxTimestamp (300) here, which is precisely the case the shift
+    // protects.
+    expect(floor).toBe(299)
     expect(uploadedChunk).toEqual([laterValidRow])
   })
 
@@ -634,8 +660,11 @@ describe('AutoSyncService cloud downloads', () => {
     expect(syncBatchSpy).toHaveBeenCalledTimes(1)
     const [firstAttemptChunk, firstAttemptFloor] = syncBatchSpy.mock.calls[0]!
     // Scan floor rewound to just below the OLD pending marker (100 - 1 =
-    // 99), re-offering row@100 despite the newer cloud max (500).
-    expect(firstAttemptFloor).toBe(99)
+    // 99), re-offering row@100 despite the newer cloud max (500). 98, not
+    // 99: the P1 fix (auto-sync-service.ts) shifts the threshold
+    // syncToCloudBatch actually receives one further millisecond earlier --
+    // see the threshold-shift comment in the backfill test below.
+    expect(firstAttemptFloor).toBe(98)
     expect(firstAttemptChunk).toEqual([recoveredRow, laterValidRow])
 
     // The critical assertion (P1 #2): even though this chunk's raw scan
@@ -654,8 +683,9 @@ describe('AutoSyncService cloud downloads', () => {
     expect(syncBatchSpy).toHaveBeenCalledTimes(2)
     const [secondAttemptChunk, secondAttemptFloor] = syncBatchSpy.mock.calls[1]!
     // Still rewound the same way -- row@100 is re-offered again (proving it
-    // was never dropped after the failed attempt).
-    expect(secondAttemptFloor).toBe(99)
+    // was never dropped after the failed attempt). 98, not 99: same P1
+    // threshold shift as the first attempt above.
+    expect(secondAttemptFloor).toBe(98)
     expect(secondAttemptChunk).toEqual([recoveredRow, laterValidRow])
 
     // Only now -- after this upload was awaited and confirmed -- is it safe
@@ -971,10 +1001,19 @@ describe('AutoSyncService cloud downloads', () => {
     cloudMaxSpy.mockResolvedValue(100)
     await service.performSync('upload')
 
-    // A's next sync uploads EXACTLY what A's own cloud lacks -- not rowA1
-    // (already covered by A's own watermark), but rowB1 and rowA2.
+    // A's next sync uploads rowB1 and rowA2 (what A's own cloud actually
+    // lacks) -- PLUS a harmless redundant re-send of rowA1 itself. rowA1's
+    // timestamp (100) is exactly A's own cloud watermark, and the P1 fix
+    // (compound-key upload pagination, auto-sync-service.ts) makes the scan
+    // INCLUSIVE of the watermark's own millisecond -- otherwise a
+    // not-yet-uploaded row sharing that exact millisecond with a DIFFERENT
+    // ApiTypeId than whatever cloud doc set the watermark there would be
+    // silently, permanently skipped (the actual release-blocker bug this
+    // fix addresses). Firestore writes are idempotent upserts keyed by
+    // `${timestamp}_${ApiTypeId}`, so re-sending rowA1 is a no-op, not a
+    // correctness issue -- see the fix's doc comment in syncToCloud().
     expect(syncBatchSpy).toHaveBeenCalledTimes(3)
-    expect(syncBatchSpy.mock.calls[2]![0]).toEqual([rowB1, rowA2])
+    expect(syncBatchSpy.mock.calls[2]![0]).toEqual([rowA1, rowB1, rowA2])
     expect(service.getSyncState().status).toBe('success')
     // A's bookkeeping is intact and correctly advances -- no permanent gap.
     expect((await chrome.storage.local.get('autoSyncLastTime:user-a'))['autoSyncLastTime:user-a']).not.toBe(aLastSyncAfterPhase1)
@@ -1431,5 +1470,181 @@ describe('AutoSyncService cloud downloads', () => {
     // earned, letting it wrongly look "already synced" on a later sign-in.
     expect(await chrome.storage.local.get('autoSyncLastTime:user-a')).toEqual({ 'autoSyncLastTime:user-a': undefined })
     expect(performSyncSpy).not.toHaveBeenCalled()
+  })
+
+  describe('P1 fix: compound-key upload pagination (release blocker, independent audit 2026-07-21)', () => {
+    // apiEvents' primary key is the compound `[timestamp+ApiTypeId]`
+    // (poker-chase-db.ts), so two raw rows CAN legitimately share the exact
+    // same millisecond with different ApiTypeId. Before this fix,
+    // `syncToCloud()` paginated uploads on bare `timestamp` alone -- a
+    // CHUNK_SIZE-row page boundary (or, in the steady state, the very first
+    // page's own boundary at the cloud watermark) that fell between two such
+    // rows permanently excluded whichever one lost the tie, and the pass
+    // still completed "successfully" (see auto-sync-service.ts's `syncToCloud`
+    // doc comment for the full writeup).
+    //
+    // These tests scale `DATABASE_CONSTANTS.SYNC_CHUNK_SIZE` down (it's a
+    // plain runtime object despite its `as const` type -- not frozen) so a
+    // chunk boundary can be forced deterministically without seeding
+    // thousands of rows.
+    const originalChunkSize = DATABASE_CONSTANTS.SYNC_CHUNK_SIZE
+
+    afterEach(() => {
+      (DATABASE_CONSTANTS as any).SYNC_CHUNK_SIZE = originalChunkSize
+    })
+
+    test('a chunk-boundary tie (two rows sharing one millisecond, different ApiTypeId, split across a CHUNK_SIZE page break) uploads BOTH rows exactly once', async () => {
+      (DATABASE_CONSTANTS as any).SYNC_CHUNK_SIZE = 4
+
+      // Four rows fill the first page exactly; the 5th shares the 4th row's
+      // exact millisecond with a DIFFERENT (higher) ApiTypeId, so it sorts
+      // immediately after row 4 in the compound-key order and lands as the
+      // very first row of page 2 -- exactly the "row 5,000 and 5,001" chunk
+      // boundary the audit describes, scaled down to 4/5.
+      const row1 = { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO, Id: 'r1', IsRetire: false, timestamp: 100 } as ApiEvent
+      const row2 = { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO, Id: 'r2', IsRetire: false, timestamp: 101 } as ApiEvent
+      const row3 = { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO, Id: 'r3', IsRetire: false, timestamp: 102 } as ApiEvent
+      // row4 and row5 tie on timestamp (103); row4's ApiTypeId (201) is
+      // lower than row5's (301), so row4 sorts first -- landing as the LAST
+      // row of page 1, with row5 pushed to page 2.
+      const row4 = { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO, Id: 'r4', IsRetire: false, timestamp: 103 } as ApiEvent
+      const row5 = {
+        ApiTypeId: ApiType.EVT_PLAYER_JOIN,
+        timestamp: 103,
+        JoinPlayer: { BetChip: 0, BetStatus: BetStatusType.NOT_IN_PLAY, Chip: 2000, SeatIndex: 2, Status: 0 },
+        JoinUser: {
+          UserId: 999, UserName: 'r5-player', FavoriteCharaId: 'chara01', CostumeId: 'costume01', EmblemId: 'emblem01',
+          IsCpu: false, IsOfficial: false, SettingDecoIds: ['', '', '', '', '', '', ''],
+          Rank: { RankId: 'gold', RankName: 'ゴールド', RankLvId: 'gold', RankLvName: 'ゴールド' }
+        }
+      } as unknown as ApiEvent
+      await db.apiEvents.bulkAdd([row1, row2, row3, row4, row5] as any)
+
+      jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockResolvedValue(null)
+      const syncBatchSpy = jest.spyOn(firestoreBackupService, 'syncToCloudBatch')
+        .mockImplementation(async (chunk: ApiEvent[]) => ({ totalEvents: chunk.length, syncedEvents: chunk.length, lastSyncTime: new Date() }))
+
+      const service = new AutoSyncService(db)
+      await service.performSync('upload')
+
+      expect(service.getSyncState().status).toBe('success')
+      // Two pages: [row1..row4], then [row5]. Without the fix, the second
+      // page's `.where('timestamp').above(103)` query would return zero
+      // rows (row5 also sits at 103), the loop would `break` early having
+      // processed only 4 of the 5 total rows, and row5 would never appear
+      // in any `syncToCloudBatch` call.
+      expect(syncBatchSpy).toHaveBeenCalledTimes(2)
+      expect(syncBatchSpy.mock.calls[0]![0]).toEqual([row1, row2, row3, row4])
+      expect(syncBatchSpy.mock.calls[1]![0]).toEqual([row5])
+
+      // Every row uploaded exactly once across the whole pass.
+      const allUploaded = syncBatchSpy.mock.calls.flatMap(([chunk]) => chunk as ApiEvent[])
+      expect(allUploaded).toHaveLength(5)
+      expect(allUploaded).toEqual([row1, row2, row3, row4, row5])
+    })
+
+    test('incremental sync: a local row sharing the cloud watermark\'s exact millisecond with a different ApiTypeId is uploaded, not silently skipped, with no duplicate upload', async () => {
+      // Mark the one-time unparseable-floor backfill already done (as it
+      // would be on any real-world Nth sync, long after the one-time
+      // post-upgrade backfill ran) -- this ISOLATES the bug under test.
+      // Without this, `backfillUnparseableFloorIfNeeded()` would itself
+      // notice `notYetUploaded` sitting at-or-below the cloud watermark and
+      // seed a floor that rewinds `scanFloor` below 100 as a side effect,
+      // accidentally masking the exact bug this test targets (that
+      // mechanism is a one-time post-upgrade reconciliation, not a
+      // substitute for correct steady-state pagination).
+      await db.meta.put({ id: 'syncUnparseableFloorBackfillDoneV2', value: true, updatedAt: Date.now() })
+
+      // Simulates the cross-pass version of the same bug: a PRIOR pass's
+      // chunk boundary already landed exactly here -- `alreadyUploaded` is
+      // what pushed the cloud watermark to exactly 100, and `notYetUploaded`
+      // shares that same millisecond with a different, never-uploaded
+      // ApiTypeId.
+      const alreadyUploaded = { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO, Id: 'already-uploaded', IsRetire: false, timestamp: 100 } as ApiEvent
+      const notYetUploaded = {
+        ApiTypeId: ApiType.EVT_PLAYER_JOIN,
+        timestamp: 100,
+        JoinPlayer: { BetChip: 0, BetStatus: BetStatusType.NOT_IN_PLAY, Chip: 2000, SeatIndex: 3, Status: 0 },
+        JoinUser: {
+          UserId: 998, UserName: 'tie-player', FavoriteCharaId: 'chara02', CostumeId: 'costume02', EmblemId: 'emblem02',
+          IsCpu: false, IsOfficial: false, SettingDecoIds: ['', '', '', '', '', '', ''],
+          Rank: { RankId: 'silver', RankName: 'シルバー', RankLvId: 'silver', RankLvName: 'シルバー' }
+        }
+      } as unknown as ApiEvent
+      const genuinelyNewRow = { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO, Id: 'genuinely-new', IsRetire: false, timestamp: 200 } as ApiEvent
+      await db.apiEvents.bulkAdd([alreadyUploaded, notYetUploaded, genuinelyNewRow] as any)
+
+      // Cloud watermark sits exactly at 100 -- the same millisecond as the
+      // not-yet-uploaded row. Without the fix, `scanFloor` (== 100 here,
+      // steady state, no pending unparseable floor) is used with a strict
+      // `.above()` bound, so `notYetUploaded` (timestamp === 100) is
+      // excluded from the very first query of the pass and never uploaded,
+      // on this pass or any future one (the watermark never moves off 100
+      // for this row's sake).
+      jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockResolvedValue(100)
+      const syncBatchSpy = jest.spyOn(firestoreBackupService, 'syncToCloudBatch')
+        .mockImplementation(async (chunk: ApiEvent[]) => ({ totalEvents: chunk.length, syncedEvents: chunk.length, lastSyncTime: new Date() }))
+
+      const service = new AutoSyncService(db)
+      await service.performSync('upload')
+
+      expect(service.getSyncState().status).toBe('success')
+      expect(syncBatchSpy).toHaveBeenCalledTimes(1)
+      const [uploadedChunk] = syncBatchSpy.mock.calls[0]!
+      // notYetUploaded IS included -- the core regression this test guards.
+      // alreadyUploaded is also harmlessly re-sent (Firestore's write is an
+      // idempotent upsert keyed by `${timestamp}_${ApiTypeId}` -- see
+      // firestore-backup-service.ts -- so this is a no-op, not data
+      // corruption or a real duplicate in Firestore).
+      expect(uploadedChunk).toEqual([alreadyUploaded, notYetUploaded, genuinelyNewRow])
+      // No row appears more than once in the single upload call itself.
+      expect(new Set(uploadedChunk.map((e: ApiEvent) => `${e.timestamp}_${e.ApiTypeId}`)).size).toBe(uploadedChunk.length)
+    })
+
+    test('floor interplay: an unparseable row that loses a chunk-boundary tie is still discovered within the SAME pass, and the floor does not advance past it', async () => {
+      (DATABASE_CONSTANTS as any).SYNC_CHUNK_SIZE = 2
+
+      // rowA and rowB exactly fill page 1 (CHUNK_SIZE=2). rowB and the
+      // unparseable row share timestamp 200; the unparseable row's ApiTypeId
+      // (309, EVT_SESSION_RESULTS) is higher than rowB's (201), so it sorts
+      // immediately after rowB -- landing as the first row of page 2, tied
+      // with the page-1/page-2 boundary itself. rowD is a genuinely later,
+      // valid row also in page 2.
+      const rowA = { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO, Id: 'rowA', IsRetire: false, timestamp: 100 } as ApiEvent
+      const rowB = { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO, Id: 'rowB', IsRetire: false, timestamp: 200 } as ApiEvent
+      // Application-typed (309) but missing every required field -- fails
+      // Zod validation exactly like the season-3 payload break (see the
+      // unparseable-floor tests above).
+      const unparseableAtBoundary = { ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 200 }
+      const rowD = { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO, Id: 'rowD', IsRetire: false, timestamp: 300 } as ApiEvent
+      await db.apiEvents.bulkAdd([rowA, rowB, unparseableAtBoundary, rowD] as any)
+
+      jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockResolvedValue(null)
+      const syncBatchSpy = jest.spyOn(firestoreBackupService, 'syncToCloudBatch')
+        .mockImplementation(async (chunk: ApiEvent[]) => ({ totalEvents: chunk.length, syncedEvents: chunk.length, lastSyncTime: new Date() }))
+
+      const service = new AutoSyncService(db)
+      await service.performSync('upload')
+
+      expect(service.getSyncState().status).toBe('success')
+      // Page 1: [rowA, rowB]. Page 2: [unparseableAtBoundary, rowD] -- without
+      // the fix, page 2's `.where('timestamp').above(200)` would exclude
+      // `unparseableAtBoundary` (also at 200) entirely; it would never be
+      // examined by `isUnparseableApplicationEvent`, `earliestUnparseableThisPass`
+      // would stay `null` for the whole pass, and the end-of-loop commit
+      // would clear the floor to `null` -- permanently losing track of a row
+      // that was never actually uploaded (it can't be; it's unparseable) and
+      // that the cloud watermark (now advanced to rowD's 300 via the
+      // uploaded chunks) has already sailed past.
+      expect(syncBatchSpy).toHaveBeenCalledTimes(2)
+      expect(syncBatchSpy.mock.calls[0]![0]).toEqual([rowA, rowB])
+      expect(syncBatchSpy.mock.calls[1]![0]).toEqual([rowD]) // unparseable row filtered out of the upload itself
+
+      // The floor must reflect the still-unparseable row's timestamp (200),
+      // not be cleared -- this is what lets a future schema fix re-offer it
+      // instead of it being permanently orphaned below the (now-advanced)
+      // cloud watermark.
+      expect((await db.meta.get('syncUnparseableFloor'))?.value).toBe(200)
+    })
   })
 })

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -770,9 +770,79 @@ export class AutoSyncService {
       console.log(`[AutoSync] Rewinding upload scan to ${scanFloor} to re-offer a previously unparseable row at ${pendingUnparseableTimestamp}`)
     }
 
-    // Count events newer than the (possibly rewound) scan floor
+    // ==========================================================================
+    // P1 FIX (release blocker; independent audit, 2026-07-21) -- COMPOUND-KEY
+    // UPLOAD PAGINATION
+    // ==========================================================================
+    //
+    // apiEvents' PRIMARY KEY is the compound `[timestamp+ApiTypeId]`
+    // (poker-chase-db.ts), not bare `timestamp` alone -- two raw rows CAN
+    // legitimately share the exact same millisecond with different
+    // ApiTypeId (a burst of near-simultaneous API responses). Every cursor
+    // below (the count, the pass-start cursor, and the per-chunk cursor at
+    // the end of the while-loop further down) used to key off bare
+    // `timestamp` alone via `.where('timestamp').above(x)`. That is broken
+    // in two equivalent ways:
+    //
+    // (a) MID-PASS CHUNK BOUNDARY: if a CHUNK_SIZE-row page boundary falls
+    //     between two same-millisecond rows, the chunk that uploads first
+    //     advances `lastProcessedTimestamp` to that shared millisecond, and
+    //     the NEXT page's `.above(lastProcessedTimestamp)` is strictly
+    //     greater-than -- it permanently excludes the second row. The loop
+    //     still completes "successfully" (every OTHER row uploaded and
+    //     confirmed), so the end-of-loop commit further down advances/clears
+    //     the unparseable-floor protection right past the silently-skipped
+    //     row exactly as if it had actually been uploaded.
+    //
+    // (b) PASS-START BOUNDARY (the same bug, one layer up): even with (a)
+    //     fixed, the very first chunk of a pass still started its query
+    //     strictly above `scanFloor` (== `cloudMaxTimestamp` in the common,
+    //     no-pending-floor case). A local row sharing `cloudMaxTimestamp`'s
+    //     exact millisecond with a DIFFERENT ApiTypeId than whatever cloud
+    //     doc actually pushed the watermark there -- because a PRIOR pass
+    //     hit exactly the (a) bug at what happened to be its own last chunk
+    //     -- would never even be fetched, on this pass or any future one,
+    //     since every future pass's `cloudMaxTimestamp` still reads back
+    //     that same millisecond.
+    //
+    // FIX: cursor the primary key `[timestamp+ApiTypeId]` end-to-end,
+    // tracking BOTH components between chunks (fixes (a)), and make the
+    // PASS-START cursor's ApiTypeId component `ApiTypeIdFloorSentinel` (0) --
+    // below every real ApiTypeId (all >= 100; see `ApiTypeValues` /
+    // `z.number().int()` in types/api.ts, and the existing `[apiTypeId, 0]`
+    // lower-bound convention already used in
+    // `backfillUnparseableFloorIfNeeded` above) -- which makes the first
+    // page's lower bound INCLUSIVE of `scanFloor`'s own millisecond instead
+    // of strictly-after it (fixes (b)).
+    //
+    // COST: the pass-start inclusivity means the first page may re-examine,
+    // and harmlessly re-upload, whatever OTHER row(s) already sit at cloud's
+    // exact watermark millisecond -- Firestore writes are idempotent upserts
+    // keyed by `${timestamp}_${ApiTypeId}` (firestore-backup-service.ts), so
+    // this is a no-op write, not a correctness or growing-cost concern: it's
+    // bounded to however many rows tie at that one instant, and the
+    // watermark itself advances past it on the next pass that uploads
+    // anything newer.
+    //
+    // `firestoreBackupService.syncToCloudBatch()`'s OWN internal dedup filter
+    // (`event.timestamp > <threshold>`, see its doc comment) is bare-
+    // timestamp-only -- it has no ApiTypeId to compare against, so it can't
+    // be made compound-aware the way the cursor above just was. Shifting the
+    // threshold VALUE passed to it one millisecond earlier than `scanFloor`
+    // makes its `>` check inclusive of `scanFloor`'s own millisecond too,
+    // consistent with the cursor above -- reusing the exact same "pass a
+    // deliberately lowered threshold, rely on idempotent upserts" pattern
+    // this file already established for the unparseable-floor rewind (see
+    // the big comment block above this one). Pre-existing floor-rewind
+    // tests' asserted `floor` values shift down by 1 accordingly (see
+    // auto-sync-service.test.ts).
+    const ApiTypeIdFloorSentinel = 0
+    const uploadDedupThreshold = scanFloor !== null ? scanFloor - 1 : null
+
+    // Count events at-or-newer than the (possibly rewound) scan floor,
+    // inclusive of ties at `scanFloor`'s own millisecond (see fix (b) above).
     const totalCount = scanFloor !== null
-      ? await this.db.apiEvents.where('timestamp').above(scanFloor).count()
+      ? await this.db.apiEvents.where('[timestamp+ApiTypeId]').above([scanFloor, ApiTypeIdFloorSentinel]).count()
       : await this.db.apiEvents.count()
 
     if (totalCount === 0) {
@@ -792,7 +862,11 @@ export class AutoSyncService {
     const CHUNK_SIZE = DATABASE_CONSTANTS.SYNC_CHUNK_SIZE
     let processed = 0
     let synced = 0
-    let lastProcessedTimestamp = scanFloor || 0
+    // Compound cursor: BOTH components must track the actual last-processed
+    // row between chunks (see fix (a) above). Starts at `scanFloor`'s own
+    // millisecond with the sentinel ApiTypeId (see fix (b) above).
+    let lastProcessedTimestamp = scanFloor ?? 0
+    let lastProcessedApiTypeId = ApiTypeIdFloorSentinel
     // Earliest still-unparseable-application timestamp seen across this whole
     // pass (see invariant spec above). Only ever reflects rows that are
     // STILL unparseable as of this pass's scan -- a row that resolved (now
@@ -809,20 +883,27 @@ export class AutoSyncService {
     let persistedFloorValue = pendingUnparseableTimestamp
 
     while (processed < totalCount) {
-      // Get chunk of raw events newer than lastProcessedTimestamp. apiEvents is the
-      // raw Lake (see docs/architecture.md) — it may contain non-application noise
-      // (202/205 keepalive/timer events) that we deliberately never sync to cloud
-      // (cost decision: only application-type events go to Firestore).
+      // Get chunk of raw events newer than the compound (timestamp, ApiTypeId)
+      // cursor. apiEvents is the raw Lake (see docs/architecture.md) — it may
+      // contain non-application noise (202/205 keepalive/timer events) that
+      // we deliberately never sync to cloud (cost decision: only
+      // application-type events go to Firestore). Cursoring the PRIMARY key
+      // `[timestamp+ApiTypeId]` (not bare `timestamp`) is the P1 fix above --
+      // it is what lets same-millisecond rows survive a CHUNK_SIZE page
+      // boundary instead of one of them being silently, permanently skipped.
       const rawChunk = await this.db.apiEvents
-        .where('timestamp')
-        .above(lastProcessedTimestamp)
+        .where('[timestamp+ApiTypeId]')
+        .above([lastProcessedTimestamp, lastProcessedApiTypeId])
         .limit(CHUNK_SIZE)
         .toArray()
 
       if (rawChunk.length === 0) break
 
-      // Sort chunk by timestamp to ensure order
-      rawChunk.sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0))
+      // Sort chunk by the full compound key (timestamp, then ApiTypeId) --
+      // matches primary-key order already, but sorting explicitly (rather
+      // than relying on Dexie's cursor order) keeps same-millisecond ties
+      // deterministically ordered regardless of index internals.
+      rawChunk.sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0) || (a.ApiTypeId || 0) - (b.ApiTypeId || 0))
 
       // Application-type-only filter for cloud upload. Deliberately filtered AFTER
       // sorting/tracking the raw chunk's boundary, not before: lastProcessedTimestamp
@@ -877,16 +958,26 @@ export class AutoSyncService {
       if (chunk.length > 0) {
         const summary = await firestoreBackupService.syncToCloudBatch(
           chunk,
-          // Pass the (possibly rewound) scan floor, not the raw Firestore max:
-          // otherwise a just-recovered row whose timestamp sits below the real
-          // cloud max would be filtered back out by syncToCloudBatch's own
-          // dedup check, defeating the whole point of rewinding. Firestore
-          // writes are idempotent upserts keyed by `${timestamp}_${ApiTypeId}`,
-          // so redundantly re-sending already-uploaded rows in
+          // Pass the (possibly rewound, and now also millisecond-shifted)
+          // scan floor, not the raw Firestore max: otherwise a just-recovered
+          // row whose timestamp sits below the real cloud max would be
+          // filtered back out by syncToCloudBatch's own dedup check,
+          // defeating the whole point of rewinding. Firestore writes are
+          // idempotent upserts keyed by `${timestamp}_${ApiTypeId}`, so
+          // redundantly re-sending already-uploaded rows in
           // [scanFloor, cloudMaxTimestamp] while a marker is pending is safe --
           // just extra write cost, bounded to however much happened since the
           // break, and it stops once the row resolves.
-          scanFloor,
+          //
+          // `uploadDedupThreshold` (== `scanFloor - 1` when a floor exists;
+          // see P1 fix doc comment above) rather than `scanFloor` itself:
+          // syncToCloudBatch's own filter is `event.timestamp > threshold`,
+          // bare-timestamp-only. Passing `scanFloor` unchanged would make
+          // that filter re-exclude the exact same-millisecond row the
+          // compound-key cursor above was just fixed to include (its
+          // timestamp equals `scanFloor`, not greater than it) -- silently
+          // undoing the fix one layer downstream.
+          uploadDedupThreshold,
           (progress) => {
             this.updateSyncState({
               progress: {
@@ -908,10 +999,15 @@ export class AutoSyncService {
 
       processed += rawChunk.length
 
-      // Update timestamp for next chunk (based on the raw chunk, see comment above)
+      // Update the compound cursor for next chunk (based on the raw chunk's
+      // actual last row's FULL [timestamp, ApiTypeId] key -- see P1 fix doc
+      // comment above). Tracking ApiTypeId here too is what lets the NEXT
+      // chunk's query correctly resume mid-millisecond instead of skipping
+      // past every row sharing the boundary row's timestamp.
       const lastRawEvent = rawChunk[rawChunk.length - 1]
-      if (lastRawEvent && lastRawEvent.timestamp) {
+      if (lastRawEvent && typeof lastRawEvent.timestamp === 'number') {
         lastProcessedTimestamp = lastRawEvent.timestamp
+        lastProcessedApiTypeId = typeof lastRawEvent.ApiTypeId === 'number' ? lastRawEvent.ApiTypeId : ApiTypeIdFloorSentinel
       }
     }
 
@@ -1381,6 +1477,20 @@ export class AutoSyncService {
 
     try {
       // Check how many events we have since last sync
+      //
+      // AUDITED (P1 fix bookkeeping review, 2026-07-21): `lastSyncTime` here
+      // is a WALL-CLOCK `Date` (`syncCompletedAt = new Date()` at the moment
+      // a sync pass finished, see `performSync()`), not an event-position
+      // watermark like `cloudMaxTimestamp`/the unparseable-row floor. This
+      // bare `.where('timestamp').above(lastSyncTime)` count is used ONLY as
+      // a heuristic threshold gate ("is it worth triggering another sync
+      // pass at all") -- it is NOT the actual upload cursor, so it cannot
+      // cause the compound-key data-loss bug fixed in `syncToCloud()` above
+      // (that logic owns the real cursor and is unaffected by whatever this
+      // count returns). Worst case if a same-millisecond event coincides
+      // with `lastSyncTime` and gets excluded here: one proactive sync is
+      // skipped and its backlog is simply picked up by the next trigger --
+      // not a permanent gap. Left as bare-timestamp intentionally.
       const lastSyncTime = this.syncState.lastSyncTime?.getTime() || 0
       const newEventsCount = await this.db.apiEvents
         .where('timestamp')
@@ -1477,7 +1587,14 @@ export class AutoSyncService {
   }> {
     await this.updateTimestamps()
     
-    // Calculate upload pending count based on cloud timestamp
+    // Calculate upload pending count based on cloud timestamp.
+    //
+    // AUDITED (P1 fix bookkeeping review, 2026-07-21): display-only figure
+    // (see the return type below) -- not the actual sync cursor, so a
+    // same-millisecond boundary tie can at worst undercount this UI number
+    // by the tied row(s); it never causes the tied row to be skipped by an
+    // actual upload, which is driven entirely by `syncToCloud()`'s own
+    // compound-key cursor above. Left as bare-timestamp intentionally.
     let uploadPendingCount = 0
     if (this.syncState.cloudLastTimestamp !== undefined) {
       uploadPendingCount = await this.db.apiEvents


### PR DESCRIPTION
## Summary

**Independent audit finding (P1, release blocker)**: `AutoSyncService.syncToCloud()`'s upload pagination cursor advanced on `timestamp > lastProcessedTimestamp` alone, but `apiEvents`' primary key is the compound `[timestamp+ApiTypeId]` (`poker-chase-db.ts:39`). Two raw rows can legitimately share the exact same millisecond with different `ApiTypeId` (a burst of near-simultaneous API responses). If a `SYNC_CHUNK_SIZE`-row (5,000) page boundary fell between such a pair, the next page's `.where('timestamp').above(timestamp)` permanently excluded the second event — the loop still completed "successfully" and (further down) advanced/cleared the unparseable-row watermark protection right past the silently-skipped row. The event never reached the cloud, permanently.

The same defect exists one layer up: even with the mid-pass cursor fixed, the very first page of *any* pass still started strictly above `scanFloor` (== `cloudMaxTimestamp` in the common, no-pending-floor case) — so a not-yet-uploaded local row sharing the cloud watermark's own millisecond with a different `ApiTypeId` was never even fetched, on that pass or any future one (every future pass reads back the same watermark).

## Fix

- Cursor the primary key `[timestamp+ApiTypeId]` end-to-end in `syncToCloud()`: the per-chunk cursor now tracks both `timestamp` and `ApiTypeId` between pages (closes the mid-pass boundary gap), and the pass-start cursor uses a sentinel `ApiTypeId` (0, below every real value — see `ApiTypeValues`) so the very first page is inclusive of `scanFloor`'s own millisecond (closes the pass-start boundary gap). The `totalCount` query mirrors the same compound cursor so the loop's termination stays consistent.
- `firestoreBackupService.syncToCloudBatch()`'s own internal dedup filter (`event.timestamp > threshold`) is bare-timestamp-only and can't be made compound-aware — instead, the threshold value passed to it from `syncToCloud()` is shifted one millisecond earlier (`scanFloor - 1`), reusing the exact "pass a deliberately lowered threshold, rely on idempotent Firestore upserts" pattern this file already established for the unparseable-floor rewind mechanism. Cost is a bounded, harmless re-send of whatever already-uploaded row(s) share the boundary millisecond (Firestore writes are idempotent upserts keyed by `${timestamp}_${ApiTypeId}`) — not a correctness issue, and not a cost that grows pass over pass.
- **Bookkeeping audit** (as requested): `lastSyncTime`/`autoSyncLastTime` is a wall-clock `Date` (`syncCompletedAt = new Date()`), not a data-position watermark — it's used only as a heuristic "is it worth triggering another sync" gate (`syncIfBacklogExceedsThreshold`) and a UI display figure (`getSyncInfo`'s `uploadPendingCount`). Neither can cause permanent data loss from this class of bug (worst case: one proactive sync heuristically skipped, or a UI count off by the tied row — the real upload cursor in `syncToCloud()` is what was fixed). Documented inline at both call sites rather than changed.

## Tests

Added to `src/services/auto-sync-service.test.ts` (describe block `P1 fix: compound-key upload pagination`):
1. **Chunk-boundary tie**: `DATABASE_CONSTANTS.SYNC_CHUNK_SIZE` scaled to 4; rows 4 and 5 share a millisecond with different `ApiTypeId` — both upload exactly once, across two `syncToCloudBatch` calls.
2. **Incremental-sync equal-timestamp**: a local row sharing the cloud watermark's exact millisecond with a different `ApiTypeId` (and the one-time backfill pre-marked done, to isolate this from that separate mechanism) — gets uploaded, no duplicates.
3. **Floor interplay**: an unparseable row that loses a chunk-boundary tie (`SYNC_CHUNK_SIZE` scaled to 2) is still discovered within the same pass, and the unparseable-floor marker correctly reflects it (200) instead of being cleared past it.

All three verified fail-before/pass-after via `git apply -R` against the implementation diff (no stash).

Also updated 5 pre-existing floor-rewind tests' asserted threshold values (99→98, 149→148, 300→299, 199→198×2) to reflect the 1ms shift described above, and one pre-existing account-switch test (`rowA1` now legitimately reappears in a redundant, harmless re-send) — each with an inline comment explaining why.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` (jest) — 108 suites / 1048 tests, run twice, both clean
- [x] `npm run e2e:smoke` — all 6 checks pass
- [x] Fail-before/pass-after verified for all 3 new regression tests via `git apply -R`

🤖 Generated with [Claude Code](https://claude.com/claude-code)