### PR TITLE
chore: re-ignore legacy e2e/.cache browser cache dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,9 @@ coverage/
 
 # E2E QA harness (see e2e/README.md)
 # Chrome for Testing downloads live in ~/.cache/puppeteer/ (see BROWSER_CACHE_DIR
-# in e2e/config.ts), not a per-worktree e2e/.cache/, so nothing to ignore here.
+# in e2e/config.ts). e2e/.cache/ was the pre-#193 per-worktree location; runs
+# from branches predating that change can still recreate it, so keep it ignored.
+e2e/.cache/
 e2e/.build/
 e2e/out/
 # the blanket *.ndjson rule above would also hide our committed, anonymized


### PR DESCRIPTION
## Summary
- `e2e/.cache/` is the pre-#193 per-worktree Chrome for Testing download location. Checkouts or worktrees based on commits before #193 still recreate it (356MB of regenerable browser binaries), showing up as untracked noise in `git status`.
- Re-adds the ignore rule for `e2e/.cache/` with a comment explaining why it stays even though current code uses `~/.cache/puppeteer/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)