### PR TITLE
fix(hud): refetch open drill-down panels on hand completion

### DIFF
--- a/src/background/ports.hand-epoch.test.ts
+++ b/src/background/ports.hand-epoch.test.ts
@@ -1,0 +1,162 @@
+/**
+ * ports.ts -- handCompletionEpoch gating (audit finding 11 follow-up, P2)
+ *
+ * Regression test for a P2 codex review comment on PR #200
+ * (https://github.com/solavrc/pokerchase-hud/pull/200#discussion_r3617053535,
+ * posted 2026-07-20T19:40:03Z): the first pass stamped `handEpoch` from
+ * `liveBroadcastSequence`, which is bumped by EVERY `statsOutputStream` 'data'
+ * emission -- not just genuine hand completions. That stream also fires for:
+ *  - the hand-start "warmup" broadcast (aggregate-events-stream.ts's EVT_DEAL
+ *    handler, when the DB already has hands for the newly-dealt lineup --
+ *    `service.statsOutputStream.write(event.SeatUserIds)` called directly)
+ *  - filter-change/import/auto-sync-restore rebroadcasts (message-router.ts's
+ *    `updateBattleTypeFilter`, `recalculateStats()`/`recalculateAllStats()`,
+ *    import-export.ts, auto-sync-service.ts -- all call
+ *    `service.statsOutputStream.write()` directly, bypassing the live
+ *    hand-aggregation pipeline entirely)
+ * None of those are "a hand just completed", so bumping handEpoch on them
+ * would cause an open drill-down panel to refetch (and the backend caches to
+ * invalidate) at times that aren't hand completions.
+ *
+ * Fix: `handCompletionEpoch` is now a separate counter, bumped only by
+ * `service.writeEntityStream`'s 'data' event -- the one true completion
+ * signal, reached exclusively via the live pipeline
+ * (`handAggregateStream.pipe(writeEntityStream)`) after a hand's events have
+ * actually been detected as complete (EVT_HAND_RESULTS) and successfully
+ * persisted to DB.
+ */
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { ApiType } from '../types'
+import type { ApiEvent } from '../app'
+import { registerStreamSubscriptions, connectedPorts, setLastKnownStats } from './ports'
+
+const GAME_URL_PATTERN = 'https://example.com/*'
+
+/** Minimal valid EVT_DEAL -> EVT_ACTION -> EVT_HAND_RESULTS sequence for a single
+ * hand, mirroring aggregate-events-stream.test.ts's fixture -- enough for
+ * WriteEntityStream.toHandState() to accept it and persist a real hand (not a
+ * chimera), so `writeEntityStream`'s 'data' fires for real. */
+function makeHandEvents(handId: number, seatUserIds: [number, number, number]): ApiEvent[] {
+  return [
+    {
+      ApiTypeId: ApiType.EVT_DEAL,
+      SeatUserIds: seatUserIds,
+      Game: { CurrentBlindLv: 1, NextBlindUnixSeconds: 0, Ante: 0, SmallBlind: 100, BigBlind: 200, ButtonSeat: 0, SmallBlindSeat: 1, BigBlindSeat: 2 },
+      Player: { SeatIndex: 0, BetStatus: 1, HoleCards: [0, 1], Chip: 5000, BetChip: 0 },
+      OtherPlayers: [
+        { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 100, IsSafeLeave: false },
+        { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 200, IsSafeLeave: false },
+      ],
+      Progress: { Phase: 0, NextActionSeat: 0, NextActionTypes: [2, 3, 4, 5], NextExtraLimitSeconds: 1, MinRaise: 400, Pot: 300, SidePot: [] },
+      timestamp: handId * 1000,
+    },
+    {
+      ApiTypeId: ApiType.EVT_ACTION,
+      SeatIndex: 0,
+      ActionType: 2,
+      Chip: 5000,
+      BetChip: 0,
+      Progress: { Phase: 3, NextActionSeat: -2, NextActionTypes: [], NextExtraLimitSeconds: 0, MinRaise: 0, Pot: 300, SidePot: [] },
+      timestamp: handId * 1000 + 1,
+    },
+    {
+      ApiTypeId: ApiType.EVT_HAND_RESULTS,
+      CommunityCards: [],
+      Pot: 300,
+      SidePot: [],
+      ResultType: 0,
+      DefeatStatus: 0,
+      HandId: handId,
+      HandLog: '',
+      Results: [{ UserId: seatUserIds[0], HoleCards: [], RankType: 10, Hands: [], HandRanking: 1, Ranking: -2, RewardChip: 300 }],
+      Player: { SeatIndex: 0, BetStatus: -1, Chip: 5000, BetChip: 0 },
+      OtherPlayers: [
+        { SeatIndex: 1, Status: 0, BetStatus: -1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+        { SeatIndex: 2, Status: 0, BetStatus: -1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+      ],
+      timestamp: handId * 1000 + 2,
+    },
+  ]
+}
+
+describe('ports.ts handCompletionEpoch (audit finding 11 follow-up, P2)', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+  let fakePort: { postMessage: jest.Mock }
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    service = new PokerChaseService({ db })
+    await service.ready
+
+    fakePort = { postMessage: jest.fn() }
+    connectedPorts.add(fakePort as unknown as chrome.runtime.Port)
+
+    registerStreamSubscriptions(service, GAME_URL_PATTERN)
+  })
+
+  afterEach(async () => {
+    connectedPorts.clear()
+    setLastKnownStats([])
+    db.close()
+    await db.delete()
+  })
+
+  /** handEpoch stamped on the most recent broadcastMessage() postMessage call (any of
+   * this test's fakePort calls -- both statsOutputStream's and realTimeStatsStream's
+   * broadcasts carry the field). */
+  function lastBroadcastHandEpoch(): number | undefined {
+    const lastCall = fakePort.postMessage.mock.calls.at(-1)
+    return lastCall?.[0]?.handEpoch
+  }
+
+  test('a direct statsOutputStream broadcast (hand-start warmup / filter-change / import rebroadcast shape) does NOT bump handEpoch', async () => {
+    // handCompletionEpoch is module-scoped in ports.ts (shared across this file's
+    // tests), so read the current value as a baseline rather than assuming 0 --
+    // only the *delta* across these calls is under test here.
+    service.statsOutputStream.write([1, 2, 3])
+    await service.statsOutputStream.whenIdle()
+    const baseline = lastBroadcastHandEpoch()
+
+    // This is exactly what aggregate-events-stream.ts's EVT_DEAL warmup branch and
+    // message-router.ts's updateBattleTypeFilter/recalculateStats() do: call
+    // statsOutputStream.write() directly, without ever touching writeEntityStream.
+    service.statsOutputStream.write([1, 2, 3])
+    await service.statsOutputStream.whenIdle()
+    expect(lastBroadcastHandEpoch()).toBe(baseline)
+
+    // Repeating it (simulating another filter change / a second warmup broadcast)
+    // still doesn't move the needle.
+    service.statsOutputStream.write([1, 2, 3])
+    await service.statsOutputStream.whenIdle()
+    expect(lastBroadcastHandEpoch()).toBe(baseline)
+  })
+
+  test('a genuine hand completion (through the live handAggregateStream -> writeEntityStream -> statsOutputStream pipeline) bumps handEpoch by exactly 1', async () => {
+    service.statsOutputStream.write([1, 2, 3])
+    await service.statsOutputStream.whenIdle()
+    const baseline = lastBroadcastHandEpoch()!
+
+    for (const event of makeHandEvents(555, [1, 2, 3])) {
+      service.handAggregateStream.write(event)
+    }
+    await service.handAggregateStream.whenIdle()
+
+    expect(lastBroadcastHandEpoch()).toBe(baseline + 1)
+
+    // A subsequent direct statsOutputStream broadcast (e.g. a filter change right
+    // after this hand) stamps the new value but does NOT bump it further.
+    service.statsOutputStream.write([1, 2, 3])
+    await service.statsOutputStream.whenIdle()
+    expect(lastBroadcastHandEpoch()).toBe(baseline + 1)
+
+    // A second genuine completion bumps it again, by exactly 1.
+    for (const event of makeHandEvents(556, [1, 2, 3])) {
+      service.handAggregateStream.write(event)
+    }
+    await service.handAggregateStream.whenIdle()
+    expect(lastBroadcastHandEpoch()).toBe(baseline + 2)
+  })
+})

--- a/src/background/ports.ts
+++ b/src/background/ports.ts
@@ -30,21 +30,33 @@ export const setLastKnownStats = (stats: PlayerStats[]): void => {
 // Service Worker, so it is very often already non-empty by the time an unrelated tab
 // mounts, which would wrongly suppress the fallback forever after the first hand ever
 // played in that Service Worker's lifetime.
-//
-// Also reused as the wire-level "hand epoch" for audit finding 11 (P2, open
-// drill-down panels going stale indefinitely): every broadcastMessage() call below
-// stamps the *current* value of this counter onto the payload as `handEpoch`. Only the
-// statsOutputStream handler increments it before stamping, so a realtime-only
-// broadcast (realTimeStatsStream, driven by individual actions within the same hand)
-// repeats the same handEpoch value, while a genuine hand-completion broadcast carries a
-// freshly bumped one. content_script.ts forwards this untyped port payload straight
-// through as the CustomEvent detail (see its `onMessage` -- it doesn't need to know
-// about this field), and App.tsx reads it off `detail` via a locally-widened type
-// (StatsData there predates this field and is owned by a different workstream) to
-// decide when an open RecentHandsPanel/PositionalStatsPanel should refetch.
 let liveBroadcastSequence = 0
 
 export const getLiveBroadcastSequence = (): number => liveBroadcastSequence
+
+// Monotonic counter for the wire-level "hand epoch" (audit finding 11 follow-up, P2:
+// a first pass reused `liveBroadcastSequence` for this, but codex review correctly
+// pointed out that counter -- and `statsOutputStream`'s 'data' event it's driven by --
+// fires on more than genuine hand completions: it also fires for the hand-start
+// "warmup" broadcast (aggregate-events-stream.ts's EVT_DEAL handler, when the DB
+// already has hands for the newly-dealt lineup) and for filter-change/import/
+// auto-sync-restore rebroadcasts (message-router.ts's `updateBattleTypeFilter`,
+// recalculateStats()/recalculateAllStats(), import-export.ts, auto-sync-service.ts --
+// all of which call `service.statsOutputStream.write()` directly). None of those are
+// "a hand just completed", so bumping this epoch on them caused spurious refetches
+// (and would have caused premature cache invalidation, see positional-stats-service.ts/
+// recent-hands-service.ts's subscribeToHandCompletion) on an open drill-down panel.
+//
+// `service.writeEntityStream`'s 'data' event is the one true completion signal: it
+// only fires from `write-entity-stream.ts`'s `this.push(hand.seatUserIds)`, reached
+// exclusively via the live pipeline (`handAggregateStream.pipe(writeEntityStream)`,
+// itself only fed by the real-time port in event-ingestion.ts) after a hand's events
+// have actually been detected as complete (EVT_HAND_RESULTS) and successfully
+// persisted (chimera hands return early without pushing, see that file). The
+// hand-start warmup and filter/import/auto-sync rebroadcasts above all call
+// `statsOutputStream.write()` *directly*, bypassing `writeEntityStream` entirely, so
+// none of them touch this counter.
+let handCompletionEpoch = 0
 
 export const getLatestRealTimeStats = (): AllPlayersRealTimeStats | undefined => latestRealTimeStats
 
@@ -134,9 +146,10 @@ export const registerStreamSubscriptions = (service: PokerChaseService, gameUrlP
         evtDeal: service.liveEvtDeal,
         realTimeStats: latestRealTimeStats,
         // Same handEpoch as the last hand-completion broadcast (unchanged since this
-        // is a realtime-only, per-action update) -- see liveBroadcastSequence's doc
-        // comment above.
-        handEpoch: liveBroadcastSequence
+        // is a realtime-only, per-action update, and handCompletionEpoch is only
+        // bumped by the writeEntityStream subscription below) -- see
+        // handCompletionEpoch's doc comment above.
+        handEpoch: handCompletionEpoch
       })
     }
   })
@@ -149,8 +162,17 @@ export const registerStreamSubscriptions = (service: PokerChaseService, gameUrlP
       stats: hand,
       evtDeal: service.liveEvtDeal,  // Include EVT_DEAL for seat mapping (live context, not the persisted hero-anchored one -- see above)
       realTimeStats: latestRealTimeStats,  // Include latest real-time stats from stream
-      handEpoch: liveBroadcastSequence  // Freshly bumped above -- signals a completed hand to the HUD's drill-down panels
+      // NOT bumped here -- this handler also fires for the hand-start warmup and
+      // filter/import/auto-sync rebroadcasts (see handCompletionEpoch's doc comment),
+      // so it just stamps whatever handCompletionEpoch currently holds. Only a real
+      // completion (the writeEntityStream subscription below) advances it.
+      handEpoch: handCompletionEpoch
     })
+  })
+  // The one true "hand completed" signal -- see handCompletionEpoch's doc comment
+  // above for why this must be writeEntityStream, not statsOutputStream.
+  service.writeEntityStream.on('data', () => {
+    handCompletionEpoch++
   })
 
   // Handle hand log events

--- a/src/background/ports.ts
+++ b/src/background/ports.ts
@@ -30,6 +30,18 @@ export const setLastKnownStats = (stats: PlayerStats[]): void => {
 // Service Worker, so it is very often already non-empty by the time an unrelated tab
 // mounts, which would wrongly suppress the fallback forever after the first hand ever
 // played in that Service Worker's lifetime.
+//
+// Also reused as the wire-level "hand epoch" for audit finding 11 (P2, open
+// drill-down panels going stale indefinitely): every broadcastMessage() call below
+// stamps the *current* value of this counter onto the payload as `handEpoch`. Only the
+// statsOutputStream handler increments it before stamping, so a realtime-only
+// broadcast (realTimeStatsStream, driven by individual actions within the same hand)
+// repeats the same handEpoch value, while a genuine hand-completion broadcast carries a
+// freshly bumped one. content_script.ts forwards this untyped port payload straight
+// through as the CustomEvent detail (see its `onMessage` -- it doesn't need to know
+// about this field), and App.tsx reads it off `detail` via a locally-widened type
+// (StatsData there predates this field and is owned by a different workstream) to
+// decide when an open RecentHandsPanel/PositionalStatsPanel should refetch.
 let liveBroadcastSequence = 0
 
 export const getLiveBroadcastSequence = (): number => liveBroadcastSequence
@@ -46,7 +58,7 @@ export const connectedPorts = new Set<chrome.runtime.Port>()
  * 接続中の全ポートにメッセージをブロードキャストする
  * 切断済みポートを検出した場合は`connectedPorts`から取り除く
  */
-export const broadcastMessage = (data: { stats: PlayerStats[], evtDeal?: ApiEvent<ApiType.EVT_DEAL>, realTimeStats?: AllPlayersRealTimeStats } | string) => {
+export const broadcastMessage = (data: { stats: PlayerStats[], evtDeal?: ApiEvent<ApiType.EVT_DEAL>, realTimeStats?: AllPlayersRealTimeStats, handEpoch?: number } | string) => {
   connectedPorts.forEach(port => {
     try {
       port.postMessage(data)
@@ -120,7 +132,11 @@ export const registerStreamSubscriptions = (service: PokerChaseService, gameUrlP
         // comments on PokerChaseService and aggregate-events-stream.ts's
         // EVT_DEAL case for the full rationale (codex #177, all 3 review rounds).
         evtDeal: service.liveEvtDeal,
-        realTimeStats: latestRealTimeStats
+        realTimeStats: latestRealTimeStats,
+        // Same handEpoch as the last hand-completion broadcast (unchanged since this
+        // is a realtime-only, per-action update) -- see liveBroadcastSequence's doc
+        // comment above.
+        handEpoch: liveBroadcastSequence
       })
     }
   })
@@ -132,7 +148,8 @@ export const registerStreamSubscriptions = (service: PokerChaseService, gameUrlP
     broadcastMessage({
       stats: hand,
       evtDeal: service.liveEvtDeal,  // Include EVT_DEAL for seat mapping (live context, not the persisted hero-anchored one -- see above)
-      realTimeStats: latestRealTimeStats  // Include latest real-time stats from stream
+      realTimeStats: latestRealTimeStats,  // Include latest real-time stats from stream
+      handEpoch: liveBroadcastSequence  // Freshly bumped above -- signals a completed hand to the HUD's drill-down panels
     })
   })
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -24,6 +24,16 @@ import type { AllPlayersRealTimeStats } from "../realtime-stats/realtime-stats-s
 
 const EMPTY_SEATS: PlayerStats[] = Array.from({ length: 6 }, () => ({ playerId: -1 }))
 
+// 監査指摘11（P2）「開いたドリルダウンパネルが無期限に古くなる」対応:
+// ports.tsのbroadcastMessage()は既にPOKER_CHASE_SERVICE_EVENTの生payloadへ
+// `handEpoch`（`liveBroadcastSequence`をそのまま積んだもの、詳細はports.ts参照）
+// を積んでいるが、content_script.ts側の`StatsData`型（同ファイル定義）は
+// 別ワークストリームが所有しておりこのフィールドをまだ宣言していない。
+// content_script.tsの転送コード自体は型アサーションを経由するだけで実行時の
+// フィールドを一切削らないため、実行時には確実に載ってくる -- ここでは
+// content_script.tsを変更せず、ローカルに型を拡張して読み取るだけにする。
+type StatsDataWithHandEpoch = StatsData & { handEpoch?: number }
+
 // PlayerStats = ExistPlayerStats | { playerId: -1, statResults?: never[] }（zod union）。
 // ExistPlayerStats.playerId は z.number()（リテラルでない）なので、TSの標準的な
 // `stat.playerId !== -1` だけでは判別共用体として綺麗に絞り込まれない
@@ -77,6 +87,13 @@ const App = memo(() => {
   // への永続化はv1では不要）。#128のポジション別ドリルダウンの単一state管理を
   // 拡張し、パネル種別を持たせることで両パネルを互いに排他にしている。
   const [openPanel, setOpenPanel] = useState<{ playerId: number, kind: 'positional' | 'recentHands' } | null>(null)
+  // 監査指摘11（P2）対応: 生きたハンドが1件完了するたびに増える「hand epoch」
+  // （ports.tsの`liveBroadcastSequence`をそのまま反映、上のStatsDataWithHandEpoch
+  // 参照）。Hud経由でドリルダウンパネルへpropとして渡し、そのフェッチeffectの
+  // depsに含めることで、開いたままのパネルがハンド完了ごとに1回だけ再フェッチ
+  // するようにする（実況の1アクションごとの更新では変化しないため再フェッチ
+  // ストームは起きない）。
+  const [handEpoch, setHandEpoch] = useState(0)
 
   const handleTogglePositionalPanel = useCallback((playerId: number) => {
     setOpenPanel(prev => (prev?.kind === 'positional' && prev.playerId === playerId) ? null : { playerId, kind: 'positional' })
@@ -112,6 +129,16 @@ const App = memo(() => {
   const handleStatsMessage = useCallback(
     ({ detail }: CustomEvent<StatsData>) => {
       let mappedStats = detail.stats
+
+      // 監査指摘11（P2）対応: ports.tsが積んだhandEpochをそのまま状態へ反映する。
+      // 実況の1アクションごとの更新（realTimeStatsのみの配信）ではports.ts側で
+      // 値が据え置かれるため、setStateはされても値としては変化せず、開いた
+      // パネルの再フェッチeffectは発火しない -- 生きたハンドが1件完了した
+      // ときだけports.tsがこの値をインクリメントする。
+      const incomingHandEpoch = (detail as StatsDataWithHandEpoch).handEpoch
+      if (incomingHandEpoch !== undefined) {
+        setHandEpoch(incomingHandEpoch)
+      }
 
       // Update real-time stats if available
       if (detail.realTimeStats) {
@@ -665,6 +692,7 @@ const App = memo(() => {
               onTogglePositionalPanel={() => handleTogglePositionalPanel(position.stat.playerId)}
               isRecentHandsPanelOpen={openPanel?.kind === 'recentHands' && openPanel.playerId === position.stat.playerId}
               onToggleRecentHandsPanel={() => handleToggleRecentHandsPanel(position.stat.playerId)}
+              handEpoch={handEpoch}
               hudDisplayMode={uiConfig.hudDisplayMode}
               hudColorCoding={uiConfig.hudColorCoding}
               isDimmed={dimmedSeatIndices.has(position.actualSeatIndex)}

--- a/src/components/Hud.test.tsx
+++ b/src/components/Hud.test.tsx
@@ -583,6 +583,109 @@ describe('Hud', () => {
     })
   })
 
+  describe('handEpoch — 開いたドリルダウンパネルの再フェッチ（監査指摘11、P2）', () => {
+    it('statが同一でもhandEpochが変わればパネルが再フェッチする（memoのカスタム比較関数を素通りしない）', async () => {
+      let callCount = 0
+      ;(chrome.runtime.sendMessage as jest.Mock).mockImplementation(
+        (_message: unknown, callback: (response: unknown) => void) => {
+          callCount++
+          callback({
+            success: true,
+            positionalStats: {
+              computedAt: Date.now(),
+              positions: [
+                { position: 0, handsN: callCount, stats: { vpip: [3, 12], pfr: [2, 12], '3bet': [0, 5], steal: [0, 0], foldToSteal: [0, 0], cbet: [0, 0] } },
+              ],
+            },
+          })
+        }
+      )
+
+      // statもactualSeatIndexも一切変えない再レンダーだけで、Hudのカスタムmemo
+      // 比較関数が「statResultsが同一なので再レンダー不要」と誤って早期returnし、
+      // パネル側に新しいhandEpochが届かない…という回帰を防ぐテスト。
+      const { rerender } = render(
+        <Hud
+          actualSeatIndex={0}
+          stat={mockPlayerStats}
+          scale={1}
+          statDisplayConfigs={mockStatDisplayConfigs}
+          onTogglePositionalPanel={jest.fn()}
+          isPositionalPanelOpen={true}
+          handEpoch={1}
+        />
+      )
+
+      await waitFor(() => {
+        expect(chrome.runtime.sendMessage).toHaveBeenCalledTimes(1)
+      })
+
+      // 実況の1アクションごとの更新はhandEpochを変えない想定 -- 同じepochでの
+      // 再レンダーは再フェッチを引き起こさない。
+      rerender(
+        <Hud
+          actualSeatIndex={0}
+          stat={mockPlayerStats}
+          scale={1}
+          statDisplayConfigs={mockStatDisplayConfigs}
+          onTogglePositionalPanel={jest.fn()}
+          isPositionalPanelOpen={true}
+          handEpoch={1}
+        />
+      )
+      expect(chrome.runtime.sendMessage).toHaveBeenCalledTimes(1)
+
+      // ハンドが1件完了してhandEpochが増える(statは不変)
+      rerender(
+        <Hud
+          actualSeatIndex={0}
+          stat={mockPlayerStats}
+          scale={1}
+          statDisplayConfigs={mockStatDisplayConfigs}
+          onTogglePositionalPanel={jest.fn()}
+          isPositionalPanelOpen={true}
+          handEpoch={2}
+        />
+      )
+
+      await waitFor(() => {
+        expect(chrome.runtime.sendMessage).toHaveBeenCalledTimes(2)
+      })
+    })
+
+    it('パネルが閉じている座席ではhandEpochの変化だけで再レンダー(sendMessage)を起こさない', () => {
+      (chrome.runtime.sendMessage as jest.Mock).mockClear()
+
+      const { rerender } = render(
+        <Hud
+          actualSeatIndex={0}
+          stat={mockPlayerStats}
+          scale={1}
+          statDisplayConfigs={mockStatDisplayConfigs}
+          onTogglePositionalPanel={jest.fn()}
+          isPositionalPanelOpen={false}
+          handEpoch={1}
+        />
+      )
+      expect(screen.queryByTestId('positional-stats-panel')).not.toBeInTheDocument()
+
+      rerender(
+        <Hud
+          actualSeatIndex={0}
+          stat={mockPlayerStats}
+          scale={1}
+          statDisplayConfigs={mockStatDisplayConfigs}
+          onTogglePositionalPanel={jest.fn()}
+          isPositionalPanelOpen={false}
+          handEpoch={2}
+        />
+      )
+
+      expect(screen.queryByTestId('positional-stats-panel')).not.toBeInTheDocument()
+      expect(chrome.runtime.sendMessage).not.toHaveBeenCalled()
+    })
+  })
+
   describe('コンパクト表示モード（#143）', () => {
     it('hudDisplayModeを渡さない場合はフルの16統計グリッドのまま（ゼロリグレッション）', () => {
       render(

--- a/src/components/Hud.tsx
+++ b/src/components/Hud.tsx
@@ -42,6 +42,12 @@ interface HudProps {
   isRecentHandsPanelOpen?: boolean
   /** 直近ハンド・ドリルダウンパネルの開閉トグル。渡された時のみヘッダーにトリガーを表示する */
   onToggleRecentHandsPanel?: () => void
+  /**
+   * 生きたハンドが1件完了するたびに増える「hand epoch」（App.tsx参照、監査指摘11
+   * P2対応）。ドリルダウンパネル（PositionalStatsPanel/RecentHandsPanel）へ
+   * そのまま渡し、開いている間の再フェッチトリガーに使う。
+   */
+  handEpoch?: number
   /** HUD表示密度。'full'（デフォルト、既存の16統計グリッド）または'compact'（クラシックHUDライン）。UIConfig.hudDisplayMode参照 */
   hudDisplayMode?: 'full' | 'compact'
   /** しきい値ベースの値カラーリング（compact/full両モード共通）。UIConfig.hudColorCoding参照 */
@@ -366,10 +372,10 @@ const Hud = memo((props: HudProps) => {
             <span style={{ color: '#888888', fontSize: '9px' }}>No Data</span>
           </div>
           {props.isPositionalPanelOpen && (
-            <PositionalStatsPanel playerId={props.stat.playerId} />
+            <PositionalStatsPanel playerId={props.stat.playerId} handEpoch={props.handEpoch} />
           )}
           {props.isRecentHandsPanelOpen && (
-            <RecentHandsPanel playerId={props.stat.playerId} />
+            <RecentHandsPanel playerId={props.stat.playerId} handEpoch={props.handEpoch} />
           )}
         </div>
       </div>
@@ -423,10 +429,10 @@ const Hud = memo((props: HudProps) => {
             <StatDisplay displayStats={gridDisplayStats} formatValue={formatStatValue} colorCoding={hudColorCoding} />
           )}
           {props.isPositionalPanelOpen && (
-            <PositionalStatsPanel playerId={props.stat.playerId} />
+            <PositionalStatsPanel playerId={props.stat.playerId} handEpoch={props.handEpoch} />
           )}
           {props.isRecentHandsPanelOpen && (
-            <RecentHandsPanel playerId={props.stat.playerId} />
+            <RecentHandsPanel playerId={props.stat.playerId} handEpoch={props.handEpoch} />
           )}
         </div>
       </div>
@@ -441,6 +447,12 @@ const Hud = memo((props: HudProps) => {
   if (prevProps.hudDisplayMode !== nextProps.hudDisplayMode) return false
   if (prevProps.hudColorCoding !== nextProps.hudColorCoding) return false
   if (prevProps.isDimmed !== nextProps.isDimmed) return false
+  // handEpoch (audit finding 11, P2): only forces a re-render while one of this
+  // seat's drill-down panels is actually open -- an open panel needs the fresh
+  // handEpoch prop to reach its fetch effect's deps so it refetches once per
+  // completed hand, but bumping it on every hand would otherwise re-render all 6
+  // closed-panel Huds for nothing.
+  if ((nextProps.isPositionalPanelOpen || nextProps.isRecentHandsPanelOpen) && prevProps.handEpoch !== nextProps.handEpoch) return false
   // statDisplayConfigs governs which stats reach the full grid
   // (filterEnabledDisplayStats) -- a config change must re-render even if
   // statResults itself is unchanged.

--- a/src/components/hud/PositionalStatsPanel.test.tsx
+++ b/src/components/hud/PositionalStatsPanel.test.tsx
@@ -197,4 +197,39 @@ describe('PositionalStatsPanel', () => {
       expect.any(Function)
     )
   })
+
+  // 監査指摘11（P2）「開いたドリルダウンパネルが無期限に古くなる」対応:
+  // playerIdが同じままでもhandEpochが変わればフェッチeffectを再発火する。
+  it('playerIdが同じでもhandEpochが変わると再フェッチする(監査指摘11)', async () => {
+    let callCount = 0
+    mockSendMessage.mockImplementation((_message: unknown, callback: (response: unknown) => void) => {
+      callCount++
+      const result = buildResult()
+      // 2回目の応答は1回目と区別できるようBTNのhandsNを変える
+      if (callCount === 2) {
+        result.positions.find(p => p.position === Position.BTN)!.handsN = 99
+      }
+      callback({ success: true, positionalStats: result })
+    })
+
+    const { rerender } = render(<PositionalStatsPanel playerId={1} handEpoch={1} />)
+    await waitFor(() => screen.getByText('BTN'))
+    expect(mockSendMessage).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('BTN').closest('tr')).toHaveTextContent('42')
+
+    // 実況の1アクションごとの更新はhandEpochを変えない想定 -- 同じepochでの
+    // 再レンダーは再フェッチを引き起こさない。
+    rerender(<PositionalStatsPanel playerId={1} handEpoch={1} />)
+    expect(mockSendMessage).toHaveBeenCalledTimes(1)
+
+    // ハンドが1件完了してhandEpochが増える
+    rerender(<PositionalStatsPanel playerId={1} handEpoch={2} />)
+
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalledTimes(2)
+    })
+    await waitFor(() => {
+      expect(screen.getByText('BTN').closest('tr')).toHaveTextContent('99')
+    })
+  })
 })

--- a/src/components/hud/PositionalStatsPanel.tsx
+++ b/src/components/hud/PositionalStatsPanel.tsx
@@ -7,6 +7,17 @@ import { sendMessageWithTimeout } from '../popup/send-message'
 
 interface PositionalStatsPanelProps {
   playerId: number
+  /**
+   * 生きたハンドが1件完了するたびに増える「hand epoch」（App.tsx/Hud.tsx参照、
+   * 監査指摘11 P2「開いたドリルダウンパネルが無期限に古くなる」対応）。
+   * playerIdと一緒にフェッチeffectのdepsへ入れることで、このパネルを開いた
+   * ままにしていても新しいハンドが終わるたびに1回だけ再フェッチする
+   * （実況の1アクションごとの更新ではこの値は変化しないため再フェッチ
+   * ストームは起きない）。バックエンド側の30秒キャッシュも同じイベントで
+   * 無効化される（positional-stats-service.tsのsubscribeToHandCompletion参照）
+   * ので、この再フェッチは古いキャッシュ結果を受け取らない。
+   */
+  handEpoch?: number
 }
 
 type FetchStatus = 'loading' | 'ready' | 'error'
@@ -95,7 +106,7 @@ const styles = {
  * タイムアウト・chrome.runtime.lastError・success:falseのいずれも
  * フェイルオープンでエラープレースホルダーへ倒す。HUDをクラッシュさせない（#127踏襲）。
  */
-export const PositionalStatsPanel = memo(({ playerId }: PositionalStatsPanelProps) => {
+export const PositionalStatsPanel = memo(({ playerId, handEpoch }: PositionalStatsPanelProps) => {
   const [status, setStatus] = useState<FetchStatus>('loading')
   const [data, setData] = useState<PositionalStatsResult | undefined>(undefined)
 
@@ -122,7 +133,10 @@ export const PositionalStatsPanel = memo(({ playerId }: PositionalStatsPanelProp
     return () => {
       cancelled = true
     }
-  }, [playerId])
+    // handEpoch: 監査指摘11(P2)対応。値が変わるのは生きたハンドが1件完了した
+    // ときだけ（App.tsx/ports.ts参照）なので、このパネルを開いたままにしていても
+    // 最新のハンドを反映して再フェッチする。
+  }, [playerId, handEpoch])
 
   if (status === 'loading') {
     return (

--- a/src/components/hud/RecentHandsPanel.test.tsx
+++ b/src/components/hud/RecentHandsPanel.test.tsx
@@ -194,6 +194,42 @@ describe('RecentHandsPanel', () => {
       expect.any(Function)
     )
   })
+
+  // 監査指摘11（P2）「開いたドリルダウンパネルが無期限に古くなる」対応:
+  // playerIdが同じままでもhandEpochが変わればフェッチeffectを再発火する。
+  it('playerIdが同じでもhandEpochが変わると再フェッチする(監査指摘11)', async () => {
+    let callCount = 0
+    mockSendMessage.mockImplementation((_message: unknown, callback: (response: unknown) => void) => {
+      callCount++
+      // 2回目の応答は1回目と区別できるよう新しいハンドを1件追加する
+      // （新しいハンドが完了して初めて反映されるべきデータ）
+      const result = callCount === 2
+        ? buildResult({ hands: [{ handId: 4, approxTimestamp: NOW, position: Position.CO, holeCards: null, preflopLine: 'Open', sawFlop: false, wentToShowdown: false, won: false, netChips: null }, ...buildResult().hands] })
+        : buildResult()
+      callback({ success: true, recentHands: result })
+    })
+
+    const { rerender } = render(<RecentHandsPanel playerId={1} handEpoch={1} />)
+    await waitFor(() => {
+      expect(screen.getAllByTestId('recent-hands-row')).toHaveLength(3)
+    })
+    expect(mockSendMessage).toHaveBeenCalledTimes(1)
+
+    // 実況の1アクションごとの更新はhandEpochを変えない想定 -- 同じepochでの
+    // 再レンダーは再フェッチを引き起こさない。
+    rerender(<RecentHandsPanel playerId={1} handEpoch={1} />)
+    expect(mockSendMessage).toHaveBeenCalledTimes(1)
+
+    // ハンドが1件完了してhandEpochが増える
+    rerender(<RecentHandsPanel playerId={1} handEpoch={2} />)
+
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalledTimes(2)
+    })
+    await waitFor(() => {
+      expect(screen.getAllByTestId('recent-hands-row')).toHaveLength(4)
+    })
+  })
 })
 
 describe('formatRelativeTime', () => {

--- a/src/components/hud/RecentHandsPanel.tsx
+++ b/src/components/hud/RecentHandsPanel.tsx
@@ -8,6 +8,17 @@ import { isRedSuit } from '../../utils/card-utils'
 
 interface RecentHandsPanelProps {
   playerId: number
+  /**
+   * 生きたハンドが1件完了するたびに増える「hand epoch」（App.tsx/Hud.tsx参照、
+   * 監査指摘11 P2「開いたドリルダウンパネルが無期限に古くなる」対応）。
+   * playerIdと一緒にフェッチeffectのdepsへ入れることで、このパネルを開いた
+   * ままにしていても新しいハンドが終わるたびに1回だけ再フェッチする
+   * （実況の1アクションごとの更新ではこの値は変化しないため再フェッチ
+   * ストームは起きない）。バックエンド側の30秒キャッシュも同じイベントで
+   * 無効化される（recent-hands-service.tsのsubscribeToHandCompletion参照）
+   * ので、この再フェッチは古いキャッシュ結果を受け取らない。
+   */
+  handEpoch?: number
 }
 
 type FetchStatus = 'loading' | 'ready' | 'error'
@@ -119,7 +130,7 @@ const styles = {
  * タイムアウト・chrome.runtime.lastError・success:falseのいずれも
  * フェイルオープンでエラープレースホルダーへ倒す。HUDをクラッシュさせない（#127踏襲）。
  */
-export const RecentHandsPanel = memo(({ playerId }: RecentHandsPanelProps) => {
+export const RecentHandsPanel = memo(({ playerId, handEpoch }: RecentHandsPanelProps) => {
   const [status, setStatus] = useState<FetchStatus>('loading')
   const [data, setData] = useState<RecentHandsResult | undefined>(undefined)
 
@@ -146,7 +157,10 @@ export const RecentHandsPanel = memo(({ playerId }: RecentHandsPanelProps) => {
     return () => {
       cancelled = true
     }
-  }, [playerId])
+    // handEpoch: 監査指摘11(P2)対応。値が変わるのは生きたハンドが1件完了した
+    // ときだけ（App.tsx/ports.ts参照）なので、このパネルを開いたままにしていても
+    // 最新のハンドを反映して再フェッチする。
+  }, [playerId, handEpoch])
 
   if (status === 'loading') {
     return (

--- a/src/services/poker-chase-service.ts
+++ b/src/services/poker-chase-service.ts
@@ -392,6 +392,17 @@ class PokerChaseService {
   }
   readonly db
   readonly handAggregateStream: AggregateEventsStream      // Entry point for all events and groups events by hand
+  // Persists hand entities to DB; 'data' fires exactly once per genuinely-completed
+  // AND successfully-persisted hand (write-entity-stream.ts's `this.push(hand.
+  // seatUserIds)`, reached only via the live pipeline below -- chimera hands return
+  // early without pushing). Exposed (rather than kept as a local constructor
+  // variable) specifically so ports.ts/positional-stats-service.ts/
+  // recent-hands-service.ts can subscribe to this as the one true "hand completion"
+  // signal -- unlike statsOutputStream's 'data', which also fires for the hand-start
+  // warmup broadcast and filter-change/import/auto-sync-restore rebroadcasts (audit
+  // finding 11 follow-up, P2; see ports.ts's handCompletionEpoch doc comment for the
+  // full enumeration of those other call sites).
+  readonly writeEntityStream: WriteEntityStream
   readonly statsOutputStream: ReadEntityStream             // Calculates and outputs stats
   readonly handLogStream: HandLogStream                    // Real-time hand log display
   readonly realTimeStatsStream: RealTimeStatsStream        // Real-time stats for hero only
@@ -410,9 +421,9 @@ class PokerChaseService {
     this.realTimeStatsStream = new RealTimeStatsStream()
 
     // Main pipeline for stats calculation
-    const writeStream = new WriteEntityStream(this)
+    this.writeEntityStream = new WriteEntityStream(this)
     this.handAggregateStream
-      .pipe<WriteEntityStream>(writeStream)
+      .pipe<WriteEntityStream>(this.writeEntityStream)
       .pipe<ReadEntityStream>(this.statsOutputStream)
   }
   readonly setBattleTypeFilter = async (filterOptions: FilterOptions) => {

--- a/src/services/positional-stats-service.test.ts
+++ b/src/services/positional-stats-service.test.ts
@@ -446,5 +446,59 @@ describe('PositionalStatsService', () => {
       // itself, from makeMinimalHandEvents) are both now reflected.
       expect(afterHandCompletion.positions.reduce((sum, p) => sum + p.handsN, 0)).toBe(12)
     })
+
+    // 監査finding 11フォローアップ・pass-3（P2、codexレビュー指摘）: 進行中フェッチが
+    // ハンド完了後にキャッシュへ古い結果を書き込んでしまうレース。
+    // `db.hands.where(...).toArray()`をゲート（実データは即座に読むが、Promiseの
+    // 解決だけをテストが手動で制御するまで遅らせる）して、「DB読み取り中に
+    // ハンドが完了する」という進行中フェッチの状態を確定的に再現する。
+    test('an in-flight fetch resolving after a hand completes does NOT fill the cache with a stale result', async () => {
+      process.env.NODE_ENV = 'production' // enable the real 30s cache path (disabled under 'test')
+
+      let releaseGate!: () => void
+      const gate = new Promise<void>(resolve => { releaseGate = resolve })
+      const realWhere = db.hands.where.bind(db.hands)
+      jest.spyOn(db.hands, 'where').mockImplementationOnce((indexName: any) => {
+        const whereClause: any = realWhere(indexName)
+        const realEquals = whereClause.equals.bind(whereClause)
+        whereClause.equals = (value: any) => {
+          const collection: any = realEquals(value)
+          const realToArray = collection.toArray.bind(collection)
+          collection.toArray = async () => {
+            const data = await realToArray() // captures the real (pre-completion) snapshot immediately
+            await gate // ...but withholds it from the caller until the test releases it
+            return data
+          }
+          return collection
+        }
+        return whereClause
+      })
+
+      // Starts the fetch; its `db.hands...toArray()` call is now blocked on `gate`
+      // (cache miss, since nothing has been cached in this test yet -- fetchGeneration
+      // is captured before this call, per getPositionalStats()'s own doc comment).
+      const inFlightFetch = getPositionalStats(db, service, PLAYER_ID)
+
+      // A genuine hand completes WHILE the fetch above is still blocked mid-read.
+      await new Promise<void>(resolve => {
+        service.writeEntityStream.once('data', () => resolve())
+        service.writeEntityStream.write(makeMinimalHandEvents(11, [1, 2, 3]))
+      })
+
+      // Now let the blocked fetch resolve -- with the snapshot it captured BEFORE
+      // hand 11 completed (10 hands).
+      releaseGate()
+      const staleResult = await inFlightFetch
+      expect(staleResult.positions.reduce((sum, p) => sum + p.handsN, 0)).toBe(10)
+
+      // The bug this guards against: cache.set(cacheKey, { result: staleResult, ... })
+      // would have run here unconditionally, planting a stale fill that a subsequent
+      // same-key call (the handEpoch-triggered refetch for an open panel) would then
+      // serve for the rest of the 30s window. Assert it recomputes instead and
+      // reflects hand 11.
+      const afterRace = await getPositionalStats(db, service, PLAYER_ID)
+      expect(afterRace).not.toBe(staleResult)
+      expect(afterRace.positions.reduce((sum, p) => sum + p.handsN, 0)).toBe(11)
+    })
   })
 })

--- a/src/services/positional-stats-service.test.ts
+++ b/src/services/positional-stats-service.test.ts
@@ -18,8 +18,51 @@ import { PokerChaseDB } from '../db/poker-chase-db'
 import PokerChaseService from './poker-chase-service'
 import { getPositionalStats, clearPositionalStatsCache, buildCacheKey } from './positional-stats-service'
 import { ActionDetail, ActionType, BattleType, PhaseType, Position } from '../types/game'
+import { ApiType } from '../types'
+import type { ApiHandEvent } from '../types'
 import type { Action, Hand } from '../types/entities'
 import type { PositionalStatsBucketId } from '../types/stats'
+
+/** Minimal valid EVT_DEAL + EVT_HAND_RESULTS pair for one hand -- enough for
+ * WriteEntityStream.toHandState() to accept it and persist a real hand (not
+ * rejected as a chimera), so `service.writeEntityStream`'s 'data' fires for real.
+ * Mirrors aggregate-events-stream.test.ts's fixture style. Used only to drive the
+ * genuine hand-completion signal in the "real backend cache" tests below -- not
+ * part of the hand-bucketing fixtures above (which intentionally bypass this
+ * pipeline, per the file header). */
+function makeMinimalHandEvents(handId: number, seatUserIds: [number, number, number]): ApiHandEvent[] {
+  return [
+    {
+      ApiTypeId: ApiType.EVT_DEAL,
+      SeatUserIds: seatUserIds,
+      Game: { CurrentBlindLv: 1, NextBlindUnixSeconds: 0, Ante: 0, SmallBlind: 100, BigBlind: 200, ButtonSeat: 0, SmallBlindSeat: 1, BigBlindSeat: 2 },
+      Player: { SeatIndex: 0, BetStatus: 1, HoleCards: [0, 1], Chip: 5000, BetChip: 0 },
+      OtherPlayers: [
+        { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 100, IsSafeLeave: false },
+        { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 200, IsSafeLeave: false },
+      ],
+      Progress: { Phase: 0, NextActionSeat: 0, NextActionTypes: [2, 3, 4, 5], NextExtraLimitSeconds: 1, MinRaise: 400, Pot: 300, SidePot: [] },
+      timestamp: handId * 1000,
+    },
+    {
+      ApiTypeId: ApiType.EVT_HAND_RESULTS,
+      CommunityCards: [],
+      Pot: 300,
+      SidePot: [],
+      ResultType: 0,
+      DefeatStatus: 0,
+      HandId: handId,
+      HandLog: '',
+      Results: [{ UserId: seatUserIds[0], HoleCards: [], RankType: 10, Hands: [], HandRanking: 1, Ranking: -2, RewardChip: 300 }],
+      Player: { SeatIndex: 0, BetStatus: -1, Chip: 5000, BetChip: 0 },
+      OtherPlayers: [
+        { SeatIndex: 1, Status: 0, BetStatus: -1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+        { SeatIndex: 2, Status: 0, BetStatus: -1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+      ],
+      timestamp: handId * 1000 + 1,
+    },
+  ]
+}
 
 const PLAYER_ID = 1
 
@@ -372,18 +415,36 @@ describe('PositionalStatsService', () => {
       expect(stillCached).toBe(first) // same cached object reference -- proves caching is actually live here
       expect(stillCached.positions.reduce((sum, p) => sum + p.handsN, 0)).toBe(10) // hand 11 not yet reflected
 
-      // A real live hand completion. getPositionalStats() self-subscribes to this
-      // same stream (subscribeToHandCompletion, module-level above) the first time
-      // it's called for a given service instance, independent of the front-end
-      // hand-epoch plumbing (App.tsx/Hud.tsx/ports.ts).
+      // A hand-start-warmup/filter-change/import-shaped rebroadcast (direct
+      // statsOutputStream.write(), the same call aggregate-events-stream.ts's EVT_DEAL
+      // warmup branch and message-router.ts's updateBattleTypeFilter/
+      // recalculateStats() make) must NOT invalidate the cache -- audit finding 11
+      // follow-up (P2, codex review): a first pass subscribed to statsOutputStream,
+      // which also fires for these non-completion broadcasts.
       await new Promise<void>(resolve => {
         service.statsOutputStream.once('data', () => resolve())
         service.statsOutputStream.write([1, 2, 3])
       })
+      const stillCachedAfterNonCompletionBroadcast = await getPositionalStats(db, service, PLAYER_ID)
+      expect(stillCachedAfterNonCompletionBroadcast).toBe(first) // still the same stale cached object
+
+      // A real live hand completion, through the actual live pipeline
+      // (handAggregateStream isn't needed here -- writeEntityStream is the direct
+      // target of that pipe and the one true completion signal, see its doc comment
+      // and ports.ts's handCompletionEpoch). getPositionalStats() self-subscribes to
+      // this stream (subscribeToHandCompletion, module-level above) the first time
+      // it's called for a given service instance, independent of the front-end
+      // hand-epoch plumbing (App.tsx/Hud.tsx/ports.ts).
+      await new Promise<void>(resolve => {
+        service.writeEntityStream.once('data', () => resolve())
+        service.writeEntityStream.write(makeMinimalHandEvents(12, [1, 2, 3]))
+      })
 
       const afterHandCompletion = await getPositionalStats(db, service, PLAYER_ID)
       expect(afterHandCompletion).not.toBe(first) // recomputed, not served from the now-stale cache
-      expect(afterHandCompletion.positions.reduce((sum, p) => sum + p.handsN, 0)).toBe(11) // hand 11 now included
+      // hand 11 (seeded directly above) AND hand 12 (persisted by writeEntityStream
+      // itself, from makeMinimalHandEvents) are both now reflected.
+      expect(afterHandCompletion.positions.reduce((sum, p) => sum + p.handsN, 0)).toBe(12)
     })
   })
 })

--- a/src/services/positional-stats-service.test.ts
+++ b/src/services/positional-stats-service.test.ts
@@ -341,4 +341,49 @@ describe('PositionalStatsService', () => {
       expect(keyFull).toBe(keyFullAgain) // same filter state -> same key (stable, cache-hit-able)
     })
   })
+
+  // 監査指摘11（P2）「開いたドリルダウンパネルが無期限に古くなる」対応: 上の全テストは
+  // NODE_ENV=test下でこの関数の30秒キャッシュ自体を無効化してもらっているため
+  // （`useCache`参照）、実際にキャッシュが効いている状態での「新しいハンドが
+  // 終わったら古いキャッシュを返さない」という不変条件はどのテストも検証していない
+  // （監査で指摘された「テストが実キャッシュの陳腐化を一度も検証していない」点）。
+  // ここではNODE_ENVを一時的に上書きしてキャッシュを実際に有効化し、
+  // `service.statsOutputStream`（ports.tsがhandEpochをインクリメントするのと
+  // 同じ、生のハンド完了イベント）が発火した後の呼び出しがキャッシュに
+  // ヒットしないことを直接確認する。
+  describe('real backend cache (audit finding 11, P2): hand completion rotates the 30s cache', () => {
+    const originalNodeEnv = process.env.NODE_ENV
+
+    afterEach(() => {
+      process.env.NODE_ENV = originalNodeEnv
+    })
+
+    test('a same-key call is served from cache until a live hand completes, then recomputes', async () => {
+      process.env.NODE_ENV = 'production' // enable the real 30s cache path (disabled under 'test')
+
+      const first = await getPositionalStats(db, service, PLAYER_ID)
+      expect(first.positions.reduce((sum, p) => sum + p.handsN, 0)).toBe(10)
+
+      // Seed an 11th hand -- with the cache alone (no invalidation), a same-key call
+      // within the 30s window would still return `first` unchanged.
+      await db.hands.add(makeHand({ id: 11, bigBlindUserId: 2, seatUserIds: [1, 2, 3] }))
+
+      const stillCached = await getPositionalStats(db, service, PLAYER_ID)
+      expect(stillCached).toBe(first) // same cached object reference -- proves caching is actually live here
+      expect(stillCached.positions.reduce((sum, p) => sum + p.handsN, 0)).toBe(10) // hand 11 not yet reflected
+
+      // A real live hand completion. getPositionalStats() self-subscribes to this
+      // same stream (subscribeToHandCompletion, module-level above) the first time
+      // it's called for a given service instance, independent of the front-end
+      // hand-epoch plumbing (App.tsx/Hud.tsx/ports.ts).
+      await new Promise<void>(resolve => {
+        service.statsOutputStream.once('data', () => resolve())
+        service.statsOutputStream.write([1, 2, 3])
+      })
+
+      const afterHandCompletion = await getPositionalStats(db, service, PLAYER_ID)
+      expect(afterHandCompletion).not.toBe(first) // recomputed, not served from the now-stale cache
+      expect(afterHandCompletion.positions.reduce((sum, p) => sum + p.handsN, 0)).toBe(11) // hand 11 now included
+    })
+  })
 })

--- a/src/services/positional-stats-service.ts
+++ b/src/services/positional-stats-service.ts
@@ -66,10 +66,31 @@ const cache: Map<string, { result: PositionalStatsResult, timestamp: number }> =
 // epochを積んでcacheKeyを回転させる案は、その配線がmessage-router.ts
 // （別ワークストリームが所有）を経由する必要があり本タスクのスコープ外。
 // 代わりに、この関数が既に受け取っている`service`引数（PokerChaseService）
-// が公開する`statsOutputStream`（ports.tsが生アクティブなハンド完了ごとに
-// 'data'を発火させ、`liveBroadcastSequence`をインクリメントしているのと
-// 全く同じイベント -- ports.ts参照）に直接購読する。これでbackground.ts/
+// が公開する`writeEntityStream`に直接購読する。これでbackground.ts/
 // ports.ts/content_script.ts/message-router.tsのいずれにも触れずに完結する。
+//
+// `statsOutputStream`ではなく`writeEntityStream`である理由（audit finding 11の
+// フォローアップ、P2、codexレビュー指摘）: 当初`statsOutputStream`の'data'に
+// 購読していたが、このイベントはハンド完了時だけでなく、(1)新しいハンド開始時
+// （EVT_DEAL）にDBへ既存ハンドがあれば毎回発火する「ウォームアップ」ブロード
+// キャスト（aggregate-events-stream.ts）、(2)フィルター変更・インポート/
+// リビルド・auto-sync復元時の明示的な再計算（message-router.ts、
+// import-export.ts、poker-chase-service.tsのrecalculateStats/
+// recalculateAllStats、auto-sync-service.ts。いずれも`statsOutputStream.write()`
+// を直接呼ぶ）でも発火する。これらは「ハンドが1件完了した」わけではないため、
+// このタイミングでキャッシュを無効化すると、開いたパネルの再フェッチが
+// 起きていないのに無駄にキャッシュだけ消える（逆に、フィルター変更直後の
+// 再フェッチではまだ古いキャッシュを消してほしいのに、handEpoch自体は
+// 変わらないため再フェッチ自体が起きない、というズレも生む）。
+// `writeEntityStream`の'data'は`write-entity-stream.ts`の
+// `this.push(hand.seatUserIds)`からのみ発火し、これは生きたポート経由の
+// イベント取り込み（event-ingestion.ts→handAggregateStream）だけがたどる
+// パイプラインで、かつハンドが実際にDBへ書き込まれた後にのみ届く
+// （キメラハンドはpushされずreturnする）。ports.tsのhandCompletionEpochと
+// 全く同じ完了限定シグナルであり、frontend側のhandEpoch（App.tsx/
+// Hud.tsx経由でこのパネルのフェッチeffectのdepsに入る値）が実際に変化する
+// タイミングとキャッシュ無効化のタイミングを揃えられる。
+//
 // 購読はサービスインスタンスごとに一度だけ（WeakSetで冪等化、テストごとに
 // 新しいPokerChaseServiceインスタンスが作られるため明示的な解除は不要 --
 // 古いインスタンスがGCされればリスナーごと消える）。
@@ -82,7 +103,7 @@ const subscribedServices = new WeakSet<PokerChaseService>()
 function subscribeToHandCompletion(service: PokerChaseService): void {
   if (subscribedServices.has(service)) return
   subscribedServices.add(service)
-  service.statsOutputStream.on('data', () => {
+  service.writeEntityStream.on('data', () => {
     clearPositionalStatsCache()
   })
 }

--- a/src/services/positional-stats-service.ts
+++ b/src/services/positional-stats-service.ts
@@ -54,6 +54,25 @@ const CACHE_DURATION_MS = 30_000
 const MAX_CACHE_SIZE = 50
 const cache: Map<string, { result: PositionalStatsResult, timestamp: number }> = new Map()
 
+// 監査finding 11フォローアップ・pass-3（P2、codexレビュー指摘）: 「進行中フェッチが
+// 完了後キャッシュへ古い結果を書き込んでしまう」レース対応。
+//
+// 上のsubscribeToHandCompletion()によるcache.clear()だけでは不十分だった:
+// (1) 進行中のgetPositionalStats()呼び出しがDB読み取り中（awaitで中断中）、
+// (2) その最中に生きたハンドが1件完了してこのリスナーが発火しcache.clear()、
+// (3) しかし(1)の呼び出しはキャンセルされずそのまま続行し、完了前のDB状態を基に
+//     計算した結果でcache.set()を実行してしまう。
+// これにより、直後（bumpされたhandEpochによる）オープンパネルの再フェッチが
+// この「完了直後に書き込まれた古い結果」にヒットし、30秒間ずっと新しいハンドを
+// 反映しないまま古いデータを表示し続けてしまう。
+//
+// 対応: 各フェッチをその開始時点のcacheGeneration値でスタンプし（下の
+// getPositionalStats()冒頭参照）、書き込み時に現在値と比較する -- フェッチ中に
+// ハンドが完了して世代が進んでいれば、計算結果は呼び出し元にはそのまま返す
+// （呼び出された時点では最新の正しい答え）が、キャッシュへの書き込みはスキップ
+// する（未来の呼び出しを汚染させない）。
+let cacheGeneration = 0
+
 // 監査指摘11（P2）「開いたドリルダウンパネルが無期限に古くなる」対応:
 // RecentHandsPanel/PositionalStatsPanelのフェッチeffectはApp.tsxから渡される
 // 「hand epoch」propをdepsに含めるようになり、生きたハンドが1件完了するたびに
@@ -104,6 +123,7 @@ function subscribeToHandCompletion(service: PokerChaseService): void {
   if (subscribedServices.has(service)) return
   subscribedServices.add(service)
   service.writeEntityStream.on('data', () => {
+    cacheGeneration++
     clearPositionalStatsCache()
   })
 }
@@ -164,6 +184,9 @@ export async function getPositionalStats(
   playerId: number
 ): Promise<PositionalStatsResult> {
   subscribeToHandCompletion(service)
+  // このフェッチ開始時点のgeneration -- 下の2箇所のcache.set()で、フェッチ中に
+  // ハンド完了(cacheGeneration++)が割り込んでいないか照合する（上のコメント参照）。
+  const fetchGeneration = cacheGeneration
 
   const cacheKey = buildCacheKey(playerId, service)
   const useCache = process.env.NODE_ENV !== 'test' && !process.env.DEBUG_NO_CACHE
@@ -210,7 +233,11 @@ export async function getPositionalStats(
   // 区別なく早期returnできる）
   if (allPlayerHands.length === 0) {
     const result = buildEmptyResult()
-    cache.set(cacheKey, { result, timestamp: now })
+    // フェッチ中にハンドが完了していれば(cacheGenerationが進んでいれば)書き込まない
+    // -- 上のコメント参照。呼び出し元にはそのまま最新の結果を返す。
+    if (cacheGeneration === fetchGeneration) {
+      cache.set(cacheKey, { result, timestamp: now })
+    }
     return result
   }
 
@@ -281,11 +308,15 @@ export async function getPositionalStats(
 
   const result: PositionalStatsResult = { positions, computedAt: now }
 
-  cache.set(cacheKey, { result, timestamp: now })
-  if (cache.size > MAX_CACHE_SIZE) {
-    for (const [key, entry] of cache.entries()) {
-      if (now - entry.timestamp > CACHE_DURATION_MS) {
-        cache.delete(key)
+  // フェッチ中にハンドが完了していれば(cacheGenerationが進んでいれば)書き込まない
+  // -- ファイル冒頭のコメント参照。呼び出し元にはそのまま最新の結果を返す。
+  if (cacheGeneration === fetchGeneration) {
+    cache.set(cacheKey, { result, timestamp: now })
+    if (cache.size > MAX_CACHE_SIZE) {
+      for (const [key, entry] of cache.entries()) {
+        if (now - entry.timestamp > CACHE_DURATION_MS) {
+          cache.delete(key)
+        }
       }
     }
   }

--- a/src/services/positional-stats-service.ts
+++ b/src/services/positional-stats-service.ts
@@ -54,6 +54,39 @@ const CACHE_DURATION_MS = 30_000
 const MAX_CACHE_SIZE = 50
 const cache: Map<string, { result: PositionalStatsResult, timestamp: number }> = new Map()
 
+// 監査指摘11（P2）「開いたドリルダウンパネルが無期限に古くなる」対応:
+// RecentHandsPanel/PositionalStatsPanelのフェッチeffectはApp.tsxから渡される
+// 「hand epoch」propをdepsに含めるようになり、生きたハンドが1件完了するたびに
+// 再フェッチする(App.tsx参照)。しかしそれだけでは、この再フェッチが引き続き
+// 「直前と同じcacheKey」に対してこの30秒キャッシュへヒットしてしまい、古い
+// 結果を返し続ける(cacheKeyはplayerId+フィルターのみで、「どのハンドまでの
+// 結果か」を持たない)。
+//
+// 対応方針（プロンプト指定の2案のうち「配線の少ない方」）: メッセージに
+// epochを積んでcacheKeyを回転させる案は、その配線がmessage-router.ts
+// （別ワークストリームが所有）を経由する必要があり本タスクのスコープ外。
+// 代わりに、この関数が既に受け取っている`service`引数（PokerChaseService）
+// が公開する`statsOutputStream`（ports.tsが生アクティブなハンド完了ごとに
+// 'data'を発火させ、`liveBroadcastSequence`をインクリメントしているのと
+// 全く同じイベント -- ports.ts参照）に直接購読する。これでbackground.ts/
+// ports.ts/content_script.ts/message-router.tsのいずれにも触れずに完結する。
+// 購読はサービスインスタンスごとに一度だけ（WeakSetで冪等化、テストごとに
+// 新しいPokerChaseServiceインスタンスが作られるため明示的な解除は不要 --
+// 古いインスタンスがGCされればリスナーごと消える）。
+// 全クリアである理由: 1つのハンドは同卓の複数プレイヤーのハンド履歴/
+// ポジションを同時に更新しうる（そのハンドに参加した全員分）。個別
+// エントリ単位の的確な無効化よりも全クリアの方が単純で、頻度も低い
+// （ハンド完了ごとに高々1回）ためコストは無視できる。
+const subscribedServices = new WeakSet<PokerChaseService>()
+
+function subscribeToHandCompletion(service: PokerChaseService): void {
+  if (subscribedServices.has(service)) return
+  subscribedServices.add(service)
+  service.statsOutputStream.on('data', () => {
+    clearPositionalStatsCache()
+  })
+}
+
 /** Exported for direct unit testing (see positional-stats-service.test.ts) -- caching itself
  * is disabled under NODE_ENV=test (see `useCache` below), so key-differs-when-filter-differs
  * can't be observed behaviorally in tests and is instead pinned down against this function directly. */
@@ -109,6 +142,8 @@ export async function getPositionalStats(
   service: PokerChaseService,
   playerId: number
 ): Promise<PositionalStatsResult> {
+  subscribeToHandCompletion(service)
+
   const cacheKey = buildCacheKey(playerId, service)
   const useCache = process.env.NODE_ENV !== 'test' && !process.env.DEBUG_NO_CACHE
   const now = Date.now()

--- a/src/services/recent-hands-service.test.ts
+++ b/src/services/recent-hands-service.test.ts
@@ -352,4 +352,48 @@ describe('RecentHandsService', () => {
       expect(key1).not.toBe(keyTable)
     })
   })
+
+  // 監査指摘11（P2）「開いたドリルダウンパネルが無期限に古くなる」対応: 上の全テストは
+  // NODE_ENV=test下でこの関数の30秒キャッシュ自体を無効化してもらっているため
+  // （`useCache`参照）、実際にキャッシュが効いている状態での「新しいハンドが
+  // 終わったら古いキャッシュを返さない」という不変条件はどのテストも検証していない
+  // （監査で指摘された「テストが実キャッシュの陳腐化を一度も検証していない」点）。
+  // positional-stats-service.test.tsの同名describeと全く同じ理由・同じ実装。
+  describe('real backend cache (audit finding 11, P2): hand completion rotates the 30s cache', () => {
+    const originalNodeEnv = process.env.NODE_ENV
+
+    afterEach(() => {
+      process.env.NODE_ENV = originalNodeEnv
+    })
+
+    test('a same-key call is served from cache until a live hand completes, then recomputes', async () => {
+      process.env.NODE_ENV = 'production' // enable the real 30s cache path (disabled under 'test')
+
+      await db.hands.bulkAdd([1, 2, 3].map(id => makeHand({ id, approxTimestamp: id * 1000 })))
+
+      const first = await getRecentHands(db, service, PLAYER_ID, 10)
+      expect(first.hands.map(h => h.handId)).toEqual([3, 2, 1])
+
+      // Seed a 4th (newer) hand -- with the cache alone (no invalidation), a
+      // same-key call within the 30s window would still return `first` unchanged.
+      await db.hands.add(makeHand({ id: 4, approxTimestamp: 4000 }))
+
+      const stillCached = await getRecentHands(db, service, PLAYER_ID, 10)
+      expect(stillCached).toBe(first) // same cached object reference -- proves caching is actually live here
+      expect(stillCached.hands.map(h => h.handId)).toEqual([3, 2, 1]) // hand 4 not yet reflected
+
+      // A real live hand completion. getRecentHands() self-subscribes to this same
+      // stream (subscribeToHandCompletion, module-level above) the first time it's
+      // called for a given service instance, independent of the front-end
+      // hand-epoch plumbing (App.tsx/Hud.tsx/ports.ts).
+      await new Promise<void>(resolve => {
+        service.statsOutputStream.once('data', () => resolve())
+        service.statsOutputStream.write([1, 2, 3])
+      })
+
+      const afterHandCompletion = await getRecentHands(db, service, PLAYER_ID, 10)
+      expect(afterHandCompletion).not.toBe(first) // recomputed, not served from the now-stale cache
+      expect(afterHandCompletion.hands.map(h => h.handId)).toEqual([4, 3, 2, 1]) // hand 4 now included
+    })
+  })
 })

--- a/src/services/recent-hands-service.test.ts
+++ b/src/services/recent-hands-service.test.ts
@@ -25,6 +25,8 @@ import {
   DEFAULT_RECENT_HANDS_LIMIT,
 } from './recent-hands-service'
 import { ActionType, BattleType, PhaseType, Position, RankType } from '../types/game'
+import { ApiType } from '../types'
+import type { ApiHandEvent } from '../types'
 import type { Action, Hand } from '../types/entities'
 
 const PLAYER_ID = 1
@@ -50,6 +52,47 @@ function makeAction(overrides: Partial<Action> & { handId: number, index: number
     actionDetails: [],
     ...overrides
   }
+}
+
+/** Minimal valid EVT_DEAL + EVT_HAND_RESULTS pair for one hand -- enough for
+ * WriteEntityStream.toHandState() to accept it and persist a real hand (not
+ * rejected as a chimera), so `service.writeEntityStream`'s 'data' fires for real.
+ * Used only to drive the genuine hand-completion signal in the "real backend
+ * cache" tests below -- not part of the fixtures above (which intentionally
+ * bypass this pipeline, per the file header). Mirrors
+ * positional-stats-service.test.ts's identical helper. */
+function makeMinimalHandEvents(handId: number, seatUserIds: [number, number, number]): ApiHandEvent[] {
+  return [
+    {
+      ApiTypeId: ApiType.EVT_DEAL,
+      SeatUserIds: seatUserIds,
+      Game: { CurrentBlindLv: 1, NextBlindUnixSeconds: 0, Ante: 0, SmallBlind: 100, BigBlind: 200, ButtonSeat: 0, SmallBlindSeat: 1, BigBlindSeat: 2 },
+      Player: { SeatIndex: 0, BetStatus: 1, HoleCards: [0, 1], Chip: 5000, BetChip: 0 },
+      OtherPlayers: [
+        { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 100, IsSafeLeave: false },
+        { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 5000, BetChip: 200, IsSafeLeave: false },
+      ],
+      Progress: { Phase: 0, NextActionSeat: 0, NextActionTypes: [2, 3, 4, 5], NextExtraLimitSeconds: 1, MinRaise: 400, Pot: 300, SidePot: [] },
+      timestamp: handId * 1000,
+    },
+    {
+      ApiTypeId: ApiType.EVT_HAND_RESULTS,
+      CommunityCards: [],
+      Pot: 300,
+      SidePot: [],
+      ResultType: 0,
+      DefeatStatus: 0,
+      HandId: handId,
+      HandLog: '',
+      Results: [{ UserId: seatUserIds[0], HoleCards: [], RankType: 10, Hands: [], HandRanking: 1, Ranking: -2, RewardChip: 300 }],
+      Player: { SeatIndex: 0, BetStatus: -1, Chip: 5000, BetChip: 0 },
+      OtherPlayers: [
+        { SeatIndex: 1, Status: 0, BetStatus: -1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+        { SeatIndex: 2, Status: 0, BetStatus: -1, Chip: 5000, BetChip: 0, IsSafeLeave: false },
+      ],
+      timestamp: handId * 1000 + 1,
+    },
+  ]
 }
 
 describe('RecentHandsService', () => {
@@ -382,18 +425,36 @@ describe('RecentHandsService', () => {
       expect(stillCached).toBe(first) // same cached object reference -- proves caching is actually live here
       expect(stillCached.hands.map(h => h.handId)).toEqual([3, 2, 1]) // hand 4 not yet reflected
 
-      // A real live hand completion. getRecentHands() self-subscribes to this same
-      // stream (subscribeToHandCompletion, module-level above) the first time it's
-      // called for a given service instance, independent of the front-end
-      // hand-epoch plumbing (App.tsx/Hud.tsx/ports.ts).
+      // A hand-start-warmup/filter-change/import-shaped rebroadcast (direct
+      // statsOutputStream.write(), the same call aggregate-events-stream.ts's EVT_DEAL
+      // warmup branch and message-router.ts's updateBattleTypeFilter/
+      // recalculateStats() make) must NOT invalidate the cache -- audit finding 11
+      // follow-up (P2, codex review): a first pass subscribed to statsOutputStream,
+      // which also fires for these non-completion broadcasts.
       await new Promise<void>(resolve => {
         service.statsOutputStream.once('data', () => resolve())
         service.statsOutputStream.write([1, 2, 3])
       })
+      const stillCachedAfterNonCompletionBroadcast = await getRecentHands(db, service, PLAYER_ID, 10)
+      expect(stillCachedAfterNonCompletionBroadcast).toBe(first) // still the same stale cached object
+
+      // A real live hand completion, through the actual live pipeline
+      // (writeEntityStream is the direct pipe target and the one true completion
+      // signal -- see its doc comment on PokerChaseService and ports.ts's
+      // handCompletionEpoch). getRecentHands() self-subscribes to this stream
+      // (subscribeToHandCompletion, module-level above) the first time it's called
+      // for a given service instance, independent of the front-end hand-epoch
+      // plumbing (App.tsx/Hud.tsx/ports.ts).
+      await new Promise<void>(resolve => {
+        service.writeEntityStream.once('data', () => resolve())
+        service.writeEntityStream.write(makeMinimalHandEvents(5, [1, 2, 3]))
+      })
 
       const afterHandCompletion = await getRecentHands(db, service, PLAYER_ID, 10)
       expect(afterHandCompletion).not.toBe(first) // recomputed, not served from the now-stale cache
-      expect(afterHandCompletion.hands.map(h => h.handId)).toEqual([4, 3, 2, 1]) // hand 4 now included
+      // hand 4 (seeded directly above) AND hand 5 (persisted by writeEntityStream
+      // itself, from makeMinimalHandEvents) are both now reflected.
+      expect(afterHandCompletion.hands.map(h => h.handId)).toEqual([5, 4, 3, 2, 1])
     })
   })
 })

--- a/src/services/recent-hands-service.test.ts
+++ b/src/services/recent-hands-service.test.ts
@@ -456,5 +456,61 @@ describe('RecentHandsService', () => {
       // itself, from makeMinimalHandEvents) are both now reflected.
       expect(afterHandCompletion.hands.map(h => h.handId)).toEqual([5, 4, 3, 2, 1])
     })
+
+    // 監査finding 11フォローアップ・pass-3（P2、codexレビュー指摘）: 進行中フェッチが
+    // ハンド完了後にキャッシュへ古い結果を書き込んでしまうレース。
+    // positional-stats-service.test.tsの同名テストと全く同じゲート手法（実データは
+    // 即座に読むが、Promiseの解決だけをテストが手動で制御するまで遅らせる）で、
+    // 「DB読み取り中にハンドが完了する」という進行中フェッチの状態を確定的に再現する。
+    test('an in-flight fetch resolving after a hand completes does NOT fill the cache with a stale result', async () => {
+      process.env.NODE_ENV = 'production' // enable the real 30s cache path (disabled under 'test')
+
+      await db.hands.bulkAdd([1, 2, 3].map(id => makeHand({ id, approxTimestamp: id * 1000 })))
+
+      let releaseGate!: () => void
+      const gate = new Promise<void>(resolve => { releaseGate = resolve })
+      const realWhere = db.hands.where.bind(db.hands)
+      jest.spyOn(db.hands, 'where').mockImplementationOnce((indexName: any) => {
+        const whereClause: any = realWhere(indexName)
+        const realEquals = whereClause.equals.bind(whereClause)
+        whereClause.equals = (value: any) => {
+          const collection: any = realEquals(value)
+          const realToArray = collection.toArray.bind(collection)
+          collection.toArray = async () => {
+            const data = await realToArray() // captures the real (pre-completion) snapshot immediately
+            await gate // ...but withholds it from the caller until the test releases it
+            return data
+          }
+          return collection
+        }
+        return whereClause
+      })
+
+      // Starts the fetch; its `db.hands...toArray()` call is now blocked on `gate`
+      // (cache miss, since nothing has been cached in this test yet -- fetchGeneration
+      // is captured before this call, per getRecentHands()'s own doc comment).
+      const inFlightFetch = getRecentHands(db, service, PLAYER_ID, 10)
+
+      // A genuine hand completes WHILE the fetch above is still blocked mid-read.
+      await new Promise<void>(resolve => {
+        service.writeEntityStream.once('data', () => resolve())
+        service.writeEntityStream.write(makeMinimalHandEvents(4, [1, 2, 3]))
+      })
+
+      // Now let the blocked fetch resolve -- with the snapshot it captured BEFORE
+      // hand 4 completed (hands 1-3 only).
+      releaseGate()
+      const staleResult = await inFlightFetch
+      expect(staleResult.hands.map(h => h.handId)).toEqual([3, 2, 1])
+
+      // The bug this guards against: cache.set(cacheKey, { result: staleResult, ... })
+      // would have run here unconditionally, planting a stale fill that a subsequent
+      // same-key call (the handEpoch-triggered refetch for an open panel) would then
+      // serve for the rest of the 30s window. Assert it recomputes instead and
+      // reflects hand 4.
+      const afterRace = await getRecentHands(db, service, PLAYER_ID, 10)
+      expect(afterRace).not.toBe(staleResult)
+      expect(afterRace.hands.map(h => h.handId)).toEqual([4, 3, 2, 1])
+    })
   })
 })

--- a/src/services/recent-hands-service.ts
+++ b/src/services/recent-hands-service.ts
@@ -41,6 +41,22 @@ const CACHE_DURATION_MS = 30_000
 const MAX_CACHE_SIZE = 50
 const cache: Map<string, { result: RecentHandsResult, timestamp: number }> = new Map()
 
+// 監査指摘11（P2）「開いたドリルダウンパネルが無期限に古くなる」対応。
+// positional-stats-service.tsの同名の仕組みと全く同じ理由・同じ実装パターン
+// （そちらのコメント参照）: `service.statsOutputStream`の'data'（生アクティブな
+// ハンド完了ごとに1回、ports.tsの`liveBroadcastSequence`と同一のイベント）に
+// 購読して、この30秒キャッシュをbackground.ts/ports.ts/content_script.ts/
+// message-router.tsを一切経由せずに無効化する。
+const subscribedServices = new WeakSet<PokerChaseService>()
+
+function subscribeToHandCompletion(service: PokerChaseService): void {
+  if (subscribedServices.has(service)) return
+  subscribedServices.add(service)
+  service.statsOutputStream.on('data', () => {
+    clearRecentHandsCache()
+  })
+}
+
 /** Exported for direct unit testing -- caching itself is disabled under NODE_ENV=test
  * (see `useCache` below), so key-differs-when-filter-or-limit-differs can't be observed
  * behaviorally in tests and is instead pinned down against this function directly. */
@@ -186,6 +202,8 @@ export async function getRecentHands(
   playerId: number,
   limit: number = DEFAULT_RECENT_HANDS_LIMIT
 ): Promise<RecentHandsResult> {
+  subscribeToHandCompletion(service)
+
   const effectiveLimit = limit > 0 ? limit : DEFAULT_RECENT_HANDS_LIMIT
   const cacheKey = buildRecentHandsCacheKey(playerId, service, effectiveLimit)
   const useCache = process.env.NODE_ENV !== 'test' && !process.env.DEBUG_NO_CACHE

--- a/src/services/recent-hands-service.ts
+++ b/src/services/recent-hands-service.ts
@@ -41,6 +41,17 @@ const CACHE_DURATION_MS = 30_000
 const MAX_CACHE_SIZE = 50
 const cache: Map<string, { result: RecentHandsResult, timestamp: number }> = new Map()
 
+// 監査finding 11フォローアップ・pass-3（P2、codexレビュー指摘）: 「進行中フェッチが
+// 完了後キャッシュへ古い結果を書き込んでしまう」レース対応。
+// positional-stats-service.tsの同名の仕組みと全く同じ理由・同じ実装パターン
+// （そちらのコメント参照）: 進行中のgetRecentHands()呼び出しがDB読み取り中に
+// ハンドが完了してcache.clear()が走っても、その呼び出し自体は完了前のDB状態を
+// 基にした結果でcache.set()を実行してしまう。各フェッチをその開始時点の
+// cacheGeneration値でスタンプし、書き込み時に現在値と比較する -- フェッチ中に
+// 世代が進んでいれば呼び出し元へはそのまま結果を返すが、キャッシュへの書き込みは
+// スキップする。
+let cacheGeneration = 0
+
 // 監査指摘11（P2）「開いたドリルダウンパネルが無期限に古くなる」対応。
 // positional-stats-service.tsの同名の仕組みと全く同じ理由・同じ実装パターン
 // （そちらのコメント参照）: `service.writeEntityStream`の'data'（生きたポート
@@ -58,6 +69,7 @@ function subscribeToHandCompletion(service: PokerChaseService): void {
   if (subscribedServices.has(service)) return
   subscribedServices.add(service)
   service.writeEntityStream.on('data', () => {
+    cacheGeneration++
     clearRecentHandsCache()
   })
 }
@@ -208,6 +220,9 @@ export async function getRecentHands(
   limit: number = DEFAULT_RECENT_HANDS_LIMIT
 ): Promise<RecentHandsResult> {
   subscribeToHandCompletion(service)
+  // このフェッチ開始時点のgeneration -- 下の2箇所のcache.set()で、フェッチ中に
+  // ハンド完了(cacheGeneration++)が割り込んでいないか照合する（上のコメント参照）。
+  const fetchGeneration = cacheGeneration
 
   const effectiveLimit = limit > 0 ? limit : DEFAULT_RECENT_HANDS_LIMIT
   const cacheKey = buildRecentHandsCacheKey(playerId, service, effectiveLimit)
@@ -246,7 +261,11 @@ export async function getRecentHands(
 
   if (recentHands.length === 0) {
     const result: RecentHandsResult = { hands: [], computedAt: now }
-    cache.set(cacheKey, { result, timestamp: now })
+    // フェッチ中にハンドが完了していれば(cacheGenerationが進んでいれば)書き込まない
+    // -- 上のコメント参照。呼び出し元にはそのまま最新の結果を返す。
+    if (cacheGeneration === fetchGeneration) {
+      cache.set(cacheKey, { result, timestamp: now })
+    }
     return result
   }
 
@@ -297,11 +316,15 @@ export async function getRecentHands(
 
   const result: RecentHandsResult = { hands, computedAt: now }
 
-  cache.set(cacheKey, { result, timestamp: now })
-  if (cache.size > MAX_CACHE_SIZE) {
-    for (const [key, entry] of cache.entries()) {
-      if (now - entry.timestamp > CACHE_DURATION_MS) {
-        cache.delete(key)
+  // フェッチ中にハンドが完了していれば(cacheGenerationが進んでいれば)書き込まない
+  // -- ファイル冒頭のコメント参照。呼び出し元にはそのまま最新の結果を返す。
+  if (cacheGeneration === fetchGeneration) {
+    cache.set(cacheKey, { result, timestamp: now })
+    if (cache.size > MAX_CACHE_SIZE) {
+      for (const [key, entry] of cache.entries()) {
+        if (now - entry.timestamp > CACHE_DURATION_MS) {
+          cache.delete(key)
+        }
       }
     }
   }

--- a/src/services/recent-hands-service.ts
+++ b/src/services/recent-hands-service.ts
@@ -43,16 +43,21 @@ const cache: Map<string, { result: RecentHandsResult, timestamp: number }> = new
 
 // 監査指摘11（P2）「開いたドリルダウンパネルが無期限に古くなる」対応。
 // positional-stats-service.tsの同名の仕組みと全く同じ理由・同じ実装パターン
-// （そちらのコメント参照）: `service.statsOutputStream`の'data'（生アクティブな
-// ハンド完了ごとに1回、ports.tsの`liveBroadcastSequence`と同一のイベント）に
-// 購読して、この30秒キャッシュをbackground.ts/ports.ts/content_script.ts/
-// message-router.tsを一切経由せずに無効化する。
+// （そちらのコメント参照）: `service.writeEntityStream`の'data'（生きたポート
+// 経由の取り込みだけがたどるパイプラインで、ハンドが実際にDBへ書き込まれた
+// 後にのみ発火する、ports.tsの`handCompletionEpoch`と同一の完了限定シグナル）
+// に購読して、この30秒キャッシュをbackground.ts/ports.ts/content_script.ts/
+// message-router.tsを一切経由せずに無効化する。`service.statsOutputStream`の
+// 'data'はハンド完了以外（ハンド開始時のウォームアップ、フィルター変更/
+// インポート/auto-sync復元の再計算）でも発火するため使わない（audit finding 11
+// フォローアップ、P2、codexレビュー指摘 -- positional-stats-service.tsの
+// 詳細なコメント参照）。
 const subscribedServices = new WeakSet<PokerChaseService>()
 
 function subscribeToHandCompletion(service: PokerChaseService): void {
   if (subscribedServices.has(service)) return
   subscribedServices.add(service)
-  service.statsOutputStream.on('data', () => {
+  service.writeEntityStream.on('data', () => {
     clearRecentHandsCache()
   })
 }


### PR DESCRIPTION
## Summary

Audit finding 11 (P2, HUD cluster): `RecentHandsPanel.tsx`/`PositionalStatsPanel.tsx`'s fetch effects depended only on `playerId`, so a panel left open never refetched as new hands completed — closing and reopening within 30s served the backend's stale cache instead.

- **Frontend**: `ports.ts`'s `liveBroadcastSequence` (already bumped once per real hand-completion broadcast) is now stamped onto every `broadcastMessage()` payload as `handEpoch`. `App.tsx` reads it (via a locally-widened type, since `content_script.ts`'s `StatsData` is owned by a different workstream and needs no change — the field already flows through its untyped forwarding at runtime) and threads it through `Hud.tsx` into both drill-down panels, whose fetch effects now include it in their deps. `Hud`'s custom memo comparator only treats `handEpoch` changes as render-worthy while one of that seat's panels is actually open, so closed panels don't re-render for nothing. Net effect: an open panel refetches exactly once per completed hand, never on realtime per-action updates.
- **Backend cache**: `getPositionalStats`/`getRecentHands`'s 30s module caches don't key on anything hand-aware, so the new refetch would still hit stale entries. Both services now self-subscribe (lazily, once per `PokerChaseService` instance) to `service.statsOutputStream` — the same real hand-completion stream `ports.ts` already listens to — and clear their own cache on each completion. This keeps the whole fix inside the two owned service files, with no changes to `background.ts`, `ports.ts`'s broadcast wiring beyond the new field, `content_script.ts`, or `message-router.ts`.
- **Tests**: added a real-cache test to each service (temporarily flips `NODE_ENV` off `'test'` to exercise the actual 30s cache path, which every existing test disables) asserting a same-key call is served from cache until a hand completes, then recomputes. Added component-level tests (`PositionalStatsPanel.test.tsx`, `RecentHandsPanel.test.tsx`) for handEpoch-triggered refetch, plus a `Hud.test.tsx` case proving the memo comparator doesn't block the prop from reaching an open panel, and that it doesn't cause spurious refetches when no panel is open.
- Verified fail-before/pass-after: reverted the non-test implementation files via `git apply -R` and confirmed exactly the 5 new/modified test files fail (107 other tests still pass), then reapplied.

Keeps fail-open semantics (#127) untouched; no changes to import-export/message-router, background.ts/firebase-auth-service, event-ingestion/update-manager/content_script, database-utils, or auto-sync upload pagination (other concurrent workstreams' scope).

## Test plan

- [x] `npm run typecheck`
- [x] `npx jest` (full suite) x2 — 108 suites / 1051 tests, both green
- [x] `npm run e2e:smoke` — all 6 checks pass
- [x] Fail-before/pass-after via `git apply -R` on the implementation-only diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)