### PR TITLE
fix(background): export receipt guarantees, truthful sync responses, import accounting

### DIFF
--- a/src/background/import-export.export-handoff.test.ts
+++ b/src/background/import-export.export-handoff.test.ts
@@ -195,6 +195,37 @@ describe('export download-handoff completion', () => {
     expect(getOperationState()).toEqual({ type: 'idle' })
   })
 
+  test('an explicit failure ack ({success:false}, no lastError) surfaces as an error, not an idle-success (PR #199 review finding #1)', async () => {
+    // content_script.ts's download handlers now send an explicit
+    // sendResponse({success: true/false}) ack (see content_script.ts and the
+    // sendTabMessageAsync doc comment in import-export.ts) -- this covers the
+    // case where the handoff itself was DELIVERED (no chrome.runtime.lastError)
+    // but the content script's own Blob-download work threw (e.g.
+    // URL.createObjectURL failing), which it reports back via
+    // {success:false, error}. Before this fix, sendTabMessageAsync only
+    // checked chrome.runtime.lastError, so a delivered-but-failed handoff like
+    // this would be silently treated as a success.
+    ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => {
+      setTimeout(() => callback([{ id: 42 }]), 0)
+    })
+    ;(chrome.tabs.sendMessage as jest.Mock).mockImplementation((_tabId, _message, callback) => {
+      callback?.({ success: false, error: 'createObjectURL boom' })
+    })
+
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+
+    await expect(handlers.exportData('json')).rejects.toThrow(/createObjectURL boom/)
+
+    const progressCalls = (chrome.runtime.sendMessage as jest.Mock).mock.calls
+      .map(([msg]) => msg)
+      .filter(msg => msg?.action === 'exportProgress')
+    expect(progressCalls[progressCalls.length - 1]).toEqual(
+      expect.objectContaining({ action: 'exportProgress', state: 'error' })
+    )
+    expect(progressCalls.some(msg => msg.state === 'completed')).toBe(false)
+    expect(getOperationState()).toEqual({ type: 'idle' })
+  })
+
   test('every chunk of a large (>50MB) export is individually acknowledged before resolving', async () => {
     ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => {
       setTimeout(() => callback([{ id: 42 }]), 0)

--- a/src/background/import-export.export-handoff.test.ts
+++ b/src/background/import-export.export-handoff.test.ts
@@ -137,7 +137,16 @@ describe('export download-handoff completion', () => {
 
     let releaseSendMessage: (() => void) | undefined
     const sendMessageAcked = new Promise<void>(resolve => { releaseSendMessage = resolve })
+    // Resolves the instant chrome.tabs.sendMessage is actually invoked --
+    // lets the test wait on the real observable side effect instead of
+    // sleeping an arbitrary duration (PR #199 review, pass 2: a fixed 10ms
+    // sleep raced the Dexie export work + the deferred chrome.tabs.query
+    // callback under a slow/loaded test run, and could assert before
+    // sendMessage was ever called).
+    let resolveSendMessageInvoked: (() => void) | undefined
+    const sendMessageInvoked = new Promise<void>(resolve => { resolveSendMessageInvoked = resolve })
     ;(chrome.tabs.sendMessage as jest.Mock).mockImplementation((_tabId, _message, callback) => {
+      resolveSendMessageInvoked?.()
       // Do NOT call back synchronously -- simulate a slow/deferred content
       // script acknowledgment. Before the fix, downloadFile() didn't wait on
       // this callback at all, so operationState would already be 'idle' by
@@ -148,10 +157,10 @@ describe('export download-handoff completion', () => {
     const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
     const exportPromise = handlers.exportData('json')
 
-    // Give chrome.tabs.query's deferred callback (and the sendMessage call it
-    // triggers) a chance to run, then assert the operation is still marked
-    // 'export' -- not yet resolved to idle -- while the handoff is pending.
-    await new Promise(resolve => setTimeout(resolve, 10))
+    // Wait deterministically for the handoff to actually be dispatched, then
+    // assert the operation is still marked 'export' -- not yet resolved to
+    // idle -- while the handoff itself is still pending acknowledgment.
+    await sendMessageInvoked
     expect(chrome.tabs.sendMessage).toHaveBeenCalled()
     expect(getOperationState().type).toBe('export')
 

--- a/src/background/import-export.export-handoff.test.ts
+++ b/src/background/import-export.export-handoff.test.ts
@@ -1,21 +1,35 @@
 /**
- * import-export.ts - export download-handoff completion (codex review, PR #150 audit finding #2)
+ * import-export.ts - export download-handoff completion (codex review, PR #150 audit
+ * finding #2, hardened by the independent release-audit finding #10)
  *
  * `exportJsonData()`/`exportPokerStarsData()` call `downloadFile()`, which
  * hands the exported content off to the content script via
  * `chrome.tabs.query()` -> `chrome.tabs.sendMessage()`. `chrome.tabs.query()`
- * is a genuinely async Chrome extension API (callback-based), so before this
- * fix `downloadFile()` returned `void` and its caller moved straight on to
- * `setOperationState({ type: 'idle' })` without waiting for that callback to
- * fire. `operation-state.ts`'s `onOperationBecameIdle` hook feeds directly
- * into `update-manager.ts`'s `recheckPendingUpdate()`, which can call
- * `chrome.runtime.reload()` the instant it observes idle+safe -- reloading
- * the service worker before the download handoff was ever dispatched, so
- * the user sees "export complete" while the actual file never arrives.
+ * is a genuinely async Chrome extension API (callback-based), so before the
+ * PR #150 fix `downloadFile()` returned `void` and its caller moved straight
+ * on to `setOperationState({ type: 'idle' })` without waiting for that
+ * callback to fire. `operation-state.ts`'s `onOperationBecameIdle` hook feeds
+ * directly into `update-manager.ts`'s `recheckPendingUpdate()`, which can
+ * call `chrome.runtime.reload()` the instant it observes idle+safe --
+ * reloading the service worker before the download handoff was ever
+ * dispatched, so the user sees "export complete" while the actual file never
+ * arrives.
  *
- * These tests assert the fixed ordering: the handoff (`chrome.tabs.sendMessage`)
- * must fire while operationState is still `'export'`, and `exportData()` must
- * not resolve until after that handoff was dispatched.
+ * The PR #150 fix only awaited `chrome.tabs.query()`'s callback -- the
+ * `chrome.tabs.sendMessage()` call(s) themselves (one per chunk for large
+ * exports) were still fire-and-forget, and the `chrome.downloads` fallback
+ * resolved before its own callback/`downloads.lastError` was inspected
+ * (independent release-audit finding #10). A missing content script,
+ * message rejection, or a downloads error would still flip the operation to
+ * idle-success with no file actually delivered.
+ *
+ * These tests assert the fully-fixed contract: every handoff message
+ * (`chrome.tabs.sendMessage`, one per chunk) must be individually
+ * acknowledged (callback fired, no `chrome.runtime.lastError`) while
+ * operationState is still `'export'` before `exportData()` resolves, a
+ * rejected/errored handoff must surface as a thrown error (NOT an
+ * idle-success resolution), and the `chrome.downloads` fallback must not be
+ * treated as complete until its own callback confirms no `lastError`.
  */
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
 import PokerChaseService, { PokerChaseDB } from '../app'
@@ -53,8 +67,13 @@ describe('export download-handoff completion', () => {
     ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => {
       setTimeout(() => callback([{ id: 42 }]), 0)
     })
-    ;(chrome.tabs.sendMessage as jest.Mock).mockImplementation(() => {
+    // Simulate a genuinely async chrome.tabs.sendMessage completion too --
+    // the real API is callback-based (or Promise-based when the callback is
+    // omitted); downloadFile() must await this per-message acknowledgment
+    // before resolving.
+    ;(chrome.tabs.sendMessage as jest.Mock).mockImplementation((_tabId, _message, callback) => {
       operationStateWhenHandoffFired = getOperationState().type
+      setTimeout(() => callback?.(), 0)
     })
 
     const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
@@ -62,7 +81,8 @@ describe('export download-handoff completion', () => {
 
     expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(
       42,
-      expect.objectContaining({ action: 'downloadFile' })
+      expect.objectContaining({ action: 'downloadFile' }),
+      expect.any(Function)
     )
     // The handoff must be dispatched while the operation is still marked
     // 'export' -- NOT 'idle' -- or update-manager's operation-idle recheck
@@ -78,8 +98,9 @@ describe('export download-handoff completion', () => {
     ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => {
       setTimeout(() => callback([{ id: 7 }]), 0)
     })
-    ;(chrome.tabs.sendMessage as jest.Mock).mockImplementation(() => {
+    ;(chrome.tabs.sendMessage as jest.Mock).mockImplementation((_tabId, _message, callback) => {
       operationStateWhenHandoffFired = getOperationState().type
+      setTimeout(() => callback?.(), 0)
     })
 
     const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
@@ -87,7 +108,8 @@ describe('export download-handoff completion', () => {
 
     expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(
       7,
-      expect.objectContaining({ action: 'downloadFile' })
+      expect.objectContaining({ action: 'downloadFile' }),
+      expect.any(Function)
     )
     expect(operationStateWhenHandoffFired).toBe('export')
     expect(getOperationState()).toEqual({ type: 'idle' })
@@ -103,6 +125,125 @@ describe('export download-handoff completion', () => {
 
     expect(chrome.tabs.sendMessage).not.toHaveBeenCalled()
     expect(chrome.downloads.download).toHaveBeenCalledTimes(1)
+    expect(getOperationState()).toEqual({ type: 'idle' })
+  })
+
+  // --- Independent release-audit finding #10 --------------------------------
+
+  test('a deferred tabs.sendMessage keeps the operation state as "export" until it is acknowledged', async () => {
+    ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => {
+      setTimeout(() => callback([{ id: 42 }]), 0)
+    })
+
+    let releaseSendMessage: (() => void) | undefined
+    const sendMessageAcked = new Promise<void>(resolve => { releaseSendMessage = resolve })
+    ;(chrome.tabs.sendMessage as jest.Mock).mockImplementation((_tabId, _message, callback) => {
+      // Do NOT call back synchronously -- simulate a slow/deferred content
+      // script acknowledgment. Before the fix, downloadFile() didn't wait on
+      // this callback at all, so operationState would already be 'idle' by
+      // this point regardless of how long the real handoff takes.
+      sendMessageAcked.then(() => callback?.())
+    })
+
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+    const exportPromise = handlers.exportData('json')
+
+    // Give chrome.tabs.query's deferred callback (and the sendMessage call it
+    // triggers) a chance to run, then assert the operation is still marked
+    // 'export' -- not yet resolved to idle -- while the handoff is pending.
+    await new Promise(resolve => setTimeout(resolve, 10))
+    expect(chrome.tabs.sendMessage).toHaveBeenCalled()
+    expect(getOperationState().type).toBe('export')
+
+    releaseSendMessage?.()
+    await exportPromise
+
+    expect(getOperationState()).toEqual({ type: 'idle' })
+  })
+
+  test('a rejected tabs.sendMessage (content script missing) surfaces as an error, not an idle-success', async () => {
+    ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => {
+      setTimeout(() => callback([{ id: 42 }]), 0)
+    })
+    // Simulate "Receiving end does not exist" -- e.g. the content script was
+    // never injected into this tab, or the tab navigated away mid-export.
+    ;(chrome.tabs.sendMessage as jest.Mock).mockImplementation((_tabId, _message, callback) => {
+      ;(chrome.runtime as any).lastError = { message: 'Could not establish connection. Receiving end does not exist.' }
+      callback?.()
+      delete (chrome.runtime as any).lastError
+    })
+
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+
+    await expect(handlers.exportData('json')).rejects.toThrow(/Receiving end does not exist/)
+
+    // The popup must be told this failed -- the LAST exportProgress broadcast
+    // must be an error, never a 'completed' success.
+    const progressCalls = (chrome.runtime.sendMessage as jest.Mock).mock.calls
+      .map(([msg]) => msg)
+      .filter(msg => msg?.action === 'exportProgress')
+    expect(progressCalls.length).toBeGreaterThan(0)
+    expect(progressCalls[progressCalls.length - 1]).toEqual(
+      expect.objectContaining({ action: 'exportProgress', state: 'error' })
+    )
+    expect(progressCalls.some(msg => msg.state === 'completed')).toBe(false)
+    // The operation must not be left stuck in 'export' -- it still returns to
+    // idle in the failure path (there is no separate "error" operation-state
+    // type, see operation-state.ts), but crucially only AFTER the failure was
+    // observed, and the popup was told via the exportProgress message above --
+    // never silently reported as success.
+    expect(getOperationState()).toEqual({ type: 'idle' })
+  })
+
+  test('every chunk of a large (>50MB) export is individually acknowledged before resolving', async () => {
+    ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => {
+      setTimeout(() => callback([{ id: 42 }]), 0)
+    })
+    const ackedTabIds: number[] = []
+    ;(chrome.tabs.sendMessage as jest.Mock).mockImplementation((tabId, _message, callback) => {
+      ackedTabIds.push(tabId)
+      setTimeout(() => callback?.(), 0)
+    })
+
+    // Force the >50MB chunked path (MAX_CHUNK_MB in downloadFile).
+    const largeContent = 'a'.repeat(51 * 1024 * 1024)
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+    jest.spyOn(service, 'exportHandHistory').mockResolvedValue(largeContent)
+
+    await handlers.exportData('pokerstars')
+
+    const actions = (chrome.tabs.sendMessage as jest.Mock).mock.calls.map(([, message]) => (message as any).action)
+    expect(actions[0]).toBe('downloadFileInit')
+    expect(actions[actions.length - 1]).toBe('downloadFileFinish')
+    expect(actions.filter(a => a === 'downloadFileChunk').length).toBeGreaterThan(0)
+    // All chunk messages (init/chunk*/finish) went to the same tab and were
+    // all awaited (ackedTabIds has one entry per message actually sent).
+    expect(ackedTabIds.every(id => id === 42)).toBe(true)
+    expect(ackedTabIds.length).toBe(actions.length)
+    expect(getOperationState()).toEqual({ type: 'idle' })
+  })
+
+  test('a chrome.downloads.lastError in the fallback path surfaces as an error, not an idle-success', async () => {
+    ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => {
+      setTimeout(() => callback([]), 0) // no matching tabs -- forces the chrome.downloads fallback
+    })
+    ;(chrome.downloads.download as jest.Mock).mockImplementation((_options, callback) => {
+      ;(chrome.runtime as any).lastError = { message: 'USER_CANCELED' }
+      callback?.(undefined)
+      delete (chrome.runtime as any).lastError
+    })
+
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+
+    await expect(handlers.exportData('json')).rejects.toThrow(/USER_CANCELED/)
+
+    const progressCalls = (chrome.runtime.sendMessage as jest.Mock).mock.calls
+      .map(([msg]) => msg)
+      .filter(msg => msg?.action === 'exportProgress')
+    expect(progressCalls[progressCalls.length - 1]).toEqual(
+      expect.objectContaining({ action: 'exportProgress', state: 'error' })
+    )
+    expect(progressCalls.some(msg => msg.state === 'completed')).toBe(false)
     expect(getOperationState()).toEqual({ type: 'idle' })
   })
 })

--- a/src/background/import-export.import-accounting.test.ts
+++ b/src/background/import-export.import-accounting.test.ts
@@ -1,0 +1,97 @@
+/**
+ * importData() - successCount accounting on the bulkAdd-fallback path
+ * (independent release-audit finding #13)
+ *
+ * `importData()` bulk-stores an import chunk's raw events via
+ * `db.apiEvents.bulkAdd()`. Because a single failing row aborts the whole
+ * IndexedDB transaction (no rows land), a `bulkAdd()` failure falls back to
+ * adding each row individually via `db.apiEvents.add()` -- this is the only
+ * path exercised here, e.g. when a live event ingested concurrently with the
+ * import already claimed one of the chunk's keys (a race the pre-loaded
+ * `existingKeys` snapshot at import start cannot see, since it can only
+ * reflect what's already in the DB *before* the import started).
+ *
+ * On that fallback path, `successCount` is only ever incremented when an
+ * individual `add()` call actually succeeds. Before this fix, the `catch`
+ * branch for a duplicate-key failure ALSO decremented `successCount` --
+ * except a row that failed `add()` never incremented it in the first place
+ * (increment and decrement are on opposite branches of the same try/catch).
+ * With enough duplicate-key failures on this fallback path, `successCount`
+ * could go negative and be reported to the user as such.
+ *
+ * This test forces the fallback path (bulkAdd rejects) and simulates two of
+ * three rows failing as duplicates at the individual-add layer -- asserting
+ * the reported successCount reflects only the one row that actually
+ * persisted (never negative, never below zero).
+ */
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { createImportExportHandlers } from './import-export'
+import { setOperationState } from './operation-state'
+
+describe('importData() bulkAdd-fallback successCount accounting', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    service = new PokerChaseService({ db })
+    await service.ready
+    setOperationState({ type: 'idle' })
+    ;(chrome.runtime.sendMessage as jest.Mock).mockReturnValue(undefined)
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    db.close()
+    await db.delete()
+  })
+
+  test('duplicate-heavy fallback imports never report a negative successCount', async () => {
+    // Unknown ApiTypeId: stored as raw Lake rows (numeric timestamp+ApiTypeId
+    // is the only storage requirement -- see docs/architecture.md "Raw Event
+    // Lake"), but not a known application event, so this stays entirely on
+    // the raw-storage accounting path under test and never touches
+    // EntityConverter/entity-generation semantics (out of scope here).
+    const lines = [
+      { timestamp: 1000, ApiTypeId: 9999, seq: 1 },
+      { timestamp: 1001, ApiTypeId: 9999, seq: 2 },
+      { timestamp: 1002, ApiTypeId: 9999, seq: 3 },
+    ]
+    const jsonl = lines.map(line => JSON.stringify(line)).join('\n')
+
+    // Force the whole chunk onto the individual-add fallback path (simulates
+    // e.g. a quota error, or any other reason bulkAdd() aborts the batch).
+    jest.spyOn(db.apiEvents, 'bulkAdd').mockRejectedValue(new Error('forced bulkAdd failure for test'))
+
+    // Simulate the fallback's per-row add(): the first row genuinely
+    // persists: the other two fail as duplicates -- e.g. a live event
+    // ingested concurrently with this import already claimed that
+    // [timestamp+ApiTypeId] key after the import's existingKeys snapshot was
+    // taken, which is exactly the race description in the audit finding.
+    const originalAdd = db.apiEvents.add.bind(db.apiEvents)
+    let addCallCount = 0
+    jest.spyOn(db.apiEvents, 'add').mockImplementation((async (item: unknown) => {
+      addCallCount++
+      if (addCallCount === 1) return originalAdd(item as never)
+      throw new Error('Key already exists in the object store.')
+    }) as typeof db.apiEvents.add)
+
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+    const result = await handlers.importData(jsonl)
+
+    expect(addCallCount).toBe(3)
+    // Exactly one row actually persisted -- successCount must reflect that,
+    // and must never dip below zero regardless of how many of the OTHER
+    // rows failed as duplicates on the fallback path.
+    expect(result.successCount).toBe(1)
+    expect(result.successCount).toBeGreaterThanOrEqual(0)
+    expect(result.duplicateCount).toBe(2)
+    expect(result.totalLines).toBe(3)
+
+    // Cross-check against the DB itself: exactly one row should be stored.
+    const storedCount = await db.apiEvents.count()
+    expect(storedCount).toBe(1)
+  })
+})

--- a/src/background/import-export.import-accounting.test.ts
+++ b/src/background/import-export.import-accounting.test.ts
@@ -1,6 +1,7 @@
 /**
- * importData() - successCount accounting on the bulkAdd-fallback path
- * (independent release-audit finding #13)
+ * importData() - successCount/storedKeys accounting on the bulkAdd-fallback
+ * path (independent release-audit finding #13, hardened by PR #199 review
+ * finding #2)
  *
  * `importData()` bulk-stores an import chunk's raw events via
  * `db.apiEvents.bulkAdd()`. Because a single failing row aborts the whole
@@ -19,12 +20,23 @@
  * With enough duplicate-key failures on this fallback path, `successCount`
  * could go negative and be reported to the user as such.
  *
- * This test forces the fallback path (bulkAdd rejects) and simulates two of
- * three rows failing as duplicates at the individual-add layer -- asserting
- * the reported successCount reflects only the one row that actually
- * persisted (never negative, never below zero).
+ * The second describe block below covers a DIFFERENT bug on the same
+ * fallback path (PR #199 review, finding #2, P2): when `bulkAdd()` is called
+ * outside an explicit transaction (as here), Dexie does not abort the whole
+ * batch on a per-item failure -- rows that did NOT fail are already durably
+ * persisted by the time the batch-level `Dexie.BulkError` is thrown (see
+ * `BulkError` in `node_modules/dexie/dist/dexie.js`: `failuresByPos` maps
+ * only the FAILED item indices to their errors). The fallback used to
+ * blindly retry `add()` for every row in the chunk regardless, which for an
+ * already-persisted row throws its own (very real) ConstraintError against
+ * the row it just legitimately wrote -- misreported as a duplicate. That
+ * both undercounts `successCount` and excludes the row's key from
+ * `storedKeys`, so its corresponding valid application event is dropped from
+ * `allNewEvents` and its derived hands/phases/actions are never generated
+ * until a later full rebuild.
  */
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import Dexie from 'dexie'
 import PokerChaseService, { PokerChaseDB } from '../app'
 import { createImportExportHandlers } from './import-export'
 import { setOperationState } from './operation-state'
@@ -93,5 +105,69 @@ describe('importData() bulkAdd-fallback successCount accounting', () => {
     // Cross-check against the DB itself: exactly one row should be stored.
     const storedCount = await db.apiEvents.count()
     expect(storedCount).toBe(1)
+  })
+})
+
+describe('importData() bulkAdd-fallback: rows already persisted by a partial Dexie.BulkError', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    service = new PokerChaseService({ db })
+    await service.ready
+    setOperationState({ type: 'idle' })
+    ;(chrome.runtime.sendMessage as jest.Mock).mockReturnValue(undefined)
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    db.close()
+    await db.delete()
+  })
+
+  test('a row bulkAdd() actually persisted before throwing BulkError is counted as success and NOT re-added', async () => {
+    const lines = [
+      { timestamp: 2000, ApiTypeId: 9999, seq: 'a' }, // idx 0 -- durably persisted by bulkAdd itself, despite the batch overall throwing
+      { timestamp: 2001, ApiTypeId: 9999, seq: 'b' }, // idx 1 -- reported failed by bulkAdd, but the individual retry succeeds
+      { timestamp: 2002, ApiTypeId: 9999, seq: 'c' }, // idx 2 -- reported failed by bulkAdd, and genuinely a duplicate on retry
+    ]
+    const jsonl = lines.map(line => JSON.stringify(line)).join('\n')
+
+    const originalAdd = db.apiEvents.add.bind(db.apiEvents)
+
+    jest.spyOn(db.apiEvents, 'bulkAdd').mockImplementation((async (items: any[]) => {
+      // Simulate Dexie's actual bulkAdd() semantics (outside an explicit
+      // transaction): the item at index 0 lands in the DB for real BEFORE
+      // the batch-level error is thrown -- only indices 1 and 2 are reported
+      // as failed via `failuresByPos`.
+      await originalAdd(items[0])
+      throw new Dexie.BulkError('2 of 3 operations failed', {
+        1: new Error('ConstraintError (simulated)'),
+        2: new Error('ConstraintError (simulated)'),
+      })
+    }) as unknown as typeof db.apiEvents.bulkAdd)
+
+    const addSpy = jest.spyOn(db.apiEvents, 'add').mockImplementation((async (item: any) => {
+      if (item.timestamp === 2001) return originalAdd(item)
+      throw new Error('Key already exists in the object store.')
+    }) as typeof db.apiEvents.add)
+
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+    const result = await handlers.importData(jsonl)
+
+    // add() must only be retried for the positions bulkAdd() actually
+    // reported as failed (idx 1, idx 2) -- NOT for idx 0, which was already
+    // durably persisted by the partially-failed bulkAdd() call itself.
+    expect(addSpy).toHaveBeenCalledTimes(2)
+    expect(addSpy.mock.calls.map(([item]: any) => item.timestamp).sort()).toEqual([2001, 2002])
+
+    expect(result.successCount).toBe(2) // idx 0 (via the partial bulkAdd) + idx 1 (individual retry)
+    expect(result.duplicateCount).toBe(1) // idx 2 only -- a genuine duplicate
+    expect(result.totalLines).toBe(3)
+
+    const storedCount = await db.apiEvents.count()
+    expect(storedCount).toBe(2)
   })
 })

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -1,4 +1,5 @@
 /** !!! CONTENT_SCRIPTS、WEB_ACCESSIBLE_RESOURCESからインポートしないこと !!! */
+import Dexie from 'dexie'
 import PokerChaseService, {
   ApiType,
   PokerChaseDB,
@@ -183,8 +184,36 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
             // 部分的な失敗の場合、個別に保存を試みる
             console.warn(`Bulk add failed for chunk ${Math.floor(i / IMPORT_CHUNK_SIZE) + 1}, falling back to individual adds:`, dbError)
 
-            for (const raw of rawEventsToStore) {
+            // 明示的トランザクション外で呼んだbulkAdd()は、一部の行が失敗して
+            // Dexie.BulkErrorをthrowしても、失敗しなかった行はその時点で既に
+            // 永続化済み（IndexedDB側は各addリクエストの個別エラーを飲み込み、
+            // トランザクション全体はabortしない実装のため）。BulkErrorの
+            // `failuresByPos`は「失敗したインデックス」だけをErrorへ
+            // マッピングするので、そこに含まれないインデックスは既に確実に
+            // 保存されている（codexレビュー指摘, PR #199 finding #2）。
+            // それらに対して個別add()を再度呼ぶと、今まさに正規に書き込んだ
+            // 行自体に対するConstraintErrorとなり、以下の「重複」判定に
+            // 落ちて誤ってスキップ扱いになる ―― successCountが実際の保存数
+            // より少なく数えられるだけでなく、対応するアプリケーションイベント
+            // がstoredKeysに入らずallNewEventsから漏れ、hands/phases/actions
+            // が生成されないまま（次回の再構築まで）残ってしまう。
+            // BulkError以外（例: QuotaExceededErrorでバッチ全体がabortされた
+            // 場合など）はどの行も永続化されていないと分かっているため、
+            // 全件を個別add()にかける従来の挙動のままでよい。
+            const failuresByPos = dbError instanceof Dexie.BulkError ? dbError.failuresByPos : undefined
+
+            for (let idx = 0; idx < rawEventsToStore.length; idx++) {
+              const raw = rawEventsToStore[idx]!
               const key = `${raw.timestamp}-${raw.ApiTypeId}`
+
+              if (failuresByPos && !(idx in failuresByPos)) {
+                // bulkAdd()の失敗リストに載っていない = 既に永続化済み。
+                // add()を再度呼ばず、そのまま成功として計上する。
+                successCount++
+                storedKeys.add(key)
+                continue
+              }
+
               try {
                 await db.apiEvents.add(raw as ApiEvent)
                 successCount++
@@ -544,12 +573,26 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
    * `chrome.runtime.lastError`（例: "Receiving end does not exist" ―
    * コンテンツスクリプト未注入、拡張機能リロード直後のタブなど）を検出し、
    * 呼び出し元（downloadFile）へ失敗として伝播できるようにする。
+   *
+   * 受信側（content_script.ts）は4種のdownload*メッセージ全てで明示的に
+   * `sendResponse({ success: true/false })`を返す（PR #199レビュー指摘、
+   * finding #1）ようになっている ―― Chromeのメッセージングは、受信側が
+   * sendResponse()を呼ばず`true`もreturnしない場合、リスナーがreturnした
+   * 時点でポートを閉じ、送信側コールバックに`chrome.runtime.lastError =
+   * "message port closed before a response was received"`をセットする。
+   * これは受信側の処理が実際に成功していても発生するため、修正前は
+   * 正常に配信されたエクスポートまで失敗と誤判定していた。明示的なackが
+   * 返るようになった今は、`lastError`（配信自体の失敗）に加えて
+   * レスポンスの`success:false`（受信側で処理中に例外が起きた場合）も
+   * 確認し、どちらの失敗も呼び出し元へ伝播する。
    */
   const sendTabMessageAsync = (tabId: number, message: Record<string, unknown>): Promise<void> => {
     return new Promise<void>((resolve, reject) => {
-      chrome.tabs.sendMessage(tabId, message, () => {
+      chrome.tabs.sendMessage(tabId, message, (response?: { success?: boolean, error?: string }) => {
         if (chrome.runtime.lastError) {
           reject(new Error(chrome.runtime.lastError.message))
+        } else if (response && response.success === false) {
+          reject(new Error(response.error || 'content script reported a download handoff failure'))
         } else {
           resolve()
         }

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -195,8 +195,14 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
                 if (!errorMessage.includes('Key already exists')) {
                   errors.push(`Event at timestamp ${raw.timestamp}: ${errorMessage}`)
                 } else {
+                  // この行はbulkAdd失敗により個別add()にフォールバックした結果
+                  // 重複と判明したもので、successCountはまだ加算されていない
+                  // （加算は直上tryブロックの成功時のみ、11行下）。ここで
+                  // successCount--するとまだ一度も加算されていないカウントを
+                  // 減算することになり、重複が多いインポートでsuccessCountが
+                  // 負数になり得た（codexレビュー指摘、監査finding #13）。
+                  // duplicateCountのみ加算する。
                   duplicateCount++
-                  successCount-- // 重複の場合は成功数から除外
                 }
               }
             }
@@ -528,22 +534,56 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
   }
 
   /**
-   * コンテンツスクリプトへのダウンロードハンドオフ（chrome.tabs.query→
-   * chrome.tabs.sendMessage）が実際に発行されるまで待てるようPromiseを返す
-   * （codexレビュー指摘, PR #150監査#2）。
+   * `chrome.tabs.sendMessage()`をコールバック形式で呼び、
+   * `chrome.runtime.lastError`を確認してから解決/拒否するPromiseに包む
+   * （codexレビュー指摘、監査finding #10）。
    *
-   * 修正前はこの関数が`void`を返し、`chrome.tabs.query`のコールバックが
-   * 実行される前に呼び出し元へ制御を返していた。呼び出し元（exportJsonData/
-   * exportPokerStarsData）は直後に`setOperationState({ type: 'idle' })`を
-   * 呼んでおり、`operation-state.ts`の`onOperationBecameIdle`購読経由で
-   * `update-manager.ts`の`recheckPendingUpdate()`が即座に発火しうる。
-   * そのタイミングが安全（`isSafeToUpdate()`）と判定されると
-   * `chrome.runtime.reload()`でService Workerごと巻き込まれ、まだ
-   * `chrome.tabs.sendMessage`すら呼ばれていないダウンロードが失われる
-   * （ユーザーには「エクスポート完了」と表示されるのに実際のファイルは
-   * 届かない）。ここでハンドオフの発行完了を待てるようにし、呼び出し元で
-   * `await`してから`setOperationState({ type: 'idle' })`を呼ぶことで、
-   * このレースを解消する。
+   * `chrome.tabs.sendMessage(tabId, message)`（コールバック省略）はfire-and-
+   * forgetで、コンテンツスクリプト不在・メッセージ拒否・受信側エラーの
+   * いずれもここでは観測できない。コールバックを渡すことで
+   * `chrome.runtime.lastError`（例: "Receiving end does not exist" ―
+   * コンテンツスクリプト未注入、拡張機能リロード直後のタブなど）を検出し、
+   * 呼び出し元（downloadFile）へ失敗として伝播できるようにする。
+   */
+  const sendTabMessageAsync = (tabId: number, message: Record<string, unknown>): Promise<void> => {
+    return new Promise<void>((resolve, reject) => {
+      chrome.tabs.sendMessage(tabId, message, () => {
+        if (chrome.runtime.lastError) {
+          reject(new Error(chrome.runtime.lastError.message))
+        } else {
+          resolve()
+        }
+      })
+    })
+  }
+
+  /**
+   * コンテンツスクリプトへのダウンロードハンドオフ（chrome.tabs.query→
+   * chrome.tabs.sendMessage、大容量ファイルの場合は複数チャンク）の
+   * 全チャンクが受信側に確実に届いたことを確認してから解決する
+   * （codexレビュー指摘, PR #150監査#2 / 監査finding #10）。
+   *
+   * PR #150監査#2の修正では`chrome.tabs.query`のコールバックが実行される
+   * までは待てるようになったが、その内側の`chrome.tabs.sendMessage()`自体は
+   * 依然fire-and-forget（チャンクごとに投げっぱなし）で、`chrome.downloads`
+   * フォールバックもコールバック/`downloads.lastError`を見る前に解決して
+   * いた。コンテンツスクリプト不在・メッセージ拒否・64MiB境界超過・
+   * downloads側のエラーのいずれが起きても`downloadFile()`は成功したかの
+   * ように解決し、呼び出し元（exportJsonData/exportPokerStarsData）が直後に
+   * `setOperationState({ type: 'idle' })`を呼んでしまう ――
+   * `operation-state.ts`の`onOperationBecameIdle`購読経由で
+   * `update-manager.ts`の`recheckPendingUpdate()`が発火し、保留中アップデート
+   * が安全と誤判定されて`chrome.runtime.reload()`が先行し得るうえ、
+   * ユーザーには「エクスポート完了」と表示されるのに実際のファイルは
+   * 一切届かない。
+   *
+   * ここでは各ハンドオフ（単発送信・チャンク送信の全て）を`await`し、
+   * いずれかが失敗（拒否）したら`downloadFile()`自体もreject、
+   * `chrome.downloads`フォールバックも`downloads.lastError`を確認して
+   * からでなければ解決しないようにする。呼び出し元は`await downloadFile()`
+   * が投げた例外を既存のcatchブロックでそのまま処理する ―― `state: 'error'`
+   * をpopupへ通知し、`idle`への遷移は「完了成功」としてではなく単に
+   * 操作終了として行われる。
    */
   const downloadFile = (content: string, filename: string, contentType: string): Promise<void> => {
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
@@ -568,35 +608,46 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
     const finalFilename = getFinalFilename()
 
     // Send to content script for Blob-based download (avoids data URL size limits)
-    return new Promise<void>(resolve => {
+    return new Promise<void>((resolve, reject) => {
       chrome.tabs.query({ url: gameUrlPattern }, async tabs => {
         const tab = tabs.find(t => t.id)
         if (tab?.id) {
-          const sizeMB = content.length / 1024 / 1024
-          const MAX_CHUNK_MB = 50 // Under Chrome's 64MiB message limit
-          const maxChunkSize = MAX_CHUNK_MB * 1024 * 1024
+          const tabId = tab.id
+          try {
+            const sizeMB = content.length / 1024 / 1024
+            const MAX_CHUNK_MB = 50 // Under Chrome's 64MiB message limit
+            const maxChunkSize = MAX_CHUNK_MB * 1024 * 1024
 
-          if (content.length <= maxChunkSize) {
-            chrome.tabs.sendMessage(tab.id, { action: 'downloadFile', content, filename: finalFilename, contentType })
-          } else {
-            // Split into chunks for large files
-            const totalChunks = Math.ceil(content.length / maxChunkSize)
-            console.log(`[Export] Splitting ${sizeMB.toFixed(1)}MB into ${totalChunks} chunks...`)
-            chrome.tabs.sendMessage(tab.id, { action: 'downloadFileInit', filename: finalFilename, contentType, totalChunks })
-            for (let i = 0; i < totalChunks; i++) {
-              const chunk = content.slice(i * maxChunkSize, (i + 1) * maxChunkSize)
-              chrome.tabs.sendMessage(tab.id, { action: 'downloadFileChunk', chunkIndex: i, chunk, totalChunks })
+            if (content.length <= maxChunkSize) {
+              await sendTabMessageAsync(tabId, { action: 'downloadFile', content, filename: finalFilename, contentType })
+            } else {
+              // Split into chunks for large files
+              const totalChunks = Math.ceil(content.length / maxChunkSize)
+              console.log(`[Export] Splitting ${sizeMB.toFixed(1)}MB into ${totalChunks} chunks...`)
+              await sendTabMessageAsync(tabId, { action: 'downloadFileInit', filename: finalFilename, contentType, totalChunks })
+              for (let i = 0; i < totalChunks; i++) {
+                const chunk = content.slice(i * maxChunkSize, (i + 1) * maxChunkSize)
+                await sendTabMessageAsync(tabId, { action: 'downloadFileChunk', chunkIndex: i, chunk, totalChunks })
+              }
+              await sendTabMessageAsync(tabId, { action: 'downloadFileFinish', filename: finalFilename, contentType })
             }
-            chrome.tabs.sendMessage(tab.id, { action: 'downloadFileFinish', filename: finalFilename, contentType })
+            console.log(`[Export] Download initiated via content script: ${finalFilename} (${sizeMB.toFixed(1)}MB)`)
+            resolve()
+          } catch (error) {
+            console.error('[Export] Content script download handoff failed:', error)
+            reject(error instanceof Error ? error : new Error(String(error)))
           }
-          console.log(`[Export] Download initiated via content script: ${finalFilename} (${sizeMB.toFixed(1)}MB)`)
-          resolve()
           return
         }
-        // Fallback: data URL (may fail for large files >2MB)
+        // Fallback: data URL via chrome.downloads (may fail for large files >2MB)
         console.warn('[Export] No game tab found, falling back to data URL download')
-        downloadViaDataUrl(content, finalFilename, contentType)
-        resolve()
+        try {
+          await downloadViaDataUrl(content, finalFilename, contentType)
+          resolve()
+        } catch (error) {
+          console.error('[Export] chrome.downloads fallback failed:', error)
+          reject(error instanceof Error ? error : new Error(String(error)))
+        }
       })
     })
   }
@@ -932,17 +983,31 @@ export const startKeepAlive = async (): Promise<() => void> => {
   return () => clearInterval(id)
 }
 
-const downloadViaDataUrl = (content: string, finalFilename: string, contentType: string) => {
+/**
+ * `chrome.downloads.download()`のコールバック（および`downloads.lastError`）
+ * を確認してから解決/拒否するPromiseを返す（codexレビュー指摘、監査
+ * finding #10）。修正前はコールバック内で`lastError`をログするだけで
+ * 呼び出し元（downloadFile）は待たずに解決していたため、ダウンロード自体が
+ * 失敗（例: ユーザーがsaveAsダイアログをキャンセル、ディスク容量不足）
+ * してもエクスポートは「完了」として扱われていた。
+ */
+const downloadViaDataUrl = (content: string, finalFilename: string, contentType: string): Promise<void> => {
   const base64Content = btoa(encodeURIComponent(content).replace(/%([0-9A-F]{2})/g, (_match, p1) => String.fromCharCode(parseInt(p1, 16))))
   const dataUrl = `data:${contentType};base64,${base64Content}`
 
-  chrome.downloads.download({
-    url: dataUrl,
-    filename: finalFilename,
-    saveAs: true
-  }, () => {
-    if (chrome.runtime.lastError) {
-      console.error('Download error:', chrome.runtime.lastError)
-    }
+  return new Promise<void>((resolve, reject) => {
+    chrome.downloads.download({
+      url: dataUrl,
+      filename: finalFilename,
+      saveAs: true
+    }, (downloadId) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message))
+      } else if (downloadId === undefined) {
+        reject(new Error('chrome.downloads.download failed: no downloadId returned'))
+      } else {
+        resolve()
+      }
+    })
   })
 }

--- a/src/background/message-router.manual-sync-outcome.test.ts
+++ b/src/background/message-router.manual-sync-outcome.test.ts
@@ -1,0 +1,113 @@
+/**
+ * message-router.ts - manual sync response truthfulness (independent
+ * release-audit finding #12, "manual sync reports success on internal
+ * failure")
+ *
+ * `autoSyncService.performSync()` has a long-standing never-throw contract
+ * on its own internal failure paths (the remote min-version gate blocking
+ * sync, or `syncToCloud()`/`syncFromCloud()` throwing) -- `initialize()` and
+ * `syncIfBacklogExceedsThreshold()` both rely on it resolving cleanly on
+ * every path so their own retry/backoff logic keeps running. Before this
+ * fix, `performSync()` returned `Promise<void>`, so a caller checking only
+ * resolve-vs-reject (as `message-router.ts`'s manual-sync handlers did) had
+ * no way to see those internal failures: `firebaseSyncToCloud`/
+ * `firebaseSyncFromCloud`/`manualSyncUpload`/`manualSyncDownload` all did
+ * `.then(() => sendResponse({ success: true }))` unconditionally on
+ * resolution, so a Firestore failure or a min-version-gate block --
+ * `updateSyncState({ status: 'error', ... })` ran internally -- was still
+ * reported to the popup as `{ success: true }`.
+ *
+ * `performSync()` now resolves with a structured `SyncOutcome`
+ * (`{ success: boolean, error?: string }`) instead, and message-router.ts's
+ * manual-sync handlers build their response from it. These tests assert the
+ * manual sync response is truthful for both failure modes the audit named,
+ * using `jest.spyOn(autoSyncService, 'performSync')` to simulate each
+ * (rather than driving real Firestore/min-version-gate failures, which
+ * belong to auto-sync-service.ts's own test suite) -- this test's job is
+ * only to verify message-router.ts's contract with whatever performSync()
+ * resolves.
+ */
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { registerMessageRouter } from './message-router'
+import { setOperationState } from './operation-state'
+import { autoSyncService, MIN_VERSION_SYNC_BLOCKED_MESSAGE } from '../services/auto-sync-service'
+import type { ChromeMessage, MessageResponse } from '../types/messages'
+
+describe('message-router manual sync response truthfulness', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+  let listener: (request: ChromeMessage, sender: chrome.runtime.MessageSender, sendResponse: (response: MessageResponse) => void) => boolean | void
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    service = new PokerChaseService({ db })
+    await service.ready
+    setOperationState({ type: 'idle' })
+
+    ;(chrome.runtime.onMessage.addListener as jest.Mock).mockClear()
+    registerMessageRouter(service, db, 'https://example.com/*')
+    listener = (chrome.runtime.onMessage.addListener as jest.Mock).mock.calls[0][0]
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    db.close()
+    await db.delete()
+  })
+
+  describe.each([
+    ['firebaseSyncToCloud' as const],
+    ['manualSyncUpload' as const],
+    ['manualSyncDownload' as const],
+  ])('%s', (action) => {
+    test('reports failure (not success) when performSync resolves with an internal Firestore-style error', async () => {
+      jest.spyOn(autoSyncService, 'performSync').mockResolvedValue({
+        success: false,
+        error: 'Firestore write failed: permission-denied'
+      })
+
+      const sendResponse = jest.fn()
+      const handled = listener({ action } as ChromeMessage, {}, sendResponse)
+      expect(handled).toBe(true)
+
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(sendResponse).toHaveBeenCalledWith({
+        success: false,
+        error: 'Firestore write failed: permission-denied'
+      })
+    })
+
+    test('reports failure (not success) when performSync resolves min-version-gate-blocked', async () => {
+      jest.spyOn(autoSyncService, 'performSync').mockResolvedValue({
+        success: false,
+        error: MIN_VERSION_SYNC_BLOCKED_MESSAGE
+      })
+
+      const sendResponse = jest.fn()
+      const handled = listener({ action } as ChromeMessage, {}, sendResponse)
+      expect(handled).toBe(true)
+
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(sendResponse).toHaveBeenCalledWith({
+        success: false,
+        error: MIN_VERSION_SYNC_BLOCKED_MESSAGE
+      })
+    })
+
+    test('reports success when performSync resolves successfully', async () => {
+      jest.spyOn(autoSyncService, 'performSync').mockResolvedValue({ success: true })
+
+      const sendResponse = jest.fn()
+      const handled = listener({ action } as ChromeMessage, {}, sendResponse)
+      expect(handled).toBe(true)
+
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(sendResponse).toHaveBeenCalledWith({ success: true })
+    })
+  })
+})

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -303,27 +303,35 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
         })
       return true
     } else if (request.action === 'firebaseSyncToCloud' || request.action === 'firebaseSyncFromCloud') {
-      // Manual sync now uses auto sync service
+      // Manual sync now uses auto sync service.
+      // performSync() never rejects on an internal sync failure (see its own
+      // never-throw contract, relied on by initialize()/
+      // syncIfBacklogExceedsThreshold()) -- it reports failure via the
+      // resolved SyncOutcome instead (min-version gate block, Firestore
+      // error, etc.). Forwarding `.then(() => sendResponse({success:true}))`
+      // unconditionally here used to report success even when the sync
+      // itself failed (independent release-audit finding #12) -- the
+      // resolved outcome must be inspected, not just its resolution.
       autoSyncService.performSync()
-        .then(() => sendResponse({ success: true }))
+        .then(result => sendResponse(result.success ? { success: true } : { success: false, error: result.error }))
         .catch(error => {
           console.error('Manual sync error:', error)
           sendResponse({ success: false, error: error.message })
         })
       return true
     } else if (request.action === 'manualSyncUpload') {
-      // Manual upload to cloud
+      // Manual upload to cloud (see the truthful-outcome note above)
       autoSyncService.performSync('upload')
-        .then(() => sendResponse({ success: true }))
+        .then(result => sendResponse(result.success ? { success: true } : { success: false, error: result.error }))
         .catch(error => {
           console.error('Manual upload error:', error)
           sendResponse({ success: false, error: error.message })
         })
       return true
     } else if (request.action === 'manualSyncDownload') {
-      // Manual download from cloud
+      // Manual download from cloud (see the truthful-outcome note above)
       autoSyncService.performSync('download')
-        .then(() => sendResponse({ success: true }))
+        .then(result => sendResponse(result.success ? { success: true } : { success: false, error: result.error }))
         .catch(error => {
           console.error('Manual download error:', error)
           sendResponse({ success: false, error: error.message })

--- a/src/content_script.download-ack.test.ts
+++ b/src/content_script.download-ack.test.ts
@@ -1,0 +1,121 @@
+/**
+ * content_script.ts - explicit ack for download handoff messages
+ * (PR #199 review, finding #1 P1: "Send an ACK before treating lastError as
+ * handoff failure")
+ *
+ * `import-export.ts`'s `downloadFile()` awaits each
+ * `chrome.tabs.sendMessage()` handoff via a callback and rejects on
+ * `chrome.runtime.lastError` (release-audit finding #10). Chrome's
+ * messaging API sets `lastError` to "The message port closed before a
+ * response was received" whenever the RECEIVING listener returns without
+ * calling `sendResponse()` and without returning `true` -- which is exactly
+ * what the four `downloadFile*` handlers below used to do (Blob-download
+ * work, then a bare `return`). That made every SUCCESSFULLY handled
+ * download handoff look like a delivery failure to the sender, indistinguishable
+ * from a genuinely missing content script or a rejected message.
+ *
+ * This loads content_script.ts fresh (mocking `chrome.runtime.connect` so
+ * its top-level `portManager.connect()` side effect doesn't throw, and
+ * `URL.createObjectURL`/`HTMLAnchorElement.prototype.click`, which jsdom
+ * doesn't implement) and asserts its `chrome.runtime.onMessage` listener
+ * now calls `sendResponse()` for each of the four download actions -- the
+ * explicit ack that prevents the false "port closed" failure on the sender
+ * side (see `sendTabMessageAsync` in `background/import-export.ts`).
+ */
+
+describe('content_script.ts download message handlers send an explicit ack', () => {
+  let listener: (message: any, sender: any, sendResponse: (response?: any) => void) => boolean | void
+
+  beforeEach(() => {
+    jest.resetModules()
+    ;(chrome.runtime as any).connect = jest.fn(() => ({
+      postMessage: jest.fn(),
+      disconnect: jest.fn(),
+      onMessage: { addListener: jest.fn(), removeListener: jest.fn() },
+      onDisconnect: { addListener: jest.fn(), removeListener: jest.fn() },
+    }))
+    ;(chrome.runtime.onMessage.addListener as jest.Mock).mockClear()
+    // jsdom doesn't implement these; the handlers under test call them
+    // unconditionally as part of the (real, working) Blob-download path --
+    // without these, the handler itself would throw before reaching
+    // sendResponse(), which would make these tests pass for the wrong reason.
+    ;(URL as any).createObjectURL = jest.fn(() => 'blob:mock-url')
+    ;(URL as any).revokeObjectURL = jest.fn()
+    jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => { })
+
+    jest.isolateModules(() => {
+      require('./content_script')
+    })
+
+    listener = (chrome.runtime.onMessage.addListener as jest.Mock).mock.calls[0]![0]
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('downloadFile sends an explicit success ack (single-message path)', () => {
+    const sendResponse = jest.fn()
+    listener(
+      { action: 'downloadFile', content: 'line1\nline2', filename: 'pokerchase_raw_data.ndjson', contentType: 'application/x-ndjson' },
+      {},
+      sendResponse
+    )
+    expect(sendResponse).toHaveBeenCalledTimes(1)
+    expect(sendResponse).toHaveBeenCalledWith({ success: true })
+  })
+
+  test('downloadFileInit sends an explicit success ack (chunked path start)', () => {
+    const sendResponse = jest.fn()
+    listener(
+      { action: 'downloadFileInit', filename: 'pokerchase_raw_data.ndjson', contentType: 'application/x-ndjson', totalChunks: 2 },
+      {},
+      sendResponse
+    )
+    expect(sendResponse).toHaveBeenCalledTimes(1)
+    expect(sendResponse).toHaveBeenCalledWith({ success: true })
+  })
+
+  test('downloadFileChunk sends an explicit success ack (per chunk)', () => {
+    const sendResponse = jest.fn()
+    listener(
+      { action: 'downloadFileInit', filename: 'pokerchase_raw_data.ndjson', contentType: 'application/x-ndjson', totalChunks: 2 },
+      {},
+      jest.fn()
+    )
+    listener(
+      { action: 'downloadFileChunk', chunkIndex: 0, chunk: 'abc', totalChunks: 2 },
+      {},
+      sendResponse
+    )
+    expect(sendResponse).toHaveBeenCalledTimes(1)
+    expect(sendResponse).toHaveBeenCalledWith({ success: true })
+  })
+
+  test('downloadFileFinish sends an explicit success ack (chunked path end)', () => {
+    listener({ action: 'downloadFileInit', filename: 'f.ndjson', contentType: 'application/x-ndjson', totalChunks: 1 }, {}, jest.fn())
+    listener({ action: 'downloadFileChunk', chunkIndex: 0, chunk: 'abc', totalChunks: 1 }, {}, jest.fn())
+
+    const sendResponse = jest.fn()
+    listener(
+      { action: 'downloadFileFinish', filename: 'f.ndjson', contentType: 'application/x-ndjson' },
+      {},
+      sendResponse
+    )
+    expect(sendResponse).toHaveBeenCalledTimes(1)
+    expect(sendResponse).toHaveBeenCalledWith({ success: true })
+  })
+
+  test('downloadFile reports a failure ack (not a silent success) when the Blob download itself throws', () => {
+    ;(URL.createObjectURL as jest.Mock).mockImplementation(() => { throw new Error('createObjectURL boom') })
+
+    const sendResponse = jest.fn()
+    listener(
+      { action: 'downloadFile', content: 'line1', filename: 'f.ndjson', contentType: 'application/x-ndjson' },
+      {},
+      sendResponse
+    )
+    expect(sendResponse).toHaveBeenCalledTimes(1)
+    expect(sendResponse).toHaveBeenCalledWith({ success: false, error: 'createObjectURL boom' })
+  })
+})

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -224,43 +224,77 @@ const messageHandlers: Record<string, (message: ChromeMessage) => void> = {
   }
 }
 
-chrome.runtime.onMessage.addListener((message: ChromeMessage | { action: string, [key: string]: unknown }) => {
+// downloadFile/downloadFileInit/downloadFileChunk/downloadFileFinishの4種は
+// 必ずsendResponse()を呼ぶ（PR #199レビュー指摘、finding #1）。
+//
+// import-export.ts側のdownloadFile()は各ハンドオフをchrome.tabs.sendMessage()
+// のコールバック経由でawaitし、chrome.runtime.lastErrorがあれば失敗として
+// reject するようになった。ところがChromeのメッセージングAPIは、受信側の
+// リスナーがsendResponse()を呼ばず`true`もreturnしない場合、リスナーが
+// returnした時点でメッセージポートを閉じ、送信側のコールバックに
+// `chrome.runtime.lastError = "The message port closed before a response was
+// received"`をセットする ―― これは受信側の処理が実際に成功していても発生する。
+// 修正前のこの4ハンドラーはBlobダウンロード処理をして`return`するだけだった
+// ため、正常に配信されたエクスポートまで送信側から失敗と誤判定されていた
+// （content scriptが実在しない・メッセージ拒否などの本物の配信失敗とは
+// 区別できなかった）。
+// ここで明示的に`sendResponse({ success: true/false })`を返すことで、
+// 送信側は「本当に届いたか」を`chrome.runtime.lastError`だけでなく
+// レスポンスの中身でも確認できる（import-export.tsのsendTabMessageAsync
+// 参照）。sendResponse()はリスナー内で同期的に呼んでいるため、
+// 非同期レスポンス用の`return true`は不要。
+chrome.runtime.onMessage.addListener((message: ChromeMessage | { action: string, [key: string]: unknown }, _sender, sendResponse) => {
   // Blob-based file download (avoids Service Worker data URL size limits)
   if (message.action === 'downloadFile' && 'content' in message) {
     const m = message as any
-    const blob = new Blob([m.content], { type: m.contentType })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = m.filename
-    a.click()
-    URL.revokeObjectURL(url)
-    console.log(`[content_script] Download: ${m.filename} (${(m.content.length / 1024 / 1024).toFixed(1)}MB)`)
+    try {
+      const blob = new Blob([m.content], { type: m.contentType })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = m.filename
+      a.click()
+      URL.revokeObjectURL(url)
+      console.log(`[content_script] Download: ${m.filename} (${(m.content.length / 1024 / 1024).toFixed(1)}MB)`)
+      sendResponse({ success: true })
+    } catch (error) {
+      console.error('[content_script] Download failed:', error)
+      sendResponse({ success: false, error: error instanceof Error ? error.message : String(error) })
+    }
     return
   }
   // Chunked file download for large files (>50MB)
   if (message.action === 'downloadFileInit') {
     (window as any).__downloadChunks = []
+    sendResponse({ success: true })
     return
   }
   if (message.action === 'downloadFileChunk' && 'chunk' in message) {
     const m = message as any
     if (!(window as any).__downloadChunks) (window as any).__downloadChunks = []
     ;(window as any).__downloadChunks.push(m.chunk)
+    sendResponse({ success: true })
     return
   }
   if (message.action === 'downloadFileFinish' && 'filename' in message) {
     const m = message as any
-    const chunks = (window as any).__downloadChunks || []
-    const blob = new Blob(chunks, { type: m.contentType })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = m.filename
-    a.click()
-    URL.revokeObjectURL(url)
-    console.log(`[content_script] Chunked download: ${m.filename} (${(blob.size / 1024 / 1024).toFixed(1)}MB, ${chunks.length} chunks)`)
-    ;(window as any).__downloadChunks = null
+    try {
+      const chunks = (window as any).__downloadChunks || []
+      const blob = new Blob(chunks, { type: m.contentType })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = m.filename
+      a.click()
+      URL.revokeObjectURL(url)
+      console.log(`[content_script] Chunked download: ${m.filename} (${(blob.size / 1024 / 1024).toFixed(1)}MB, ${chunks.length} chunks)`)
+      sendResponse({ success: true })
+    } catch (error) {
+      console.error('[content_script] Chunked download failed:', error)
+      sendResponse({ success: false, error: error instanceof Error ? error.message : String(error) })
+    } finally {
+      ;(window as any).__downloadChunks = null
+    }
     return
   }
   const handler = messageHandlers[message.action as keyof typeof messageHandlers]

--- a/src/services/auto-sync-service.session-triggers.test.ts
+++ b/src/services/auto-sync-service.session-triggers.test.ts
@@ -48,7 +48,7 @@ describe('AutoSyncService session start/end sync triggers', () => {
     await db.apiEvents.bulkAdd(events)
 
     const service = new AutoSyncService(db)
-    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue(undefined)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue({ success: true })
 
     await service.onNewSessionStart()
 
@@ -60,7 +60,7 @@ describe('AutoSyncService session start/end sync triggers', () => {
     await db.apiEvents.bulkAdd(events)
 
     const service = new AutoSyncService(db)
-    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue(undefined)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue({ success: true })
 
     await service.onNewSessionStart()
 
@@ -72,7 +72,7 @@ describe('AutoSyncService session start/end sync triggers', () => {
     await db.apiEvents.bulkAdd(events)
 
     const service = new AutoSyncService(db)
-    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue(undefined)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue({ success: true })
 
     await service.onGameSessionEnd()
 
@@ -84,7 +84,7 @@ describe('AutoSyncService session start/end sync triggers', () => {
     await db.apiEvents.bulkAdd(events)
 
     const service = new AutoSyncService(db)
-    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue(undefined)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue({ success: true })
 
     // Simulate a sync already in progress (e.g. 309's onGameSessionEnd fired
     // just before this session-start event arrived)
@@ -105,6 +105,7 @@ describe('AutoSyncService session start/end sync triggers', () => {
       // backlog it just cleared -- mirror that here without exercising the
       // full Firestore path.
       ;(service as any).syncState.lastSyncTime = new Date(events[events.length - 1]!.timestamp!)
+      return { success: true }
     })
 
     // 309 fires first (session end) and clears the backlog
@@ -123,7 +124,7 @@ describe('AutoSyncService session start/end sync triggers', () => {
     await db.apiEvents.bulkAdd(events)
 
     const service = new AutoSyncService(db)
-    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue(undefined)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue({ success: true })
 
     await service.onNewSessionStart()
     await service.onGameSessionEnd()

--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -846,6 +846,7 @@ describe('AutoSyncService cloud downloads', () => {
     // dedicated test below.
     const performSyncSpy = jest.spyOn(service, 'performSync').mockImplementation(async () => {
       (service as any).syncState.lastSyncTime = new Date()
+      return { success: true } as const
     })
 
     // --- Account A is the first to sign in after upgrade -------------------
@@ -1085,6 +1086,7 @@ describe('AutoSyncService cloud downloads', () => {
     const service = new AutoSyncService(db)
     const performSyncSpy = jest.spyOn(service, 'performSync').mockImplementation(async () => {
       (service as any).syncState.lastSyncTime = new Date()
+      return { success: true } as const
     })
 
     await service.initialize()
@@ -1130,6 +1132,7 @@ describe('AutoSyncService cloud downloads', () => {
     const service = new AutoSyncService(db)
     const performSyncSpy = jest.spyOn(service, 'performSync').mockImplementation(async () => {
       (service as any).syncState.lastSyncTime = new Date()
+      return { success: true } as const
     })
 
     await service.initialize()
@@ -1169,7 +1172,7 @@ describe('AutoSyncService cloud downloads', () => {
     })
 
     const service = new AutoSyncService(db)
-    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue(undefined)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue({ success: true })
 
     await service.initialize()
 
@@ -1348,7 +1351,7 @@ describe('AutoSyncService cloud downloads', () => {
     })
 
     const service = new AutoSyncService(db)
-    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue(undefined)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue({ success: true })
 
     await service.initialize()
 
@@ -1400,6 +1403,7 @@ describe('AutoSyncService cloud downloads', () => {
     // dedicated test elsewhere) and inflating the call count asserted below.
     const performSyncSpy = jest.spyOn(service, 'performSync').mockImplementation(async () => {
       (service as any).syncState.lastSyncTime = new Date()
+      return { success: true } as const
     })
 
     await service.initialize()
@@ -1457,7 +1461,7 @@ describe('AutoSyncService cloud downloads', () => {
     })
 
     const service = new AutoSyncService(db)
-    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue(undefined)
+    const performSyncSpy = jest.spyOn(service, 'performSync').mockResolvedValue({ success: true })
 
     await service.initialize()
 

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -50,6 +50,37 @@ interface SyncPassIdentity {
 export type SyncStatus = 'idle' | 'syncing' | 'error' | 'success'
 export type SyncDirection = 'upload' | 'download' | 'both'
 
+/**
+ * `performSync()`'s resolved return value (independent release-audit finding
+ * #12, "manual sync reports success on internal failure").
+ *
+ * `performSync()` itself must keep its long-standing NEVER-THROW contract on
+ * its own internal failure paths (the remote min-version gate blocking sync,
+ * or `syncToCloud()`/`syncFromCloud()` throwing) -- `initialize()` and
+ * `syncIfBacklogExceedsThreshold()` both call it fire-and-forget-style
+ * (`await this.performSync()` / `await this.performSync('upload')`, ignoring
+ * the resolved value entirely) and rely on that resolving cleanly so their
+ * own retry/backoff logic runs on every path, not just the happy one. Before
+ * this fix, `Promise<void>` gave callers no way to distinguish "sync ran and
+ * succeeded" from "sync ran and failed internally" other than re-reading
+ * `getSyncState()` afterward -- `message-router.ts`'s manual-sync handlers
+ * (`firebaseSyncToCloud`/`firebaseSyncFromCloud`/`manualSyncUpload`/
+ * `manualSyncDownload`) didn't do that, so `.then(() => sendResponse({
+ * success: true }))` fired unconditionally on resolution, even when the
+ * min-version gate blocked the sync or Firestore itself failed --
+ * `updateSyncState({ status: 'error', ... })` ran, but the message response
+ * still claimed success.
+ *
+ * This structured outcome lets `performSync()` keep resolving (never
+ * rejecting) on those same internal failure paths while still reporting the
+ * truth to a caller that chooses to look -- `message-router.ts`'s manual-sync
+ * handlers now build their response from this value instead of assuming
+ * resolution implies success.
+ */
+export type SyncOutcome =
+  | { success: true }
+  | { success: false, error: string }
+
 export interface SyncState {
   status: SyncStatus
   lastSyncTime?: Date
@@ -493,19 +524,30 @@ export class AutoSyncService {
   /**
    * Perform sync with optional direction
    * @param direction - Optional sync direction: 'upload', 'download', or 'both' (default)
+   * @returns A {@link SyncOutcome} describing whether this call actually
+   *   synced successfully. NEVER rejects on an internal sync failure (see the
+   *   `SyncOutcome` doc comment) -- only a truly unexpected/unhandled
+   *   exception (e.g. `firebaseAuthService.ready()` itself throwing) would
+   *   reject this promise, same as before this fix.
    */
-  async performSync(direction: SyncDirection = 'both'): Promise<void> {
+  async performSync(direction: SyncDirection = 'both'): Promise<SyncOutcome> {
     // Check minimum interval (currently disabled)
     const now = Date.now()
     if (this.MIN_SYNC_INTERVAL_MS > 0 && now - this.lastSyncAttempt < this.MIN_SYNC_INTERVAL_MS) {
       console.log('[AutoSync] Skipping sync - too soon since last attempt')
-      return
+      // Not a failure -- this pass simply deferred to whatever the previous
+      // sync already established (MIN_SYNC_INTERVAL_MS is currently 0/
+      // disabled, so this path is not reachable today; kept truthful for
+      // when it's re-enabled).
+      return { success: true }
     }
 
     // Check if already syncing
     if (this._isSyncing) {
       console.log('[AutoSync] Sync already in progress')
-      return
+      // Not a failure -- a concurrent pass owns this sync; its own outcome
+      // (success or failure) is what will actually land in syncState.
+      return { success: true }
     }
 
     // Latch BEFORE the awaited gate check below (codex#3612092798): if we set
@@ -552,7 +594,11 @@ export class AutoSyncService {
       if (await isCloudSyncBlockedByMinVersionGate()) {
         console.warn('[AutoSync] Cloud sync blocked: extension version is below the remote minimum-supported version')
         this.updateSyncState({ status: 'error', error: MIN_VERSION_SYNC_BLOCKED_MESSAGE })
-        return
+        // Independent release-audit finding #12: this used to be a bare
+        // `return` (implicit success) even though the gate just blocked the
+        // sync -- a manual-sync caller inspecting only promise resolution
+        // (message-router.ts) would report `{ success: true }` to the popup.
+        return { success: false, error: MIN_VERSION_SYNC_BLOCKED_MESSAGE }
       }
 
       this.lastSyncAttempt = now
@@ -624,12 +670,25 @@ export class AutoSyncService {
         })
 
         console.log(`[AutoSync] Sync completed successfully (direction: ${direction})`)
+        return { success: true }
       } catch (error) {
         console.error('[AutoSync] Sync error:', error)
+        // Independent release-audit finding #12, "manual sync reports
+        // success on internal failure": this catch block used to only
+        // update `syncState` and fall off the end of the function (implicit
+        // `return undefined`), so `performSync()` still RESOLVED here --
+        // `message-router.ts`'s manual-sync handlers, which only checked
+        // resolve-vs-reject, reported `{ success: true }` to the popup even
+        // though the sync (e.g. a Firestore write) actually failed. Keeping
+        // this never-throw for internal callers (`initialize()`,
+        // `syncIfBacklogExceedsThreshold()`, both of which ignore the
+        // resolved value) -- only the resolved SHAPE now tells the truth.
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error'
         this.updateSyncState({
           status: 'error',
-          error: error instanceof Error ? error.message : 'Unknown error'
+          error: errorMessage
         })
+        return { success: false, error: errorMessage }
       }
     } finally {
       this._isSyncing = false


### PR DESCRIPTION
## Summary

Three fixes from the independent release audit's P2/P3 "messaging cluster" (findings #10, #12, #13). Scope: `import-export.ts` (export/import paths only), `message-router.ts`'s sync-response handler, and a surgical `performSync()` return-shape change in `auto-sync-service.ts`.

- **finding #10 (P2) — export completion doesn't mean file receipt.** `downloadFile()` awaited `chrome.tabs.query()` but not `chrome.tabs.sendMessage()` itself (fire-and-forget per chunk), and the `chrome.downloads` fallback resolved before its callback/`downloads.lastError` was inspected. A missing content script, message rejection, the 64MiB message boundary, or a downloads error could all flip the export operation to idle-success with no file ever delivered — and could green-light a pending update reload in the same window. `downloadFile()`/`downloadViaDataUrl()` now await every handoff (callback + `chrome.runtime.lastError`) and reject on failure, so the existing `exportJsonData`/`exportPokerStarsData` catch blocks correctly surface `state: 'error'` to the popup instead of a false completion.

- **finding #12 (P3) — manual sync reports success on internal failure.** `performSync()` swallowed internal failures (min-version gate block, Firestore errors) and always resolved, so `message-router.ts`'s manual-sync handlers (`firebaseSyncToCloud`/`firebaseSyncFromCloud`/`manualSyncUpload`/`manualSyncDownload`) reported `{success:true}` regardless. `performSync()` now resolves a structured `SyncOutcome` (`{success, error?}`) while keeping its never-throw contract for internal callers (`initialize()`/`syncIfBacklogExceedsThreshold()`, both of which ignore the resolved value and rely on it resolving cleanly) — `message-router.ts` now builds its response from the outcome instead of assuming resolution implies success.

- **finding #13 (P3) — import successCount can go negative.** `importData()`'s bulkAdd-fallback path decremented `successCount` for a duplicate-key failure even though that row's success was never counted in the first place (the increment/decrement are on opposite branches of the same try/catch). A duplicate-heavy fallback import (e.g. a live event racing the import for the same key) could report a negative `successCount`. Removed the erroneous decrement; `duplicateCount` alone tracks it.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx jest` full suite green, run twice (109→110 suites, 1050→1059 tests, no flakiness)
- [x] `npm run e2e:smoke` — all 6 checks pass
- [x] `import-export.export-handoff.test.ts` extended: deferred/rejected `tabs.sendMessage` (operation stays `'export'` until acknowledged, rejection surfaces as `state:'error'` not idle-success), chunked (>50MB) per-chunk acknowledgment, `chrome.downloads.lastError` fallback path
- [x] New `import-export.import-accounting.test.ts`: duplicate-heavy bulkAdd-fallback import never reports negative `successCount`
- [x] New `message-router.manual-sync-outcome.test.ts`: manual sync truthfully reports failure for both an internal Firestore-style error and a min-version-gate block, across all three manual-sync actions
- [x] Fail-before/pass-after verified via `git apply -R` for both the export-receipt fix and the false-success sync fix (reverting each production change reproduces exactly the audit-described symptom in the new tests, re-applying restores green)

Audit reference: `codex-review-output.md` findings #10, #12, #13 (independent release-readiness audit of v5.2.0, HEAD `4b02f23`).