### PR TITLE
fix(sync): surface rebuild failures and harden Firestore transport

### DIFF
--- a/src/constants/database.ts
+++ b/src/constants/database.ts
@@ -19,7 +19,10 @@ export const DATABASE_CONSTANTS = {
   FIRESTORE_PARALLEL_BATCHES: 3, // Number of parallel Firestore batches
   FIRESTORE_BATCH_DELAY_MS: 500, // Delay between batch groups
   FIRESTORE_DOWNLOAD_PAGE_SIZE: 1000, // Maximum documents per Firestore download response
-  
+  FIRESTORE_REQUEST_TIMEOUT_MS: 30000,   // Per-request AbortController timeout (a stalled fetch must not hold isSyncing forever)
+  FIRESTORE_TRANSIENT_RETRIES: 2,        // Extra attempts after the first, for transient failures only (network error/timeout/5xx/429)
+  FIRESTORE_RETRY_BASE_DELAY_MS: 500,    // Backoff base: 500ms, then 1000ms (doubles per retry)
+
   // Cache durations
   PLAYER_CACHE_DURATION_MS: 60000,     // 1 minute
   STATS_CACHE_DURATION_MS: 5000,       // 5 seconds

--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -3,7 +3,8 @@ import { PokerChaseDB } from '../db/poker-chase-db'
 import { ApiType, ApiTypeValues, BattleType, BetStatusType } from '../types'
 import type { ApiEvent } from '../types'
 import { DATABASE_CONSTANTS } from '../constants/database'
-import { AutoSyncService } from './auto-sync-service'
+import { EntityConverter } from '../entity-converter'
+import { AutoSyncService, REBUILD_AFTER_DOWNLOAD_FAILED_MESSAGE } from './auto-sync-service'
 import { firestoreBackupService } from './firestore-backup-service'
 import { firebaseAuthService } from './firebase-auth-service'
 import * as minVersionGate from './min-version-gate'
@@ -66,6 +67,92 @@ describe('AutoSyncService cloud downloads', () => {
       lastProcessedTimestamp: 101,
       lastProcessedEventCount: 2
     })
+  })
+
+  test('a failed derived-table rebuild after download surfaces as a sync ERROR and is not marked as done (release audit 2026-07-21, finding 5)', async () => {
+    const cloudEvent = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Code: 0,
+      BattleType: BattleType.SIT_AND_GO,
+      Id: 'stage-rebuild-fail',
+      IsRetire: false,
+      timestamp: 100
+    } as ApiEvent
+
+    // Download succeeds and durably stores the raw event...
+    jest.spyOn(firestoreBackupService, 'syncFromCloud')
+      .mockImplementation(async options => {
+        await options.onBatch([cloudEvent])
+        return 1
+      })
+    // ...but deriving hands/phases/actions from it fails (quota, transaction
+    // abort, malformed chunk -- any error in the rebuild path).
+    jest.spyOn(EntityConverter.prototype, 'convertEventChunk').mockImplementation(() => {
+      throw new Error('QuotaExceededError: derived-table save failed')
+    })
+
+    const service = new AutoSyncService(db)
+    await service.performSync('download')
+
+    // The pass must NOT be reported as a success -- before this fix the
+    // rebuild error was swallowed and the popup showed 成功 over stale stats.
+    const state = service.getSyncState()
+    expect(state.status).toBe('error')
+    expect(state.error).toContain(REBUILD_AFTER_DOWNLOAD_FAILED_MESSAGE)
+    expect(state.error).toContain('QuotaExceededError')
+
+    // The error state reaches the popup via the same chrome.runtime message
+    // channel every other sync-state change already uses.
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'SYNC_STATE_UPDATE',
+        state: expect.objectContaining({ status: 'error' })
+      })
+    )
+
+    // Raw Event Lake invariant: the downloaded raw event stays stored -- only
+    // the derived tables are stale.
+    expect(await db.apiEvents.count()).toBe(1)
+
+    // A failed rebuild is never marked complete: `importStatus` (the rebuild's
+    // own completion bookkeeping) must remain untouched so nothing claims the
+    // derived tables are current.
+    expect(await db.meta.get('importStatus')).toBeUndefined()
+  })
+
+  test('partial download (page 1 durable, page 2 fails) with a failing rebuild still surfaces the DOWNLOAD error and leaves no completion bookkeeping (release audit 2026-07-21, coverage gap #5)', async () => {
+    const pageOneEvent = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Code: 0,
+      BattleType: BattleType.SIT_AND_GO,
+      Id: 'stage-page-1',
+      IsRetire: false,
+      timestamp: 100
+    } as ApiEvent
+
+    // Page 1 lands via onBatch, then the next REST page fails.
+    jest.spyOn(firestoreBackupService, 'syncFromCloud')
+      .mockImplementation(async options => {
+        await options.onBatch([pageOneEvent])
+        throw new Error('Cloud sync failed: Firestore REST request failed: 503')
+      })
+    // The best-effort rebuild over the partial data fails as well.
+    jest.spyOn(EntityConverter.prototype, 'convertEventChunk').mockImplementation(() => {
+      throw new Error('derived-table save failed')
+    })
+
+    const service = new AutoSyncService(db)
+    await service.performSync('download')
+
+    // The download failure is the primary error surfaced (the rebuild
+    // failure is logged, not allowed to mask the root cause).
+    const state = service.getSyncState()
+    expect(state.status).toBe('error')
+    expect(state.error).toContain('503')
+
+    // Page 1's raw events remain durable, and nothing marked the rebuild done.
+    expect(await db.apiEvents.count()).toBe(1)
+    expect(await db.meta.get('importStatus')).toBeUndefined()
   })
 
   test('upload: filters non-application noise before syncing, and still advances past a chunk that is 100% noise', async () => {

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -17,6 +17,15 @@ import { isCloudSyncBlockedByMinVersionGate } from './min-version-gate'
 export const MIN_VERSION_SYNC_BLOCKED_MESSAGE = 'このバージョンはサポートが終了しました。Chromeを再起動すると更新が適用されます'
 
 /**
+ * Shown in the popup (via `syncState.error`) when a cloud download stored its
+ * raw events but the derived-table rebuild failed. The raw data is safe (Raw
+ * Event Lake invariant) -- only hands/phases/actions are stale until a
+ * rebuild succeeds, which the user can trigger manually from the popup.
+ */
+export const REBUILD_AFTER_DOWNLOAD_FAILED_MESSAGE =
+  'クラウドデータの保存は完了しましたが、統計データの再構築に失敗しました。ポップアップの「データ再構築」を実行してください'
+
+/**
  * Thrown internally whenever a bookkeeping write is about to happen under an
  * auth-state generation that no longer matches the one live when this sync
  * pass started -- i.e. the account changed (possibly more than once) since
@@ -1260,7 +1269,17 @@ export class AutoSyncService {
     } catch (error) {
       // A previous page may already be durable. Rebuild before surfacing the
       // error so partially downloaded raw events cannot leave entities stale.
-      if (downloadedEvents > 0) await this.rebuildLocalEntities()
+      // If the rebuild ALSO fails here, log it but keep the DOWNLOAD error as
+      // the primary failure surfaced to performSync()'s catch -- both paths
+      // end in `syncState.status = 'error'` either way, and the download
+      // error is the root cause the user should see first.
+      if (downloadedEvents > 0) {
+        try {
+          await this.rebuildLocalEntities()
+        } catch (rebuildError) {
+          console.error('[AutoSync] Rebuild after a partial download failed too:', rebuildError)
+        }
+      }
       throw error
     }
 
@@ -1270,7 +1289,28 @@ export class AutoSyncService {
     }
   }
 
-  /** Rebuild derived tables without loading the entire event history into memory. */
+  /**
+   * Rebuild derived tables without loading the entire event history into memory.
+   *
+   * THROWS on failure (independent release audit 2026-07-21, finding 5,
+   * "派生テーブル再構築失敗を同期成功として確定する"): this used to catch and
+   * swallow every error, so a download pass whose raw `bulkPut` succeeded but
+   * whose hands/phases/actions derivation failed (quota, malformed chunk,
+   * transaction abort) still reported `status: 'success'` to the popup while
+   * the HUD silently served stale/partial aggregates. Now the error
+   * propagates to `performSync()`'s catch, which sets
+   * `syncState.status = 'error'` and broadcasts it via the existing
+   * `SYNC_STATE_UPDATE` chrome.runtime message the popup already renders.
+   *
+   * Failure-state invariants:
+   * - Raw Event Lake is unaffected: the downloaded raw rows were durably
+   *   `bulkPut` BEFORE this rebuild ran and are never rolled back -- only the
+   *   DERIVED tables are stale, and a manual データ再構築 (or the next
+   *   successful download's rebuild) re-derives everything from the Lake.
+   * - A failed rebuild is never marked as done: the `importStatus` meta write
+   *   below only runs after every chunk (and the final flush) succeeded, so
+   *   an error always leaves the previous `importStatus` untouched.
+   */
   private async rebuildLocalEntities(): Promise<void> {
     try {
       console.log('[AutoSync] Triggering chunked data rebuild after download...')
@@ -1342,8 +1382,12 @@ export class AutoSyncService {
       console.log(`[AutoSync] Chunked data rebuild completed (${totalEventCount} events)`)
     } catch (error) {
       console.error('[AutoSync] Data rebuild error:', error)
-      // Preserve the existing behavior: raw event sync remains successful even
-      // if rebuilding derived data fails.
+      // Surface the failure instead of confirming the sync as successful (see
+      // doc comment above). The raw events are already durable; only the
+      // derived statistics are stale until a rebuild succeeds.
+      throw new Error(
+        `${REBUILD_AFTER_DOWNLOAD_FAILED_MESSAGE} (${error instanceof Error ? error.message : 'Unknown error'})`
+      )
     }
   }
 

--- a/src/services/firestore-backup-service.test.ts
+++ b/src/services/firestore-backup-service.test.ts
@@ -308,6 +308,24 @@ describe('FirestoreBackupService transport hardening (release audit 2026-07-21: 
     expect(secondHeaders['Authorization']).toBe('Bearer refreshed-token')
   })
 
+  test('a hung INITIAL token acquisition is bounded by the transport timeout too -- no fetch is ever issued (codex review r3617258715)', async () => {
+    // An expired cached token makes the very first getIdToken() of a request
+    // hit the same unbounded Secure Token API fetch as the forced refresh --
+    // simulate it stalling forever. This runs BEFORE fetchWithTimeout() ever
+    // gets involved, so without its own bound the whole sync pass hung here.
+    jest.spyOn(firebaseAuthService, 'getIdToken').mockImplementation(
+      () => new Promise<string>(() => { }) // hangs forever
+    )
+    const fetchMock = jest.fn()
+    global.fetch = fetchMock
+
+    await expect(new FirestoreBackupService(fastTransport).getCloudMaxTimestamp())
+      .rejects.toThrow('initial token acquisition timed out after 30ms')
+    // Terminal auth failure: nothing was ever sent, no forced refresh tried.
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(firebaseAuthService.getIdToken).not.toHaveBeenCalledWith(true)
+  })
+
   test('a hung forced token refresh during 401 recovery is bounded by the transport timeout instead of stalling the request funnel (codex review r3617177865)', async () => {
     // FirebaseAuthService.getIdToken()'s internal Secure Token API fetch has
     // no AbortController -- simulate it stalling forever on the forced

--- a/src/services/firestore-backup-service.test.ts
+++ b/src/services/firestore-backup-service.test.ts
@@ -328,9 +328,11 @@ describe('FirestoreBackupService transport hardening (release audit 2026-07-21: 
     // Generation moves between the request-start snapshot and the 401
     // handling -- an account switch landed while the request was in flight.
     // A uid comparison could be fooled by an A -> B -> A round trip; the
-    // generation counter cannot.
+    // generation counter cannot. Reads in order: pass-start snapshot (7),
+    // the fail-fast check after the initial token acquisition (still 7 --
+    // the switch lands later, mid-request), then the 401 gate (9).
     const generationSpy = firebaseAuthService.getAuthGeneration as jest.Mock
-    generationSpy.mockReturnValueOnce(7).mockReturnValue(9)
+    generationSpy.mockReturnValueOnce(7).mockReturnValueOnce(7).mockReturnValue(9)
 
     const fetchMock = jest.fn().mockResolvedValue({
       ok: false,
@@ -375,6 +377,55 @@ describe('FirestoreBackupService transport hardening (release audit 2026-07-21: 
 
     await expect(new FirestoreBackupService(fastTransport).getCloudMaxTimestamp()).resolves.toBeNull()
     expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('an account switch DURING the initial token acquisition aborts before any request is issued (codex review r3617090425)', async () => {
+    // getIdToken() internally awaits a network refresh when the cached token
+    // is expired -- an account switch landing inside that await used to slip
+    // past the gate entirely, because the generation snapshot was taken
+    // AFTER the token await (against the NEW account's baseline). Reads in
+    // order: pass-start snapshot (7), then the post-acquisition check (9 --
+    // the switch landed while the token was being refreshed).
+    const generationSpy = firebaseAuthService.getAuthGeneration as jest.Mock
+    generationSpy.mockReturnValueOnce(7).mockReturnValue(9)
+
+    const fetchMock = jest.fn()
+    global.fetch = fetchMock
+
+    await expect(new FirestoreBackupService(fastTransport).getCloudMaxTimestamp())
+      .rejects.toThrow('the signed-in account changed while the request was in flight')
+    // Fails fast: nothing is ever sent under the ambiguous identity, and no
+    // forced refresh is attempted.
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(firebaseAuthService.getIdToken).not.toHaveBeenCalledWith(true)
+  })
+
+  test('a persistent 429 on a write batch is retried by exactly one layer -- the transport budget, not writeBatch times transport (codex review r3617090429)', async () => {
+    let commitCalls = 0
+    const fetchMock = jest.fn().mockImplementation(async (url: string) => {
+      if (!String(url).endsWith(':commit')) {
+        return { ok: true, status: 200, text: async () => '{}' } as Response
+      }
+      commitCalls++
+      return {
+        ok: false,
+        status: 429,
+        text: async () => JSON.stringify({
+          error: { code: 429, message: 'RESOURCE_EXHAUSTED', status: 'RESOURCE_EXHAUSTED' }
+        })
+      } as Response
+    })
+    global.fetch = fetchMock
+
+    const event = { timestamp: 1779859063171, ApiTypeId: 304 } as unknown as ApiEvent
+
+    await expect(new FirestoreBackupService(fastTransport).syncToCloudBatch([event], null))
+      .rejects.toThrow('Cloud sync failed')
+    // Exactly the transport's budget (1 initial + 2 transient retries).
+    // Before r3617090429's fix, writeBatch ran its OWN 3-attempt rate-limit
+    // loop on top of the transport's, hammering the throttled backend with
+    // up to 9 commit attempts for a single batch.
+    expect(commitCalls).toBe(3)
   })
 
   test('a non-retryable 4xx (400) fails immediately with no retry and no token refresh', async () => {

--- a/src/services/firestore-backup-service.test.ts
+++ b/src/services/firestore-backup-service.test.ts
@@ -308,6 +308,31 @@ describe('FirestoreBackupService transport hardening (release audit 2026-07-21: 
     expect(secondHeaders['Authorization']).toBe('Bearer refreshed-token')
   })
 
+  test('a hung forced token refresh during 401 recovery is bounded by the transport timeout instead of stalling the request funnel (codex review r3617177865)', async () => {
+    // FirebaseAuthService.getIdToken()'s internal Secure Token API fetch has
+    // no AbortController -- simulate it stalling forever on the forced
+    // refresh, while the initial (cached-token) call resolves normally.
+    jest.spyOn(firebaseAuthService, 'getIdToken').mockImplementation(
+      (forceRefresh?: boolean) => forceRefresh
+        ? new Promise<string>(() => { }) // hangs forever
+        : Promise.resolve('initial-token')
+    )
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => JSON.stringify({ error: { code: 401, status: 'UNAUTHENTICATED' } })
+    } as Response)
+    global.fetch = fetchMock
+
+    // Fails within the bound (30ms here) as an auth failure -- before this
+    // fix the bare `await getIdToken(true)` hung the funnel indefinitely,
+    // leaving AutoSyncService._isSyncing latched.
+    await expect(new FirestoreBackupService(fastTransport).getCloudMaxTimestamp())
+      .rejects.toThrow('forced token refresh timed out after 30ms')
+    // Terminal: no retry was attempted after the timed-out refresh.
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   test('a second 401 on the refreshed token is terminal (no refresh loop)', async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: false,

--- a/src/services/firestore-backup-service.test.ts
+++ b/src/services/firestore-backup-service.test.ts
@@ -173,6 +173,8 @@ describe('FirestoreBackupService', () => {
     // one-time unparseable-floor backfill treats it as "cloud proven empty,
     // nothing to backfill past"). A transient auth/network/REST failure must
     // never be indistinguishable from that -- it has to throw instead.
+    // (Small retryBaseDelayMs keeps the transient-retry backoff from slowing
+    // the suite -- a persistent 500 is retried before the final throw.)
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,
       status: 500,
@@ -181,7 +183,7 @@ describe('FirestoreBackupService', () => {
       })
     } as Response)
 
-    await expect(new FirestoreBackupService().getCloudMaxTimestamp())
+    await expect(new FirestoreBackupService({ retryBaseDelayMs: 1 }).getCloudMaxTimestamp())
       .rejects.toThrow('Firestore REST request failed: 500')
   })
 
@@ -229,5 +231,163 @@ describe('FirestoreBackupService', () => {
     const onBatch = jest.fn()
     await expect(new FirestoreBackupService().syncFromCloud({ onBatch })).resolves.toBe(0)
     expect(onBatch).not.toHaveBeenCalled()
+  })
+})
+
+describe('FirestoreBackupService transport hardening (release audit 2026-07-21: timeout/abort/retry/401-refresh)', () => {
+  const originalFetch = global.fetch
+  // Small values so timeout/backoff paths run in milliseconds. Retry budget
+  // matches the production default shape: 1 initial attempt + 2 transient
+  // retries = 3 attempts max.
+  const fastTransport = { requestTimeoutMs: 30, retryBaseDelayMs: 1, maxTransientRetries: 2 }
+
+  beforeEach(() => {
+    jest.spyOn(firebaseAuthService, 'ready').mockResolvedValue()
+    jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue({
+      uid: 'XK00mmVIZdg8J52OlfyKvN467SK2',
+      email: null,
+      displayName: null,
+      photoURL: null,
+      getIdToken: jest.fn()
+    })
+    jest.spyOn(firebaseAuthService, 'getIdToken').mockImplementation(
+      async (forceRefresh?: boolean) => forceRefresh ? 'refreshed-token' : 'initial-token'
+    )
+    jest.spyOn(firebaseAuthService, 'getAuthGeneration').mockReturnValue(7)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    if (originalFetch) {
+      global.fetch = originalFetch
+    } else {
+      delete (global as { fetch?: typeof fetch }).fetch
+    }
+  })
+
+  test('a stalled fetch is aborted by the request timeout, retried with backoff, and rejects after the bounded retry budget', async () => {
+    // Never-resolving fetch that only settles when the AbortController fires
+    // -- the exact "stalled connection holds isSyncing forever" failure mode
+    // the timeout exists to prevent.
+    const fetchMock = jest.fn().mockImplementation((_url: string, init?: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(Object.assign(new Error('The operation was aborted.'), { name: 'AbortError' }))
+        })
+      })
+    )
+    global.fetch = fetchMock
+
+    await expect(new FirestoreBackupService(fastTransport).getCloudMaxTimestamp())
+      .rejects.toThrow('Firestore REST request timed out after 30ms')
+    // 1 initial attempt + 2 transient retries, then a terminal throw.
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  test('401 force-refreshes the token via getIdToken(true) and retries exactly once with the refreshed token', async () => {
+    const fetchMock = jest.fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: async () => JSON.stringify({ error: { code: 401, status: 'UNAUTHENTICATED' } })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify([{ readTime: '2026-07-21T00:00:00Z' }])
+      } as Response)
+    global.fetch = fetchMock
+
+    await expect(new FirestoreBackupService(fastTransport).getCloudMaxTimestamp()).resolves.toBeNull()
+
+    expect(firebaseAuthService.getIdToken).toHaveBeenCalledWith(true)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const firstHeaders = (fetchMock.mock.calls[0]![1] as RequestInit).headers as Record<string, string>
+    const secondHeaders = (fetchMock.mock.calls[1]![1] as RequestInit).headers as Record<string, string>
+    expect(firstHeaders['Authorization']).toBe('Bearer initial-token')
+    expect(secondHeaders['Authorization']).toBe('Bearer refreshed-token')
+  })
+
+  test('a second 401 on the refreshed token is terminal (no refresh loop)', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => JSON.stringify({ error: { code: 401, status: 'UNAUTHENTICATED' } })
+    } as Response)
+    global.fetch = fetchMock
+
+    await expect(new FirestoreBackupService(fastTransport).getCloudMaxTimestamp())
+      .rejects.toThrow('Firestore REST request failed: 401')
+    // Exactly one refresh, exactly two attempts -- 401 is not in the
+    // transient-retry class, so no backoff retries pile on top.
+    expect(firebaseAuthService.getIdToken).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('the 401 retry is aborted without a token refresh when the signed-in account changed mid-request (auth generation gate)', async () => {
+    // Generation moves between the request-start snapshot and the 401
+    // handling -- an account switch landed while the request was in flight.
+    // A uid comparison could be fooled by an A -> B -> A round trip; the
+    // generation counter cannot.
+    const generationSpy = firebaseAuthService.getAuthGeneration as jest.Mock
+    generationSpy.mockReturnValueOnce(7).mockReturnValue(9)
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => JSON.stringify({ error: { code: 401, status: 'UNAUTHENTICATED' } })
+    } as Response)
+    global.fetch = fetchMock
+
+    await expect(new FirestoreBackupService(fastTransport).getCloudMaxTimestamp())
+      .rejects.toThrow('the signed-in account changed while the request was in flight')
+    // Aborted WITHOUT committing to a retry: no forced refresh, no second fetch.
+    expect(firebaseAuthService.getIdToken).not.toHaveBeenCalledWith(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('persistent 5xx is retried with backoff but strictly bounded', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => JSON.stringify({ error: { code: 503, status: 'UNAVAILABLE' } })
+    } as Response)
+    global.fetch = fetchMock
+
+    await expect(new FirestoreBackupService(fastTransport).getCloudMaxTimestamp())
+      .rejects.toThrow('Firestore REST request failed: 503')
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  test('a transient 5xx recovers on retry without failing the call', async () => {
+    const fetchMock = jest.fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => JSON.stringify({ error: { code: 500, status: 'INTERNAL' } })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify([{ readTime: '2026-07-21T00:00:00Z' }])
+      } as Response)
+    global.fetch = fetchMock
+
+    await expect(new FirestoreBackupService(fastTransport).getCloudMaxTimestamp()).resolves.toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('a non-retryable 4xx (400) fails immediately with no retry and no token refresh', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () => JSON.stringify({ error: { code: 400, status: 'INVALID_ARGUMENT' } })
+    } as Response)
+    global.fetch = fetchMock
+
+    await expect(new FirestoreBackupService(fastTransport).getCloudMaxTimestamp())
+      .rejects.toThrow('Firestore REST request failed: 400')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(firebaseAuthService.getIdToken).not.toHaveBeenCalledWith(true)
   })
 })

--- a/src/services/firestore-backup-service.ts
+++ b/src/services/firestore-backup-service.ts
@@ -450,10 +450,13 @@ export class FirestoreBackupService {
    *   mid-request (including an A -> B -> A round trip, which a uid
    *   comparison would miss), the retry is ABORTED instead of silently
    *   re-issuing the request against whichever account is live now. A 401
-   *   on the refreshed token is terminal (no second refresh). The forced
-   *   refresh itself is bounded by the same timeout as requests
-   *   (`forceRefreshIdTokenBounded()`) -- a hung refresh fails the request
-   *   instead of stalling it indefinitely.
+   *   on the refreshed token is terminal (no second refresh).
+   * - BOUNDED AUTH: every auth-service await in this method (the `ready()`
+   *   restore, the initial `getIdToken()`, and the 401 path's
+   *   `getIdToken(true)`) goes through `boundedAuthAcquisition()` -- the
+   *   same timeout discipline as the fetches themselves, so a stalled
+   *   Secure Token endpoint (or storage restore) fails the request instead
+   *   of stalling it indefinitely outside the timeout budget.
    * - NON-RETRYABLE: any other 4xx (permission denied, bad request, ...)
    *   throws immediately, preserving the pre-existing
    *   `Firestore REST request failed: <status> <body>` message shape that
@@ -475,9 +478,18 @@ export class FirestoreBackupService {
     // The assert right after the token acquisition fails fast: if the
     // account switched while the initial token was being fetched/refreshed,
     // the request aborts before anything is sent under an ambiguous identity.
-    await firebaseAuthService.ready()
+    //
+    // BOTH awaits are bounded (codex review r3617258715, P2, "Bound the
+    // initial token refresh too"): when the cached token is expired, the
+    // INITIAL `getIdToken()` performs the exact same unbounded Secure Token
+    // API fetch as the 401 path's forced refresh -- it runs before
+    // `fetchWithTimeout()` ever gets involved, so without this bound a
+    // stalled token endpoint left the sync pass hanging outside every
+    // timeout budget. Same discipline applied to `ready()` for completeness
+    // (storage-only, but an unbounded await is an unbounded await).
+    await this.boundedAuthAcquisition(() => firebaseAuthService.ready(), 'auth state restore')
     const generationAtStart = firebaseAuthService.getAuthGeneration()
-    let token = await firebaseAuthService.getIdToken()
+    let token = await this.boundedAuthAcquisition(() => firebaseAuthService.getIdToken(), 'initial token acquisition')
     this.assertAccountUnchanged(generationAtStart, 'after initial token acquisition')
     let authRetryUsed = false
     let transientRetriesUsed = 0
@@ -516,7 +528,7 @@ export class FirestoreBackupService {
         // refresh await, which is itself a window for a switch to land.
         this.assertAccountUnchanged(generationAtStart, 'before 401 token-refresh retry')
         console.warn('[Firestore] Request returned 401, force-refreshing token and retrying once...')
-        token = await this.forceRefreshIdTokenBounded()
+        token = await this.boundedAuthAcquisition(() => firebaseAuthService.getIdToken(true), 'forced token refresh')
         this.assertAccountUnchanged(generationAtStart, 'after 401 token refresh')
         authRetryUsed = true
         continue
@@ -559,35 +571,42 @@ export class FirestoreBackupService {
   }
 
   /**
-   * The 401 recovery's forced token refresh, bounded by the same transport
-   * timeout as requests (codex review r3617177865, P2, "Bound the forced
-   * token refresh"): `FirebaseAuthService.getIdToken()` performs its own
-   * Secure Token API `fetch` WITHOUT an `AbortController`, so awaiting it
-   * bare in the 401 path reintroduced exactly the unbounded stall this
-   * transport hardening exists to prevent -- a hung refresh never reached
-   * the retry loop or the outer timeout and could leave
-   * `AutoSyncService._isSyncing` latched indefinitely.
+   * Runs one auth-service acquisition bounded by the same transport timeout
+   * as the requests themselves. Used for EVERY auth await in `request()`:
+   * the `ready()` restore, the initial `getIdToken()`, and the 401 path's
+   * `getIdToken(true)`.
+   *
+   * WHY (codex reviews r3617177865 + r3617258715, P2 x2, "Bound the forced
+   * token refresh" / "Bound the initial token refresh too"):
+   * `FirebaseAuthService.getIdToken()` performs its own Secure Token API
+   * `fetch` WITHOUT an `AbortController` whenever the cached token is
+   * expired -- and BOTH acquisition sites can hit that path, the forced 401
+   * refresh and the very first `getIdToken()` of a request alike. Each runs
+   * outside `fetchWithTimeout()`'s budget, so a bare await on either meant
+   * a stalled token endpoint left the sync pass hanging with
+   * `AutoSyncService._isSyncing` latched indefinitely -- exactly the stall
+   * this transport hardening exists to prevent.
    *
    * Bounded from the CALLER side via `Promise.race` (`firebase-auth-service.
    * ts` is deliberately untouched -- other callers keep its existing
    * semantics). A timeout is terminal for this request: treated as an auth
-   * failure, surfaced as an error, no retry. The underlying refresh promise
-   * is not cancelled (nothing to abort without touching the auth service);
-   * a late settle just updates the auth service's own cached state
-   * harmlessly, and its potential late REJECTION is explicitly observed so
-   * it can never surface as an unhandled rejection.
+   * failure, surfaced as an error, no retry. The losing promise is not
+   * cancelled (nothing to abort without touching the auth service); a late
+   * settle just updates the auth service's own cached state harmlessly, and
+   * its potential late REJECTION is explicitly observed so it can never
+   * surface as an unhandled rejection.
    */
-  private async forceRefreshIdTokenBounded(): Promise<string> {
-    const refreshPromise = firebaseAuthService.getIdToken(true)
+  private async boundedAuthAcquisition<T>(acquire: () => Promise<T>, label: string): Promise<T> {
+    const acquisition = acquire()
     // Observe (don't act on) a rejection that lands after the race is lost.
-    refreshPromise.catch(() => { })
+    acquisition.catch(() => { })
     let timer: ReturnType<typeof setTimeout> | undefined
     try {
       return await Promise.race([
-        refreshPromise,
+        acquisition,
         new Promise<never>((_resolve, reject) => {
           timer = setTimeout(
-            () => reject(new Error(`Firestore 401 recovery aborted: forced token refresh timed out after ${this.REQUEST_TIMEOUT_MS}ms`)),
+            () => reject(new Error(`Firestore ${label} timed out after ${this.REQUEST_TIMEOUT_MS}ms`)),
             this.REQUEST_TIMEOUT_MS
           )
         })

--- a/src/services/firestore-backup-service.ts
+++ b/src/services/firestore-backup-service.ts
@@ -450,7 +450,10 @@ export class FirestoreBackupService {
    *   mid-request (including an A -> B -> A round trip, which a uid
    *   comparison would miss), the retry is ABORTED instead of silently
    *   re-issuing the request against whichever account is live now. A 401
-   *   on the refreshed token is terminal (no second refresh).
+   *   on the refreshed token is terminal (no second refresh). The forced
+   *   refresh itself is bounded by the same timeout as requests
+   *   (`forceRefreshIdTokenBounded()`) -- a hung refresh fails the request
+   *   instead of stalling it indefinitely.
    * - NON-RETRYABLE: any other 4xx (permission denied, bad request, ...)
    *   throws immediately, preserving the pre-existing
    *   `Firestore REST request failed: <status> <body>` message shape that
@@ -513,7 +516,7 @@ export class FirestoreBackupService {
         // refresh await, which is itself a window for a switch to land.
         this.assertAccountUnchanged(generationAtStart, 'before 401 token-refresh retry')
         console.warn('[Firestore] Request returned 401, force-refreshing token and retrying once...')
-        token = await firebaseAuthService.getIdToken(true)
+        token = await this.forceRefreshIdTokenBounded()
         this.assertAccountUnchanged(generationAtStart, 'after 401 token refresh')
         authRetryUsed = true
         continue
@@ -550,6 +553,45 @@ export class FirestoreBackupService {
       })
       const text = await response.text()
       return { ok: response.ok, status: response.status, text }
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+  /**
+   * The 401 recovery's forced token refresh, bounded by the same transport
+   * timeout as requests (codex review r3617177865, P2, "Bound the forced
+   * token refresh"): `FirebaseAuthService.getIdToken()` performs its own
+   * Secure Token API `fetch` WITHOUT an `AbortController`, so awaiting it
+   * bare in the 401 path reintroduced exactly the unbounded stall this
+   * transport hardening exists to prevent -- a hung refresh never reached
+   * the retry loop or the outer timeout and could leave
+   * `AutoSyncService._isSyncing` latched indefinitely.
+   *
+   * Bounded from the CALLER side via `Promise.race` (`firebase-auth-service.
+   * ts` is deliberately untouched -- other callers keep its existing
+   * semantics). A timeout is terminal for this request: treated as an auth
+   * failure, surfaced as an error, no retry. The underlying refresh promise
+   * is not cancelled (nothing to abort without touching the auth service);
+   * a late settle just updates the auth service's own cached state
+   * harmlessly, and its potential late REJECTION is explicitly observed so
+   * it can never surface as an unhandled rejection.
+   */
+  private async forceRefreshIdTokenBounded(): Promise<string> {
+    const refreshPromise = firebaseAuthService.getIdToken(true)
+    // Observe (don't act on) a rejection that lands after the race is lost.
+    refreshPromise.catch(() => { })
+    let timer: ReturnType<typeof setTimeout> | undefined
+    try {
+      return await Promise.race([
+        refreshPromise,
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(
+            () => reject(new Error(`Firestore 401 recovery aborted: forced token refresh timed out after ${this.REQUEST_TIMEOUT_MS}ms`)),
+            this.REQUEST_TIMEOUT_MS
+          )
+        })
+      ])
     } finally {
       clearTimeout(timer)
     }

--- a/src/services/firestore-backup-service.ts
+++ b/src/services/firestore-backup-service.ts
@@ -56,6 +56,17 @@ interface EventQueryCursor {
   documentName: string
 }
 
+/**
+ * Transport tuning knobs for `FirestoreBackupService.request()`. Production
+ * uses the `DATABASE_CONSTANTS` defaults; tests inject small values so
+ * timeout/backoff paths run in milliseconds instead of seconds.
+ */
+export interface FirestoreTransportOptions {
+  requestTimeoutMs?: number
+  retryBaseDelayMs?: number
+  maxTransientRetries?: number
+}
+
 export class FirestoreBackupService {
   private readonly USERS_COLLECTION = 'users'
   private readonly EVENTS_COLLECTION = 'apiEvents'
@@ -65,8 +76,17 @@ export class FirestoreBackupService {
   private readonly BATCH_DELAY_MS = DATABASE_CONSTANTS.FIRESTORE_BATCH_DELAY_MS
   private readonly DELETE_BATCH_SIZE = DATABASE_CONSTANTS.FIRESTORE_DELETE_BATCH
   private readonly DOWNLOAD_PAGE_SIZE = DATABASE_CONSTANTS.FIRESTORE_DOWNLOAD_PAGE_SIZE
+  private readonly REQUEST_TIMEOUT_MS: number
+  private readonly RETRY_BASE_DELAY_MS: number
+  private readonly MAX_TRANSIENT_RETRIES: number
   private readonly documentsPath = `projects/${firebaseConfig.projectId}/databases/(default)/documents`
   private readonly baseUrl = `https://firestore.googleapis.com/v1/${this.documentsPath}`
+
+  constructor(transportOptions?: FirestoreTransportOptions) {
+    this.REQUEST_TIMEOUT_MS = transportOptions?.requestTimeoutMs ?? DATABASE_CONSTANTS.FIRESTORE_REQUEST_TIMEOUT_MS
+    this.RETRY_BASE_DELAY_MS = transportOptions?.retryBaseDelayMs ?? DATABASE_CONSTANTS.FIRESTORE_RETRY_BASE_DELAY_MS
+    this.MAX_TRANSIENT_RETRIES = transportOptions?.maxTransientRetries ?? DATABASE_CONSTANTS.FIRESTORE_TRANSIENT_RETRIES
+  }
 
   /**
    * Sync local events to cloud (upload events newer than cloud's latest timestamp).
@@ -412,29 +432,138 @@ export class FirestoreBackupService {
     })
   }
 
+  /**
+   * Hardened REST transport (release audit 2026-07-21, "Firestore fetchに
+   * timeout/abort/401 refresh retryがなく同期が固着可能"): every Firestore
+   * REST call in this service funnels through here, and used to be a single
+   * bare `fetch` -- a stalled connection held `AutoSyncService.isSyncing`
+   * (and therefore the forced-update safety gate) indefinitely, a transient
+   * 5xx/network blip failed the whole sync pass outright, and an expired
+   * token (401) had no recovery path.
+   *
+   * Behavior:
+   * - TIMEOUT: each attempt is bounded by an `AbortController` timeout
+   *   (`REQUEST_TIMEOUT_MS`, covering the response body read as well), so a
+   *   hung fetch can never stall a sync pass forever.
+   * - TRANSIENT RETRY: network errors, timeouts, HTTP 5xx and 429 are
+   *   retried with exponential backoff (`RETRY_BASE_DELAY_MS * 2^n`), at
+   *   most `MAX_TRANSIENT_RETRIES` extra attempts. Retrying is safe for
+   *   every call in this service: reads (`:runQuery`/`:runAggregationQuery`)
+   *   are side-effect-free, and writes (`:commit` upserts/deletes keyed by
+   *   document name, metadata `PATCH`) are idempotent.
+   * - 401 TOKEN REFRESH: a single retry after `getIdToken(true)` (forced
+   *   refresh). Gated on the auth generation (`firebaseAuthService.
+   *   getAuthGeneration()`) still matching the value snapshotted when this
+   *   request acquired its original token -- if the signed-in account
+   *   changed mid-request (including an A -> B -> A round trip, which a
+   *   uid comparison would miss), the retry is ABORTED instead of silently
+   *   re-issuing the request against whichever account is live now. A 401
+   *   on the refreshed token is terminal (no second refresh).
+   * - NON-RETRYABLE: any other 4xx (permission denied, bad request, ...)
+   *   throws immediately, preserving the pre-existing
+   *   `Firestore REST request failed: <status> <body>` message shape that
+   *   callers (e.g. `writeBatch`'s RESOURCE_EXHAUSTED check) match on.
+   */
   private async request<T = unknown>(url: string, init: RequestInit): Promise<T | null> {
-    const token = await firebaseAuthService.getIdToken()
-    const response = await fetch(url, {
-      ...init,
-      headers: {
-        ...(init.headers || {}),
-        Authorization: `Bearer ${token}`
+    // `getIdToken()` awaits auth restore internally (`ready()`), so the
+    // generation snapshot below is taken AFTER the initial-restore bump --
+    // it only moves again on a real sign-in/sign-out transition.
+    let token = await firebaseAuthService.getIdToken()
+    const generationAtStart = firebaseAuthService.getAuthGeneration()
+    let authRetryUsed = false
+    let transientRetriesUsed = 0
+
+    while (true) {
+      let outcome: { ok: boolean, status: number, text: string }
+      try {
+        outcome = await this.fetchWithTimeout(url, init, token)
+      } catch (error) {
+        const timedOut = (error as { name?: string })?.name === 'AbortError'
+        if (transientRetriesUsed < this.MAX_TRANSIENT_RETRIES) {
+          transientRetriesUsed++
+          console.warn(`[Firestore] ${timedOut ? 'Request timed out' : 'Network error'}, retrying (${transientRetriesUsed}/${this.MAX_TRANSIENT_RETRIES})...`)
+          await this.delayBeforeRetry(transientRetriesUsed)
+          continue
+        }
+        throw new Error(timedOut
+          ? `Firestore REST request timed out after ${this.REQUEST_TIMEOUT_MS}ms`
+          : `Firestore REST request failed: network error (${error instanceof Error ? error.message : 'Unknown error'})`)
       }
-    })
-    const responseText = await response.text()
 
-    if (!response.ok) {
-      throw new Error(`Firestore REST request failed: ${response.status} ${responseText}`)
+      if (outcome.ok) {
+        if (!outcome.text.trim()) return null
+        try {
+          return JSON.parse(outcome.text) as T
+        } catch (error) {
+          throw new Error(
+            `Firestore REST response was invalid JSON (${outcome.text.length} bytes): ${error instanceof Error ? error.message : 'Unknown error'}`
+          )
+        }
+      }
+
+      if (outcome.status === 401 && !authRetryUsed) {
+        // Abort (do not refresh, do not retry) if the signed-in account
+        // changed since this request started -- both before AND after the
+        // refresh await, which is itself a window for a switch to land.
+        this.assertAccountUnchanged(generationAtStart, 'before 401 token-refresh retry')
+        console.warn('[Firestore] Request returned 401, force-refreshing token and retrying once...')
+        token = await firebaseAuthService.getIdToken(true)
+        this.assertAccountUnchanged(generationAtStart, 'after 401 token refresh')
+        authRetryUsed = true
+        continue
+      }
+
+      const transientStatus = outcome.status === 429 || outcome.status >= 500
+      if (transientStatus && transientRetriesUsed < this.MAX_TRANSIENT_RETRIES) {
+        transientRetriesUsed++
+        console.warn(`[Firestore] Request failed with ${outcome.status}, retrying (${transientRetriesUsed}/${this.MAX_TRANSIENT_RETRIES})...`)
+        await this.delayBeforeRetry(transientRetriesUsed)
+        continue
+      }
+
+      throw new Error(`Firestore REST request failed: ${outcome.status} ${outcome.text}`)
     }
+  }
 
-    if (!responseText.trim()) return null
-
+  /**
+   * One fetch attempt bounded by `REQUEST_TIMEOUT_MS` via `AbortController`.
+   * The timer also covers `response.text()` (cleared only after the body is
+   * fully read), so a connection that stalls mid-body is aborted too.
+   */
+  private async fetchWithTimeout(url: string, init: RequestInit, token: string): Promise<{ ok: boolean, status: number, text: string }> {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), this.REQUEST_TIMEOUT_MS)
     try {
-      return JSON.parse(responseText) as T
-    } catch (error) {
-      throw new Error(
-        `Firestore REST response was invalid JSON (${responseText.length} bytes): ${error instanceof Error ? error.message : 'Unknown error'}`
-      )
+      const response = await fetch(url, {
+        ...init,
+        headers: {
+          ...(init.headers || {}),
+          Authorization: `Bearer ${token}`
+        },
+        signal: controller.signal
+      })
+      const text = await response.text()
+      return { ok: response.ok, status: response.status, text }
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+  private async delayBeforeRetry(retryNumber: number): Promise<void> {
+    const delayMs = this.RETRY_BASE_DELAY_MS * 2 ** (retryNumber - 1)
+    await new Promise(resolve => setTimeout(resolve, delayMs))
+  }
+
+  /**
+   * Throws if the auth-state generation moved since `generationAtStart` --
+   * i.e. the signed-in account changed (sign-in/sign-out/switch, including an
+   * A -> B -> A round trip) while this request was in flight. Deliberately a
+   * generation comparison, not a uid comparison, for the same ABA rationale
+   * as `AutoSyncService.assertGenerationUnchanged()`.
+   */
+  private assertAccountUnchanged(generationAtStart: number, context: string): void {
+    if (firebaseAuthService.getAuthGeneration() !== generationAtStart) {
+      throw new Error(`Firestore request aborted (${context}): the signed-in account changed while the request was in flight`)
     }
   }
 

--- a/src/services/firestore-backup-service.ts
+++ b/src/services/firestore-backup-service.ts
@@ -273,24 +273,16 @@ export class FirestoreBackupService {
       }
     })
 
-    let retries = 3
-    while (retries > 0) {
-      try {
-        await this.commitWrites(writes)
-        return
-      } catch (error: any) {
-        const message = error instanceof Error ? error.message : ''
-        const rateLimited = message.includes('RESOURCE_EXHAUSTED') ||
-          message.includes('REST request failed: 429')
-        if (rateLimited && retries > 1) {
-          console.warn(`[Firestore] Rate limit hit, retrying in ${this.BATCH_DELAY_MS}ms...`)
-          await new Promise(resolve => setTimeout(resolve, this.BATCH_DELAY_MS))
-          retries--
-        } else {
-          throw error
-        }
-      }
-    }
+    // 429/RESOURCE_EXHAUSTED retry ownership lives in `request()`'s
+    // transport-level classification (codex review r3617090429, P2, "Avoid
+    // stacking 429 retries for write batches"): this method used to run its
+    // own 3-attempt rate-limit loop on top, which -- once the transport
+    // gained its own 429 backoff -- multiplied to up to 9 commit attempts
+    // per batch under a persistent rate limit, amplifying the very
+    // throttling being backed off from. Exactly one layer (the transport)
+    // now retries 429; an error surfacing here has already exhausted that
+    // bounded budget and must propagate.
+    await this.commitWrites(writes)
   }
 
   private async updateLastSyncTimestamp(uid: string, timestamp: number): Promise<void> {
@@ -453,10 +445,10 @@ export class FirestoreBackupService {
    *   document name, metadata `PATCH`) are idempotent.
    * - 401 TOKEN REFRESH: a single retry after `getIdToken(true)` (forced
    *   refresh). Gated on the auth generation (`firebaseAuthService.
-   *   getAuthGeneration()`) still matching the value snapshotted when this
-   *   request acquired its original token -- if the signed-in account
-   *   changed mid-request (including an A -> B -> A round trip, which a
-   *   uid comparison would miss), the retry is ABORTED instead of silently
+   *   getAuthGeneration()`) still matching the value snapshotted BEFORE the
+   *   initial token acquisition -- if the signed-in account changed
+   *   mid-request (including an A -> B -> A round trip, which a uid
+   *   comparison would miss), the retry is ABORTED instead of silently
    *   re-issuing the request against whichever account is live now. A 401
    *   on the refreshed token is terminal (no second refresh).
    * - NON-RETRYABLE: any other 4xx (permission denied, bad request, ...)
@@ -465,11 +457,25 @@ export class FirestoreBackupService {
    *   callers (e.g. `writeBatch`'s RESOURCE_EXHAUSTED check) match on.
    */
   private async request<T = unknown>(url: string, init: RequestInit): Promise<T | null> {
-    // `getIdToken()` awaits auth restore internally (`ready()`), so the
-    // generation snapshot below is taken AFTER the initial-restore bump --
-    // it only moves again on a real sign-in/sign-out transition.
-    let token = await firebaseAuthService.getIdToken()
+    // SNAPSHOT ORDER (codex review r3617090425, P2, "Snapshot auth
+    // generation before awaiting the token"): the generation snapshot must
+    // be taken BEFORE the awaited `getIdToken()` call, not after it --
+    // `getIdToken()` internally awaits a network token refresh when the
+    // cached token is expired, and an account switch landing during THAT
+    // await used to be invisible: the old account's refreshed token came
+    // back while the snapshot recorded the NEW account's generation as the
+    // baseline, so a later 401 passed `assertAccountUnchanged` and re-issued
+    // the old account's request with the new account's token. `ready()` is
+    // awaited explicitly first so the initial-restore generation bump (every
+    // Service Worker start does one) settles before the snapshot -- after
+    // that, the counter only moves on a real sign-in/sign-out transition.
+    // The assert right after the token acquisition fails fast: if the
+    // account switched while the initial token was being fetched/refreshed,
+    // the request aborts before anything is sent under an ambiguous identity.
+    await firebaseAuthService.ready()
     const generationAtStart = firebaseAuthService.getAuthGeneration()
+    let token = await firebaseAuthService.getIdToken()
+    this.assertAccountUnchanged(generationAtStart, 'after initial token acquisition')
     let authRetryUsed = false
     let transientRetriesUsed = 0
 


### PR DESCRIPTION
## Summary

This PR fixes two findings from the independent v5.2.0 release audit (2026-07-21): finding 5 (a failed derived-table rebuild after a cloud download was reported as sync success) and the Firestore transport risk (no timeout/abort, no retry, no 401 recovery on the REST client).

## 1. Rebuild failures are surfaced instead of confirmed as success (audit finding 5, P2)

`AutoSyncService.rebuildLocalEntities()` previously caught and discarded every error, so a download pass whose raw `bulkPut` succeeded but whose hands/phases/actions derivation failed (quota, transaction abort, malformed chunk) still set `syncState.status = 'success'` — the popup showed a successful sync while the HUD served stale or partial aggregates with no retry path.

The rebuild now rethrows a user-facing error (`REBUILD_AFTER_DOWNLOAD_FAILED_MESSAGE`, telling the user their raw data is saved and pointing at the popup's データ再構築 action). `performSync()`'s existing catch turns it into `syncState.status = 'error'`, which is broadcast over the same `SYNC_STATE_UPDATE` chrome.runtime message the popup already renders.

Invariants preserved:
- **Raw Event Lake**: the downloaded raw rows were durably stored before the rebuild ran and are never rolled back — only the derived tables are stale until a rebuild succeeds.
- **A failed rebuild is never marked done**: the `importStatus` completion record is only written after every chunk and the final flush succeeded, so an error always leaves the previous bookkeeping untouched.
- **Partial-download path**: when a download error triggers the best-effort rebuild over partial data and that rebuild also fails, the rebuild failure is logged and the download error remains the primary error surfaced (the root cause is not masked).

## 2. Firestore REST transport hardening (audit design-risk item)

`FirestoreBackupService.request()` — the single funnel every Firestore REST call in the service goes through — was a bare `fetch`. A stalled connection held `AutoSyncService.isSyncing` (and with it the forced-update safety gate) indefinitely, any transient 5xx/network blip failed the whole sync pass, and an expired token had no recovery.

The transport now provides:
- **Timeout**: each attempt is bounded by an `AbortController` timeout (30s, covering the response-body read as well), so a hung fetch can never stall a sync pass forever.
- **Bounded transient retry**: network errors, timeouts, HTTP 5xx and 429 are retried with exponential backoff (500ms base, doubling), at most 2 extra attempts. Every call in the service is retry-safe: reads are side-effect-free and writes (`:commit` upserts/deletes keyed by document name, metadata `PATCH`) are idempotent.
- **401 → refresh → retry once**: a 401 triggers `firebaseAuthService.getIdToken(true)` and a single retry with the refreshed token. The retry is gated on the auth generation still matching the request-start snapshot (checked both before and after the refresh await), so an account switch mid-request — including an A→B→A round trip that a uid comparison would miss — aborts the request instead of re-issuing it under the wrong account. A second 401 is terminal.
- **Non-retryable classification**: other 4xx statuses (403, 400, …) fail immediately, preserving the pre-existing `Firestore REST request failed: <status> <body>` message shape that callers (e.g. `writeBatch`'s RESOURCE_EXHAUSTED check) match on.

Transport knobs (timeout, backoff base, retry budget) are injectable via optional constructor options so the tests exercise these paths in milliseconds; production uses new `DATABASE_CONSTANTS` defaults.

## Tests

New regression tests (verified fail-before/pass-after by reverse-applying the source hunks):
- Failed rebuild after download → sync state is `error` (with the new message), `SYNC_STATE_UPDATE` broadcast carries it, raw events remain stored, `importStatus` is not written.
- Partial download (page 1 durable, page 2 fails) with a failing rebuild → the download error surfaces, no completion bookkeeping.
- Stalled fetch → aborted by timeout, retried with backoff, bounded rejection after 3 attempts.
- 401 → forced refresh → exactly one retry carrying the refreshed token; a second 401 is terminal.
- Auth-generation change during a 401 → request aborts with no token refresh and no retry.
- Persistent 5xx → bounded retries then rejection; transient 5xx → recovers on retry.
- 400 → fails immediately, no retry, no refresh.

## Verification

- `npm run typecheck` clean
- `npm test` fully green twice (109 suites, 1060 tests)
- `npm run e2e:smoke` passes (6/6 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)