### PR TITLE
fix(import): repair derived state for overlapping imports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,21 +322,32 @@ Statistics Refresh (batch mode)
   `EVT_ENTRY_QUEUED` (201) at/before that boundary (session-context anchor —
   anchoring on the 201 nearest the new events directly would be wrong, since
   an MTT table-move 201 can land mid-hand and cut off the opening
-  `EVT_DEAL`), and forward to the first *valid* 306 at/after the latest new
-  event — so a hand split between existing and imported rows (e.g.
-  re-importing a complete export into a DB missing the hand's middle ACTIONs)
-  gets its derived entities repaired. Boundary candidates are re-validated
+  `EVT_DEAL`), and forward to the first *valid pre-existing* 306 at/after the
+  latest new event (newly-imported 306s are skipped, so the range always
+  reaches the end of the OLD derivation's hand pairing — e.g. a DEAL that a
+  capture gap had mis-paired with a later 306) — so a hand split between
+  existing and imported rows (e.g. re-importing a complete export into a DB
+  missing the hand's middle ACTIONs) gets its derived entities repaired. Boundary candidates are re-validated
   with the current Zod schema before use, because the Lake intentionally
   stores unparseable rows (a malformed 306 must not truncate the range). New
   events alone cannot form such a hand's 303→306 boundary. The converter is
   seeded with the empty default session only when the range actually starts
   at a found 201 anchor; otherwise (incremental hands without a 201) the
   live `service.session` seeds it, matching the direct path and the #104
-  SessionState-seeding regression. Re-deriving existing hands is idempotent
-  (deterministic entity keys + `bulkPut`). See `collectOverlapRepairEvents()`
-  in `src/background/import-export.ts` (independent release-audit finding #7;
-  boundary/session refinements from PR #203 codex review). A fresh import
-  into an empty DB keeps the direct new-events path.
+  SessionState-seeding regression. Saving is delete-then-put in one
+  transaction: derived hands whose `approxTimestamp` falls in the stale
+  window (previous completed-hand boundary exclusive → end boundary
+  inclusive) are deleted with their phases/actions before the regenerated
+  bundle is `bulkPut` — upsert alone (idempotent for hands present in both
+  derivations via deterministic entity keys) would leave rows that existed
+  only in the old derivation (a mis-paired hand's id absent from the new
+  derivation, or leftover `[handId+index]` action tails), double-counting
+  stats. Every hand in that window is re-derivable from the range by
+  construction; the Raw Event Lake is never touched. See
+  `collectOverlapRepairEvents()` in `src/background/import-export.ts`
+  (independent release-audit finding #7; boundary/session/stale-deletion
+  refinements from PR #203 codex review). A fresh import into an empty DB
+  keeps the direct new-events path.
 
 **Critical Design Constraints (learned 2026-03):**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,7 +317,7 @@ Statistics Refresh (batch mode)
 - **Overlap imports re-derive from the Lake, not from new events alone**: when
   the DB already contained events before the import, the entity pass re-reads
   the affected range from `apiEvents` — expanded back to the last *valid*
-  `EVT_ENTRY_QUEUED` (201) strictly before the earliest new event that is
+  `EVT_ENTRY_QUEUED` (201) at or before the earliest new event that is
   *provably outside any hand* (session-context anchor — an MTT table-move 201
   can land mid-hand, including inside a previous completed hand, and would
   cut off an opening `EVT_DEAL`; a candidate qualifies only if its most
@@ -330,27 +330,37 @@ Statistics Refresh (batch mode)
   mis-paired with a later 306) — so a hand split between existing and
   imported rows (e.g. re-importing a complete export into a DB missing the
   hand's middle ACTIONs) gets its derived entities repaired. The anchor scan
-  searches the whole Lake below the earliest new event, not just below the
+  searches the whole Lake up to the earliest new event, not just below the
   previous completed hand's 306 — a valid session-boundary 201 can sit in the
-  gap *after* that 306 and *before* the affected hand's own DEAL, and capping
-  the scan there would miss it (this doesn't risk picking a mid-hand 201
-  instead: the outside-any-hand proof rejects those regardless of how far the
-  scan window reaches). Boundary candidates are re-validated with the current
-  Zod schema before use, because the Lake intentionally stores unparseable
-  rows (a malformed 306 must not truncate the range). New events alone cannot
-  form such a hand's 303→306 boundary. The converter is seeded with the empty
-  default session only when a qualifying 201 anchor was found (the range
-  starts at a session boundary, whether or not a previous completed hand
-  precedes it); otherwise (incremental hands without a 201 anywhere in the
-  Lake below them) the live `service.session` seeds it, matching the direct
-  path and the #104 SessionState-seeding regression (a 201 overwrites
-  id/battleType but not `session.name`, so live-session seeding at a session
-  boundary could leak a live table name into historical repairs). Saving is
-  delete-then-put in one transaction:
-  existing derived hands whose `id` matches a *validated*
-  `EVT_HAND_RESULTS` HandId inside the repair range (the hands this repair
-  can account for) are deleted with their phases/actions before the
-  regenerated bundle is `bulkPut` — upsert alone (idempotent for hands
+  gap *after* that 306 and *before* the affected hand's own DEAL. A newly
+  imported 201 at exactly the earliest-new timestamp is eligible too, so
+  unrelated earlier Lake rows do not force the replay to start before the
+  import's own boundary. The same outside-hand proof applies in both cases,
+  so a mid-hand 201 is still rejected. Boundary candidates are re-validated
+  with the current Zod schema before use, because the Lake intentionally
+  stores unparseable rows (a malformed 306 must not truncate the range). New
+  events alone cannot form such a hand's 303→306 boundary.
+
+  After range selection and validation, two content-based invariants apply.
+  First, the converter is seeded with the empty rebuild-style session **iff**
+  the range's first opening DEAL is preceded within that validated range by a
+  valid 201, regardless of whether the 201 came from the old Lake, the new
+  import, or Lake-start fallback. Leading mid-hand ACTION/306 fragments do not
+  change that rule; a 201 after the first DEAL does not qualify. Otherwise the
+  live `service.session` seeds the converter, matching the direct path and the
+  #104 SessionState-seeding regression (a 201 overwrites id/battleType but not
+  `session.name`, so live-session seeding at a real boundary could leak a live
+  table name into historical repairs).
+
+  Second, saving is delete-then-put in one transaction. Existing derived hands
+  are cleanup-accounted only when their HandId closes a validated DEAL→306
+  pairing wholly inside the range under either the old replay (new import keys
+  excluded) or the repaired replay (all range rows). Considering both pairings
+  deletes stale ids from the OLD derivation while retaining ids introduced by
+  the repaired derivation; requiring an in-range opening DEAL prevents a
+  leading orphan 306 from authorizing deletion. Accounted hands and their
+  phases/actions are deleted before the regenerated bundle is `bulkPut` —
+  upsert alone (idempotent for hands
   present in both derivations via deterministic entity keys) would leave
   rows that existed only in the old derivation (a mis-paired hand's id
   absent from the new derivation, or leftover `[handId+index]` action

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,14 +343,26 @@ Statistics Refresh (batch mode)
 
   After range selection and validation, two content-based invariants apply.
   First, the converter is seeded with the empty rebuild-style session **iff**
-  the range's first opening DEAL is preceded within that validated range by a
-  valid 201, regardless of whether the 201 came from the old Lake, the new
-  import, or Lake-start fallback. Leading mid-hand ACTION/306 fragments do not
-  change that rule; a 201 after the first DEAL does not qualify. Otherwise the
-  live `service.session` seeds the converter, matching the direct path and the
-  #104 SessionState-seeding regression (a 201 overwrites id/battleType but not
-  `session.name`, so live-session seeding at a real boundary could leak a live
-  table name into historical repairs).
+  either (a) the range's first opening DEAL is preceded within that validated
+  range by a valid 201, regardless of whether the 201 came from the old Lake,
+  the new import, or Lake-start fallback (leading mid-hand ACTION/306
+  fragments do not change that rule; a 201 after the first DEAL does not
+  qualify), **or** (b) the range already contains a complete DEAL→306 pair
+  that pre-dates this import — an already-derived hand the repair is about to
+  delete-then-put. (b) exists because a Lake with no 201 anywhere falls back
+  to replaying from Lake start, and that range's first DEAL is often an
+  unrelated older hand's, not the newly-imported hand's; judging solely on
+  201-before-first-DEAL would seed that whole replay from the live session and
+  stamp the live table's id/battleType/name onto a previously-contextless
+  historical hand, corrupting it and any battle-type/table filters over it
+  (PR #203 codex review pass 7, "Avoid live-session seeding for Lake-start
+  replays"). A range with no such pre-existing pair — a genuinely new
+  incremental hand with nothing but non-application noise around it — has no
+  existing derived hand to corrupt, so the live `service.session` seeds the
+  converter there, matching the direct path and the #104 SessionState-seeding
+  regression (a 201 overwrites id/battleType but not `session.name`, so
+  live-session seeding at a real boundary, or over pre-existing hands, could
+  leak a live table name into historical repairs).
 
   Second, saving is delete-then-put in one transaction. Existing derived hands
   are cleanup-accounted only when their HandId closes a validated DEAL→306

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,19 @@ Statistics Refresh (batch mode)
 - Storage and entity generation are decoupled: a line that fails to parse (or
   is a known non-application type) is still stored raw — it just doesn't
   reach `EntityConverter`. See "Raw Event Lake" (Design Principles #16).
+- **Overlap imports re-derive from the Lake, not from new events alone**: when
+  the DB already contained events before the import, the entity pass re-reads
+  the affected range from `apiEvents` — expanded back to the last
+  `EVT_ENTRY_QUEUED` (201) at/before the earliest new event (hand boundary and
+  session-context start) and forward to the first `EVT_HAND_RESULTS` (306)
+  at/after the latest new event — so a hand split between existing and
+  imported rows (e.g. re-importing a complete export into a DB missing the
+  hand's middle ACTIONs) gets its derived entities repaired. New events alone
+  cannot form such a hand's 303→306 boundary. Re-deriving existing hands is
+  idempotent (deterministic entity keys + `bulkPut`). See
+  `collectOverlapRepairEvents()` in `src/background/import-export.ts`
+  (independent release-audit finding #7). A fresh import into an empty DB
+  keeps the direct new-events path.
 
 **Critical Design Constraints (learned 2026-03):**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,30 +317,36 @@ Statistics Refresh (batch mode)
 - **Overlap imports re-derive from the Lake, not from new events alone**: when
   the DB already contained events before the import, the entity pass re-reads
   the affected range from `apiEvents` — expanded back to the last *valid*
-  `EVT_HAND_RESULTS` (306) strictly before the earliest new event (the
-  previous completed-hand boundary), then to the last *valid*
-  `EVT_ENTRY_QUEUED` (201) at/before that boundary that is *provably outside
-  any hand* (session-context anchor — an MTT table-move 201 can land
-  mid-hand, including inside the previous completed hand itself, and would
-  cut off an opening `EVT_DEAL`; candidates whose most recent valid DEAL
-  isn't yet closed by a valid 306 are rejected and the scan steps back one
-  hand at a time), and forward to the first *valid pre-existing* 306 at/after the
-  latest new event (newly-imported 306s are skipped, so the range always
-  reaches the end of the OLD derivation's hand pairing — e.g. a DEAL that a
-  capture gap had mis-paired with a later 306) — so a hand split between
-  existing and imported rows (e.g. re-importing a complete export into a DB
-  missing the hand's middle ACTIONs) gets its derived entities repaired. Boundary candidates are re-validated
-  with the current Zod schema before use, because the Lake intentionally
-  stores unparseable rows (a malformed 306 must not truncate the range). New
-  events alone cannot form such a hand's 303→306 boundary. The converter is
-  seeded with the empty default session only when the range starts at a
-  session boundary — a found 201 anchor, or (Lake-start fallback) a Lake
-  that begins with a valid 201 before its first valid DEAL; otherwise
-  (incremental hands without a 201) the live `service.session` seeds it,
-  matching the direct path and the #104 SessionState-seeding regression (a
-  201 overwrites id/battleType but not `session.name`, so live-session
-  seeding at a session boundary could leak a live table name into
-  historical repairs). Saving is delete-then-put in one transaction:
+  `EVT_ENTRY_QUEUED` (201) strictly before the earliest new event that is
+  *provably outside any hand* (session-context anchor — an MTT table-move 201
+  can land mid-hand, including inside a previous completed hand, and would
+  cut off an opening `EVT_DEAL`; a candidate qualifies only if its most
+  recent valid DEAL is already closed by a valid 306 between that DEAL and
+  the candidate, or has no preceding DEAL at all; candidates that fail this
+  are rejected and the scan steps back one hand at a time), and forward to
+  the first *valid pre-existing* 306 at/after the latest new event
+  (newly-imported 306s are skipped, so the range always reaches the end of
+  the OLD derivation's hand pairing — e.g. a DEAL that a capture gap had
+  mis-paired with a later 306) — so a hand split between existing and
+  imported rows (e.g. re-importing a complete export into a DB missing the
+  hand's middle ACTIONs) gets its derived entities repaired. The anchor scan
+  searches the whole Lake below the earliest new event, not just below the
+  previous completed hand's 306 — a valid session-boundary 201 can sit in the
+  gap *after* that 306 and *before* the affected hand's own DEAL, and capping
+  the scan there would miss it (this doesn't risk picking a mid-hand 201
+  instead: the outside-any-hand proof rejects those regardless of how far the
+  scan window reaches). Boundary candidates are re-validated with the current
+  Zod schema before use, because the Lake intentionally stores unparseable
+  rows (a malformed 306 must not truncate the range). New events alone cannot
+  form such a hand's 303→306 boundary. The converter is seeded with the empty
+  default session only when a qualifying 201 anchor was found (the range
+  starts at a session boundary, whether or not a previous completed hand
+  precedes it); otherwise (incremental hands without a 201 anywhere in the
+  Lake below them) the live `service.session` seeds it, matching the direct
+  path and the #104 SessionState-seeding regression (a 201 overwrites
+  id/battleType but not `session.name`, so live-session seeding at a session
+  boundary could leak a live table name into historical repairs). Saving is
+  delete-then-put in one transaction:
   existing derived hands whose `id` matches a *validated*
   `EVT_HAND_RESULTS` HandId inside the repair range (the hands this repair
   can account for) are deleted with their phases/actions before the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,17 +316,27 @@ Statistics Refresh (batch mode)
   reach `EntityConverter`. See "Raw Event Lake" (Design Principles #16).
 - **Overlap imports re-derive from the Lake, not from new events alone**: when
   the DB already contained events before the import, the entity pass re-reads
-  the affected range from `apiEvents` — expanded back to the last
-  `EVT_ENTRY_QUEUED` (201) at/before the earliest new event (hand boundary and
-  session-context start) and forward to the first `EVT_HAND_RESULTS` (306)
-  at/after the latest new event — so a hand split between existing and
-  imported rows (e.g. re-importing a complete export into a DB missing the
-  hand's middle ACTIONs) gets its derived entities repaired. New events alone
-  cannot form such a hand's 303→306 boundary. Re-deriving existing hands is
-  idempotent (deterministic entity keys + `bulkPut`). See
-  `collectOverlapRepairEvents()` in `src/background/import-export.ts`
-  (independent release-audit finding #7). A fresh import into an empty DB
-  keeps the direct new-events path.
+  the affected range from `apiEvents` — expanded back to the last *valid*
+  `EVT_HAND_RESULTS` (306) strictly before the earliest new event (the
+  previous completed-hand boundary), then to the last *valid*
+  `EVT_ENTRY_QUEUED` (201) at/before that boundary (session-context anchor —
+  anchoring on the 201 nearest the new events directly would be wrong, since
+  an MTT table-move 201 can land mid-hand and cut off the opening
+  `EVT_DEAL`), and forward to the first *valid* 306 at/after the latest new
+  event — so a hand split between existing and imported rows (e.g.
+  re-importing a complete export into a DB missing the hand's middle ACTIONs)
+  gets its derived entities repaired. Boundary candidates are re-validated
+  with the current Zod schema before use, because the Lake intentionally
+  stores unparseable rows (a malformed 306 must not truncate the range). New
+  events alone cannot form such a hand's 303→306 boundary. The converter is
+  seeded with the empty default session only when the range actually starts
+  at a found 201 anchor; otherwise (incremental hands without a 201) the
+  live `service.session` seeds it, matching the direct path and the #104
+  SessionState-seeding regression. Re-deriving existing hands is idempotent
+  (deterministic entity keys + `bulkPut`). See `collectOverlapRepairEvents()`
+  in `src/background/import-export.ts` (independent release-audit finding #7;
+  boundary/session refinements from PR #203 codex review). A fresh import
+  into an empty DB keeps the direct new-events path.
 
 **Critical Design Constraints (learned 2026-03):**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,19 +331,28 @@ Statistics Refresh (batch mode)
   with the current Zod schema before use, because the Lake intentionally
   stores unparseable rows (a malformed 306 must not truncate the range). New
   events alone cannot form such a hand's 303→306 boundary. The converter is
-  seeded with the empty default session only when the range actually starts
-  at a found 201 anchor; otherwise (incremental hands without a 201) the
-  live `service.session` seeds it, matching the direct path and the #104
-  SessionState-seeding regression. Saving is delete-then-put in one
-  transaction: derived hands whose `approxTimestamp` falls in the stale
-  window (previous completed-hand boundary exclusive → end boundary
-  inclusive) are deleted with their phases/actions before the regenerated
-  bundle is `bulkPut` — upsert alone (idempotent for hands present in both
-  derivations via deterministic entity keys) would leave rows that existed
-  only in the old derivation (a mis-paired hand's id absent from the new
-  derivation, or leftover `[handId+index]` action tails), double-counting
-  stats. Every hand in that window is re-derivable from the range by
-  construction; the Raw Event Lake is never touched. See
+  seeded with the empty default session only when the range starts at a
+  session boundary — a found 201 anchor, or (Lake-start fallback) a Lake
+  that begins with a valid 201 before its first valid DEAL; otherwise
+  (incremental hands without a 201) the live `service.session` seeds it,
+  matching the direct path and the #104 SessionState-seeding regression (a
+  201 overwrites id/battleType but not `session.name`, so live-session
+  seeding at a session boundary could leak a live table name into
+  historical repairs). Saving is delete-then-put in one transaction:
+  existing derived hands whose `id` matches a *validated*
+  `EVT_HAND_RESULTS` HandId inside the repair range (the hands this repair
+  can account for) are deleted with their phases/actions before the
+  regenerated bundle is `bulkPut` — upsert alone (idempotent for hands
+  present in both derivations via deterministic entity keys) would leave
+  rows that existed only in the old derivation (a mis-paired hand's id
+  absent from the new derivation, or leftover `[handId+index]` action
+  tails), double-counting stats. Id-based accounting (not a timestamp
+  window) means legacy hands lacking `approxTimestamp` are still cleaned
+  up, while hands whose source raw rows no longer pass the current schema
+  are never deleted (the re-derivation could not recreate them; they keep
+  their pre-import derived state until an explicit rebuild, same as
+  before). The regenerated bundle's hand ids are a subset of the accounted
+  set by construction; the Raw Event Lake is never touched. See
   `collectOverlapRepairEvents()` in `src/background/import-export.ts`
   (independent release-audit finding #7; boundary/session/stale-deletion
   refinements from PR #203 codex review). A fresh import into an empty DB

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,44 +314,58 @@ Statistics Refresh (batch mode)
 - Storage and entity generation are decoupled: a line that fails to parse (or
   is a known non-application type) is still stored raw — it just doesn't
   reach `EntityConverter`. See "Raw Event Lake" (Design Principles #16).
-- **Overlap imports repair per hand from the Lake, not per range from new
-  events alone**: when the DB already contained rows, the entity pass reads a
-  bounded replay window from `apiEvents` and builds validated DEAL→306 pairings
-  for both the pre-import view (new keys removed) and post-import view. The
-  lower boundary is immediately after the last valid 306 before the minimum
-  new compound key, so a split hand keeps its opening DEAL without replaying a
-  whole session on a pure append. The upper boundary reaches the later of the
-  first valid old-view and post-view 306 at/after the **maximum new
-  `[timestamp+ApiTypeId]` key**. Compound-key comparison is required: at one
-  millisecond `[T,308]` sorts after `[T,306]`, so a timestamp-only boundary
-  would drop a newly imported session-detail/player-context tail row. Every
-  boundary candidate and replay row is re-validated with the current schema;
-  malformed raw Lake rows never become boundaries.
+- **Overlap imports repair whole session windows from the Lake**: when the DB
+  already contained rows, `buildOverlapRepairPlan()` first reads only the
+  indexed, validated 201/303/306 boundary rows. A new row selects the session
+  window containing it: the governing valid `EVT_ENTRY_QUEUED` (201), or Lake
+  start when no 201 exists, through the next valid 201 or Lake end. Hand rows
+  are assigned by their DEAL's window, so an MTT table-move 201 inside an open
+  hand never cuts off that hand's opening DEAL. Complete raw rows are then read
+  only for selected windows, and every complete hand in those windows is
+  re-derived. This deliberately trades the previous fragile per-hand minimum
+  write set for a bounded, convergent invariant. Hands in all other sessions
+  are neither deleted nor put and remain byte-identical. Boundary, pairing, and
+  context rows are re-validated with the current schema and ordered by the full
+  `[timestamp+ApiTypeId]` compound key; malformed Lake rows cannot create a
+  boundary. The Raw Event Lake is read-only throughout repair.
 
-  The replay window supplies context only; it does **not** authorize rewriting
-  every hand in that window. A hand is affected only when (a) its validated
-  DEAL→306 source span contains a new row, (b) its DEAL/result pairing differs
-  between the pre/post views, or (c) its Lake-derived session at DEAL changes.
-  Only affected HandIds and their phases/actions are deleted, then only
-  affected post-view hands are `bulkPut` in the same transaction. This removes
-  stale old pair ids and action tails while leaving unrelated bystander hands
-  byte-identical, including legacy hands without `approxTimestamp` and hands
-  whose raw sources no longer validate. A leading orphan 306 has no DEAL pair
-  and therefore grants no deletion authority. The Raw Event Lake is never
-  mutated by repair.
+  Session context is still frozen per hand at its DEAL. The latest valid 201
+  before the DEAL sets id/battleType and resets name; the latest valid 308 after
+  that 201 sets name. If no 201 exists, a preceding valid 308 still establishes
+  a real `{name}` context (id/battleType remain undefined), rather than falling
+  through to the contextless seed. Only when neither 201 nor 308 exists is the
+  rebuild-style seed empty. The sole exception remains a genuinely appended,
+  not-previously-derived tail hand (the minimum new application compound key is
+  after the old valid-application tail): that hand is seeded from live
+  `service.session`, preserving #104. Older hands in the same affected window
+  continue to use Lake/empty context; live state never leaks backward.
 
-  Session context is also per hand. For each affected DEAL, use the most recent
-  valid 201 before that DEAL for id/battleType and the latest valid 308 after
-  that 201 but before the DEAL for name. This remains true when discarded or
-  unterminated leading rows precede the 201; a mid-hand 201 affects a later
-  DEAL, not the already-open hand. With no preceding 201, use an empty
-  rebuild-style session. The sole exception is a genuinely new, not previously
-  derived hand in a pure incremental tail append (all new application keys are
-  after the old valid-application tail): seed that hand from live
-  `service.session`, preserving #104. The old range-wide `hasSessionAnchor`
-  decision must not be reintroduced. See `buildOverlapRepairPlan()` in
-  `src/background/import-export.ts` (independent release-audit finding #7 and
-  PR #203 review refinements). A fresh empty-DB import keeps the direct path.
+  Delete-then-put is atomic across `hands`/`phases`/`actions`. Its candidate ids
+  are the union of old-view and post-view validated DEAL→306 pairs whose DEAL
+  belongs to an affected window. Before deletion, every post-view pair is run
+  through `EntityConverter`: if current semantic guards reject it (duplicate
+  DEAL_ROUND, RESULTS outside the dealt lineup, etc.) while that post pair's raw
+  rows still exist, its HandId is removed from the delete set and all legacy
+  derived rows are preserved byte-for-byte. An old-only pair may be deleted
+  because the post-import pairing no longer contains that logical raw hand;
+  this is what removes capture-gap stale ids/action tails. Unparseable raw rows
+  and orphan 306 fragments form no validated pair and grant no deletion scope.
+
+  Complete decision matrix:
+
+  | Added rows | Context at each DEAL | Converter outcome | Repair result |
+  | --- | --- | --- | --- |
+  | hand rows | 201 (+ optional later 308) | re-emitted | rebuild the full governing session; delete-then-put old/post ids |
+  | hand rows | 308 only | re-emitted | rebuild the Lake-start window with `{name}` context |
+  | hand rows | none | re-emitted | empty rebuild seed; live seed only for a genuinely new tail hand |
+  | session rows (201 or 308) | 201 or 308 only | re-emitted | rebuild every hand through the next 201/Lake end, not only the first 306 |
+  | hand + session rows | 201, 308 only, or none | re-emitted | union the selected windows and apply the same per-DEAL rules |
+  | any of the above | any | rejected, post raw pair persists | preserve existing hand/phases/actions; do not delete |
+  | any of the above | any | old pair absent from post view | delete the stale old-only id |
+
+  See `buildOverlapRepairPlan()` in `src/background/import-export.ts`
+  (independent release-audit finding #7 and PR #203 review refinements). A fresh
+  empty-DB import keeps the direct path.
 
 **Critical Design Constraints (learned 2026-03):**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,79 +314,44 @@ Statistics Refresh (batch mode)
 - Storage and entity generation are decoupled: a line that fails to parse (or
   is a known non-application type) is still stored raw — it just doesn't
   reach `EntityConverter`. See "Raw Event Lake" (Design Principles #16).
-- **Overlap imports re-derive from the Lake, not from new events alone**: when
-  the DB already contained events before the import, the entity pass re-reads
-  the affected range from `apiEvents` — expanded back to the last *valid*
-  `EVT_ENTRY_QUEUED` (201) at or before the earliest new event that is
-  *provably outside any hand* (session-context anchor — an MTT table-move 201
-  can land mid-hand, including inside a previous completed hand, and would
-  cut off an opening `EVT_DEAL`; a candidate qualifies only if its most
-  recent valid DEAL is already closed by a valid 306 between that DEAL and
-  the candidate, or has no preceding DEAL at all; candidates that fail this
-  are rejected and the scan steps back one hand at a time), and forward to
-  the first *valid pre-existing* 306 at/after the latest new event
-  (newly-imported 306s are skipped, so the range always reaches the end of
-  the OLD derivation's hand pairing — e.g. a DEAL that a capture gap had
-  mis-paired with a later 306) — so a hand split between existing and
-  imported rows (e.g. re-importing a complete export into a DB missing the
-  hand's middle ACTIONs) gets its derived entities repaired. The anchor scan
-  searches the whole Lake up to the earliest new event, not just below the
-  previous completed hand's 306 — a valid session-boundary 201 can sit in the
-  gap *after* that 306 and *before* the affected hand's own DEAL. A newly
-  imported 201 at exactly the earliest-new timestamp is eligible too, so
-  unrelated earlier Lake rows do not force the replay to start before the
-  import's own boundary. The same outside-hand proof applies in both cases,
-  so a mid-hand 201 is still rejected. Boundary candidates are re-validated
-  with the current Zod schema before use, because the Lake intentionally
-  stores unparseable rows (a malformed 306 must not truncate the range). New
-  events alone cannot form such a hand's 303→306 boundary.
+- **Overlap imports repair per hand from the Lake, not per range from new
+  events alone**: when the DB already contained rows, the entity pass reads a
+  bounded replay window from `apiEvents` and builds validated DEAL→306 pairings
+  for both the pre-import view (new keys removed) and post-import view. The
+  lower boundary is immediately after the last valid 306 before the minimum
+  new compound key, so a split hand keeps its opening DEAL without replaying a
+  whole session on a pure append. The upper boundary reaches the later of the
+  first valid old-view and post-view 306 at/after the **maximum new
+  `[timestamp+ApiTypeId]` key**. Compound-key comparison is required: at one
+  millisecond `[T,308]` sorts after `[T,306]`, so a timestamp-only boundary
+  would drop a newly imported session-detail/player-context tail row. Every
+  boundary candidate and replay row is re-validated with the current schema;
+  malformed raw Lake rows never become boundaries.
 
-  After range selection and validation, two content-based invariants apply.
-  First, the converter is seeded with the empty rebuild-style session **iff**
-  either (a) the range's first opening DEAL is preceded within that validated
-  range by a valid 201, regardless of whether the 201 came from the old Lake,
-  the new import, or Lake-start fallback (leading mid-hand ACTION/306
-  fragments do not change that rule; a 201 after the first DEAL does not
-  qualify), **or** (b) the range already contains a complete DEAL→306 pair
-  that pre-dates this import — an already-derived hand the repair is about to
-  delete-then-put. (b) exists because a Lake with no 201 anywhere falls back
-  to replaying from Lake start, and that range's first DEAL is often an
-  unrelated older hand's, not the newly-imported hand's; judging solely on
-  201-before-first-DEAL would seed that whole replay from the live session and
-  stamp the live table's id/battleType/name onto a previously-contextless
-  historical hand, corrupting it and any battle-type/table filters over it
-  (PR #203 codex review pass 7, "Avoid live-session seeding for Lake-start
-  replays"). A range with no such pre-existing pair — a genuinely new
-  incremental hand with nothing but non-application noise around it — has no
-  existing derived hand to corrupt, so the live `service.session` seeds the
-  converter there, matching the direct path and the #104 SessionState-seeding
-  regression (a 201 overwrites id/battleType but not `session.name`, so
-  live-session seeding at a real boundary, or over pre-existing hands, could
-  leak a live table name into historical repairs).
+  The replay window supplies context only; it does **not** authorize rewriting
+  every hand in that window. A hand is affected only when (a) its validated
+  DEAL→306 source span contains a new row, (b) its DEAL/result pairing differs
+  between the pre/post views, or (c) its Lake-derived session at DEAL changes.
+  Only affected HandIds and their phases/actions are deleted, then only
+  affected post-view hands are `bulkPut` in the same transaction. This removes
+  stale old pair ids and action tails while leaving unrelated bystander hands
+  byte-identical, including legacy hands without `approxTimestamp` and hands
+  whose raw sources no longer validate. A leading orphan 306 has no DEAL pair
+  and therefore grants no deletion authority. The Raw Event Lake is never
+  mutated by repair.
 
-  Second, saving is delete-then-put in one transaction. Existing derived hands
-  are cleanup-accounted only when their HandId closes a validated DEAL→306
-  pairing wholly inside the range under either the old replay (new import keys
-  excluded) or the repaired replay (all range rows). Considering both pairings
-  deletes stale ids from the OLD derivation while retaining ids introduced by
-  the repaired derivation; requiring an in-range opening DEAL prevents a
-  leading orphan 306 from authorizing deletion. Accounted hands and their
-  phases/actions are deleted before the regenerated bundle is `bulkPut` —
-  upsert alone (idempotent for hands
-  present in both derivations via deterministic entity keys) would leave
-  rows that existed only in the old derivation (a mis-paired hand's id
-  absent from the new derivation, or leftover `[handId+index]` action
-  tails), double-counting stats. Id-based accounting (not a timestamp
-  window) means legacy hands lacking `approxTimestamp` are still cleaned
-  up, while hands whose source raw rows no longer pass the current schema
-  are never deleted (the re-derivation could not recreate them; they keep
-  their pre-import derived state until an explicit rebuild, same as
-  before). The regenerated bundle's hand ids are a subset of the accounted
-  set by construction; the Raw Event Lake is never touched. See
-  `collectOverlapRepairEvents()` in `src/background/import-export.ts`
-  (independent release-audit finding #7; boundary/session/stale-deletion
-  refinements from PR #203 codex review). A fresh import into an empty DB
-  keeps the direct new-events path.
+  Session context is also per hand. For each affected DEAL, use the most recent
+  valid 201 before that DEAL for id/battleType and the latest valid 308 after
+  that 201 but before the DEAL for name. This remains true when discarded or
+  unterminated leading rows precede the 201; a mid-hand 201 affects a later
+  DEAL, not the already-open hand. With no preceding 201, use an empty
+  rebuild-style session. The sole exception is a genuinely new, not previously
+  derived hand in a pure incremental tail append (all new application keys are
+  after the old valid-application tail): seed that hand from live
+  `service.session`, preserving #104. The old range-wide `hasSessionAnchor`
+  decision must not be reintroduced. See `buildOverlapRepairPlan()` in
+  `src/background/import-export.ts` (independent release-audit finding #7 and
+  PR #203 review refinements). A fresh empty-DB import keeps the direct path.
 
 **Critical Design Constraints (learned 2026-03):**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,10 +319,12 @@ Statistics Refresh (batch mode)
   the affected range from `apiEvents` — expanded back to the last *valid*
   `EVT_HAND_RESULTS` (306) strictly before the earliest new event (the
   previous completed-hand boundary), then to the last *valid*
-  `EVT_ENTRY_QUEUED` (201) at/before that boundary (session-context anchor —
-  anchoring on the 201 nearest the new events directly would be wrong, since
-  an MTT table-move 201 can land mid-hand and cut off the opening
-  `EVT_DEAL`), and forward to the first *valid pre-existing* 306 at/after the
+  `EVT_ENTRY_QUEUED` (201) at/before that boundary that is *provably outside
+  any hand* (session-context anchor — an MTT table-move 201 can land
+  mid-hand, including inside the previous completed hand itself, and would
+  cut off an opening `EVT_DEAL`; candidates whose most recent valid DEAL
+  isn't yet closed by a valid 306 are rejected and the scan steps back one
+  hand at a time), and forward to the first *valid pre-existing* 306 at/after the
   latest new event (newly-imported 306s are skipped, so the range always
   reaches the end of the OLD derivation's hand pairing — e.g. a DEAL that a
   capture gap had mis-paired with a later 306) — so a hand split between

--- a/src/background/import-export.overlap-repair.test.ts
+++ b/src/background/import-export.overlap-repair.test.ts
@@ -13,18 +13,14 @@
  * the raw Lake got repaired but the derived hands/phases/actions (and every
  * stat computed from them) stayed stale until a later full rebuild.
  *
- * The fix (see `collectOverlapRepairEvents()` in import-export.ts): when the
- * DB already contained events before the import, the derived-entity pass
- * re-reads the affected range from the Lake -- expanded backwards to the last
- * validated outside-hand EVT_ENTRY_QUEUED(201) at/before the earliest new
- * event (including a newly imported 201 at the exact endpoint), and forwards
- * to the first validated pre-existing EVT_HAND_RESULTS(306) at/after the
- * latest new event -- and re-derives entities from existing and new rows
- * together. Converter seeding and cleanup authority are then derived from the
- * validated range content, not from which boundary scan happened to succeed.
- * Re-deriving hands already present is idempotent: hands
- * (id), phases ([handId+phase]) and actions ([handId+index]) all have
- * deterministic keys and `saveEntities()` uses bulkPut.
+ * The fix (see `buildOverlapRepairPlan()` in import-export.ts): when the
+ * DB already contained events before the import, a bounded Lake replay builds
+ * pre/post-import DEAL->306 pairings, but deletion, conversion, and writes are
+ * selected per hand. Only a hand whose source span contains a new row, whose
+ * pairing changes, or whose Lake-derived session context changes is repaired;
+ * replayed bystanders are discarded and remain byte-identical. Each affected
+ * hand is seeded from the latest valid 201 (+ subsequent 308 name) before its
+ * own DEAL, with live-session seeding reserved for a genuinely new tail append.
  *
  * Each scenario below asserts the repaired DB's derived state deep-equals a
  * control DB produced by importing the same complete export into an empty DB
@@ -68,6 +64,10 @@ const shiftHand = (deltaMs: number, handId: number) => HAND1_EVENTS.map(event =>
 const HAND2_ID = 384370065
 const HAND2_EVENTS = shiftHand(1_000_000, HAND2_ID)
 
+// A third hand strictly after HAND2, used by the pure-append scope test.
+const HAND3_ID = 384370066
+const HAND3_EVENTS = shiftHand(2_000_000, HAND3_ID)
+
 // A hand strictly before HAND1 (still after ENTRY_QUEUED's timestamp).
 const HAND0_ID = 384370063
 const HAND0_EVENTS = shiftHand(-10_000, HAND0_ID)
@@ -93,6 +93,28 @@ const MALFORMED_RESULTS_ROW = { "ApiTypeId": 306, "timestamp": 1752427319000 }
 // (...313426) -- legitimately outside any hand (HAND0 is already closed,
 // HAND1 hasn't opened yet).
 const GAP_ENTRY_QUEUED = { ...ENTRY_QUEUED, "timestamp": 1752427310000 }
+
+// Minimal current-schema EVT_SESSION_DETAILS fixtures. The replacement sits
+// at the exact same millisecond as HAND0's RESULTS but sorts after it by the
+// compound [timestamp+ApiTypeId] key (308 > 306).
+const sessionDetails = (timestamp: number, name: string) => ({
+  "ApiTypeId": 308,
+  "BlindStructures": [{ "ActiveMinutes": -1, "Ante": 0, "BigBlind": 200, "Lv": 1 }],
+  "CoinNum": -1,
+  "DefaultChip": 6000,
+  "IsReplay": false,
+  "Items": [],
+  "LimitSeconds": 8,
+  "MoneyList": [],
+  "Name": name,
+  "Name2": "",
+  "timestamp": timestamp,
+})
+const INITIAL_SESSION_DETAILS = sessionDetails(1752427303300, 'Initial Lake Table')
+const SAME_MS_REPLACEMENT_SESSION_DETAILS = sessionDetails(
+  (HAND0_EVENTS[4] as { timestamp: number }).timestamp,
+  'Same-ms Replacement Table'
+)
 
 // Valid tail fragments whose opening DEAL is outside the captured Lake.
 // They exercise the range-content and delete-safety invariants without
@@ -741,10 +763,8 @@ describe('importData() overlap import repair (audit finding #7)', () => {
       expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(0)
 
       // A live session with a table name that must NOT leak into HAND1's
-      // repaired session: if GAP_ENTRY_QUEUED isn't recognized as a session
-      // anchor, hasSessionAnchor comes back false and importData() falls
-      // back to seeding the converter with this live session instead of the
-      // empty default one used at a real session boundary.
+      // repaired session: the affected hand must derive its own context from
+      // this Lake 201 rather than inherit the live session.
       service.session.setId('live-session-456')
       service.session.setBattleType(1)
       service.session.setName('Live Table Name')
@@ -822,6 +842,146 @@ describe('importData() overlap import repair (audit finding #7)', () => {
       expect(hand1).toBeDefined()
       expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(3)
       expect(await db.hands.count()).toBe(2)
+    })
+  })
+
+  test('an appended contextless hand keeps the live service.session even when an older complete contextless hand exists (PR #203 codex P2, pass 8 #1)', async () => {
+    await runWithFreshDb(async ({ db, service, handlers }) => {
+      await db.apiEvents.bulkAdd(HAND0_EVENTS as never[])
+      await handlers.rebuildAllData()
+      const hand0Before = await db.hands.get(HAND0_ID)
+      expect(hand0Before).toBeDefined()
+
+      service.session.setId('live-appended-session')
+      service.session.setBattleType(4)
+      service.session.setName('Live Appended Table')
+
+      const result = await handlers.importData(toJsonl(HAND1_EVENTS))
+      expect(result.successCount).toBe(HAND1_EVENTS.length)
+      expect(result.duplicateCount).toBe(0)
+
+      expect(await db.hands.get(HAND0_ID)).toEqual(hand0Before)
+      expect((await db.hands.get(HAND1_ID))?.session).toEqual({
+        id: 'live-appended-session',
+        battleType: 4,
+        name: 'Live Appended Table',
+      })
+    })
+  })
+
+  test('a valid 201 after a discarded leading DEAL supplies the repaired hand session without leaking the live name (PR #203 codex P2, pass 8 #2)', async () => {
+    await runWithFreshDb(async ({ db, service, handlers }) => {
+      // The first DEAL never closes. EntityConverter discards it when HAND1's
+      // real DEAL arrives, so the 201 between those DEALs is HAND1's Lake
+      // session anchor even though it follows the range's first DEAL.
+      await db.apiEvents.bulkAdd([PRE_ENTRY_HAND_EVENTS[0]!, ENTRY_QUEUED] as never[])
+      await handlers.rebuildAllData()
+      expect(await db.hands.count()).toBe(0)
+
+      service.session.setId('live-session-should-not-win')
+      service.session.setBattleType(1)
+      service.session.setName('Leaked Live Table')
+
+      await handlers.importData(toJsonl(HAND1_EVENTS))
+
+      const hand1 = await db.hands.get(HAND1_ID)
+      expect(hand1?.session).toMatchObject({ id: 'stage000_003', battleType: 0 })
+      expect(hand1?.session.name).toBeUndefined()
+    })
+  })
+
+  test('a pure append converts and writes only the appended hand, not every older hand since the 201 (PR #203 codex P2, pass 8 #3)', async () => {
+    await runWithFreshDb(async ({ db, handlers }) => {
+      await db.apiEvents.bulkAdd([
+        ENTRY_QUEUED,
+        ...HAND0_EVENTS,
+        ...HAND1_EVENTS,
+        ...HAND2_EVENTS,
+      ] as never[])
+      await handlers.rebuildAllData()
+
+      const deletedHandIds: number[] = []
+      const updatedHandIds: number[] = []
+      db.hands.hook('deleting', primaryKey => {
+        deletedHandIds.push(primaryKey as number)
+      })
+      db.hands.hook('updating', (_modifications, primaryKey) => {
+        updatedHandIds.push(primaryKey as number)
+      })
+
+      const result = await handlers.importData(toJsonl(HAND3_EVENTS))
+      expect(result.successCount).toBe(HAND3_EVENTS.length)
+      expect(result.duplicateCount).toBe(0)
+      expect(deletedHandIds).toEqual([])
+      expect(updatedHandIds).toEqual([])
+      expect((await db.hands.orderBy('id').primaryKeys()).sort()).toEqual([
+        HAND0_ID,
+        HAND1_ID,
+        HAND2_ID,
+        HAND3_ID,
+      ])
+    })
+  })
+
+  test('a same-millisecond 308 after a 306 remains inside the repair range and updates the following hand (PR #203 codex P2, pass 8 #4)', async () => {
+    await runWithFreshDb(async ({ db, handlers }) => {
+      await db.apiEvents.bulkAdd([
+        ENTRY_QUEUED,
+        INITIAL_SESSION_DETAILS,
+        ...HAND0_EVENTS,
+        ...HAND1_EVENTS,
+      ] as never[])
+      await handlers.rebuildAllData()
+      expect((await db.hands.get(HAND1_ID))?.session.name).toBe('Initial Lake Table')
+
+      const result = await handlers.importData(toJsonl([SAME_MS_REPLACEMENT_SESSION_DETAILS]))
+      expect(result.successCount).toBe(1)
+      expect(result.duplicateCount).toBe(0)
+
+      expect((await db.hands.get(HAND1_ID))?.session).toMatchObject({
+        id: 'stage000_003',
+        battleType: 0,
+        name: 'Same-ms Replacement Table',
+      })
+    })
+  })
+
+  test('an unrelated bystander hand stays byte-identical while a later hand is repaired', async () => {
+    const fullExport = [ENTRY_QUEUED, ...HAND0_EVENTS, ...HAND1_EVENTS]
+
+    await runWithFreshDb(async ({ db, handlers }) => {
+      await db.apiEvents.bulkAdd([
+        ENTRY_QUEUED,
+        ...HAND0_EVENTS,
+        HAND1_DEAL,
+        HAND1_RESULTS,
+      ] as never[])
+      await handlers.rebuildAllData()
+
+      // A valid persisted value that does not come from the Lake makes any
+      // delete-then-recreate of the bystander observable, even if ordinary
+      // converter output would otherwise compare equal by coincidence.
+      await db.hands.update(HAND0_ID, {
+        session: { id: 'bystander-sentinel', battleType: 5, name: 'Do Not Rewrite' },
+      })
+      const before = {
+        hand: await db.hands.get(HAND0_ID),
+        phases: await db.phases.where('handId').equals(HAND0_ID).sortBy('phase'),
+        actions: await db.actions.where('handId').equals(HAND0_ID).sortBy('index'),
+      }
+      const beforeBytes = JSON.stringify(before)
+
+      const result = await handlers.importData(toJsonl(fullExport))
+      expect(result.successCount).toBe(HAND1_ACTIONS.length)
+      expect(result.duplicateCount).toBe(fullExport.length - HAND1_ACTIONS.length)
+      expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(3)
+
+      const after = {
+        hand: await db.hands.get(HAND0_ID),
+        phases: await db.phases.where('handId').equals(HAND0_ID).sortBy('phase'),
+        actions: await db.actions.where('handId').equals(HAND0_ID).sortBy('index'),
+      }
+      expect(JSON.stringify(after)).toBe(beforeBytes)
     })
   })
 

--- a/src/background/import-export.overlap-repair.test.ts
+++ b/src/background/import-export.overlap-repair.test.ts
@@ -512,6 +512,61 @@ describe('importData() overlap import repair (audit finding #7)', () => {
     })
   })
 
+  test('a table-move 201 inside the PREVIOUS completed hand does not become the anchor: that hand survives the repair (PR #203 codex P2, pass 4)', async () => {
+    // Lake layout: 201 -> HAND0's DEAL -> mid-hand 201 (MTT table move
+    // INSIDE the previous completed hand) -> HAND0's ACTIONs/RESULTS ->
+    // HAND1's DEAL -> [missing ACTIONs] -> HAND1's RESULTS. The anchor scan
+    // walks back from HAND0's RESULTS (previous completed-hand boundary);
+    // the nearest 201 at/before it is the mid-hand one. Anchoring there
+    // would put HAND0's RESULTS inside the repair range but its DEAL
+    // outside -- the cleanup would account HAND0's id and delete it while
+    // the converter (buffering starts at DEAL) cannot re-emit it, erasing
+    // HAND0 until a full rebuild. The anchor must instead walk back past
+    // the mid-hand 201 to the outer 201, keeping HAND0 fully in range.
+    const MID_HAND0_ENTRY_QUEUED = { ...ENTRY_QUEUED, "timestamp": 1752427304000 } // between HAND0's DEAL (...303426) and its first ACTION (...305428)
+    const fullExport = [
+      ENTRY_QUEUED,
+      HAND0_EVENTS[0]!, // HAND0 DEAL
+      MID_HAND0_ENTRY_QUEUED,
+      ...HAND0_EVENTS.slice(1), // HAND0 ACTIONs + RESULTS
+      ...HAND1_EVENTS,
+    ]
+
+    const expected = await runWithFreshDb(async ({ db, handlers }) => {
+      await handlers.importData(toJsonl(fullExport))
+      return snapshotDerived(db)
+    })
+    expect(expected.hands.map(hand => hand.id).sort()).toEqual([HAND0_ID, HAND1_ID])
+
+    await runWithFreshDb(async ({ db, handlers }) => {
+      // Damaged DB: everything except HAND1's middle ACTIONs.
+      await db.apiEvents.bulkAdd([
+        ENTRY_QUEUED,
+        HAND0_EVENTS[0]!,
+        MID_HAND0_ENTRY_QUEUED,
+        ...HAND0_EVENTS.slice(1),
+        HAND1_DEAL,
+        HAND1_RESULTS,
+      ] as never[])
+      await handlers.rebuildAllData()
+      expect(await db.actions.where('handId').equals(HAND0_ID).count()).toBe(3)
+      expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(0)
+
+      const result = await handlers.importData(toJsonl(fullExport))
+      expect(result.successCount).toBe(3) // HAND1's ACTIONs
+      expect(result.duplicateCount).toBe(fullExport.length - 3)
+
+      // HAND0 must survive intact (not deleted-without-re-emit), HAND1 must
+      // be repaired, and the whole derived state must equal a from-scratch
+      // import of the same data.
+      expect(await snapshotDerived(db)).toEqual(expected)
+      expect(await db.hands.get(HAND0_ID)).toBeDefined()
+      expect(await db.actions.where('handId').equals(HAND0_ID).count()).toBe(3)
+      expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(3)
+      expect(await db.hands.count()).toBe(2)
+    })
+  })
+
   test('a fresh import into an empty DB still derives entities through the unchanged direct path', async () => {
     await runWithFreshDb(async ({ db, handlers }) => {
       const result = await handlers.importData(toJsonl([ENTRY_QUEUED, ...HAND1_EVENTS]))

--- a/src/background/import-export.overlap-repair.test.ts
+++ b/src/background/import-export.overlap-repair.test.ts
@@ -14,13 +14,13 @@
  * stat computed from them) stayed stale until a later full rebuild.
  *
  * The fix (see `buildOverlapRepairPlan()` in import-export.ts): when the
- * DB already contained events before the import, a bounded Lake replay builds
- * pre/post-import DEAL->306 pairings, but deletion, conversion, and writes are
- * selected per hand. Only a hand whose source span contains a new row, whose
- * pairing changes, or whose Lake-derived session context changes is repaired;
- * replayed bystanders are discarded and remain byte-identical. Each affected
- * hand is seeded from the latest valid 201 (+ subsequent 308 name) before its
- * own DEAL, with live-session seeding reserved for a genuinely new tail append.
+ * DB already contained events before the import, indexed session/hand
+ * boundaries identify the affected session window(s). Every complete hand in
+ * those windows is re-derived; hands in other sessions remain byte-identical.
+ * Each hand is seeded from validated 201/308 context before its own DEAL (308
+ * works even without a 201), with live-session seeding reserved for a genuinely
+ * new tail append. A legacy hand whose post-import raw pair still exists but
+ * whose converter guards reject it is preserved instead of deleted.
  *
  * Each scenario below asserts the repaired DB's derived state deep-equals a
  * control DB produced by importing the same complete export into an empty DB
@@ -93,6 +93,17 @@ const MALFORMED_RESULTS_ROW = { "ApiTypeId": 306, "timestamp": 1752427319000 }
 // (...313426) -- legitimately outside any hand (HAND0 is already closed,
 // HAND1 hasn't opened yet).
 const GAP_ENTRY_QUEUED = { ...ENTRY_QUEUED, "timestamp": 1752427310000 }
+const RECOVERED_SESSION_ENTRY = {
+  ...GAP_ENTRY_QUEUED,
+  "Id": "recovered-session",
+  "BattleType": 1,
+}
+const NEXT_SESSION_ENTRY = {
+  ...ENTRY_QUEUED,
+  "Id": "next-session",
+  "BattleType": 2,
+  "timestamp": 1752428800000,
+}
 
 // Minimal current-schema EVT_SESSION_DETAILS fixtures. The replacement sits
 // at the exact same millisecond as HAND0's RESULTS but sorts after it by the
@@ -111,6 +122,7 @@ const sessionDetails = (timestamp: number, name: string) => ({
   "timestamp": timestamp,
 })
 const INITIAL_SESSION_DETAILS = sessionDetails(1752427303300, 'Initial Lake Table')
+const SESSION_DETAILS_WITHOUT_201 = sessionDetails(1752427303000, '308-only Lake Table')
 const SAME_MS_REPLACEMENT_SESSION_DETAILS = sessionDetails(
   (HAND0_EVENTS[4] as { timestamp: number }).timestamp,
   'Same-ms Replacement Table'
@@ -890,7 +902,7 @@ describe('importData() overlap import repair (audit finding #7)', () => {
     })
   })
 
-  test('a pure append converts and writes only the appended hand, not every older hand since the 201 (PR #203 codex P2, pass 8 #3)', async () => {
+  test('a pure append rebuilds its session but reserves live-session seeding for the appended hand (PR #203 round 3 session granularity)', async () => {
     await runWithFreshDb(async ({ db, handlers }) => {
       await db.apiEvents.bulkAdd([
         ENTRY_QUEUED,
@@ -912,7 +924,9 @@ describe('importData() overlap import repair (audit finding #7)', () => {
       const result = await handlers.importData(toJsonl(HAND3_EVENTS))
       expect(result.successCount).toBe(HAND3_EVENTS.length)
       expect(result.duplicateCount).toBe(0)
-      expect(deletedHandIds).toEqual([])
+      // Session-granularity repair deliberately rewrites the three older hands
+      // in this same 201 window. The append itself is new, so it is not deleted.
+      expect(deletedHandIds.sort()).toEqual([HAND0_ID, HAND1_ID, HAND2_ID])
       expect(updatedHandIds).toEqual([])
       expect((await db.hands.orderBy('id').primaryKeys()).sort()).toEqual([
         HAND0_ID,
@@ -946,13 +960,139 @@ describe('importData() overlap import repair (audit finding #7)', () => {
     })
   })
 
-  test('an unrelated bystander hand stays byte-identical while a later hand is repaired', async () => {
-    const fullExport = [ENTRY_QUEUED, ...HAND0_EVENTS, ...HAND1_EVENTS]
+  test('an imported 201 repairs every later hand through the next session boundary (PR #203 round 3 P2 #1)', async () => {
+    await runWithFreshDb(async ({ db, handlers }) => {
+      await db.apiEvents.bulkAdd([
+        ENTRY_QUEUED,
+        ...HAND0_EVENTS,
+        // RECOVERED_SESSION_ENTRY is intentionally missing here.
+        ...HAND1_EVENTS,
+        ...HAND2_EVENTS,
+        NEXT_SESSION_ENTRY,
+        ...HAND3_EVENTS,
+      ] as never[])
+      await handlers.rebuildAllData()
+
+      expect((await db.hands.get(HAND1_ID))?.session.id).toBe('stage000_003')
+      expect((await db.hands.get(HAND2_ID))?.session.id).toBe('stage000_003')
+      const hand0Before = JSON.stringify(await db.hands.get(HAND0_ID))
+      const hand3Before = JSON.stringify(await db.hands.get(HAND3_ID))
+
+      const result = await handlers.importData(toJsonl([RECOVERED_SESSION_ENTRY]))
+      expect(result.successCount).toBe(1)
+      expect(result.duplicateCount).toBe(0)
+
+      // Both hands in the recovered session change, not only the first 306
+      // after the newly inserted 201.
+      expect((await db.hands.get(HAND1_ID))?.session).toMatchObject({
+        id: 'recovered-session',
+        battleType: 1,
+      })
+      expect((await db.hands.get(HAND2_ID))?.session).toMatchObject({
+        id: 'recovered-session',
+        battleType: 1,
+      })
+      // Adjacent sessions are outside the affected window.
+      expect(JSON.stringify(await db.hands.get(HAND0_ID))).toBe(hand0Before)
+      expect(JSON.stringify(await db.hands.get(HAND3_ID))).toBe(hand3Before)
+    })
+  })
+
+  test('a 308-only Lake context names every hand until the first 201 without leaking live id/battleType (PR #203 round 3 P2 #2)', async () => {
+    await runWithFreshDb(async ({ db, service, handlers }) => {
+      await db.apiEvents.bulkAdd([...HAND0_EVENTS, ...HAND1_EVENTS] as never[])
+      await handlers.rebuildAllData()
+      expect((await db.hands.get(HAND0_ID))?.session.name).toBeUndefined()
+      expect((await db.hands.get(HAND1_ID))?.session.name).toBeUndefined()
+
+      service.session.setId('live-id-must-not-fill-308-context')
+      service.session.setBattleType(4)
+      service.session.setName('Live name must not win')
+
+      const result = await handlers.importData(toJsonl([SESSION_DETAILS_WITHOUT_201]))
+      expect(result.successCount).toBe(1)
+      expect(result.duplicateCount).toBe(0)
+
+      for (const handId of [HAND0_ID, HAND1_ID]) {
+        expect((await db.hands.get(handId))?.session).toEqual({
+          id: undefined,
+          battleType: undefined,
+          name: '308-only Lake Table',
+        })
+      }
+    })
+  })
+
+  test('a legacy hand rejected by current converter guards is preserved while its valid raw pair remains (PR #203 round 3 P2 #3)', async () => {
+    await runWithFreshDb(async ({ db, handlers }) => {
+      const rejectedResults = JSON.parse(JSON.stringify(HAND1_RESULTS))
+      rejectedResults.Results[0].UserId = 999_999 // outside DEAL.SeatUserIds
+      const rejectedDeal = HAND1_DEAL as typeof HAND1_DEAL & {
+        SeatUserIds: number[]
+        Game: { SmallBlind: number, BigBlind: number }
+      }
+      await db.apiEvents.bulkAdd([
+        ENTRY_QUEUED,
+        HAND1_DEAL,
+        ...HAND1_ACTIONS,
+        rejectedResults,
+      ] as never[])
+      await handlers.rebuildAllData()
+      expect(await db.hands.count()).toBe(0)
+
+      // Simulate a hand produced by an older converter before the semantic
+      // outside-lineup guard existed. Its current raw rows still parse and its
+      // DEAL→306 pair still exists, but current EntityConverter rejects it.
+      await db.hands.put({
+        id: HAND1_ID,
+        approxTimestamp: rejectedResults.timestamp,
+        seatUserIds: rejectedDeal.SeatUserIds,
+        winningPlayerIds: [999_999],
+        smallBlind: rejectedDeal.Game.SmallBlind,
+        bigBlind: rejectedDeal.Game.BigBlind,
+        session: { id: 'legacy-session', battleType: 5, name: 'Preserve Me' },
+        results: rejectedResults.Results,
+      } as never)
+      await db.phases.put({
+        handId: HAND1_ID,
+        phase: 0,
+        seatUserIds: rejectedDeal.SeatUserIds,
+        communityCards: [],
+      } as never)
+      await db.actions.put({
+        handId: HAND1_ID,
+        index: 0,
+        playerId: rejectedDeal.SeatUserIds[0],
+        phase: 0,
+        actionType: 2,
+        bet: 0,
+        pot: 500,
+        sidePot: [],
+        position: 0,
+        actionDetails: [],
+      } as never)
+      const beforeBytes = JSON.stringify(await snapshotDerived(db))
+
+      const result = await handlers.importData(toJsonl([
+        sessionDetails(1752427303301, 'New context that triggers this session'),
+      ]))
+      expect(result.successCount).toBe(1)
+
+      expect(JSON.stringify(await snapshotDerived(db))).toBe(beforeBytes)
+      expect(await db.apiEvents.get([HAND1_DEAL.timestamp, HAND1_DEAL.ApiTypeId])).toBeDefined()
+      expect(await db.apiEvents.get([rejectedResults.timestamp, rejectedResults.ApiTypeId])).toBeDefined()
+    })
+  })
+
+  test('an unrelated bystander hand outside the affected session stays byte-identical', async () => {
+    const hand1Session = { ...GAP_ENTRY_QUEUED, Id: 'hand1-session' }
+    const fullExport = [ENTRY_QUEUED, ...HAND0_EVENTS, hand1Session, ...HAND1_EVENTS]
 
     await runWithFreshDb(async ({ db, handlers }) => {
       await db.apiEvents.bulkAdd([
         ENTRY_QUEUED,
         ...HAND0_EVENTS,
+        hand1Session,
         HAND1_DEAL,
         HAND1_RESULTS,
       ] as never[])

--- a/src/background/import-export.overlap-repair.test.ts
+++ b/src/background/import-export.overlap-repair.test.ts
@@ -52,15 +52,33 @@ const HAND1_DEAL = HAND1_EVENTS[0]!
 const HAND1_ACTIONS = HAND1_EVENTS.slice(1, 4)
 const HAND1_RESULTS = HAND1_EVENTS[4]!
 
-// A second, structurally identical hand strictly after HAND1 (timestamps
-// shifted forward, distinct HandId) for range-scoping assertions.
-const HAND2_ID = 384370065
-const HAND2_EVENTS = HAND1_EVENTS.map(event => {
+// Structurally identical hands shifted in time with distinct HandIds, for
+// boundary/range-scoping assertions.
+const shiftHand = (deltaMs: number, handId: number) => HAND1_EVENTS.map(event => {
   const clone = JSON.parse(JSON.stringify(event))
-  clone.timestamp = (event as { timestamp: number }).timestamp + 1_000_000
-  if (clone.ApiTypeId === 306) clone.HandId = HAND2_ID
+  clone.timestamp = (event as { timestamp: number }).timestamp + deltaMs
+  if (clone.ApiTypeId === 306) clone.HandId = handId
   return clone
 })
+
+// A second hand strictly after HAND1.
+const HAND2_ID = 384370065
+const HAND2_EVENTS = shiftHand(1_000_000, HAND2_ID)
+
+// A hand strictly before HAND1 (still after ENTRY_QUEUED's timestamp).
+const HAND0_ID = 384370063
+const HAND0_EVENTS = shiftHand(-10_000, HAND0_ID)
+
+// An MTT table-move EVT_ENTRY_QUEUED injected INSIDE HAND1 (between its
+// EVT_DEAL at ...313426 and its first EVT_ACTION at ...315428) -- the repo
+// documents 201 can land mid-hand on MTT table moves (docs/api-events.md).
+const MID_HAND_ENTRY_QUEUED = { ...ENTRY_QUEUED, "timestamp": 1752427314500 }
+
+// A malformed EVT_HAND_RESULTS Lake row (numeric timestamp+ApiTypeId only --
+// stored raw per the Lake rules, but unparseable under the current schema),
+// sitting between HAND1's last ACTION (...318516) and its valid RESULTS
+// (...319431).
+const MALFORMED_RESULTS_ROW = { "ApiTypeId": 306, "timestamp": 1752427319000 }
 
 const toJsonl = (events: unknown[]): string => events.map(event => JSON.stringify(event)).join('\n')
 
@@ -202,6 +220,103 @@ describe('importData() overlap import repair (audit finding #7)', () => {
 
       expect(await db.hands.get(HAND1_ID)).toBeDefined()
       expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(3)
+    })
+  })
+
+  test('a mid-hand MTT table-move 201 does not cut off the opening DEAL: the lower bound is the previous completed-hand boundary (PR #203 codex P2 #1)', async () => {
+    // Lake layout: 201 -> HAND0 (complete) -> HAND1's DEAL -> mid-hand 201
+    // (MTT table move) -> [missing ACTIONs] -> HAND1's RESULTS. Anchoring on
+    // "last 201 at/before the earliest new event" would pick the mid-hand
+    // 201 and exclude HAND1's DEAL, so the imported ACTIONs still couldn't
+    // form the hand. The correct lower bound walks back to the previous
+    // valid EVT_HAND_RESULTS (HAND0's) and then to the 201 before it.
+    const fullExport = [
+      ENTRY_QUEUED,
+      ...HAND0_EVENTS,
+      HAND1_DEAL,
+      MID_HAND_ENTRY_QUEUED,
+      ...HAND1_ACTIONS,
+      HAND1_RESULTS,
+    ]
+
+    const expected = await runWithFreshDb(async ({ db, handlers }) => {
+      await handlers.importData(toJsonl(fullExport))
+      return snapshotDerived(db)
+    })
+    expect(expected.hands.map(hand => hand.id).sort()).toEqual([HAND0_ID, HAND1_ID])
+
+    await runWithFreshDb(async ({ db, handlers }) => {
+      // Damaged DB: everything except HAND1's middle ACTIONs.
+      await db.apiEvents.bulkAdd([
+        ENTRY_QUEUED,
+        ...HAND0_EVENTS,
+        HAND1_DEAL,
+        MID_HAND_ENTRY_QUEUED,
+        HAND1_RESULTS,
+      ] as never[])
+      await handlers.rebuildAllData()
+      expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(0)
+
+      const result = await handlers.importData(toJsonl(fullExport))
+      expect(result.successCount).toBe(3) // HAND1's ACTIONs
+      expect(result.duplicateCount).toBe(fullExport.length - 3)
+
+      expect(await snapshotDerived(db)).toEqual(expected)
+      expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(3)
+      expect(await db.actions.where('handId').equals(HAND0_ID).count()).toBe(3)
+    })
+  })
+
+  test('a malformed 306 Lake row between the new events and the real RESULTS does not truncate the repair range (PR #203 codex P2 #2)', async () => {
+    await runWithFreshDb(async ({ db, handlers }) => {
+      // Damaged DB: DEAL and valid RESULTS present, ACTIONs missing, plus an
+      // unparseable ApiTypeId=306 noise row sitting between where the
+      // imported ACTIONs land and the valid RESULTS. A raw-ApiTypeId
+      // boundary search would stop at the noise row; the later
+      // filterValidApplicationEvents() pass removes it, leaving the hand
+      // unterminated and the repair silently ineffective.
+      await db.apiEvents.bulkAdd([
+        ENTRY_QUEUED,
+        HAND1_DEAL,
+        MALFORMED_RESULTS_ROW,
+        HAND1_RESULTS,
+      ] as never[])
+
+      const result = await handlers.importData(toJsonl([ENTRY_QUEUED, ...HAND1_EVENTS]))
+      expect(result.successCount).toBe(3)
+      expect(result.duplicateCount).toBe(3)
+
+      expect(await db.hands.get(HAND1_ID)).toBeDefined()
+      expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(3)
+      // The noise row itself is untouched Lake data.
+      expect(await db.apiEvents.get([1752427319000, 306])).toBeDefined()
+    })
+  })
+
+  test('an incremental import without a 201 keeps seeding hand.session from the live service.session (PR #203 codex P2 #3)', async () => {
+    await runWithFreshDb(async ({ db, service, handlers }) => {
+      // Non-empty DB (noise only, no 201 anywhere) forces the overlap path.
+      await db.apiEvents.bulkAdd([{ ApiTypeId: 9999, timestamp: 1000 }] as never[])
+
+      // Live in-memory session context, as during mid-play imports -- the
+      // same situation the #104 SessionState-seeding regression test covers
+      // for the direct path.
+      service.session.setId('live-session-456')
+      service.session.setBattleType(0)
+      service.session.setName('Live Session')
+
+      const result = await handlers.importData(toJsonl(HAND1_EVENTS)) // no EVT_ENTRY_QUEUED in the window
+      expect(result.successCount).toBe(HAND1_EVENTS.length)
+
+      const hand = await db.hands.get(HAND1_ID)
+      expect(hand).toBeDefined()
+      // No session anchor in the repair range -> the live session must seed
+      // the converter, exactly like the direct (empty-DB) path would.
+      expect(hand!.session).toMatchObject({
+        id: 'live-session-456',
+        battleType: 0,
+        name: 'Live Session',
+      })
     })
   })
 

--- a/src/background/import-export.overlap-repair.test.ts
+++ b/src/background/import-export.overlap-repair.test.ts
@@ -407,6 +407,111 @@ describe('importData() overlap import repair (audit finding #7)', () => {
     })
   })
 
+  test('a Lake starting with a 201 before its first hand counts as a session anchor: no live session name leaks into first-hand repairs (PR #203 codex P2, pass 3)', async () => {
+    await runWithFreshDb(async ({ db, service, handlers }) => {
+      // The repaired hand is the FIRST hand in the Lake: no prior 306, so
+      // the lower bound falls back to the Lake start -- which begins with a
+      // valid 201. The empty rebuild-style session must seed the converter
+      // here too: a replayed 201 overwrites id/battleType but NOT
+      // session.name, so live-session seeding would leak the live table
+      // name into a historical first-hand repair that has no 308.
+      await db.apiEvents.bulkAdd([ENTRY_QUEUED, HAND1_DEAL, HAND1_RESULTS] as never[])
+
+      service.session.setId('live-session-456')
+      service.session.setBattleType(1)
+      service.session.setName('Live Table Name')
+
+      const result = await handlers.importData(toJsonl([ENTRY_QUEUED, ...HAND1_EVENTS]))
+      expect(result.successCount).toBe(3)
+
+      const hand = await db.hands.get(HAND1_ID)
+      expect(hand).toBeDefined()
+      // Session identity comes from the Lake's own 201...
+      expect(hand!.session).toMatchObject({ id: 'stage000_003', battleType: 0 })
+      // ...and the live table name must NOT have leaked in.
+      expect(hand!.session.name).toBeUndefined()
+    })
+  })
+
+  test('legacy derived hands without approxTimestamp are still cleaned up by the repair (PR #203 codex P2, pass 3)', async () => {
+    // Same capture-gap chimera as the pass-2 test, but the stale derived
+    // hand row predates approxTimestamp (the model treats it as optional) --
+    // a timestamp-window index query would silently skip it and leave the
+    // orphaned action tail behind.
+    const damagedLake = [
+      ENTRY_QUEUED,
+      HAND1_DEAL,
+      ...HAND1_ACTIONS,
+      ...HAND2_EVENTS.slice(1, 4),
+      HAND2_EVENTS[4]!,
+    ]
+    const fullExport = [ENTRY_QUEUED, ...HAND1_EVENTS, ...HAND2_EVENTS]
+
+    const expected = await runWithFreshDb(async ({ db, handlers }) => {
+      await handlers.importData(toJsonl(fullExport))
+      return snapshotDerived(db)
+    })
+
+    await runWithFreshDb(async ({ db, handlers }) => {
+      await db.apiEvents.bulkAdd(damagedLake as never[])
+      await handlers.rebuildAllData()
+      // Simulate a legacy row: strip approxTimestamp from the stale chimera.
+      await db.hands.toCollection().modify(hand => { delete (hand as { approxTimestamp?: number }).approxTimestamp })
+      expect((await db.hands.get(HAND2_ID))?.approxTimestamp).toBeUndefined()
+      expect(await db.actions.where('handId').equals(HAND2_ID).count()).toBe(6)
+
+      const result = await handlers.importData(toJsonl(fullExport))
+      expect(result.successCount).toBe(2)
+
+      expect(await snapshotDerived(db)).toEqual(expected)
+      expect(await db.actions.where('handId').equals(HAND2_ID).count()).toBe(3)
+      expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(3)
+    })
+  })
+
+  test('derived hands whose raw rows no longer validate are NOT deleted by the repair (PR #203 codex P2, pass 3)', async () => {
+    await runWithFreshDb(async ({ db, handlers }) => {
+      // Lake: a schema-broken hand (raw 303/306 rows that no longer parse
+      // under the current schema -- e.g. an old PokerChase payload shape)
+      // sits between the 201 and HAND1, whose middle ACTIONs are missing.
+      await db.apiEvents.bulkAdd([
+        ENTRY_QUEUED,
+        { ApiTypeId: 303, timestamp: 1752427305000 }, // malformed DEAL
+        { ApiTypeId: 306, timestamp: 1752427306000, HandId: 99999 }, // malformed RESULTS
+        HAND1_DEAL,
+        HAND1_RESULTS,
+      ] as never[])
+
+      // Derived state for the schema-broken hand, as an OLDER schema once
+      // produced it. The re-derivation cannot recreate it (its raw rows are
+      // filtered out), so the repair must leave it untouched -- exactly the
+      // state a plain import would have preserved until an explicit rebuild.
+      await db.hands.put({
+        id: 99999,
+        approxTimestamp: 1752427306000, // inside what a timestamp window would cover
+        seatUserIds: [2, 4, 3, 1],
+        winningPlayerIds: [4],
+        smallBlind: 100,
+        bigBlind: 200,
+        session: { id: 'stage000_003', battleType: 0 },
+        results: [],
+      } as never)
+      await db.phases.put({ handId: 99999, phase: 0, seatUserIds: [2, 4, 3, 1], communityCards: [] } as never)
+      await db.actions.put({ handId: 99999, index: 0, playerId: 2, phase: 0, actionType: 2, bet: 0, pot: 500, sidePot: [], position: 0, actionDetails: [] } as never)
+
+      const result = await handlers.importData(toJsonl([ENTRY_QUEUED, ...HAND1_EVENTS]))
+      expect(result.successCount).toBe(3)
+
+      // HAND1 is repaired...
+      expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(3)
+      // ...and the schema-broken hand's derived state survives untouched.
+      expect(await db.hands.get(99999)).toBeDefined()
+      expect(await db.phases.where('handId').equals(99999).count()).toBe(1)
+      expect(await db.actions.where('handId').equals(99999).count()).toBe(1)
+      expect(await db.hands.count()).toBe(2)
+    })
+  })
+
   test('a fresh import into an empty DB still derives entities through the unchanged direct path', async () => {
     await runWithFreshDb(async ({ db, handlers }) => {
       const result = await handlers.importData(toJsonl([ENTRY_QUEUED, ...HAND1_EVENTS]))

--- a/src/background/import-export.overlap-repair.test.ts
+++ b/src/background/import-export.overlap-repair.test.ts
@@ -16,10 +16,13 @@
  * The fix (see `collectOverlapRepairEvents()` in import-export.ts): when the
  * DB already contained events before the import, the derived-entity pass
  * re-reads the affected range from the Lake -- expanded backwards to the last
- * EVT_ENTRY_QUEUED(201) at/before the earliest new event (hand boundary AND
- * session-context start) and forwards to the first EVT_HAND_RESULTS(306)
- * at/after the latest new event -- and re-derives entities from existing and
- * new rows together. Re-deriving hands already present is idempotent: hands
+ * validated outside-hand EVT_ENTRY_QUEUED(201) at/before the earliest new
+ * event (including a newly imported 201 at the exact endpoint), and forwards
+ * to the first validated pre-existing EVT_HAND_RESULTS(306) at/after the
+ * latest new event -- and re-derives entities from existing and new rows
+ * together. Converter seeding and cleanup authority are then derived from the
+ * validated range content, not from which boundary scan happened to succeed.
+ * Re-deriving hands already present is idempotent: hands
  * (id), phases ([handId+phase]) and actions ([handId+index]) all have
  * deterministic keys and `saveEntities()` uses bulkPut.
  *
@@ -69,6 +72,11 @@ const HAND2_EVENTS = shiftHand(1_000_000, HAND2_ID)
 const HAND0_ID = 384370063
 const HAND0_EVENTS = shiftHand(-10_000, HAND0_ID)
 
+// A contextless hand wholly before ENTRY_QUEUED, used to prove an exact-min
+// newly imported 201 can become the lower boundary without replaying history.
+const PRE_ENTRY_HAND_ID = 384370061
+const PRE_ENTRY_HAND_EVENTS = shiftHand(-20_000, PRE_ENTRY_HAND_ID)
+
 // An MTT table-move EVT_ENTRY_QUEUED injected INSIDE HAND1 (between its
 // EVT_DEAL at ...313426 and its first EVT_ACTION at ...315428) -- the repo
 // documents 201 can land mid-hand on MTT table moves (docs/api-events.md).
@@ -85,6 +93,17 @@ const MALFORMED_RESULTS_ROW = { "ApiTypeId": 306, "timestamp": 1752427319000 }
 // (...313426) -- legitimately outside any hand (HAND0 is already closed,
 // HAND1 hasn't opened yet).
 const GAP_ENTRY_QUEUED = { ...ENTRY_QUEUED, "timestamp": 1752427310000 }
+
+// Valid tail fragments whose opening DEAL is outside the captured Lake.
+// They exercise the range-content and delete-safety invariants without
+// inventing new event payload shapes.
+const LEADING_ACTION_FRAGMENT = { ...HAND1_ACTIONS[0]!, "timestamp": 1752427302000 }
+const LEADING_RESULTS_FRAGMENT_ID = 384370062
+const LEADING_RESULTS_FRAGMENT = {
+  ...HAND0_EVENTS[4]!,
+  "HandId": LEADING_RESULTS_FRAGMENT_ID,
+  "timestamp": 1752427301000,
+}
 
 const toJsonl = (events: unknown[]): string => events.map(event => JSON.stringify(event)).join('\n')
 
@@ -343,6 +362,97 @@ describe('importData() overlap import repair (audit finding #7)', () => {
         battleType: 0,
         name: 'Live Session',
       })
+    })
+  })
+
+  test('a newly imported 201 at exactly minNewTimestamp anchors after an earlier contextless hand without rewriting it or leaking the live name (PR #203 codex P2, pass 6)', async () => {
+    await runWithFreshDb(async ({ db, service, handlers }) => {
+      // An unrelated, already-complete hand precedes the import, but its Lake
+      // capture has no 201. The import itself begins with a valid 201. If the
+      // backward scan remains strictly below minNewTimestamp, it falls back
+      // to Lake start, replays/re-writes the earlier hand, and reports no anchor.
+      await db.apiEvents.bulkAdd(PRE_ENTRY_HAND_EVENTS as never[])
+      await handlers.rebuildAllData()
+      const hand0Before = await db.hands.get(PRE_ENTRY_HAND_ID)
+      expect(hand0Before).toBeDefined()
+      expect(hand0Before!.session.name).toBeUndefined()
+
+      service.session.setId('live-session-456')
+      service.session.setBattleType(1)
+      service.session.setName('Live Table Name')
+
+      const result = await handlers.importData(toJsonl([ENTRY_QUEUED, ...HAND1_EVENTS]))
+      expect(result.successCount).toBe(1 + HAND1_EVENTS.length)
+
+      // The exact-min 201 is a valid outside-hand lower boundary: HAND0 stays
+      // outside the replay/delete range and the new historical hand is seeded
+      // from an empty rebuild-style session before that 201 is applied.
+      expect(await db.hands.get(PRE_ENTRY_HAND_ID)).toEqual(hand0Before)
+      const hand1 = await db.hands.get(HAND1_ID)
+      expect(hand1).toBeDefined()
+      expect(hand1!.session).toMatchObject({ id: 'stage000_003', battleType: 0 })
+      expect(hand1!.session.name).toBeUndefined()
+    })
+  })
+
+  test('a replay range with a leading mid-hand fragment derives session anchoring from the validated range content before its first DEAL (PR #203 codex P2, pass 6)', async () => {
+    await runWithFreshDb(async ({ db, service, handlers }) => {
+      // Pre-existing non-application noise forces overlap repair. The first
+      // new valid event is an orphan ACTION fragment, followed by a new 201
+      // and then the first DEAL in the range. No backward scan can find that
+      // later 201, but the replay itself establishes session context before
+      // its first hand and must therefore use the empty seed.
+      await db.apiEvents.add({ ApiTypeId: 9999, timestamp: 1000 } as never)
+
+      service.session.setId('live-session-456')
+      service.session.setBattleType(1)
+      service.session.setName('Live Table Name')
+
+      const imported = [LEADING_ACTION_FRAGMENT, ENTRY_QUEUED, ...HAND1_EVENTS]
+      const result = await handlers.importData(toJsonl(imported))
+      expect(result.successCount).toBe(imported.length)
+
+      const hand = await db.hands.get(HAND1_ID)
+      expect(hand).toBeDefined()
+      expect(hand!.session).toMatchObject({ id: 'stage000_003', battleType: 0 })
+      expect(hand!.session.name).toBeUndefined()
+    })
+  })
+
+  test('a validated leading 306 fragment without an opening DEAL in the replay range never authorizes derived-hand deletion (PR #203 codex P2, pass 6)', async () => {
+    await runWithFreshDb(async ({ db, handlers }) => {
+      // The Lake begins with the tail of a hand whose DEAL was never captured.
+      // Keep an older-schema derived representation of that hand to prove
+      // overlap repair cannot delete it merely because its valid 306 lies in
+      // the fallback range: the range cannot re-derive or otherwise account
+      // for a hand whose opening DEAL is absent.
+      await db.apiEvents.add(LEADING_RESULTS_FRAGMENT as never)
+      const preservedHand = {
+        id: LEADING_RESULTS_FRAGMENT_ID,
+        approxTimestamp: 1752427299000,
+        seatUserIds: [2, 4, 3, 1],
+        winningPlayerIds: [4],
+        smallBlind: 100,
+        bigBlind: 200,
+        session: { id: 'older-capture', battleType: 0, name: 'Preserved Table' },
+        results: [],
+      }
+      await db.hands.put(preservedHand as never)
+      await db.phases.put({ handId: LEADING_RESULTS_FRAGMENT_ID, phase: 0, seatUserIds: [2, 4, 3, 1], communityCards: [] } as never)
+      await db.actions.put({ handId: LEADING_RESULTS_FRAGMENT_ID, index: 0, playerId: 2, phase: 0, actionType: 2, bet: 0, pot: 500, sidePot: [], position: 0, actionDetails: [] } as never)
+
+      // The orphan ACTION keeps the later 201 outside the backward scan, so
+      // the validated replay starts with the orphan 306 fragment.
+      const imported = [LEADING_ACTION_FRAGMENT, ENTRY_QUEUED, ...HAND1_EVENTS]
+      const result = await handlers.importData(toJsonl(imported))
+      expect(result.successCount).toBe(imported.length)
+
+      expect(await db.hands.get(LEADING_RESULTS_FRAGMENT_ID)).toEqual(preservedHand)
+      expect(await db.phases.where('handId').equals(LEADING_RESULTS_FRAGMENT_ID).count()).toBe(1)
+      expect(await db.actions.where('handId').equals(LEADING_RESULTS_FRAGMENT_ID).count()).toBe(1)
+      expect(await db.hands.get(HAND1_ID)).toBeDefined()
+      // Repair writes derived tables only; the raw leading fragment remains.
+      expect(await db.apiEvents.get([LEADING_RESULTS_FRAGMENT.timestamp, 306])).toEqual(LEADING_RESULTS_FRAGMENT)
     })
   })
 

--- a/src/background/import-export.overlap-repair.test.ts
+++ b/src/background/import-export.overlap-repair.test.ts
@@ -320,6 +320,93 @@ describe('importData() overlap import repair (audit finding #7)', () => {
     })
   })
 
+  test('a capture-gap mis-paired hand is fully replaced on re-import: derived rows absent from the new derivation are deleted (PR #203 codex P2, pass 2)', async () => {
+    // Damaged Lake: HAND1's RESULTS and HAND2's DEAL were both lost to a
+    // capture gap, so the old derivation pairs HAND1's DEAL with HAND2's
+    // RESULTS -- a single chimera hand under HAND2_ID carrying all 6 actions
+    // (same table lineup, so no rejection guard fires).
+    const damagedLake = [
+      ENTRY_QUEUED,
+      HAND1_DEAL,
+      ...HAND1_ACTIONS,
+      ...HAND2_EVENTS.slice(1, 4), // HAND2's ACTIONs
+      HAND2_EVENTS[4]!, // HAND2's RESULTS
+    ]
+    const fullExport = [ENTRY_QUEUED, ...HAND1_EVENTS, ...HAND2_EVENTS]
+
+    const expected = await runWithFreshDb(async ({ db, handlers }) => {
+      await handlers.importData(toJsonl(fullExport))
+      return snapshotDerived(db)
+    })
+    expect(expected.hands.map(hand => hand.id).sort()).toEqual([HAND1_ID, HAND2_ID])
+
+    await runWithFreshDb(async ({ db, handlers }) => {
+      await db.apiEvents.bulkAdd(damagedLake as never[])
+      await handlers.rebuildAllData()
+      // Stale state from the old derivation: one chimera hand under
+      // HAND2_ID that swallowed HAND1's actions.
+      expect(await db.hands.count()).toBe(1)
+      expect(await db.hands.get(HAND2_ID)).toBeDefined()
+      expect(await db.actions.where('handId').equals(HAND2_ID).count()).toBe(6)
+
+      // Re-import the complete export: only the two gap rows are new.
+      const result = await handlers.importData(toJsonl(fullExport))
+      expect(result.successCount).toBe(2) // HAND1's RESULTS + HAND2's DEAL
+      expect(result.duplicateCount).toBe(fullExport.length - 2)
+
+      // Upsert alone would overwrite the chimera's hand row and action
+      // indexes 0-2 but leave the orphaned action tail (indexes 3-5)
+      // behind. The stale-window deletion must remove the whole old
+      // derivation first, leaving state identical to a from-scratch import.
+      expect(await snapshotDerived(db)).toEqual(expected)
+      expect(await db.actions.where('handId').equals(HAND2_ID).count()).toBe(3)
+      expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(3)
+    })
+  })
+
+  test('a stale mis-paired hand whose id vanishes from the new derivation is deleted, not double-counted (PR #203 codex P2, pass 2)', async () => {
+    // Same capture-gap chimera as above, but the import brings only HAND1's
+    // events (HAND2's DEAL stays missing). The new derivation emits HAND1
+    // only -- HAND2's tail events still can't form a hand -- so the chimera
+    // under HAND2_ID must be deleted outright, or stats keep counting both
+    // the corrected HAND1 and the stale chimera until a full rebuild.
+    const damagedLake = [
+      ENTRY_QUEUED,
+      HAND1_DEAL,
+      ...HAND1_ACTIONS,
+      ...HAND2_EVENTS.slice(1, 4),
+      HAND2_EVENTS[4]!,
+    ]
+    const partialImport = [ENTRY_QUEUED, ...HAND1_EVENTS]
+    // What the damaged Lake contains AFTER the partial import -- the control
+    // is a from-scratch import of exactly that content.
+    const postImportLakeContent = [
+      ENTRY_QUEUED,
+      ...HAND1_EVENTS,
+      ...HAND2_EVENTS.slice(1),
+    ]
+
+    const expected = await runWithFreshDb(async ({ db, handlers }) => {
+      await handlers.importData(toJsonl(postImportLakeContent))
+      return snapshotDerived(db)
+    })
+    expect(expected.hands.map(hand => hand.id)).toEqual([HAND1_ID])
+
+    await runWithFreshDb(async ({ db, handlers }) => {
+      await db.apiEvents.bulkAdd(damagedLake as never[])
+      await handlers.rebuildAllData()
+      expect(await db.hands.get(HAND2_ID)).toBeDefined()
+
+      const result = await handlers.importData(toJsonl(partialImport))
+      expect(result.successCount).toBe(1) // HAND1's RESULTS
+      expect(result.duplicateCount).toBe(partialImport.length - 1)
+
+      expect(await snapshotDerived(db)).toEqual(expected)
+      expect(await db.hands.count()).toBe(1)
+      expect(await db.hands.get(HAND2_ID)).toBeUndefined()
+    })
+  })
+
   test('a fresh import into an empty DB still derives entities through the unchanged direct path', async () => {
     await runWithFreshDb(async ({ db, handlers }) => {
       const result = await handlers.importData(toJsonl([ENTRY_QUEUED, ...HAND1_EVENTS]))

--- a/src/background/import-export.overlap-repair.test.ts
+++ b/src/background/import-export.overlap-repair.test.ts
@@ -1,0 +1,219 @@
+/**
+ * importData() - overlap import repair of derived entities (independent
+ * release-audit finding #7)
+ *
+ * `importData()` stores every new raw line into the apiEvents Lake, but used
+ * to feed ONLY the newly-stored events to `EntityConverter`. EntityConverter
+ * can only form a hand from a contiguous EVT_DEAL(303) -> ... ->
+ * EVT_HAND_RESULTS(306) event run, so when an import partially overlapped
+ * existing data -- e.g. re-importing a complete export into a DB that already
+ * had a hand's DEAL and RESULTS but was missing the middle ACTIONs -- the new
+ * ACTION rows were severed from their duplicate-excluded DEAL/RESULTS,
+ * couldn't form a hand boundary, and were silently dropped by the converter:
+ * the raw Lake got repaired but the derived hands/phases/actions (and every
+ * stat computed from them) stayed stale until a later full rebuild.
+ *
+ * The fix (see `collectOverlapRepairEvents()` in import-export.ts): when the
+ * DB already contained events before the import, the derived-entity pass
+ * re-reads the affected range from the Lake -- expanded backwards to the last
+ * EVT_ENTRY_QUEUED(201) at/before the earliest new event (hand boundary AND
+ * session-context start) and forwards to the first EVT_HAND_RESULTS(306)
+ * at/after the latest new event -- and re-derives entities from existing and
+ * new rows together. Re-deriving hands already present is idempotent: hands
+ * (id), phases ([handId+phase]) and actions ([handId+index]) all have
+ * deterministic keys and `saveEntities()` uses bulkPut.
+ *
+ * Each scenario below asserts the repaired DB's derived state deep-equals a
+ * control DB produced by importing the same complete export into an empty DB
+ * (complete AND non-duplicated), per the audit's suggested regression test:
+ * "DEAL/RESULTS既存・ACTION欠落のDBへ完全exportをimportし、action/statが
+ * 再構築されることを確認する".
+ */
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { createImportExportHandlers } from './import-export'
+import { setOperationState } from './operation-state'
+
+// A known-good session-start + hand (EVT_ENTRY_QUEUED, then EVT_DEAL -> 3x
+// EVT_ACTION -> EVT_HAND_RESULTS), copied verbatim from src/app.test.ts's
+// event_timeline fixture (already exercised there against the real stats
+// pipeline) so this test isn't hand-authoring a new Zod-shaped fixture.
+const ENTRY_QUEUED = { "ApiTypeId": 201, "Code": 0, "BattleType": 0, "Id": "stage000_003", "IsRetire": false, "timestamp": 1752427303234 }
+
+const HAND1_EVENTS = [
+  { "ApiTypeId": 303, "SeatUserIds": [2, 4, 3, 1], "Game": { "CurrentBlindLv": 1, "NextBlindUnixSeconds": 1752427424, "Ante": 50, "SmallBlind": 100, "BigBlind": 200, "ButtonSeat": 3, "SmallBlindSeat": 0, "BigBlindSeat": 1 }, "Player": { "SeatIndex": 1, "BetStatus": 1, "HoleCards": [5, 21], "Chip": 5750, "BetChip": 200 }, "OtherPlayers": [{ "SeatIndex": 0, "Status": 0, "BetStatus": 1, "Chip": 5850, "BetChip": 100, "IsSafeLeave": false }, { "SeatIndex": 2, "Status": 0, "BetStatus": 1, "Chip": 5950, "BetChip": 0, "IsSafeLeave": false }, { "SeatIndex": 3, "Status": 0, "BetStatus": 1, "Chip": 5950, "BetChip": 0, "IsSafeLeave": false }], "Progress": { "Phase": 0, "NextActionSeat": 2, "NextActionTypes": [2, 3, 4, 5], "NextExtraLimitSeconds": 1, "MinRaise": 400, "Pot": 500, "SidePot": [] }, "timestamp": 1752427313426 },
+  { "ApiTypeId": 304, "SeatIndex": 2, "ActionType": 2, "Chip": 5950, "BetChip": 0, "Progress": { "Phase": 0, "NextActionSeat": 3, "NextActionTypes": [2, 3, 4, 5], "NextExtraLimitSeconds": 1, "MinRaise": 400, "Pot": 500, "SidePot": [] }, "timestamp": 1752427315428 },
+  { "ApiTypeId": 304, "SeatIndex": 3, "ActionType": 2, "Chip": 5950, "BetChip": 0, "Progress": { "Phase": 0, "NextActionSeat": 0, "NextActionTypes": [2, 3, 4, 5], "NextExtraLimitSeconds": 1, "MinRaise": 400, "Pot": 500, "SidePot": [] }, "timestamp": 1752427316928 },
+  { "ApiTypeId": 304, "SeatIndex": 0, "ActionType": 2, "Chip": 5850, "BetChip": 100, "Progress": { "Phase": 3, "NextActionSeat": -2, "NextActionTypes": [], "NextExtraLimitSeconds": 0, "MinRaise": 0, "Pot": 500, "SidePot": [] }, "timestamp": 1752427318516 },
+  { "ApiTypeId": 306, "CommunityCards": [], "Pot": 500, "SidePot": [], "ResultType": 0, "DefeatStatus": 0, "HandId": 384370064, "HandLog": "", "Results": [{ "UserId": 4, "HoleCards": [], "RankType": 10, "Hands": [], "HandRanking": 1, "Ranking": -2, "RewardChip": 500 }], "Player": { "SeatIndex": 1, "BetStatus": -1, "Chip": 6250, "BetChip": 0 }, "OtherPlayers": [{ "SeatIndex": 0, "Status": 0, "BetStatus": -1, "Chip": 5850, "BetChip": 0, "IsSafeLeave": false }, { "SeatIndex": 2, "Status": 0, "BetStatus": -1, "Chip": 5950, "BetChip": 0, "IsSafeLeave": false }, { "SeatIndex": 3, "Status": 0, "BetStatus": -1, "Chip": 5950, "BetChip": 0, "IsSafeLeave": false }], "timestamp": 1752427319431 },
+]
+const HAND1_ID = 384370064
+const HAND1_DEAL = HAND1_EVENTS[0]!
+const HAND1_ACTIONS = HAND1_EVENTS.slice(1, 4)
+const HAND1_RESULTS = HAND1_EVENTS[4]!
+
+// A second, structurally identical hand strictly after HAND1 (timestamps
+// shifted forward, distinct HandId) for range-scoping assertions.
+const HAND2_ID = 384370065
+const HAND2_EVENTS = HAND1_EVENTS.map(event => {
+  const clone = JSON.parse(JSON.stringify(event))
+  clone.timestamp = (event as { timestamp: number }).timestamp + 1_000_000
+  if (clone.ApiTypeId === 306) clone.HandId = HAND2_ID
+  return clone
+})
+
+const toJsonl = (events: unknown[]): string => events.map(event => JSON.stringify(event)).join('\n')
+
+const snapshotDerived = async (db: PokerChaseDB) => ({
+  hands: await db.hands.orderBy('id').toArray(),
+  phases: await db.phases.orderBy('[handId+phase]').toArray(),
+  actions: await db.actions.orderBy('[handId+index]').toArray(),
+})
+
+/**
+ * Run `fn` against a freshly created DB/service/handlers and always delete
+ * the DB afterwards. Sequential (never concurrent) because PokerChaseDB's
+ * IndexedDB database name is fixed -- two live instances would share storage.
+ */
+const runWithFreshDb = async <T>(
+  fn: (ctx: { db: PokerChaseDB, service: PokerChaseService, handlers: ReturnType<typeof createImportExportHandlers> }) => Promise<T>
+): Promise<T> => {
+  const db = new PokerChaseDB(indexedDB, IDBKeyRange)
+  await db.open()
+  const service = new PokerChaseService({ db })
+  await service.ready
+  // These tests assert persisted entities directly; the post-import stats
+  // broadcast (statsOutputStream -> ReadEntityStream) is irrelevant here and
+  // would otherwise race the teardown's db.close() with async DB reads.
+  jest.spyOn(service.statsOutputStream, 'write').mockImplementation()
+  const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+  try {
+    return await fn({ db, service, handlers })
+  } finally {
+    db.close()
+    await db.delete()
+  }
+}
+
+describe('importData() overlap import repair (audit finding #7)', () => {
+  beforeEach(() => {
+    setOperationState({ type: 'idle' })
+    ;(chrome.runtime.sendMessage as jest.Mock).mockReturnValue(Promise.resolve())
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('re-importing a complete export into a DB missing a hand\'s middle ACTIONs repairs the derived actions', async () => {
+    const fullExport = [ENTRY_QUEUED, ...HAND1_EVENTS]
+
+    // Control: the same complete export imported into an empty DB.
+    const expected = await runWithFreshDb(async ({ db, handlers }) => {
+      await handlers.importData(toJsonl(fullExport))
+      return snapshotDerived(db)
+    })
+    // Sanity on the control itself -- if this fails the fixture is broken.
+    expect(expected.hands).toHaveLength(1)
+    expect(expected.actions.length).toBeGreaterThan(0)
+
+    await runWithFreshDb(async ({ db, handlers }) => {
+      // Damaged DB (the audit's exact scenario): the hand's DEAL and RESULTS
+      // raw rows exist, the middle ACTIONs were lost (e.g. a capture gap).
+      await db.apiEvents.bulkAdd([ENTRY_QUEUED, HAND1_DEAL, HAND1_RESULTS] as never[])
+      // Its derived state reflects that damage: the hand exists, but with
+      // zero actions -- exactly what a rebuild over the damaged Lake yields.
+      await handlers.rebuildAllData()
+      expect(await db.hands.count()).toBe(1)
+      expect(await db.actions.count()).toBe(0)
+
+      // Re-import the complete export: DEAL/RESULTS/201 dedupe away, only
+      // the 3 ACTION rows are new.
+      const result = await handlers.importData(toJsonl(fullExport))
+      expect(result.successCount).toBe(3)
+      expect(result.duplicateCount).toBe(3)
+
+      // Derived state must now be complete AND non-duplicated -- identical
+      // to a from-scratch import of the same data.
+      const repaired = await snapshotDerived(db)
+      expect(repaired).toEqual(expected)
+      expect(repaired.actions.filter(action => action.handId === HAND1_ID)).toHaveLength(3)
+      // Session context was recovered from the EVT_ENTRY_QUEUED anchor, even
+      // though the 201 itself was a duplicate (not part of the new events).
+      expect(repaired.hands[0]!.session).toMatchObject({ id: 'stage000_003', battleType: 0 })
+      expect(await db.hands.count()).toBe(1)
+    })
+  })
+
+  test('an appended import that completes an unfinished tail hand (existing DEAL, imported ACTIONs+RESULTS) derives the hand', async () => {
+    await runWithFreshDb(async ({ db, handlers }) => {
+      // The Lake ends mid-hand: DEAL stored, rest never arrived (e.g. crash).
+      await db.apiEvents.bulkAdd([ENTRY_QUEUED, HAND1_DEAL] as never[])
+
+      // Import brings the remainder of the hand -- all strictly newer than
+      // anything in the DB (pure append), yet still overlap-repair territory
+      // because the hand boundary spans existing and new rows.
+      const result = await handlers.importData(toJsonl([...HAND1_ACTIONS, HAND1_RESULTS]))
+      expect(result.successCount).toBe(4)
+      expect(result.duplicateCount).toBe(0)
+
+      expect(await db.hands.get(HAND1_ID)).toBeDefined()
+      expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(3)
+    })
+  })
+
+  test('repair covers the affected range only in effect: a later, already-complete hand stays intact and non-duplicated', async () => {
+    const fullExport = [ENTRY_QUEUED, ...HAND1_EVENTS, ...HAND2_EVENTS]
+
+    const expected = await runWithFreshDb(async ({ db, handlers }) => {
+      await handlers.importData(toJsonl(fullExport))
+      return snapshotDerived(db)
+    })
+    expect(expected.hands).toHaveLength(2)
+
+    await runWithFreshDb(async ({ db, handlers }) => {
+      // HAND1 damaged (missing ACTIONs), HAND2 fully present.
+      await db.apiEvents.bulkAdd([ENTRY_QUEUED, HAND1_DEAL, HAND1_RESULTS, ...HAND2_EVENTS] as never[])
+      await handlers.rebuildAllData()
+      expect(await db.hands.count()).toBe(2)
+      expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(0)
+      expect(await db.actions.where('handId').equals(HAND2_ID).count()).toBe(3)
+
+      const result = await handlers.importData(toJsonl(fullExport))
+      expect(result.successCount).toBe(3) // HAND1's 3 missing ACTIONs
+      expect(result.duplicateCount).toBe(fullExport.length - 3)
+
+      expect(await snapshotDerived(db)).toEqual(expected)
+      expect(await db.hands.count()).toBe(2)
+      expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(3)
+      expect(await db.actions.where('handId').equals(HAND2_ID).count()).toBe(3)
+    })
+  })
+
+  test('falls back to converting from the Lake start when no EVT_ENTRY_QUEUED precedes the new events', async () => {
+    await runWithFreshDb(async ({ db, handlers }) => {
+      // Same damage as the main scenario, but the Lake has no 201 at all
+      // (capture began mid-session).
+      await db.apiEvents.bulkAdd([HAND1_DEAL, HAND1_RESULTS] as never[])
+
+      const result = await handlers.importData(toJsonl(HAND1_EVENTS))
+      expect(result.successCount).toBe(3)
+      expect(result.duplicateCount).toBe(2)
+
+      expect(await db.hands.get(HAND1_ID)).toBeDefined()
+      expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(3)
+    })
+  })
+
+  test('a fresh import into an empty DB still derives entities through the unchanged direct path', async () => {
+    await runWithFreshDb(async ({ db, handlers }) => {
+      const result = await handlers.importData(toJsonl([ENTRY_QUEUED, ...HAND1_EVENTS]))
+      expect(result.successCount).toBe(6)
+      expect(result.duplicateCount).toBe(0)
+
+      expect(await db.hands.get(HAND1_ID)).toBeDefined()
+      expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(3)
+      expect(await db.phases.where('handId').equals(HAND1_ID).count()).toBeGreaterThan(0)
+    })
+  })
+})

--- a/src/background/import-export.overlap-repair.test.ts
+++ b/src/background/import-export.overlap-repair.test.ts
@@ -80,6 +80,12 @@ const MID_HAND_ENTRY_QUEUED = { ...ENTRY_QUEUED, "timestamp": 1752427314500 }
 // (...319431).
 const MALFORMED_RESULTS_ROW = { "ApiTypeId": 306, "timestamp": 1752427319000 }
 
+// A valid EVT_ENTRY_QUEUED sitting in the gap strictly AFTER HAND0's
+// EVT_HAND_RESULTS (...309431) and strictly BEFORE HAND1's EVT_DEAL
+// (...313426) -- legitimately outside any hand (HAND0 is already closed,
+// HAND1 hasn't opened yet).
+const GAP_ENTRY_QUEUED = { ...ENTRY_QUEUED, "timestamp": 1752427310000 }
+
 const toJsonl = (events: unknown[]): string => events.map(event => JSON.stringify(event)).join('\n')
 
 const snapshotDerived = async (db: PokerChaseDB) => ({
@@ -108,15 +114,35 @@ const runWithFreshDb = async <T>(
   try {
     return await fn({ db, service, handlers })
   } finally {
+    // Cancel PokerChaseService's pending 500ms-debounced persistState()
+    // timer (pass-5 review, "Clear persisted service state between tests"):
+    // a test that mutates service.session (setId/setBattleType/setName/...)
+    // schedules a REAL setTimeout via the service's private
+    // `_persistStateTimer`. Without cancelling it here, that timer keeps
+    // running in the background after this db/service is torn down and can
+    // fire during a LATER test in this file, writing this (now-defunct)
+    // service's session into the shared chrome.storage.local mock --
+    // test-setup.ts's mock storage is a single module-scoped object, so a
+    // later test's freshly-constructed PokerChaseService would hydrate that
+    // leaked state on construction (restoreState()) even though it never
+    // touched service.session itself. Reaching into the private field is
+    // deliberate: there is no public dispose()/cancel() on the service.
+    clearTimeout((service as unknown as { _persistStateTimer?: ReturnType<typeof setTimeout> })._persistStateTimer)
     db.close()
     await db.delete()
   }
 }
 
 describe('importData() overlap import repair (audit finding #7)', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     setOperationState({ type: 'idle' })
     ;(chrome.runtime.sendMessage as jest.Mock).mockReturnValue(Promise.resolve())
+    // Defense in depth alongside the timer cancellation in runWithFreshDb()'s
+    // teardown above: clear any session state a previous test in this file
+    // left in the shared chrome.storage.local mock, so every test's
+    // PokerChaseService.restoreState() (called from `service.ready`) starts
+    // from a genuinely empty slate regardless of run order (pass-5 review).
+    await chrome.storage.local.set({ [PokerChaseService.STORAGE_KEY]: undefined })
   })
 
   afterEach(() => {
@@ -563,6 +589,67 @@ describe('importData() overlap import repair (audit finding #7)', () => {
       expect(await db.hands.get(HAND0_ID)).toBeDefined()
       expect(await db.actions.where('handId').equals(HAND0_ID).count()).toBe(3)
       expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(3)
+      expect(await db.hands.count()).toBe(2)
+    })
+  })
+
+  test('a valid EVT_ENTRY_QUEUED in the gap after the previous hand\'s RESULTS and before the affected hand becomes the anchor, even when the Lake starts with an earlier contextless hand (PR #203 codex P2, pass 5)', async () => {
+    // Lake layout: HAND0 (DEAL...RESULTS, no leading 201 -- a "contextless"
+    // first hand) -> GAP_ENTRY_QUEUED, strictly after HAND0's RESULTS
+    // (...309431) and strictly before HAND1's DEAL (...313426) -> HAND1's
+    // DEAL -> [missing ACTIONs] -> HAND1's RESULTS. The previous
+    // completed-hand boundary for HAND1's repair is HAND0's RESULTS; capping
+    // the anchor scan's search window there (instead of at minNewTimestamp)
+    // means GAP_ENTRY_QUEUED -- which sits AFTER that boundary -- is never
+    // even considered, even though it plainly lies outside any hand (HAND0
+    // already closed, HAND1 not yet opened) and is exactly the anchor
+    // HAND1's repair needs.
+    const fullExport = [
+      ...HAND0_EVENTS,
+      GAP_ENTRY_QUEUED,
+      ...HAND1_EVENTS,
+    ]
+
+    const expected = await runWithFreshDb(async ({ db, handlers }) => {
+      await handlers.importData(toJsonl(fullExport))
+      return snapshotDerived(db)
+    })
+    expect(expected.hands.map(hand => hand.id).sort()).toEqual([HAND0_ID, HAND1_ID])
+    const expectedHand1 = expected.hands.find(hand => hand.id === HAND1_ID)!
+    expect(expectedHand1.session).toMatchObject({ id: 'stage000_003', battleType: 0 })
+    expect(expectedHand1.session.name).toBeUndefined()
+
+    await runWithFreshDb(async ({ db, service, handlers }) => {
+      // Damaged DB: everything except HAND1's middle ACTIONs.
+      await db.apiEvents.bulkAdd([
+        ...HAND0_EVENTS,
+        GAP_ENTRY_QUEUED,
+        HAND1_DEAL,
+        HAND1_RESULTS,
+      ] as never[])
+      await handlers.rebuildAllData()
+      expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(0)
+
+      // A live session with a table name that must NOT leak into HAND1's
+      // repaired session: if GAP_ENTRY_QUEUED isn't recognized as a session
+      // anchor, hasSessionAnchor comes back false and importData() falls
+      // back to seeding the converter with this live session instead of the
+      // empty default one used at a real session boundary.
+      service.session.setId('live-session-456')
+      service.session.setBattleType(1)
+      service.session.setName('Live Table Name')
+
+      const result = await handlers.importData(toJsonl(fullExport))
+      expect(result.successCount).toBe(3) // HAND1's ACTIONs
+      expect(result.duplicateCount).toBe(fullExport.length - 3)
+
+      expect(await snapshotDerived(db)).toEqual(expected)
+      const hand1 = await db.hands.get(HAND1_ID)
+      expect(hand1).toBeDefined()
+      // Session identity comes from the Lake's own gap 201...
+      expect(hand1!.session).toMatchObject({ id: 'stage000_003', battleType: 0 })
+      // ...and the live table name must NOT have leaked in.
+      expect(hand1!.session.name).toBeUndefined()
       expect(await db.hands.count()).toBe(2)
     })
   })

--- a/src/background/import-export.overlap-repair.test.ts
+++ b/src/background/import-export.overlap-repair.test.ts
@@ -764,6 +764,67 @@ describe('importData() overlap import repair (audit finding #7)', () => {
     })
   })
 
+  test('a Lake with no 201 anywhere: repairing a later contextless hand does not leak the live session into an earlier pre-existing contextless hand (PR #203 codex P2, pass 7)', async () => {
+    // Lake layout: HAND0 (DEAL...RESULTS, fully present, already derived) ->
+    // HAND1 (DEAL...RESULTS present, middle ACTIONs missing). No
+    // EVT_ENTRY_QUEUED anywhere -- capture began mid-session, so both hands
+    // are genuinely contextless. Repairing HAND1 forces the Lake-start
+    // fallback (no 201 to anchor on), and that replay range's first opening
+    // DEAL belongs to HAND0, not the hand actually being repaired. Since the
+    // repair deletes and re-derives every accounted hand in that range (both
+    // HAND0 and HAND1 here), seeding the whole replay from a live session
+    // would rewrite HAND0's id/battleType/name even though HAND0 itself has
+    // no new data in this import at all.
+    const fullExport = [...HAND0_EVENTS, ...HAND1_EVENTS]
+
+    // Control: the same 201-less export imported into an empty DB with no
+    // live session ever set -- exactly what a from-scratch rebuild produces
+    // for both hands (empty/rebuild-style session throughout).
+    const expected = await runWithFreshDb(async ({ db, handlers }) => {
+      await handlers.importData(toJsonl(fullExport))
+      return snapshotDerived(db)
+    })
+    expect(expected.hands.map(hand => hand.id).sort()).toEqual([HAND0_ID, HAND1_ID])
+    const expectedHand0 = expected.hands.find(hand => hand.id === HAND0_ID)!
+    expect(expectedHand0.session.id).toBeUndefined()
+    expect(expectedHand0.session.name).toBeUndefined()
+
+    await runWithFreshDb(async ({ db, service, handlers }) => {
+      // HAND0 fully present and already derived via rebuild; HAND1 is
+      // missing its middle ACTIONs.
+      await db.apiEvents.bulkAdd([...HAND0_EVENTS, HAND1_DEAL, HAND1_RESULTS] as never[])
+      await handlers.rebuildAllData()
+      const hand0Before = await db.hands.get(HAND0_ID)
+      expect(hand0Before).toBeDefined()
+      expect(hand0Before!.session.id).toBeUndefined()
+      expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(0)
+
+      // A live session is active while the user keeps playing, as during any
+      // mid-session import. It must NOT leak into HAND0's re-derivation just
+      // because the Lake-start fallback replays HAND0 alongside HAND1's repair.
+      service.session.setId('live-session-456')
+      service.session.setBattleType(1)
+      service.session.setName('Live Table Name')
+
+      const result = await handlers.importData(toJsonl(fullExport))
+      expect(result.successCount).toBe(3) // HAND1's 3 missing ACTIONs
+      expect(result.duplicateCount).toBe(fullExport.length - 3)
+
+      // Derived state must match a from-scratch rebuild exactly -- HAND0's
+      // previously empty/rebuild-style session context is preserved, not
+      // overwritten by the live table's id/battleType/name.
+      expect(await snapshotDerived(db)).toEqual(expected)
+      const hand0 = await db.hands.get(HAND0_ID)
+      expect(hand0).toEqual(hand0Before)
+      expect(hand0!.session.id).toBeUndefined()
+      expect(hand0!.session.name).toBeUndefined()
+      const hand1 = await db.hands.get(HAND1_ID)
+      expect(hand1).toBeDefined()
+      expect(await db.actions.where('handId').equals(HAND1_ID).count()).toBe(3)
+      expect(await db.hands.count()).toBe(2)
+    })
+  })
+
   test('a fresh import into an empty DB still derives entities through the unchanged direct path', async () => {
     await runWithFreshDb(async ({ db, handlers }) => {
       const result = await handlers.importData(toJsonl([ENTRY_QUEUED, ...HAND1_EVENTS]))

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -68,8 +68,8 @@ export const clearImportSession = (): void => {
  * この関数は新規イベントのtimestamp範囲 [minNewTimestamp, maxNewTimestamp] を
  * 以下の境界までLake上で拡張し、既存行と新規行を合わせた連続領域を返す:
  *
- * - 開始境界（PR #203 codexレビューP2で修正、5巡目P2でさらに修正）: minNewTimestamp
- *   より厳密に前で最後の「いかなるハンドの内部でもない」と証明できた検証済み
+ * - 開始境界（PR #203 codexレビューP2で修正、5・6巡目P2でさらに修正）:
+ *   minNewTimestamp以前で最後の「いかなるハンドの内部でもない」と証明できた検証済み
  *   EVT_ENTRY_QUEUED(201) をanchorとする。201を無条件に（証明なしで）anchor
  *   にしてはならない: MTTのテーブル移動201はハンドの最中（EVT_DEALと
  *   EVT_HAND_RESULTSの間）に割り込むことがあり（docs/api-events.md、
@@ -83,6 +83,10 @@ export const clearImportSession = (): void => {
  *   anchorは必ずハンド外にあり、影響ハンドのDEALとセッション文脈
  *   （BattleType/Id、以降の313/301が積むプレイヤー名）の両方が範囲に含まれる。
  *   201が見つからない場合はLake先頭から（rebuildAllDataと同じ条件で）変換する。
+ *   minNewTimestampと同時刻の201も候補に含めるのは、インポート自身の先頭行が
+ *   セッション境界である場合に、それ以前の無関係なLake行までreplayして
+ *   「範囲の最初のハンドには201が無い」と誤判定しないため。新規201でも同じ
+ *   外部性証明を通すので、mid-handのテーブル移動201は従来どおりanchorにならない。
  *
  *   探索の上限をminNewTimestamp自体（直前の完了ハンドの306ではなく）にするのが
  *   重要（5巡目レビューP2「Include session anchors after the previous hand」）:
@@ -121,38 +125,41 @@ export const clearImportSession = (): void => {
  * （PR #203 codexレビュー2巡目P2）: 誤ペアリングされていた旧ハンドの
  * HandIdが新導出に現れない、旧導出の方がaction数が多い等。このため
  * 呼び出し元は、保存前に「この修復が説明できる既存派生ハンド」= idが
- * 「範囲内の検証済みEVT_HAND_RESULTSのHandId」に一致する既存ハンド
+ * 「範囲内で検証済みDEALにより開かれ、その後の検証済み
+ * EVT_HAND_RESULTSで閉じたHandId」に一致する既存ハンド
  * （とそのphases/actions）を、再導出バンドルの保存と同一トランザクション
  * 内で削除する。削除判定をtimestampウィンドウではなくHandIdで行うのは
  * （codexレビュー3巡目P2×2）:
  * - hand.idは必ずその導出元306のHandId由来なので、「idが範囲内の検証済み
- *   306に一致する」ことがそのハンドの導出元が範囲内にある直接の証拠に
- *   なり、approxTimestampが未設定のレガシー行（モデル上optional）も
+ *   DEAL→306ペアに一致する」ことがそのハンドの全raw spanが範囲内にある
+ *   直接の証拠になり、approxTimestampが未設定のレガシー行（モデル上optional）も
  *   インデックスに頼らず正しく対象に含まれる。
  * - 逆に、導出元の生306が現行スキーマでパース不能になったハンドは
  *   検証済み306集合に現れないため削除されない —— 再導出で作り直せない
  *   ものを消して、明示的な再構築まで残っていたはずの派生状態を
  *   失うことがない（新導出が説明できるハンドだけを削除する）。
+ * ペアは、全range（修復後の並び）とnewEventKeysを除いたrange（修復前の
+ * 並び）の両方でEntityConverterと同じ境界規則を再現して求める。後者が
+ * 必要なのは、新規306が旧DEALを先に閉じた結果、旧導出で後続306と
+ * 誤ペアリングされていたstale HandIdが修復後の並びだけでは見えなくなる
+ * ため。Lake先頭がハンド途中の断片で始まる場合など、どちらの並びにも
+ * 対応するDEALが無い先行306はこの集合に入らず、既存派生ハンドを削除する
+ * 根拠にならない。
  * 新バンドルが再生成するハンドのidはこの集合の部分集合（definition上、
- * bundleの各hand.idは範囲内の検証済み306由来）なので、削除→bulkPutで
+ * bundleの各hand.idは範囲内の検証済みDEAL→306由来）なので、削除→bulkPutで
  * 欠落は生じない。集合内だが新導出に現れないid（誤ペアリング修正・
  * キメラ棄却）は意図的な削除で、全再構築と同じ結果に収束する。範囲外の
  * 派生行には一切触れない。返す前にfilterValidApplicationEvents()で
  * 再検証するのはrebuildAllData()と同じ理由（CLAUDE.md「Raw Event
  * Lake」参照）。
  *
- * 戻り値の`hasSessionAnchor`は「範囲の先頭からハンド開始までに検証済み
+ * 戻り値の`hasSessionAnchor`は「検証済みrangeの先頭から最初のDEALまでに
  * EVT_ENTRY_QUEUEDがある = 範囲内のイベント列だけでセッション文脈を
- * 再構築できる」ことを示す —— anchorEventが見つかったかどうかそのもの
- * （`anchorEvent !== undefined`）。anchorが見つからない場合（Lake全体に
- * 「いかなるハンドの内部でもない」201が一つも無い場合）は範囲がLake先頭
- * まで広がるだけで、範囲はセッション境界を含まないため常にfalse
- * （201が無条件にLake先頭から読まれる場合を含む —— 5巡目レビューP2で
- * 探索上限をminNewTimestamp自体に広げたことで、この判定はLake先頭
- * フォールバックを特別扱いする必要がなくなった。以前はLake先頭に
- * ついてだけ別の弱い判定（「最初の検証済み201の前にDEALが無いか」）を
- * 行っていたが、直前の完了ハンドの306より後・影響ハンドのDEALより前の
- * 「隙間」にある201を探索範囲の外に置いてしまい見逃していた）。
+ * 再構築できる」ことを示す。これはanchor探索の成否ではなく、境界決定後・
+ * Zod検証後の`events`そのものを走査して決める（6巡目レビューP2）。したがって
+ * old Lake、新規import、Lake先頭fallbackのどこから来た201でも同じ定義になり、
+ * 最初にハンド途中のACTION/306断片があっても、最初のopening DEALより前の
+ * 201なら正しく数える。逆に最初のDEALより後のmid-hand 201は数えない。
  * 呼び出し元はhasSessionAnchorがtrueの場合のみコンバーターを空セッション
  * で初期化し、falseの場合（201無しの増分ハンド等）はライブの
  * service.sessionを初期値として使う——201がid/battleTypeを上書きしても
@@ -169,6 +176,8 @@ export const collectOverlapRepairEvents = async (
 ): Promise<{
   events: ApiEvent[]
   hasSessionAnchor: boolean
+  /** 修復前または修復後のrange内で検証済みDEAL→306を構成し、安全に削除→再導出できるHandId */
+  accountedHandIds: number[]
 }> => {
   // 境界候補は現行スキーマで検証してから採用する（doc comment参照）。
   // parseApiEventは同期のZodパースなのでDexieのfilterコールバック内で使える。
@@ -177,7 +186,7 @@ export const collectOverlapRepairEvents = async (
     return !!parsed && isApplicationApiEvent(parsed)
   }
 
-  // セッション文脈anchor: minNewTimestampより厳密に前で最後の「いかなる
+  // セッション文脈anchor: minNewTimestamp以前で最後の「いかなる
   // ハンドの内部でもない」と証明できた検証済みEVT_ENTRY_QUEUED（codexレビュー
   // 4巡目・5巡目P2）。探索の上限をminNewTimestamp自体にするのが重要
   // （5巡目P2「Include session anchors after the previous hand」）: 直前の
@@ -194,11 +203,12 @@ export const collectOverlapRepairEvents = async (
   // そのハンドの開始DEALより前から1ハンドずつ遡って探し直す（毎回より前の
   // DEALへ厳密に後退するため必ず停止する）。
   let anchorEvent: ApiEvent | undefined
-  let searchUpperKey: [number, number] = [minNewTimestamp, 0]
+  // 201自身が今回の最古行なら[minNewTimestamp, 201]を含める（6巡目P2）。
+  let searchUpperKey: [number, number] = [minNewTimestamp, ApiType.EVT_ENTRY_QUEUED]
   while (true) {
     const candidate = await db.apiEvents
       .where('[timestamp+ApiTypeId]')
-      .below(searchUpperKey)
+      .belowOrEqual(searchUpperKey)
       .reverse()
       .filter(event => event.ApiTypeId === ApiType.EVT_ENTRY_QUEUED && isValidApplicationRow(event))
       .first()
@@ -263,9 +273,49 @@ export const collectOverlapRepairEvents = async (
     rawRows = await db.apiEvents.orderBy('[timestamp+ApiTypeId]').toArray()
   }
 
+  const events = await filterValidApplicationEvents(rawRows)
+
+  // Post-validation range invariants (the scan path is deliberately irrelevant):
+  // 1. Empty/rebuild-style converter seed iff a valid 201 precedes the range's
+  //    first opening DEAL. With no DEAL, no session seed is needed.
+  // 2. Cleanup authority exists only for a valid 306 paired with an opening DEAL
+  //    inside this range in either the old (new rows excluded) or repaired replay.
+  //    This deletes old mis-pairings but never a leading orphan 306 fragment.
+  let sawSessionAnchorBeforeFirstDeal = false
+  let sawFirstDeal = false
+  for (const event of events) {
+    if (!sawFirstDeal && isApiEventType(event, ApiType.EVT_ENTRY_QUEUED)) {
+      sawSessionAnchorBeforeFirstDeal = true
+    }
+
+    if (isApiEventType(event, ApiType.EVT_DEAL)) {
+      sawFirstDeal = true
+    }
+  }
+
+  const collectPairedHandIds = (candidateEvents: ApiEvent[]): number[] => {
+    let hasOpenDeal = false
+    const handIds: number[] = []
+    for (const event of candidateEvents) {
+      if (isApiEventType(event, ApiType.EVT_DEAL)) {
+        // Matches EntityConverter: a later DEAL replaces any unfinished buffer.
+        hasOpenDeal = true
+      } else if (isApiEventType(event, ApiType.EVT_HAND_RESULTS)) {
+        if (hasOpenDeal) handIds.push(event.HandId)
+        hasOpenDeal = false
+      }
+    }
+    return handIds
+  }
+  const accountedHandIds = Array.from(new Set([
+    ...collectPairedHandIds(events.filter(event => !newEventKeys.has(`${event.timestamp}-${event.ApiTypeId}`))),
+    ...collectPairedHandIds(events),
+  ]))
+
   return {
-    events: await filterValidApplicationEvents(rawRows),
-    hasSessionAnchor: anchorEvent !== undefined
+    events,
+    hasSessionAnchor: sawFirstDeal && sawSessionAnchorBeforeFirstDeal,
+    accountedHandIds
   }
 }
 
@@ -527,11 +577,11 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
           //   （EVT_DEAL〜EVT_HAND_RESULTS）を構成できないため、影響範囲を
           //   Lakeから読み直して既存行と新規行を合わせて再導出する
           //   （境界の決め方・冪等性はcollectOverlapRepairEvents()参照）。
-          //   コンバーターの初期セッションは、範囲が検証済みEVT_ENTRY_QUEUED
-          //   から始まる場合のみrebuildAllData()と同じ空のデフォルト
-          //   セッションにする（範囲内のイベント列がセッション文脈を自前で
-          //   再構築でき、かつライブのservice.sessionの名前等が過去の
-          //   再導出ハンドに混入しない）。201を含まない増分ハンドの
+          //   コンバーターの初期セッションは、検証済みrangeの最初のDEALより
+          //   前に検証済みEVT_ENTRY_QUEUEDがある場合のみrebuildAllData()と
+          //   同じ空のデフォルトセッションにする（range内容がセッション文脈を
+          //   自前で再構築でき、かつライブのservice.sessionの名前等が過去の
+          //   再導出ハンドに混入しない）。最初のDEALより前に201が無い増分ハンドの
           //   インポートでは従来の直接経路と同じくservice.sessionを
           //   初期値に使う —— さもないとhand.sessionが空になり、#104の
           //   SessionState seedingリグレッションが守っている挙動が
@@ -574,24 +624,17 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
             // 統計が新旧両方を数えてしまう。
             //
             // 削除対象は「この修復が説明できるハンド」= idが範囲内の検証済み
-            // EVT_HAND_RESULTSのHandIdに一致する既存派生ハンドのみ
+            // DEAL→EVT_HAND_RESULTSペアのHandIdに一致する既存派生ハンドのみ
             // （collectOverlapRepairEvents()のdocコメント参照。codexレビュー
             // 3巡目P2×2: idベースの判定にすることで、approxTimestamp未設定の
             // レガシー行もインデックスに頼らず対象に含まれ、逆に導出元の生行が
             // 現行スキーマでパース不能になったハンド —— 再導出で作り直せない
-            // もの —— は削除されない）。それらとphases/actionsを、再導出
-            // バンドルの保存と同一トランザクションで先に削除する。
+            // もの —— は削除されない。6巡目P2: range先頭のmid-hand断片など、
+            // 306だけが範囲内にありopening DEALが無いHandIdも削除しない）。
+            // それらとphases/actionsを、再導出バンドルの保存と同一
+            // トランザクションで先に削除する。
             // Raw Event Lake（apiEvents）には一切触れない。
-            const accountedHandIds: number[] = []
-            {
-              const seen = new Set<number>()
-              for (const event of entitySourceEvents) {
-                if (isApiEventType(event, ApiType.EVT_HAND_RESULTS) && !seen.has(event.HandId)) {
-                  seen.add(event.HandId)
-                  accountedHandIds.push(event.HandId)
-                }
-              }
-            }
+            const { accountedHandIds } = repairRange
             await db.transaction('rw', [db.hands, db.phases, db.actions], async () => {
               const existingAccountedHands = accountedHandIds.length > 0
                 ? await db.hands.bulkGet(accountedHandIds)

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -68,22 +68,34 @@ export const clearImportSession = (): void => {
  * この関数は新規イベントのtimestamp範囲 [minNewTimestamp, maxNewTimestamp] を
  * 以下の境界までLake上で拡張し、既存行と新規行を合わせた連続領域を返す:
  *
- * - 開始境界（PR #203 codexレビューP2で修正）: まず minNewTimestamp より厳密に
- *   前で最後の「検証済み」EVT_HAND_RESULTS(306) = 直前の完了ハンド境界を探し、
- *   さらにその境界以前で最後の「検証済み」EVT_ENTRY_QUEUED(201) をanchorとする。
- *   201を直接（minNewTimestamp基準で）anchorにしてはならない: MTTのテーブル
- *   移動201はハンドの最中（EVT_DEALとEVT_HAND_RESULTSの間）に割り込むことが
- *   あり（docs/api-events.md、EntityConverterの融合ハンド棄却ガード参照）、
- *   その201から変換を始めると影響ハンドの先頭のDEALが範囲外になって、
- *   EntityConverter（DEALでのみバッファ開始）が新規行を導出できない。
- *   さらに「完了ハンド境界以前」というだけでは足りない（codexレビュー
- *   4巡目P2）: テーブル移動201はその「直前の完了ハンド」自身の内部にも
- *   割り込み得るため、候補201が「いかなるハンドの内部でもない」ことを
- *   確認できるまで1ハンドずつ遡る（実装内コメント参照）。こうして得た
+ * - 開始境界（PR #203 codexレビューP2で修正、5巡目P2でさらに修正）: minNewTimestamp
+ *   より厳密に前で最後の「いかなるハンドの内部でもない」と証明できた検証済み
+ *   EVT_ENTRY_QUEUED(201) をanchorとする。201を無条件に（証明なしで）anchor
+ *   にしてはならない: MTTのテーブル移動201はハンドの最中（EVT_DEALと
+ *   EVT_HAND_RESULTSの間）に割り込むことがあり（docs/api-events.md、
+ *   EntityConverterの融合ハンド棄却ガード参照）、その201から変換を始めると
+ *   影響ハンドの先頭のDEALが範囲外になって、EntityConverter（DEALでのみ
+ *   バッファ開始）が新規行を導出できない。候補201の外部性は「候補の直前の
+ *   検証済み303が、その303と候補の間の検証済み306で既に閉じている（または
+ *   303自体が存在しない）」ことで判定する。候補がこの証明に落ちたら（いずれか
+ *   のハンドの内部に割り込んだテーブル移動201）、そのハンドの開始DEALより前
+ *   から次の候補を探し直す（1ハンドずつ遡るので必ず停止する）。こうして得た
  *   anchorは必ずハンド外にあり、影響ハンドのDEALとセッション文脈
- *   （BattleType/Id、以降の313/301が積むプレイヤー名）の両方が範囲に
- *   含まれる。201が見つからない場合（および完了ハンド境界自体が無い
- *   場合）はLake先頭から（rebuildAllDataと同じ条件で）変換する。
+ *   （BattleType/Id、以降の313/301が積むプレイヤー名）の両方が範囲に含まれる。
+ *   201が見つからない場合はLake先頭から（rebuildAllDataと同じ条件で）変換する。
+ *
+ *   探索の上限をminNewTimestamp自体（直前の完了ハンドの306ではなく）にするのが
+ *   重要（5巡目レビューP2「Include session anchors after the previous hand」）:
+ *   直前の完了ハンドの306より後・影響ハンドのDEALより前という「ハンド間の
+ *   隙間」にも正当な201anchorが存在し得る。探索上限を直前の306に狭めると、
+ *   この隙間にある201が探索範囲の外に置かれて見逃され、hasSessionAnchorが
+ *   誤ってfalseになり、影響ハンドがライブのservice.sessionでseedされて
+ *   ライブのテーブル名が混入し得る（実際にはanchorは見つからず範囲がLake
+ *   先頭まで広がるため、取得されるイベント自体は正しいのに判定だけが誤る）。
+ *   上記の「いかなるハンドの内部でもない」証明はこの隙間の201を正しく
+ *   合格させる一方、真にmid-handな候補（影響ハンド自身の内部を含む）は
+ *   証明に失敗して正しく除外されるため、探索上限をminNewTimestampへ広げても
+ *   mid-hand201を誤ってanchorにする心配はない。
  * - 終了境界（PR #203 codexレビュー2巡目P2で修正）: maxNewTimestamp 以後で
  *   最初の「検証済みかつ既存（今回のインポートで保存された行を除く）」
  *   EVT_HAND_RESULTS(306)（それ自身を含む）。既存行に限るのは、修復前の
@@ -131,17 +143,22 @@ export const clearImportSession = (): void => {
  *
  * 戻り値の`hasSessionAnchor`は「範囲の先頭からハンド開始までに検証済み
  * EVT_ENTRY_QUEUEDがある = 範囲内のイベント列だけでセッション文脈を
- * 再構築できる」ことを示す。201 anchorが見つかった場合に加えて、
- * Lake先頭フォールバック時も「Lakeが最初の検証済みEVT_DEALより前の
- * 検証済み201で始まっている」ならtrue（codexレビュー3巡目P2）——
- * この場合も範囲はセッション境界から始まっており、ライブの
- * service.sessionをseedにすると、201がid/battleTypeを上書きしても
- * session.nameは消さないため、308を持たない先頭ハンドの修復結果に
- * ライブのテーブル名が混入し得る。呼び出し元はこれがtrueの場合のみ
- * コンバーターを空セッションで初期化し、falseの場合（201無しの
- * 増分ハンド等）はライブのservice.sessionを初期値として使う
- * （PR #203 codexレビューP2 / #104のSessionState seeding
- * リグレッション参照）。
+ * 再構築できる」ことを示す —— anchorEventが見つかったかどうかそのもの
+ * （`anchorEvent !== undefined`）。anchorが見つからない場合（Lake全体に
+ * 「いかなるハンドの内部でもない」201が一つも無い場合）は範囲がLake先頭
+ * まで広がるだけで、範囲はセッション境界を含まないため常にfalse
+ * （201が無条件にLake先頭から読まれる場合を含む —— 5巡目レビューP2で
+ * 探索上限をminNewTimestamp自体に広げたことで、この判定はLake先頭
+ * フォールバックを特別扱いする必要がなくなった。以前はLake先頭に
+ * ついてだけ別の弱い判定（「最初の検証済み201の前にDEALが無いか」）を
+ * 行っていたが、直前の完了ハンドの306より後・影響ハンドのDEALより前の
+ * 「隙間」にある201を探索範囲の外に置いてしまい見逃していた）。
+ * 呼び出し元はhasSessionAnchorがtrueの場合のみコンバーターを空セッション
+ * で初期化し、falseの場合（201無しの増分ハンド等）はライブの
+ * service.sessionを初期値として使う——201がid/battleTypeを上書きしても
+ * session.nameは消さないため、そうしないと308を持たないハンドの修復結果に
+ * ライブのテーブル名が混入し得る（PR #203 codexレビューP2 / #104の
+ * SessionState seedingリグレッション参照）。
  */
 export const collectOverlapRepairEvents = async (
   db: PokerChaseDB,
@@ -160,71 +177,60 @@ export const collectOverlapRepairEvents = async (
     return !!parsed && isApplicationApiEvent(parsed)
   }
 
-  // 直前の完了ハンド境界: minNewTimestampより厳密に前（.below([ts, 0])は
-  // timestampがminNewTimestamp未満の行のみを含む）で最後の検証済み306。
-  const prevHandBoundary = await db.apiEvents
-    .where('[timestamp+ApiTypeId]')
-    .below([minNewTimestamp, 0])
-    .reverse()
-    .filter(event => event.ApiTypeId === ApiType.EVT_HAND_RESULTS && isValidApplicationRow(event))
-    .first()
-
-  // セッション文脈anchor: 完了ハンド境界以前で最後の検証済みEVT_ENTRY_QUEUED
-  // …のうち「いかなるハンドの内部でもない」と証明できたもの（codexレビュー
-  // 4巡目P2）。完了ハンド境界の「以前」というだけでは不十分: MTTのテーブル
-  // 移動201は「直前の完了ハンド」自身の内部（そのDEALと306の間）にも割り込み
-  // 得る。そこから変換を始めると、直前ハンドの306は範囲内・DEALは範囲外に
-  // なり、クリーンアップがそのHandIdを（範囲内の検証済み306として）削除した
-  // 上で、EntityConverter（DEALでのみバッファ開始）が再導出できず、直前
-  // ハンドが全再構築まで消失する。候補201の外部性は「候補の直前の検証済み
-  // 303が、その303と候補の間の検証済み306で既に閉じている（または303自体が
-  // 存在しない）」ことで判定する —— この判定はコンバーターと同じ検証済み
-  // イベント列上のハンド境界に基づくため、anchorがこの判定を通れば、
-  // 範囲内のあらゆる検証済み306の開始DEALも必ず範囲内に含まれる
-  // （306がanchor後にあるのに開始303がanchor前なら、anchorはそのハンドの
-  // 内部にあったことになり判定と矛盾する）。候補がハンド内部なら、その
-  // ハンドの開始DEALより前から1ハンドずつ遡って探し直す。
+  // セッション文脈anchor: minNewTimestampより厳密に前で最後の「いかなる
+  // ハンドの内部でもない」と証明できた検証済みEVT_ENTRY_QUEUED（codexレビュー
+  // 4巡目・5巡目P2）。探索の上限をminNewTimestamp自体にするのが重要
+  // （5巡目P2「Include session anchors after the previous hand」）: 直前の
+  // 完了ハンドの306までに探索上限を狭めると、その306より後・影響ハンドの
+  // DEALより前という「ハンド間の隙間」にある正当な201anchorを見逃す
+  // （doc comment参照）。この広い探索窓でmid-hand201を誤検出しないのは、
+  // 以下の外部性の証明があるため: 候補の直前の検証済み303が、その303と
+  // 候補の間の検証済み306で既に閉じている（または303自体が存在しない）
+  // ことを確認する —— この判定はコンバーターと同じ検証済みイベント列上の
+  // ハンド境界に基づくため、anchorがこの判定を通れば、範囲内のあらゆる
+  // 検証済み306の開始DEALも必ず範囲内に含まれる（306がanchor後にあるのに
+  // 開始303がanchor前なら、anchorはそのハンドの内部にあったことになり
+  // 判定と矛盾する）。候補がハンド内部なら（影響ハンド自身の内部を含む）、
+  // そのハンドの開始DEALより前から1ハンドずつ遡って探し直す（毎回より前の
+  // DEALへ厳密に後退するため必ず停止する）。
   let anchorEvent: ApiEvent | undefined
-  if (prevHandBoundary) {
-    let searchUpperKey: [number, number] = [prevHandBoundary.timestamp!, prevHandBoundary.ApiTypeId]
-    while (true) {
-      const candidate = await db.apiEvents
-        .where('[timestamp+ApiTypeId]')
-        .belowOrEqual(searchUpperKey)
-        .reverse()
-        .filter(event => event.ApiTypeId === ApiType.EVT_ENTRY_QUEUED && isValidApplicationRow(event))
-        .first()
-      if (!candidate) break
+  let searchUpperKey: [number, number] = [minNewTimestamp, 0]
+  while (true) {
+    const candidate = await db.apiEvents
+      .where('[timestamp+ApiTypeId]')
+      .below(searchUpperKey)
+      .reverse()
+      .filter(event => event.ApiTypeId === ApiType.EVT_ENTRY_QUEUED && isValidApplicationRow(event))
+      .first()
+    if (!candidate) break
 
-      const candidateKey: [number, number] = [candidate.timestamp!, candidate.ApiTypeId]
-      const lastDealBeforeCandidate = await db.apiEvents
-        .where('[timestamp+ApiTypeId]')
-        .below(candidateKey)
-        .reverse()
-        .filter(event => event.ApiTypeId === ApiType.EVT_DEAL && isValidApplicationRow(event))
-        .first()
-      if (!lastDealBeforeCandidate) {
-        // 候補より前にハンドが一度も開いていない → ハンド外
-        anchorEvent = candidate
-        break
-      }
-
-      const resultsBetween = await db.apiEvents
-        .where('[timestamp+ApiTypeId]')
-        .between([lastDealBeforeCandidate.timestamp!, lastDealBeforeCandidate.ApiTypeId], candidateKey, false, false)
-        .filter(event => event.ApiTypeId === ApiType.EVT_HAND_RESULTS && isValidApplicationRow(event))
-        .first()
-      if (resultsBetween) {
-        // 直近に開いたハンドは候補より前に閉じている → ハンド外
-        anchorEvent = candidate
-        break
-      }
-
-      // 候補はハンド内部に割り込んだテーブル移動201 → そのハンドの開始DEALより
-      // 前（belowOrEqualだがDEAL自身は201でないため実質strictly before）から
-      // 探し直す。毎回より前のDEALへ厳密に後退するため必ず停止する。
-      searchUpperKey = [lastDealBeforeCandidate.timestamp!, lastDealBeforeCandidate.ApiTypeId]
+    const candidateKey: [number, number] = [candidate.timestamp!, candidate.ApiTypeId]
+    const lastDealBeforeCandidate = await db.apiEvents
+      .where('[timestamp+ApiTypeId]')
+      .below(candidateKey)
+      .reverse()
+      .filter(event => event.ApiTypeId === ApiType.EVT_DEAL && isValidApplicationRow(event))
+      .first()
+    if (!lastDealBeforeCandidate) {
+      // 候補より前にハンドが一度も開いていない → ハンド外
+      anchorEvent = candidate
+      break
     }
+
+    const resultsBetween = await db.apiEvents
+      .where('[timestamp+ApiTypeId]')
+      .between([lastDealBeforeCandidate.timestamp!, lastDealBeforeCandidate.ApiTypeId], candidateKey, false, false)
+      .filter(event => event.ApiTypeId === ApiType.EVT_HAND_RESULTS && isValidApplicationRow(event))
+      .first()
+    if (resultsBetween) {
+      // 直近に開いたハンドは候補より前に閉じている → ハンド外
+      anchorEvent = candidate
+      break
+    }
+
+    // 候補はハンド内部に割り込んだテーブル移動201 → そのハンドの開始DEALより
+    // 前から探し直す。
+    searchUpperKey = [lastDealBeforeCandidate.timestamp!, lastDealBeforeCandidate.ApiTypeId]
   }
 
   // 終了境界: maxNewTimestamp以後（同時刻含む）で最初の検証済み「既存」
@@ -238,27 +244,6 @@ export const collectOverlapRepairEvents = async (
       isValidApplicationRow(event)
     )
     .first()
-
-  // Lake先頭フォールバック時のセッション境界判定（codexレビュー3巡目P2）:
-  // 完了ハンド境界（またはその前の201）が無くても、Lakeが「最初の検証済み
-  // EVT_DEALより前の検証済みEVT_ENTRY_QUEUED」で始まっていれば、Lake先頭
-  // から読む範囲は同様にセッション境界から始まっている。この場合も空
-  // セッションseedを使う（doc comment参照）。
-  let lakeStartsAtSessionAnchor = false
-  if (!anchorEvent) {
-    const firstValidEntryQueued = await db.apiEvents
-      .orderBy('[timestamp+ApiTypeId]')
-      .filter(event => event.ApiTypeId === ApiType.EVT_ENTRY_QUEUED && isValidApplicationRow(event))
-      .first()
-    if (firstValidEntryQueued) {
-      const dealBeforeFirstEntryQueued = await db.apiEvents
-        .where('[timestamp+ApiTypeId]')
-        .below([firstValidEntryQueued.timestamp!, firstValidEntryQueued.ApiTypeId])
-        .filter(event => event.ApiTypeId === ApiType.EVT_DEAL && isValidApplicationRow(event))
-        .first()
-      lakeStartsAtSessionAnchor = dealBeforeFirstEntryQueued === undefined
-    }
-  }
 
   const lowerKey: [number, number] | undefined = anchorEvent
     ? [anchorEvent.timestamp!, anchorEvent.ApiTypeId]
@@ -280,7 +265,7 @@ export const collectOverlapRepairEvents = async (
 
   return {
     events: await filterValidApplicationEvents(rawRows),
-    hasSessionAnchor: anchorEvent !== undefined || lakeStartsAtSessionAnchor
+    hasSessionAnchor: anchorEvent !== undefined
   }
 }
 

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -13,6 +13,7 @@ import PokerChaseService, {
   isApplicationApiEvent
 } from '../app'
 import { EntityConverter } from '../entity-converter'
+import type { EntityBundle } from '../entity-converter'
 import { saveEntities, findLatestPlayerDealEvent, filterValidApplicationEvents } from '../utils/database-utils'
 import { DATABASE_CONSTANTS } from '../constants/database'
 import type { Session } from '../types'
@@ -52,308 +53,285 @@ export const clearImportSession = (): void => {
   currentImportSession = null
 }
 
-/**
- * 差分インポート（既存データがあるDBへのインポート）でエンティティ再導出の
- * 対象にすべきイベントを、Raw Event Lake（apiEvents）から読み直して返す
- * （独立監査finding #7）。
- *
- * 修正前は、インポートで「新規に保存された行」だけをEntityConverterへ渡して
- * いた。EntityConverterはEVT_DEAL(303)〜EVT_HAND_RESULTS(306)のイベント列が
- * 揃って初めて1ハンドを構成できるため、既存ハンドの一部（例: DEALとRESULTSは
- * 保存済みだが中間のACTIONだけ欠けていたDBに、完全なエクスポートを再インポート
- * したケース）では、新規行（ACTION単体）がduplicate除外されたDEAL/RESULTSと
- * 切り離され、ハンド境界を構成できずに黙って捨てられていた —— Raw Lakeだけが
- * 修復され、派生hands/phases/actionsと統計は古いまま残る。
- *
- * この関数は新規イベントのtimestamp範囲 [minNewTimestamp, maxNewTimestamp] を
- * 以下の境界までLake上で拡張し、既存行と新規行を合わせた連続領域を返す:
- *
- * - 開始境界（PR #203 codexレビューP2で修正、5・6巡目P2でさらに修正）:
- *   minNewTimestamp以前で最後の「いかなるハンドの内部でもない」と証明できた検証済み
- *   EVT_ENTRY_QUEUED(201) をanchorとする。201を無条件に（証明なしで）anchor
- *   にしてはならない: MTTのテーブル移動201はハンドの最中（EVT_DEALと
- *   EVT_HAND_RESULTSの間）に割り込むことがあり（docs/api-events.md、
- *   EntityConverterの融合ハンド棄却ガード参照）、その201から変換を始めると
- *   影響ハンドの先頭のDEALが範囲外になって、EntityConverter（DEALでのみ
- *   バッファ開始）が新規行を導出できない。候補201の外部性は「候補の直前の
- *   検証済み303が、その303と候補の間の検証済み306で既に閉じている（または
- *   303自体が存在しない）」ことで判定する。候補がこの証明に落ちたら（いずれか
- *   のハンドの内部に割り込んだテーブル移動201）、そのハンドの開始DEALより前
- *   から次の候補を探し直す（1ハンドずつ遡るので必ず停止する）。こうして得た
- *   anchorは必ずハンド外にあり、影響ハンドのDEALとセッション文脈
- *   （BattleType/Id、以降の313/301が積むプレイヤー名）の両方が範囲に含まれる。
- *   201が見つからない場合はLake先頭から（rebuildAllDataと同じ条件で）変換する。
- *   minNewTimestampと同時刻の201も候補に含めるのは、インポート自身の先頭行が
- *   セッション境界である場合に、それ以前の無関係なLake行までreplayして
- *   「範囲の最初のハンドには201が無い」と誤判定しないため。新規201でも同じ
- *   外部性証明を通すので、mid-handのテーブル移動201は従来どおりanchorにならない。
- *
- *   探索の上限をminNewTimestamp自体（直前の完了ハンドの306ではなく）にするのが
- *   重要（5巡目レビューP2「Include session anchors after the previous hand」）:
- *   直前の完了ハンドの306より後・影響ハンドのDEALより前という「ハンド間の
- *   隙間」にも正当な201anchorが存在し得る。探索上限を直前の306に狭めると、
- *   この隙間にある201が探索範囲の外に置かれて見逃され、hasSessionAnchorが
- *   誤ってfalseになり、影響ハンドがライブのservice.sessionでseedされて
- *   ライブのテーブル名が混入し得る（実際にはanchorは見つからず範囲がLake
- *   先頭まで広がるため、取得されるイベント自体は正しいのに判定だけが誤る）。
- *   上記の「いかなるハンドの内部でもない」証明はこの隙間の201を正しく
- *   合格させる一方、真にmid-handな候補（影響ハンド自身の内部を含む）は
- *   証明に失敗して正しく除外されるため、探索上限をminNewTimestampへ広げても
- *   mid-hand201を誤ってanchorにする心配はない。
- * - 終了境界（PR #203 codexレビュー2巡目P2で修正）: maxNewTimestamp 以後で
- *   最初の「検証済みかつ既存（今回のインポートで保存された行を除く）」
- *   EVT_HAND_RESULTS(306)（それ自身を含む）。既存行に限るのは、修復前の
- *   派生状態が「新規306の位置」ではなく「旧Lakeでの次の306」までを1ハンド
- *   として束ねていた可能性があるため（キャプチャ欠落でDEALが後続の別306と
- *   誤ペアリングされるケース）: 旧ペアリングの末尾まで範囲を広げないと、
- *   その旧ハンドを削除した後に範囲内の再導出だけで正しく作り直せない
- *   （下のstale削除ウィンドウ参照）。新規306で終わる正常な差分は、範囲が
- *   その先の既存306（または Lake末尾）まで伸びるだけで、再導出は冪等。
- *   既存306が無い場合はLake末尾まで —— 未完了ハンドはEntityConverterが
- *   HandId未設定として棄却するためゴミは生成されない。
- *
- * どちらの境界も、候補行を現行Zodスキーマで検証してから採用する
- * （PR #203 codexレビューP2）: Raw LakeにはApiTypeIdが306/201でもパース
- * 不能な行が混在し得る（Raw Event Lakeの設計上の仕様）。生のApiTypeId一致
- * だけで境界を決めると、パース不能な306を終了境界に選んでしまい、直後の
- * filterValidApplicationEvents()でその行自体が除去されて本物のRESULTSが
- * 範囲外に残り、ハンドが未終了扱いで棄却される（修復が黙って失敗する）。
- *
- * 範囲内の既存ハンドの再導出はbulkPut上書きで冪等（hands(id) /
- * phases([handId+phase]) / actions([handId+index])は決定的キー）だが、
- * 上書きだけでは「旧導出には存在したが新導出には存在しない」行が残る
- * （PR #203 codexレビュー2巡目P2）: 誤ペアリングされていた旧ハンドの
- * HandIdが新導出に現れない、旧導出の方がaction数が多い等。このため
- * 呼び出し元は、保存前に「この修復が説明できる既存派生ハンド」= idが
- * 「範囲内で検証済みDEALにより開かれ、その後の検証済み
- * EVT_HAND_RESULTSで閉じたHandId」に一致する既存ハンド
- * （とそのphases/actions）を、再導出バンドルの保存と同一トランザクション
- * 内で削除する。削除判定をtimestampウィンドウではなくHandIdで行うのは
- * （codexレビュー3巡目P2×2）:
- * - hand.idは必ずその導出元306のHandId由来なので、「idが範囲内の検証済み
- *   DEAL→306ペアに一致する」ことがそのハンドの全raw spanが範囲内にある
- *   直接の証拠になり、approxTimestampが未設定のレガシー行（モデル上optional）も
- *   インデックスに頼らず正しく対象に含まれる。
- * - 逆に、導出元の生306が現行スキーマでパース不能になったハンドは
- *   検証済み306集合に現れないため削除されない —— 再導出で作り直せない
- *   ものを消して、明示的な再構築まで残っていたはずの派生状態を
- *   失うことがない（新導出が説明できるハンドだけを削除する）。
- * ペアは、全range（修復後の並び）とnewEventKeysを除いたrange（修復前の
- * 並び）の両方でEntityConverterと同じ境界規則を再現して求める。後者が
- * 必要なのは、新規306が旧DEALを先に閉じた結果、旧導出で後続306と
- * 誤ペアリングされていたstale HandIdが修復後の並びだけでは見えなくなる
- * ため。Lake先頭がハンド途中の断片で始まる場合など、どちらの並びにも
- * 対応するDEALが無い先行306はこの集合に入らず、既存派生ハンドを削除する
- * 根拠にならない。
- * 新バンドルが再生成するハンドのidはこの集合の部分集合（definition上、
- * bundleの各hand.idは範囲内の検証済みDEAL→306由来）なので、削除→bulkPutで
- * 欠落は生じない。集合内だが新導出に現れないid（誤ペアリング修正・
- * キメラ棄却）は意図的な削除で、全再構築と同じ結果に収束する。範囲外の
- * 派生行には一切触れない。返す前にfilterValidApplicationEvents()で
- * 再検証するのはrebuildAllData()と同じ理由（CLAUDE.md「Raw Event
- * Lake」参照）。
- *
- * 戻り値の`hasSessionAnchor`は「検証済みrangeの先頭から最初のDEALまでに
- * EVT_ENTRY_QUEUEDがある = 範囲内のイベント列だけでセッション文脈を
- * 再構築できる」ことを示す。これはanchor探索の成否ではなく、境界決定後・
- * Zod検証後の`events`そのものを走査して決める（6巡目レビューP2）。したがって
- * old Lake、新規import、Lake先頭fallbackのどこから来た201でも同じ定義になり、
- * 最初にハンド途中のACTION/306断片があっても、最初のopening DEALより前の
- * 201なら正しく数える。逆に最初のDEALより後のmid-hand 201は数えない。
- *
- * これに加え、rangeが「今回のインポートより前から存在した完全な
- * DEAL→306ペア」を1つでも含む場合もhasSessionAnchorはtrueになる（7巡目
- * レビューP2「Avoid live-session seeding for Lake-start replays」）。201が
- * 全く見つからずLake先頭までfallbackするケースでは、range先頭の
- * 「最初のDEAL」はしばしば今回のimportとは無関係な既存の古いハンドの
- * ものであり、この修復はaccountされた既存ハンドをdelete-then-putで
- * 丸ごと再導出するため、201の有無だけで判定すると、その古い（本来
- * contextlessな）ハンドがライブセッションのid/battleType/nameで
- * 上書きされてしまう。判定は削除対象の算出（下記`accountedHandIds`）と
- * 同じ「今回のimportで新規保存された行を除いたevents」上でのDEAL→306
- * ペアリングを再利用する——rangeにそのような既存ペアが1つも無ければ、
- * range内のデータは今回importされた行だけで完結する真に新規の
- * インクリメンタルハンドであり（例: ノイズ行に囲まれているだけ）、
- * 書き換えられる既存の派生ハンドがそもそも無いため、従来通り直接経路と
- * 同じくlive sessionをseedに使う。
- * 呼び出し元はhasSessionAnchorがtrueの場合のみコンバーターを空セッション
- * で初期化し、falseの場合（201無しかつ既存ペアも無い増分ハンド等）は
- * ライブのservice.sessionを初期値として使う——201がid/battleTypeを
- * 上書きしてもsession.nameは消さないため、そうしないと308を持たない
- * ハンドの修復結果にライブのテーブル名が混入し得る（PR #203 codexレビュー
- * P2 / #104のSessionState seedingリグレッション参照）。
- */
-export const collectOverlapRepairEvents = async (
-  db: PokerChaseDB,
-  minNewTimestamp: number,
-  maxNewTimestamp: number,
-  /** 今回のインポートで新規保存された行のキー（`${timestamp}-${ApiTypeId}`）。終了境界の探索から除外する */
-  newEventKeys: ReadonlySet<string>
-): Promise<{
+type CompoundEventKey = [number, number]
+
+interface PairedLakeHand {
+  handId: number
+  dealKey: CompoundEventKey
+  resultKey: CompoundEventKey
+  pairKey: string
   events: ApiEvent[]
-  hasSessionAnchor: boolean
-  /** 修復前または修復後のrange内で検証済みDEAL→306を構成し、安全に削除→再導出できるHandId */
-  accountedHandIds: number[]
-}> => {
-  // 境界候補は現行スキーマで検証してから採用する（doc comment参照）。
-  // parseApiEventは同期のZodパースなのでDexieのfilterコールバック内で使える。
+}
+
+interface OverlapRepairPlan {
+  entities: EntityBundle
+  /** 旧・新viewのいずれかで実際に影響を受けたHandIdだけ。 */
+  affectedHandIds: number[]
+  replayEventCount: number
+  repairedHandCount: number
+}
+
+const eventKey = (event: ApiEvent): CompoundEventKey => [event.timestamp ?? 0, event.ApiTypeId]
+const eventStorageKey = (event: ApiEvent): string => `${event.timestamp}-${event.ApiTypeId}`
+const compareEventKeys = (left: CompoundEventKey, right: CompoundEventKey): number =>
+  left[0] - right[0] || left[1] - right[1]
+const pairStorageKey = (dealKey: CompoundEventKey, resultKey: CompoundEventKey): string =>
+  `${dealKey[0]}-${dealKey[1]}:${resultKey[0]}-${resultKey[1]}`
+
+const emptyImportSession = (): Session => ({
+  id: undefined,
+  battleType: undefined,
+  name: undefined,
+  players: new Map(),
+  reset: () => { }
+})
+
+const copyImportSession = (session: Session): Session => ({
+  id: session.id,
+  battleType: session.battleType,
+  name: session.name,
+  players: new Map(session.players),
+  reset: () => { }
+})
+
+/**
+ * Overlap修復の不変条件（独立監査finding #7、PR #203 review pass 8）:
+ *
+ * 1. replay windowはconverter文脈の読取り範囲であり、書込み範囲ではない。
+ *    新規行を含むraw hand span、旧/新viewでDEAL→306 pairingが変わるhand、
+ *    または新規session rowによりLake由来sessionが変わるhandだけを
+ *    affectedとする。その他のbystanderはconverter出力を捨て、deleteもputも
+ *    しないためbyte-identicalに残る。
+ * 2. session seedはrange単位でなくhand単位。各DEALより前で最新の検証済み
+ *    201からid/battleTypeを、その201以後・DEAL以前で最新の308からnameを
+ *    再構築する。201が無ければ空/rebuild-style。ただし全new rowが既存の
+ *    valid application tailより後に付くincremental tail importで、かつ以前に
+ *    派生していないhandだけはlive service.sessionをseedにする（#104）。
+ * 3. 範囲境界・session候補は常に現行schemaで再検証する。上端探索はtimestamp
+ *    だけでなく最大new [timestamp+ApiTypeId] keyから始めるため、同一msで
+ *    [T,306]の後ろにある[T,308]/[T,313]を落とさない。
+ * 4. Raw Event Lakeは読取り専用。affected HandIdのhands/phases/actionsだけを
+ *    同一transactionでdelete-then-putし、消滅した旧pairやaction tailも除く。
+ */
+export const buildOverlapRepairPlan = async (
+  db: PokerChaseDB,
+  newEvents: ApiEvent[],
+  liveSession: Session
+): Promise<OverlapRepairPlan> => {
+  const newEventKeys = new Set(newEvents.map(eventStorageKey))
   const isValidApplicationRow = (row: ApiEvent): boolean => {
     const parsed = parseApiEvent(row)
     return !!parsed && isApplicationApiEvent(parsed)
   }
 
-  // セッション文脈anchor: minNewTimestamp以前で最後の「いかなる
-  // ハンドの内部でもない」と証明できた検証済みEVT_ENTRY_QUEUED（codexレビュー
-  // 4巡目・5巡目P2）。探索の上限をminNewTimestamp自体にするのが重要
-  // （5巡目P2「Include session anchors after the previous hand」）: 直前の
-  // 完了ハンドの306までに探索上限を狭めると、その306より後・影響ハンドの
-  // DEALより前という「ハンド間の隙間」にある正当な201anchorを見逃す
-  // （doc comment参照）。この広い探索窓でmid-hand201を誤検出しないのは、
-  // 以下の外部性の証明があるため: 候補の直前の検証済み303が、その303と
-  // 候補の間の検証済み306で既に閉じている（または303自体が存在しない）
-  // ことを確認する —— この判定はコンバーターと同じ検証済みイベント列上の
-  // ハンド境界に基づくため、anchorがこの判定を通れば、範囲内のあらゆる
-  // 検証済み306の開始DEALも必ず範囲内に含まれる（306がanchor後にあるのに
-  // 開始303がanchor前なら、anchorはそのハンドの内部にあったことになり
-  // 判定と矛盾する）。候補がハンド内部なら（影響ハンド自身の内部を含む）、
-  // そのハンドの開始DEALより前から1ハンドずつ遡って探し直す（毎回より前の
-  // DEALへ厳密に後退するため必ず停止する）。
-  let anchorEvent: ApiEvent | undefined
-  // 201自身が今回の最古行なら[minNewTimestamp, 201]を含める（6巡目P2）。
-  let searchUpperKey: [number, number] = [minNewTimestamp, ApiType.EVT_ENTRY_QUEUED]
-  while (true) {
-    const candidate = await db.apiEvents
-      .where('[timestamp+ApiTypeId]')
-      .belowOrEqual(searchUpperKey)
-      .reverse()
-      .filter(event => event.ApiTypeId === ApiType.EVT_ENTRY_QUEUED && isValidApplicationRow(event))
-      .first()
-    if (!candidate) break
-
-    const candidateKey: [number, number] = [candidate.timestamp!, candidate.ApiTypeId]
-    const lastDealBeforeCandidate = await db.apiEvents
-      .where('[timestamp+ApiTypeId]')
-      .below(candidateKey)
-      .reverse()
-      .filter(event => event.ApiTypeId === ApiType.EVT_DEAL && isValidApplicationRow(event))
-      .first()
-    if (!lastDealBeforeCandidate) {
-      // 候補より前にハンドが一度も開いていない → ハンド外
-      anchorEvent = candidate
-      break
-    }
-
-    const resultsBetween = await db.apiEvents
-      .where('[timestamp+ApiTypeId]')
-      .between([lastDealBeforeCandidate.timestamp!, lastDealBeforeCandidate.ApiTypeId], candidateKey, false, false)
-      .filter(event => event.ApiTypeId === ApiType.EVT_HAND_RESULTS && isValidApplicationRow(event))
-      .first()
-    if (resultsBetween) {
-      // 直近に開いたハンドは候補より前に閉じている → ハンド外
-      anchorEvent = candidate
-      break
-    }
-
-    // 候補はハンド内部に割り込んだテーブル移動201 → そのハンドの開始DEALより
-    // 前から探し直す。
-    searchUpperKey = [lastDealBeforeCandidate.timestamp!, lastDealBeforeCandidate.ApiTypeId]
+  let minNewKey = eventKey(newEvents[0]!)
+  let maxNewKey = minNewKey
+  for (const event of newEvents.slice(1)) {
+    const key = eventKey(event)
+    if (compareEventKeys(key, minNewKey) < 0) minNewKey = key
+    if (compareEventKeys(key, maxNewKey) > 0) maxNewKey = key
   }
 
-  // 終了境界: maxNewTimestamp以後（同時刻含む）で最初の検証済み「既存」
-  // EVT_HAND_RESULTS（今回新規保存された306は除外 —— doc comment参照）。
-  const endEvent = await db.apiEvents
+  // 直前のvalid 306より後から読むと、new rowを含む旧handのopening DEALを
+  // 保持しつつ、pure appendでは過去session全体を読み直さない。
+  const previousResult = await db.apiEvents
     .where('[timestamp+ApiTypeId]')
-    .aboveOrEqual([maxNewTimestamp, 0])
-    .filter(event =>
-      event.ApiTypeId === ApiType.EVT_HAND_RESULTS &&
-      !newEventKeys.has(`${event.timestamp}-${event.ApiTypeId}`) &&
-      isValidApplicationRow(event)
-    )
+    .below(minNewKey)
+    .reverse()
+    .filter(row => row.ApiTypeId === ApiType.EVT_HAND_RESULTS && isValidApplicationRow(row))
     .first()
 
-  const lowerKey: [number, number] | undefined = anchorEvent
-    ? [anchorEvent.timestamp!, anchorEvent.ApiTypeId]
-    : undefined
-  const upperKey: [number, number] | undefined = endEvent
-    ? [endEvent.timestamp!, endEvent.ApiTypeId]
-    : undefined
+  // 新viewの最初の306と、new rowを除いた旧viewの最初の306の遅い方まで読む。
+  // 新306が旧pairを早く閉じるcapture-gap修復でも、旧pairの末尾を含められる。
+  // 探索開始をmaxNewKeyそのものにするのがsame-ms tail inclusivityの要点。
+  const firstPostResult = await db.apiEvents
+    .where('[timestamp+ApiTypeId]')
+    .aboveOrEqual(maxNewKey)
+    .filter(row => row.ApiTypeId === ApiType.EVT_HAND_RESULTS && isValidApplicationRow(row))
+    .first()
+  const firstOldResult = await db.apiEvents
+    .where('[timestamp+ApiTypeId]')
+    .aboveOrEqual(maxNewKey)
+    .filter(row =>
+      row.ApiTypeId === ApiType.EVT_HAND_RESULTS &&
+      !newEventKeys.has(eventStorageKey(row)) &&
+      isValidApplicationRow(row)
+    )
+    .first()
+  const upperEvent = [firstPostResult, firstOldResult]
+    .filter((event): event is ApiEvent => event !== undefined)
+    .sort((left, right) => compareEventKeys(eventKey(right), eventKey(left)))[0]
 
+  const lowerKey = previousResult ? eventKey(previousResult) : undefined
+  const upperKey = upperEvent ? eventKey(upperEvent) : undefined
   let rawRows: ApiEvent[]
   if (lowerKey && upperKey) {
-    rawRows = await db.apiEvents.where('[timestamp+ApiTypeId]').between(lowerKey, upperKey, true, true).toArray()
+    rawRows = await db.apiEvents.where('[timestamp+ApiTypeId]').between(lowerKey, upperKey, false, true).toArray()
   } else if (lowerKey) {
-    rawRows = await db.apiEvents.where('[timestamp+ApiTypeId]').aboveOrEqual(lowerKey).toArray()
+    rawRows = await db.apiEvents.where('[timestamp+ApiTypeId]').above(lowerKey).toArray()
   } else if (upperKey) {
     rawRows = await db.apiEvents.where('[timestamp+ApiTypeId]').belowOrEqual(upperKey).toArray()
   } else {
     rawRows = await db.apiEvents.orderBy('[timestamp+ApiTypeId]').toArray()
   }
-
   const events = await filterValidApplicationEvents(rawRows)
+  const oldEvents = events.filter(event => !newEventKeys.has(eventStorageKey(event)))
 
-  // Post-validation range invariants (the scan path is deliberately irrelevant):
-  // 1. Empty/rebuild-style converter seed iff EITHER a valid 201 precedes the
-  //    range's first opening DEAL, OR the range already contains a complete
-  //    pre-existing (older than this import) DEAL->306 pair -- i.e. an
-  //    already-derived hand this repair is about to delete-then-put (PR #203
-  //    codex review pass 7, "Avoid live-session seeding for Lake-start
-  //    replays"). With no 201 anywhere, the Lake-start fallback's range can
-  //    start at an unrelated older hand's DEAL; seeding that whole replay
-  //    from the live session would stamp the live table's id/battleType/name
-  //    onto that older, previously-contextless hand -- and every accounted
-  //    hand in the range gets rewritten by the delete-then-put below, not
-  //    just the newly imported one. A range with no pre-existing paired hand
-  //    at all -- a genuinely new incremental hand, e.g. one surrounded only
-  //    by non-application noise -- has no existing derived hand to corrupt,
-  //    so it keeps live-session seeding, matching the direct empty-DB path
-  //    (see the "old" pairing reused below for `accountedHandIds`). With no
-  //    DEAL at all, no session seed is needed either way.
-  // 2. Cleanup authority exists only for a valid 306 paired with an opening DEAL
-  //    inside this range in either the old (new rows excluded) or repaired replay.
-  //    This deletes old mis-pairings but never a leading orphan 306 fragment.
-  let sawSessionAnchorBeforeFirstDeal = false
-  let sawFirstDeal = false
-  for (const event of events) {
-    if (!sawFirstDeal && isApiEventType(event, ApiType.EVT_ENTRY_QUEUED)) {
-      sawSessionAnchorBeforeFirstDeal = true
-    }
-
-    if (isApiEventType(event, ApiType.EVT_DEAL)) {
-      sawFirstDeal = true
-    }
-  }
-
-  const collectPairedHandIds = (candidateEvents: ApiEvent[]): number[] => {
-    let hasOpenDeal = false
-    const handIds: number[] = []
-    for (const event of candidateEvents) {
+  const collectPairedHands = (candidateEvents: ApiEvent[]): PairedLakeHand[] => {
+    const hands: PairedLakeHand[] = []
+    let openDealIndex: number | undefined
+    for (let index = 0; index < candidateEvents.length; index++) {
+      const event = candidateEvents[index]!
       if (isApiEventType(event, ApiType.EVT_DEAL)) {
-        // Matches EntityConverter: a later DEAL replaces any unfinished buffer.
-        hasOpenDeal = true
+        // EntityConverter同様、後続DEALは未完了bufferを捨てて置き換える。
+        openDealIndex = index
       } else if (isApiEventType(event, ApiType.EVT_HAND_RESULTS)) {
-        if (hasOpenDeal) handIds.push(event.HandId)
-        hasOpenDeal = false
+        if (openDealIndex !== undefined) {
+          const deal = candidateEvents[openDealIndex]!
+          const dealKey = eventKey(deal)
+          const resultKey = eventKey(event)
+          hands.push({
+            handId: event.HandId,
+            dealKey,
+            resultKey,
+            pairKey: pairStorageKey(dealKey, resultKey),
+            events: candidateEvents.slice(openDealIndex, index + 1)
+          })
+        }
+        openDealIndex = undefined
       }
     }
-    return handIds
+    return hands
   }
-  // "Old" view = range events minus this import's own new rows -- the same
-  // view rebuildAllData()/the pre-repair Lake would have exposed. A non-empty
-  // pairing here means the range contains at least one hand that was already
-  // fully derived (DEAL+306 both pre-existing) before this import touched
-  // anything, so seeding the whole replay from the live session would leak
-  // it into that older hand once the delete-then-put below rewrites it
-  // (invariant 1 above).
-  const oldPairedHandIds = collectPairedHandIds(events.filter(event => !newEventKeys.has(`${event.timestamp}-${event.ApiTypeId}`)))
-  const accountedHandIds = Array.from(new Set([
-    ...oldPairedHandIds,
-    ...collectPairedHandIds(events),
+
+  const oldHands = collectPairedHands(oldEvents)
+  const postHands = collectPairedHands(events)
+  const oldByPair = new Map(oldHands.map(hand => [hand.pairKey, hand]))
+  const postByPair = new Map(postHands.map(hand => [hand.pairKey, hand]))
+
+  type LakeSession = Pick<Session, 'id' | 'battleType' | 'name'>
+  const sessionCache = new Map<string, LakeSession | undefined>()
+  const lakeSessionBeforeDeal = async (
+    dealKey: CompoundEventKey,
+    excludeNewRows: boolean
+  ): Promise<LakeSession | undefined> => {
+    const cacheKey = `${excludeNewRows ? 'old' : 'post'}:${dealKey[0]}-${dealKey[1]}`
+    if (sessionCache.has(cacheKey)) return sessionCache.get(cacheKey)
+
+    const anchorRow = await db.apiEvents
+      .where('[timestamp+ApiTypeId]')
+      .below(dealKey)
+      .reverse()
+      .filter(row =>
+        row.ApiTypeId === ApiType.EVT_ENTRY_QUEUED &&
+        (!excludeNewRows || !newEventKeys.has(eventStorageKey(row))) &&
+        isValidApplicationRow(row)
+      )
+      .first()
+    const anchor = anchorRow ? parseApiEvent(anchorRow) : null
+    if (!anchor || !isApiEventType(anchor, ApiType.EVT_ENTRY_QUEUED)) {
+      sessionCache.set(cacheKey, undefined)
+      return undefined
+    }
+
+    const contextRows = await db.apiEvents
+      .where('[timestamp+ApiTypeId]')
+      .between(eventKey(anchor), dealKey, true, false)
+      .filter(row =>
+        (!excludeNewRows || !newEventKeys.has(eventStorageKey(row))) &&
+        isValidApplicationRow(row)
+      )
+      .toArray()
+    let name: string | undefined
+    for (const rawContext of contextRows) {
+      const context = parseApiEvent(rawContext)
+      if (context && isApiEventType(context, ApiType.EVT_SESSION_DETAILS)) name = context.Name
+    }
+    const session = { id: anchor.Id, battleType: anchor.BattleType, name }
+    sessionCache.set(cacheKey, session)
+    return session
+  }
+
+  const sessionsEqual = (left: LakeSession | undefined, right: LakeSession | undefined): boolean =>
+    left?.id === right?.id && left?.battleType === right?.battleType && left?.name === right?.name
+  const containsNewKey = (hand: PairedLakeHand): boolean => newEvents.some(event => {
+    const key = eventKey(event)
+    return compareEventKeys(key, hand.dealKey) >= 0 && compareEventKeys(key, hand.resultKey) <= 0
+  })
+
+  const affectedOldPairs = new Set<string>()
+  const affectedPostPairs = new Set<string>()
+  for (const oldHand of oldHands) {
+    if (!postByPair.has(oldHand.pairKey) || containsNewKey(oldHand)) affectedOldPairs.add(oldHand.pairKey)
+  }
+  for (const postHand of postHands) {
+    if (!oldByPair.has(postHand.pairKey) || containsNewKey(postHand)) affectedPostPairs.add(postHand.pairKey)
+  }
+  for (const postHand of postHands) {
+    const oldHand = oldByPair.get(postHand.pairKey)
+    if (!oldHand) continue
+    const [oldSession, postSession] = await Promise.all([
+      lakeSessionBeforeDeal(oldHand.dealKey, true),
+      lakeSessionBeforeDeal(postHand.dealKey, false)
+    ])
+    if (!sessionsEqual(oldSession, postSession)) {
+      affectedOldPairs.add(oldHand.pairKey)
+      affectedPostPairs.add(postHand.pairKey)
+    }
+  }
+
+  const affectedPostHands = postHands.filter(hand => affectedPostPairs.has(hand.pairKey))
+  const affectedHandIds = Array.from(new Set([
+    ...oldHands.filter(hand => affectedOldPairs.has(hand.pairKey)).map(hand => hand.handId),
+    ...affectedPostHands.map(hand => hand.handId)
   ]))
 
+  // Pure tail append = 今回の最古new application keyが、旧viewの最後のvalid
+  // application keyより後。複数handを一度にappendしても同じ判定になる。
+  const lastOldApplicationEvent = await db.apiEvents
+    .orderBy('[timestamp+ApiTypeId]')
+    .reverse()
+    .filter(row => !newEventKeys.has(eventStorageKey(row)) && isValidApplicationRow(row))
+    .first()
+  const isTailAppend = !lastOldApplicationEvent || compareEventKeys(minNewKey, eventKey(lastOldApplicationEvent)) > 0
+  const existingAffectedHands = affectedPostHands.length > 0
+    ? await db.hands.bulkGet(affectedPostHands.map(hand => hand.handId))
+    : []
+  const previouslyDerivedIds = new Set(
+    affectedPostHands
+      .filter((_, index) => existingAffectedHands[index] !== undefined)
+      .map(hand => hand.handId)
+  )
+
+  const entities: EntityBundle = { hands: [], phases: [], actions: [] }
+  for (const hand of affectedPostHands) {
+    const lakeSession = await lakeSessionBeforeDeal(hand.dealKey, false)
+    const session = lakeSession
+      ? { ...emptyImportSession(), ...lakeSession }
+      : isTailAppend && !previouslyDerivedIds.has(hand.handId)
+        ? copyImportSession(liveSession)
+        : emptyImportSession()
+
+    // SessionはDEAL時点のLake文脈で固定する。hand内に割り込む201/308を
+    // converterへ渡すとclose時のcurrentSessionへ反映されるため、派生に必要な
+    // 303/304/305/306だけをhandごとに変換する。
+    const handEvents = hand.events.filter(event =>
+      event.ApiTypeId === ApiType.EVT_DEAL ||
+      event.ApiTypeId === ApiType.EVT_ACTION ||
+      event.ApiTypeId === ApiType.EVT_DEAL_ROUND ||
+      event.ApiTypeId === ApiType.EVT_HAND_RESULTS
+    )
+    const bundle = new EntityConverter(session).convertEventsToEntities(handEvents)
+    entities.hands.push(...bundle.hands)
+    entities.phases.push(...bundle.phases)
+    entities.actions.push(...bundle.actions)
+  }
+
   return {
-    events,
-    hasSessionAnchor: sawFirstDeal && (sawSessionAnchorBeforeFirstDeal || oldPairedHandIds.length > 0),
-    accountedHandIds
+    entities,
+    affectedHandIds,
+    replayEventCount: events.length,
+    repairedHandCount: affectedPostHands.length
   }
 }
 
@@ -400,7 +378,7 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
       // 既存データが1件でもあるインポートは「差分インポート」: 新規イベントが
       // 既存ハンドの一部（欠落していた中間イベント等）を埋める可能性があり、
       // 新規イベント単体ではエンティティを再導出できない（独立監査finding #7、
-      // collectOverlapRepairEvents()のdocコメント参照）。この判定は後続の
+      // buildOverlapRepairPlan()のdocコメント参照）。この判定は後続の
       // ループでexistingKeysへ新規キーを追記する前に確定させておく。
       const hadPreexistingEvents = existingKeys.size > 0
 
@@ -607,52 +585,17 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
         }
 
         try {
-          // エンティティ生成対象の決定（独立監査finding #7）:
-          // - 空のDBへのインポート（従来からの正常系）: 新規イベントが全て
-          //   なので、そのままEntityConverterへ渡す（従来経路そのまま）。
-          // - 既存データがあるDBへの差分インポート: 新規イベントが既存ハンドの
-          //   欠落部分を埋めた可能性がある。新規イベント単体ではハンド境界
-          //   （EVT_DEAL〜EVT_HAND_RESULTS）を構成できないため、影響範囲を
-          //   Lakeから読み直して既存行と新規行を合わせて再導出する
-          //   （境界の決め方・冪等性はcollectOverlapRepairEvents()参照）。
-          //   コンバーターの初期セッションは、検証済みrangeの最初のDEALより
-          //   前に検証済みEVT_ENTRY_QUEUEDがあるか、rangeが今回のimportより前
-          //   から存在した完全なDEAL→306ペア（＝これから削除→再導出される
-          //   既存の派生ハンド）を含む場合にのみrebuildAllData()と同じ空の
-          //   デフォルトセッションにする（range内容がセッション文脈を自前で
-          //   再構築でき、かつライブのservice.sessionの名前等が過去の再導出
-          //   ハンドに混入しない。後者の条件が無いと、201が全く無いLakeで
-          //   fallbackした際にrange先頭の既存ハンドがライブセッションで
-          //   書き換わってしまう —— PR #203 codexレビューP2 7巡目「Avoid
-          //   live-session seeding for Lake-start replays」）。どちらにも
-          //   当てはまらない、既存の派生ハンドを含まない真に新規の増分ハンド
-          //   （ノイズ行のみに囲まれている等）のインポートでは従来の直接経路
-          //   と同じくservice.sessionを初期値に使う —— さもないと
-          //   hand.sessionが空になり、#104のSessionState seedingリグレッション
-          //   が守っている挙動がoverlap経路でだけ壊れる（PR #203 codex
-          //   レビューP2）。
-          let entitySourceEvents: ApiEvent[] = allNewEvents
-          let converterSession: Session = service.session
-          let repairRange: Awaited<ReturnType<typeof collectOverlapRepairEvents>> | undefined
+          // 空DBは従来どおりnew eventsを一括変換。既存Lakeへのimportだけは
+          // old/post viewを比較し、影響handごとにLake sessionを決めたplanを使う。
+          let entities: EntityBundle
+          let repairPlan: Awaited<ReturnType<typeof buildOverlapRepairPlan>> | undefined
           if (hadPreexistingEvents) {
-            const newEventKeys = new Set(allNewEvents.map(event => `${event.timestamp}-${event.ApiTypeId}`))
-            repairRange = await collectOverlapRepairEvents(db, minNewTimestamp, maxNewTimestamp, newEventKeys)
-            entitySourceEvents = repairRange.events
-            if (repairRange.hasSessionAnchor) {
-              converterSession = {
-                id: undefined,
-                battleType: undefined,
-                name: undefined,
-                players: new Map(),
-                reset: () => { }
-              }
-            }
-            console.log(`[importData] Overlap import detected - re-deriving entities from ${entitySourceEvents.length} Lake events covering the affected range (session anchor in range: ${repairRange.hasSessionAnchor})`)
+            repairPlan = await buildOverlapRepairPlan(db, allNewEvents, service.session)
+            entities = repairPlan.entities
+            console.log(`[importData] Overlap import detected - inspected ${repairPlan.replayEventCount} Lake events and re-derived ${repairPlan.repairedHandCount} affected hand(s)`)
+          } else {
+            entities = new EntityConverter(service.session).convertEventsToEntities(allNewEvents)
           }
-
-          // EntityConverterを使用してエンティティを生成
-          const converter = new EntityConverter(converterSession)
-          const entities = converter.convertEventsToEntities(entitySourceEvents)
 
           console.log(`[importData] Generated entities - Hands: ${entities.hands.length}, Phases: ${entities.phases.length}, Actions: ${entities.actions.length}`)
 
@@ -660,33 +603,18 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
             console.log(`[importData] Saved/updated ${counts.hands} hands, ${counts.phases} phases, ${counts.actions} actions`)
           }
 
-          if (repairRange) {
-            // Overlap修復はbulkPut（上書き）だけでは足りない（PR #203 codex
-            // レビュー2巡目P2）: 旧導出には存在したが新導出には存在しない
-            // 派生行 —— 例: キャプチャ欠落で後続の306と誤ペアリングされて
-            // いた旧ハンド（HandIdが新導出に現れない）、旧導出の方が多かった
-            // action行（[handId+index]の末尾が残る）—— がそのまま残り、
-            // 統計が新旧両方を数えてしまう。
-            //
-            // 削除対象は「この修復が説明できるハンド」= idが範囲内の検証済み
-            // DEAL→EVT_HAND_RESULTSペアのHandIdに一致する既存派生ハンドのみ
-            // （collectOverlapRepairEvents()のdocコメント参照。codexレビュー
-            // 3巡目P2×2: idベースの判定にすることで、approxTimestamp未設定の
-            // レガシー行もインデックスに頼らず対象に含まれ、逆に導出元の生行が
-            // 現行スキーマでパース不能になったハンド —— 再導出で作り直せない
-            // もの —— は削除されない。6巡目P2: range先頭のmid-hand断片など、
-            // 306だけが範囲内にありopening DEALが無いHandIdも削除しない）。
-            // それらとphases/actionsを、再導出バンドルの保存と同一
-            // トランザクションで先に削除する。
-            // Raw Event Lake（apiEvents）には一切触れない。
-            const { accountedHandIds } = repairRange
+          if (repairPlan) {
+            // putだけでは消滅した旧pair/action tailが残るため、affected IDsだけ
+            // 同一transactionでdelete-then-putする。replay中のbystanderは
+            // affectedHandIdsへ入らず、hands/phases/actions全て無変更。
+            const { affectedHandIds } = repairPlan
             await db.transaction('rw', [db.hands, db.phases, db.actions], async () => {
-              const existingAccountedHands = accountedHandIds.length > 0
-                ? await db.hands.bulkGet(accountedHandIds)
+              const existingAffectedHands = affectedHandIds.length > 0
+                ? await db.hands.bulkGet(affectedHandIds)
                 : []
-              const staleHandIds = accountedHandIds.filter((_, index) => existingAccountedHands[index] !== undefined)
+              const staleHandIds = affectedHandIds.filter((_, index) => existingAffectedHands[index] !== undefined)
               if (staleHandIds.length > 0) {
-                console.log(`[importData] Removing ${staleHandIds.length} stale derived hand(s) accounted for by the repair range before re-deriving`)
+                console.log(`[importData] Removing ${staleHandIds.length} affected derived hand(s) before re-deriving`)
                 await db.hands.bulkDelete(staleHandIds)
                 await db.phases.where('handId').anyOf(staleHandIds).delete()
                 await db.actions.where('handId').anyOf(staleHandIds).delete()

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -76,11 +76,14 @@ export const clearImportSession = (): void => {
  *   あり（docs/api-events.md、EntityConverterの融合ハンド棄却ガード参照）、
  *   その201から変換を始めると影響ハンドの先頭のDEALが範囲外になって、
  *   EntityConverter（DEALでのみバッファ開始）が新規行を導出できない。
- *   「完了ハンド境界→その前の201」の順で辿ればanchorは必ずハンド外にあり、
- *   影響ハンドのDEALとセッション文脈（BattleType/Id、以降の313/301が積む
- *   プレイヤー名）の両方が範囲に含まれる。201が見つからない場合（および
- *   完了ハンド境界自体が無い場合）はLake先頭から（rebuildAllDataと同じ
- *   条件で）変換する。
+ *   さらに「完了ハンド境界以前」というだけでは足りない（codexレビュー
+ *   4巡目P2）: テーブル移動201はその「直前の完了ハンド」自身の内部にも
+ *   割り込み得るため、候補201が「いかなるハンドの内部でもない」ことを
+ *   確認できるまで1ハンドずつ遡る（実装内コメント参照）。こうして得た
+ *   anchorは必ずハンド外にあり、影響ハンドのDEALとセッション文脈
+ *   （BattleType/Id、以降の313/301が積むプレイヤー名）の両方が範囲に
+ *   含まれる。201が見つからない場合（および完了ハンド境界自体が無い
+ *   場合）はLake先頭から（rebuildAllDataと同じ条件で）変換する。
  * - 終了境界（PR #203 codexレビュー2巡目P2で修正）: maxNewTimestamp 以後で
  *   最初の「検証済みかつ既存（今回のインポートで保存された行を除く）」
  *   EVT_HAND_RESULTS(306)（それ自身を含む）。既存行に限るのは、修復前の
@@ -166,16 +169,63 @@ export const collectOverlapRepairEvents = async (
     .filter(event => event.ApiTypeId === ApiType.EVT_HAND_RESULTS && isValidApplicationRow(event))
     .first()
 
-  // セッション文脈anchor: 完了ハンド境界以前で最後の検証済みEVT_ENTRY_QUEUED。
-  // 306より前を探すため、テーブル移動でハンド中に割り込んだ201を掴むことはない。
-  const anchorEvent = prevHandBoundary
-    ? await db.apiEvents
-      .where('[timestamp+ApiTypeId]')
-      .belowOrEqual([prevHandBoundary.timestamp!, prevHandBoundary.ApiTypeId])
-      .reverse()
-      .filter(event => event.ApiTypeId === ApiType.EVT_ENTRY_QUEUED && isValidApplicationRow(event))
-      .first()
-    : undefined
+  // セッション文脈anchor: 完了ハンド境界以前で最後の検証済みEVT_ENTRY_QUEUED
+  // …のうち「いかなるハンドの内部でもない」と証明できたもの（codexレビュー
+  // 4巡目P2）。完了ハンド境界の「以前」というだけでは不十分: MTTのテーブル
+  // 移動201は「直前の完了ハンド」自身の内部（そのDEALと306の間）にも割り込み
+  // 得る。そこから変換を始めると、直前ハンドの306は範囲内・DEALは範囲外に
+  // なり、クリーンアップがそのHandIdを（範囲内の検証済み306として）削除した
+  // 上で、EntityConverter（DEALでのみバッファ開始）が再導出できず、直前
+  // ハンドが全再構築まで消失する。候補201の外部性は「候補の直前の検証済み
+  // 303が、その303と候補の間の検証済み306で既に閉じている（または303自体が
+  // 存在しない）」ことで判定する —— この判定はコンバーターと同じ検証済み
+  // イベント列上のハンド境界に基づくため、anchorがこの判定を通れば、
+  // 範囲内のあらゆる検証済み306の開始DEALも必ず範囲内に含まれる
+  // （306がanchor後にあるのに開始303がanchor前なら、anchorはそのハンドの
+  // 内部にあったことになり判定と矛盾する）。候補がハンド内部なら、その
+  // ハンドの開始DEALより前から1ハンドずつ遡って探し直す。
+  let anchorEvent: ApiEvent | undefined
+  if (prevHandBoundary) {
+    let searchUpperKey: [number, number] = [prevHandBoundary.timestamp!, prevHandBoundary.ApiTypeId]
+    while (true) {
+      const candidate = await db.apiEvents
+        .where('[timestamp+ApiTypeId]')
+        .belowOrEqual(searchUpperKey)
+        .reverse()
+        .filter(event => event.ApiTypeId === ApiType.EVT_ENTRY_QUEUED && isValidApplicationRow(event))
+        .first()
+      if (!candidate) break
+
+      const candidateKey: [number, number] = [candidate.timestamp!, candidate.ApiTypeId]
+      const lastDealBeforeCandidate = await db.apiEvents
+        .where('[timestamp+ApiTypeId]')
+        .below(candidateKey)
+        .reverse()
+        .filter(event => event.ApiTypeId === ApiType.EVT_DEAL && isValidApplicationRow(event))
+        .first()
+      if (!lastDealBeforeCandidate) {
+        // 候補より前にハンドが一度も開いていない → ハンド外
+        anchorEvent = candidate
+        break
+      }
+
+      const resultsBetween = await db.apiEvents
+        .where('[timestamp+ApiTypeId]')
+        .between([lastDealBeforeCandidate.timestamp!, lastDealBeforeCandidate.ApiTypeId], candidateKey, false, false)
+        .filter(event => event.ApiTypeId === ApiType.EVT_HAND_RESULTS && isValidApplicationRow(event))
+        .first()
+      if (resultsBetween) {
+        // 直近に開いたハンドは候補より前に閉じている → ハンド外
+        anchorEvent = candidate
+        break
+      }
+
+      // 候補はハンド内部に割り込んだテーブル移動201 → そのハンドの開始DEALより
+      // 前（belowOrEqualだがDEAL自身は201でないため実質strictly before）から
+      // 探し直す。毎回より前のDEALへ厳密に後退するため必ず停止する。
+      searchUpperKey = [lastDealBeforeCandidate.timestamp!, lastDealBeforeCandidate.ApiTypeId]
+    }
+  }
 
   // 終了境界: maxNewTimestamp以後（同時刻含む）で最初の検証済み「既存」
   // EVT_HAND_RESULTS（今回新規保存された306は除外 —— doc comment参照）。

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -68,45 +68,82 @@ export const clearImportSession = (): void => {
  * この関数は新規イベントのtimestamp範囲 [minNewTimestamp, maxNewTimestamp] を
  * 以下の境界までLake上で拡張し、既存行と新規行を合わせた連続領域を返す:
  *
- * - 開始境界: minNewTimestamp 以前で最後の EVT_ENTRY_QUEUED(201)。201は
- *   ハンド間（テーブル着席時）にのみ発行されるためハンド境界として安全で、
- *   かつEntityConverterのセッション文脈（BattleType/Id、以降の313/301が
- *   積むプレイヤー名）の起点でもある —— 新規イベントが属するハンドの
- *   DEALが既存行だった場合も、そのDEALより前から変換を始められる。
- *   201が見つからない場合はLake先頭から（rebuildAllDataと同じ条件で）変換する。
- * - 終了境界: maxNewTimestamp 以後で最初の EVT_HAND_RESULTS(306)（それ自身を
- *   含む）。新規イベントが既存ハンドの中間に挿入された場合、そのハンドの
- *   RESULTSまでを含める。306が無い場合（Lake末尾が未完了ハンド）はLake末尾
- *   まで —— 未完了ハンドはEntityConverterがHandId未設定として棄却するため
- *   ゴミは生成されない。
+ * - 開始境界（PR #203 codexレビューP2で修正）: まず minNewTimestamp より厳密に
+ *   前で最後の「検証済み」EVT_HAND_RESULTS(306) = 直前の完了ハンド境界を探し、
+ *   さらにその境界以前で最後の「検証済み」EVT_ENTRY_QUEUED(201) をanchorとする。
+ *   201を直接（minNewTimestamp基準で）anchorにしてはならない: MTTのテーブル
+ *   移動201はハンドの最中（EVT_DEALとEVT_HAND_RESULTSの間）に割り込むことが
+ *   あり（docs/api-events.md、EntityConverterの融合ハンド棄却ガード参照）、
+ *   その201から変換を始めると影響ハンドの先頭のDEALが範囲外になって、
+ *   EntityConverter（DEALでのみバッファ開始）が新規行を導出できない。
+ *   「完了ハンド境界→その前の201」の順で辿ればanchorは必ずハンド外にあり、
+ *   影響ハンドのDEALとセッション文脈（BattleType/Id、以降の313/301が積む
+ *   プレイヤー名）の両方が範囲に含まれる。201が見つからない場合（および
+ *   完了ハンド境界自体が無い場合）はLake先頭から（rebuildAllDataと同じ
+ *   条件で）変換する。
+ * - 終了境界: maxNewTimestamp 以後で最初の「検証済み」EVT_HAND_RESULTS(306)
+ *   （それ自身を含む）。新規イベントが既存ハンドの中間に挿入された場合、
+ *   そのハンドのRESULTSまでを含める。306が無い場合（Lake末尾が未完了ハンド）
+ *   はLake末尾まで —— 未完了ハンドはEntityConverterがHandId未設定として
+ *   棄却するためゴミは生成されない。
+ *
+ * どちらの境界も、候補行を現行Zodスキーマで検証してから採用する
+ * （PR #203 codexレビューP2）: Raw LakeにはApiTypeIdが306/201でもパース
+ * 不能な行が混在し得る（Raw Event Lakeの設計上の仕様）。生のApiTypeId一致
+ * だけで境界を決めると、パース不能な306を終了境界に選んでしまい、直後の
+ * filterValidApplicationEvents()でその行自体が除去されて本物のRESULTSが
+ * 範囲外に残り、ハンドが未終了扱いで棄却される（修復が黙って失敗する）。
  *
  * 範囲内の既存ハンドを再導出しても重複は生じない: hands(id) / phases
  * ([handId+phase]) / actions([handId+index]) はいずれも決定的キーで、
  * saveEntities()のbulkPutが同キー行を上書きする（冪等）。範囲外の派生行には
  * 一切触れない。返す前にfilterValidApplicationEvents()で再検証するのは
- * rebuildAllData()と同じ理由（Raw Lakeには非アプリケーション行・現行スキーマで
- * パース不能な行が混在し得る。CLAUDE.md「Raw Event Lake」参照）。
+ * rebuildAllData()と同じ理由（CLAUDE.md「Raw Event Lake」参照）。
+ *
+ * 戻り値の`hasSessionAnchor`は「範囲が検証済みEVT_ENTRY_QUEUEDから始まって
+ * いる = 範囲内のイベント列だけでセッション文脈を再構築できる」ことを示す。
+ * 呼び出し元はこれがtrueの場合のみコンバーターを空セッションで初期化し、
+ * falseの場合（201無しの増分ハンド等）はライブのservice.sessionを
+ * 初期値として使う（PR #203 codexレビューP2 / #104のSessionState
+ * seedingリグレッション参照）。
  */
 export const collectOverlapRepairEvents = async (
   db: PokerChaseDB,
   minNewTimestamp: number,
   maxNewTimestamp: number
-): Promise<ApiEvent[]> => {
-  // 開始境界: minNewTimestamp以前（同時刻含む）で最後のEVT_ENTRY_QUEUED。
-  // ApiTypeIdは小さい正の整数のため、[minNewTimestamp, MAX_SAFE_INTEGER]を
-  // 上限にすればminNewTimestampと同時刻の行も全て走査対象に含まれる。
-  const anchorEvent = await db.apiEvents
+): Promise<{ events: ApiEvent[], hasSessionAnchor: boolean }> => {
+  // 境界候補は現行スキーマで検証してから採用する（doc comment参照）。
+  // parseApiEventは同期のZodパースなのでDexieのfilterコールバック内で使える。
+  const isValidApplicationRow = (row: ApiEvent): boolean => {
+    const parsed = parseApiEvent(row)
+    return !!parsed && isApplicationApiEvent(parsed)
+  }
+
+  // 直前の完了ハンド境界: minNewTimestampより厳密に前（.below([ts, 0])は
+  // timestampがminNewTimestamp未満の行のみを含む）で最後の検証済み306。
+  const prevHandBoundary = await db.apiEvents
     .where('[timestamp+ApiTypeId]')
-    .belowOrEqual([minNewTimestamp, Number.MAX_SAFE_INTEGER])
+    .below([minNewTimestamp, 0])
     .reverse()
-    .filter(event => event.ApiTypeId === ApiType.EVT_ENTRY_QUEUED)
+    .filter(event => event.ApiTypeId === ApiType.EVT_HAND_RESULTS && isValidApplicationRow(event))
     .first()
 
-  // 終了境界: maxNewTimestamp以後（同時刻含む）で最初のEVT_HAND_RESULTS。
+  // セッション文脈anchor: 完了ハンド境界以前で最後の検証済みEVT_ENTRY_QUEUED。
+  // 306より前を探すため、テーブル移動でハンド中に割り込んだ201を掴むことはない。
+  const anchorEvent = prevHandBoundary
+    ? await db.apiEvents
+      .where('[timestamp+ApiTypeId]')
+      .belowOrEqual([prevHandBoundary.timestamp!, prevHandBoundary.ApiTypeId])
+      .reverse()
+      .filter(event => event.ApiTypeId === ApiType.EVT_ENTRY_QUEUED && isValidApplicationRow(event))
+      .first()
+    : undefined
+
+  // 終了境界: maxNewTimestamp以後（同時刻含む）で最初の検証済みEVT_HAND_RESULTS。
   const endEvent = await db.apiEvents
     .where('[timestamp+ApiTypeId]')
     .aboveOrEqual([maxNewTimestamp, 0])
-    .filter(event => event.ApiTypeId === ApiType.EVT_HAND_RESULTS)
+    .filter(event => event.ApiTypeId === ApiType.EVT_HAND_RESULTS && isValidApplicationRow(event))
     .first()
 
   const lowerKey: [number, number] | undefined = anchorEvent
@@ -127,7 +164,10 @@ export const collectOverlapRepairEvents = async (
     rawRows = await db.apiEvents.orderBy('[timestamp+ApiTypeId]').toArray()
   }
 
-  return await filterValidApplicationEvents(rawRows)
+  return {
+    events: await filterValidApplicationEvents(rawRows),
+    hasSessionAnchor: anchorEvent !== undefined
+  }
 }
 
 /**
@@ -388,22 +428,30 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
           //   （EVT_DEAL〜EVT_HAND_RESULTS）を構成できないため、影響範囲を
           //   Lakeから読み直して既存行と新規行を合わせて再導出する
           //   （境界の決め方・冪等性はcollectOverlapRepairEvents()参照）。
-          //   セッション文脈は範囲先頭のEVT_ENTRY_QUEUEDから再構築されるため、
-          //   rebuildAllData()と同じ空のデフォルトセッションを初期値にする
-          //   （ライブのservice.sessionを流用すると、現在のセッション名等が
-          //   過去の再導出ハンドに混入し得る）。
+          //   コンバーターの初期セッションは、範囲が検証済みEVT_ENTRY_QUEUED
+          //   から始まる場合のみrebuildAllData()と同じ空のデフォルト
+          //   セッションにする（範囲内のイベント列がセッション文脈を自前で
+          //   再構築でき、かつライブのservice.sessionの名前等が過去の
+          //   再導出ハンドに混入しない）。201を含まない増分ハンドの
+          //   インポートでは従来の直接経路と同じくservice.sessionを
+          //   初期値に使う —— さもないとhand.sessionが空になり、#104の
+          //   SessionState seedingリグレッションが守っている挙動が
+          //   overlap経路でだけ壊れる（PR #203 codexレビューP2）。
           let entitySourceEvents: ApiEvent[] = allNewEvents
           let converterSession: Session = service.session
           if (hadPreexistingEvents) {
-            entitySourceEvents = await collectOverlapRepairEvents(db, minNewTimestamp, maxNewTimestamp)
-            converterSession = {
-              id: undefined,
-              battleType: undefined,
-              name: undefined,
-              players: new Map(),
-              reset: () => { }
+            const repairRange = await collectOverlapRepairEvents(db, minNewTimestamp, maxNewTimestamp)
+            entitySourceEvents = repairRange.events
+            if (repairRange.hasSessionAnchor) {
+              converterSession = {
+                id: undefined,
+                battleType: undefined,
+                name: undefined,
+                players: new Map(),
+                reset: () => { }
+              }
             }
-            console.log(`[importData] Overlap import detected - re-deriving entities from ${entitySourceEvents.length} Lake events covering the affected range`)
+            console.log(`[importData] Overlap import detected - re-deriving entities from ${entitySourceEvents.length} Lake events covering the affected range (session anchor in range: ${repairRange.hasSessionAnchor})`)
           }
 
           // EntityConverterを使用してエンティティを生成

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -105,25 +105,40 @@ export const clearImportSession = (): void => {
  * 上書きだけでは「旧導出には存在したが新導出には存在しない」行が残る
  * （PR #203 codexレビュー2巡目P2）: 誤ペアリングされていた旧ハンドの
  * HandIdが新導出に現れない、旧導出の方がaction数が多い等。このため
- * 呼び出し元は、保存前に「stale削除ウィンドウ」= approxTimestampが
- * (staleWindowStartExclusive, staleWindowEndInclusive] に入る既存派生
- * ハンド（とそのphases/actions）を同一トランザクション内で削除する。
- * ウィンドウ下限が「直前の完了ハンド境界306」(exclusive)なのは、そこまでの
- * ハンドは新旧の導出が一致していて触る必要がなく、かつ範囲開始（201
- * anchor）をまたぐハンド —— ハンド中に割り込んだ201がanchorになった
- * 場合、そのDEALは範囲外 —— を誤って削除して再導出できない事態を防ぐ
- * ため。ウィンドウ内のハンドは定義上すべて範囲内のイベントだけから
- * 再導出可能（DEALは境界306より後、306は終了境界以前）。範囲外の
+ * 呼び出し元は、保存前に「この修復が説明できる既存派生ハンド」= idが
+ * 「範囲内の検証済みEVT_HAND_RESULTSのHandId」に一致する既存ハンド
+ * （とそのphases/actions）を、再導出バンドルの保存と同一トランザクション
+ * 内で削除する。削除判定をtimestampウィンドウではなくHandIdで行うのは
+ * （codexレビュー3巡目P2×2）:
+ * - hand.idは必ずその導出元306のHandId由来なので、「idが範囲内の検証済み
+ *   306に一致する」ことがそのハンドの導出元が範囲内にある直接の証拠に
+ *   なり、approxTimestampが未設定のレガシー行（モデル上optional）も
+ *   インデックスに頼らず正しく対象に含まれる。
+ * - 逆に、導出元の生306が現行スキーマでパース不能になったハンドは
+ *   検証済み306集合に現れないため削除されない —— 再導出で作り直せない
+ *   ものを消して、明示的な再構築まで残っていたはずの派生状態を
+ *   失うことがない（新導出が説明できるハンドだけを削除する）。
+ * 新バンドルが再生成するハンドのidはこの集合の部分集合（definition上、
+ * bundleの各hand.idは範囲内の検証済み306由来）なので、削除→bulkPutで
+ * 欠落は生じない。集合内だが新導出に現れないid（誤ペアリング修正・
+ * キメラ棄却）は意図的な削除で、全再構築と同じ結果に収束する。範囲外の
  * 派生行には一切触れない。返す前にfilterValidApplicationEvents()で
  * 再検証するのはrebuildAllData()と同じ理由（CLAUDE.md「Raw Event
  * Lake」参照）。
  *
- * 戻り値の`hasSessionAnchor`は「範囲が検証済みEVT_ENTRY_QUEUEDから始まって
- * いる = 範囲内のイベント列だけでセッション文脈を再構築できる」ことを示す。
- * 呼び出し元はこれがtrueの場合のみコンバーターを空セッションで初期化し、
- * falseの場合（201無しの増分ハンド等）はライブのservice.sessionを
- * 初期値として使う（PR #203 codexレビューP2 / #104のSessionState
- * seedingリグレッション参照）。
+ * 戻り値の`hasSessionAnchor`は「範囲の先頭からハンド開始までに検証済み
+ * EVT_ENTRY_QUEUEDがある = 範囲内のイベント列だけでセッション文脈を
+ * 再構築できる」ことを示す。201 anchorが見つかった場合に加えて、
+ * Lake先頭フォールバック時も「Lakeが最初の検証済みEVT_DEALより前の
+ * 検証済み201で始まっている」ならtrue（codexレビュー3巡目P2）——
+ * この場合も範囲はセッション境界から始まっており、ライブの
+ * service.sessionをseedにすると、201がid/battleTypeを上書きしても
+ * session.nameは消さないため、308を持たない先頭ハンドの修復結果に
+ * ライブのテーブル名が混入し得る。呼び出し元はこれがtrueの場合のみ
+ * コンバーターを空セッションで初期化し、falseの場合（201無しの
+ * 増分ハンド等）はライブのservice.sessionを初期値として使う
+ * （PR #203 codexレビューP2 / #104のSessionState seeding
+ * リグレッション参照）。
  */
 export const collectOverlapRepairEvents = async (
   db: PokerChaseDB,
@@ -134,10 +149,6 @@ export const collectOverlapRepairEvents = async (
 ): Promise<{
   events: ApiEvent[]
   hasSessionAnchor: boolean
-  /** stale削除ウィンドウ下限（直前の完了ハンド境界306のtimestamp、exclusive）。無ければundefined = Lake先頭から */
-  staleWindowStartExclusive: number | undefined
-  /** stale削除ウィンドウ上限（終了境界306のtimestamp、inclusive）。無ければundefined = Lake末尾まで */
-  staleWindowEndInclusive: number | undefined
 }> => {
   // 境界候補は現行スキーマで検証してから採用する（doc comment参照）。
   // parseApiEventは同期のZodパースなのでDexieのfilterコールバック内で使える。
@@ -178,6 +189,27 @@ export const collectOverlapRepairEvents = async (
     )
     .first()
 
+  // Lake先頭フォールバック時のセッション境界判定（codexレビュー3巡目P2）:
+  // 完了ハンド境界（またはその前の201）が無くても、Lakeが「最初の検証済み
+  // EVT_DEALより前の検証済みEVT_ENTRY_QUEUED」で始まっていれば、Lake先頭
+  // から読む範囲は同様にセッション境界から始まっている。この場合も空
+  // セッションseedを使う（doc comment参照）。
+  let lakeStartsAtSessionAnchor = false
+  if (!anchorEvent) {
+    const firstValidEntryQueued = await db.apiEvents
+      .orderBy('[timestamp+ApiTypeId]')
+      .filter(event => event.ApiTypeId === ApiType.EVT_ENTRY_QUEUED && isValidApplicationRow(event))
+      .first()
+    if (firstValidEntryQueued) {
+      const dealBeforeFirstEntryQueued = await db.apiEvents
+        .where('[timestamp+ApiTypeId]')
+        .below([firstValidEntryQueued.timestamp!, firstValidEntryQueued.ApiTypeId])
+        .filter(event => event.ApiTypeId === ApiType.EVT_DEAL && isValidApplicationRow(event))
+        .first()
+      lakeStartsAtSessionAnchor = dealBeforeFirstEntryQueued === undefined
+    }
+  }
+
   const lowerKey: [number, number] | undefined = anchorEvent
     ? [anchorEvent.timestamp!, anchorEvent.ApiTypeId]
     : undefined
@@ -198,9 +230,7 @@ export const collectOverlapRepairEvents = async (
 
   return {
     events: await filterValidApplicationEvents(rawRows),
-    hasSessionAnchor: anchorEvent !== undefined,
-    staleWindowStartExclusive: prevHandBoundary?.timestamp,
-    staleWindowEndInclusive: endEvent?.timestamp
+    hasSessionAnchor: anchorEvent !== undefined || lakeStartsAtSessionAnchor
   }
 }
 
@@ -506,25 +536,34 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
             // 派生行 —— 例: キャプチャ欠落で後続の306と誤ペアリングされて
             // いた旧ハンド（HandIdが新導出に現れない）、旧導出の方が多かった
             // action行（[handId+index]の末尾が残る）—— がそのまま残り、
-            // 統計が新旧両方を数えてしまう。stale削除ウィンドウ
-            // （collectOverlapRepairEvents()のdocコメント参照。ウィンドウ内の
-            // ハンドは定義上すべて範囲内から再導出可能）に入る既存派生
-            // ハンドとそのphases/actionsを、再導出バンドルの保存と同一
-            // トランザクションで先に削除する。Raw Event Lake（apiEvents）
-            // には一切触れない。
-            const { staleWindowStartExclusive, staleWindowEndInclusive } = repairRange
+            // 統計が新旧両方を数えてしまう。
+            //
+            // 削除対象は「この修復が説明できるハンド」= idが範囲内の検証済み
+            // EVT_HAND_RESULTSのHandIdに一致する既存派生ハンドのみ
+            // （collectOverlapRepairEvents()のdocコメント参照。codexレビュー
+            // 3巡目P2×2: idベースの判定にすることで、approxTimestamp未設定の
+            // レガシー行もインデックスに頼らず対象に含まれ、逆に導出元の生行が
+            // 現行スキーマでパース不能になったハンド —— 再導出で作り直せない
+            // もの —— は削除されない）。それらとphases/actionsを、再導出
+            // バンドルの保存と同一トランザクションで先に削除する。
+            // Raw Event Lake（apiEvents）には一切触れない。
+            const accountedHandIds: number[] = []
+            {
+              const seen = new Set<number>()
+              for (const event of entitySourceEvents) {
+                if (isApiEventType(event, ApiType.EVT_HAND_RESULTS) && !seen.has(event.HandId)) {
+                  seen.add(event.HandId)
+                  accountedHandIds.push(event.HandId)
+                }
+              }
+            }
             await db.transaction('rw', [db.hands, db.phases, db.actions], async () => {
-              const staleHandIds = await db.hands
-                .where('approxTimestamp')
-                .between(
-                  staleWindowStartExclusive ?? 0,
-                  staleWindowEndInclusive ?? Number.MAX_SAFE_INTEGER,
-                  staleWindowStartExclusive === undefined, // 下限は境界306自身のハンドを含めない（exclusive）。境界なしならLake先頭から（inclusive）
-                  true
-                )
-                .primaryKeys()
+              const existingAccountedHands = accountedHandIds.length > 0
+                ? await db.hands.bulkGet(accountedHandIds)
+                : []
+              const staleHandIds = accountedHandIds.filter((_, index) => existingAccountedHands[index] !== undefined)
               if (staleHandIds.length > 0) {
-                console.log(`[importData] Removing ${staleHandIds.length} stale derived hand(s) in the repair window before re-deriving`)
+                console.log(`[importData] Removing ${staleHandIds.length} stale derived hand(s) accounted for by the repair range before re-deriving`)
                 await db.hands.bulkDelete(staleHandIds)
                 await db.phases.where('handId').anyOf(staleHandIds).delete()
                 await db.actions.where('handId').anyOf(staleHandIds).delete()

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -60,15 +60,22 @@ interface PairedLakeHand {
   dealKey: CompoundEventKey
   resultKey: CompoundEventKey
   pairKey: string
-  events: ApiEvent[]
 }
 
 interface OverlapRepairPlan {
   entities: EntityBundle
-  /** 旧・新viewのいずれかで実際に影響を受けたHandIdだけ。 */
-  affectedHandIds: number[]
+  /** 同一transactionでdeleteしてからentitiesで置き換えるHandId。 */
+  replaceHandIds: number[]
   replayEventCount: number
   repairedHandCount: number
+  affectedSessionCount: number
+  preservedRejectedHandCount: number
+}
+
+interface SessionWindow {
+  id: string
+  startKey?: CompoundEventKey
+  endKey?: CompoundEventKey
 }
 
 const eventKey = (event: ApiEvent): CompoundEventKey => [event.timestamp ?? 0, event.ApiTypeId]
@@ -95,23 +102,32 @@ const copyImportSession = (session: Session): Session => ({
 })
 
 /**
- * Overlap修復の不変条件（独立監査finding #7、PR #203 review pass 8）:
+ * Overlap修復の不変条件（独立監査finding #7、PR #203 review pass 9）:
  *
- * 1. replay windowはconverter文脈の読取り範囲であり、書込み範囲ではない。
- *    新規行を含むraw hand span、旧/新viewでDEAL→306 pairingが変わるhand、
- *    または新規session rowによりLake由来sessionが変わるhandだけを
- *    affectedとする。その他のbystanderはconverter出力を捨て、deleteもputも
- *    しないためbyte-identicalに残る。
- * 2. session seedはrange単位でなくhand単位。各DEALより前で最新の検証済み
- *    201からid/battleTypeを、その201以後・DEAL以前で最新の308からnameを
- *    再構築する。201が無ければ空/rebuild-style。ただし全new rowが既存の
- *    valid application tailより後に付くincremental tail importで、かつ以前に
- *    派生していないhandだけはlive service.sessionをseedにする（#104）。
- * 3. 範囲境界・session候補は常に現行schemaで再検証する。上端探索はtimestamp
- *    だけでなく最大new [timestamp+ApiTypeId] keyから始めるため、同一msで
- *    [T,306]の後ろにある[T,308]/[T,313]を落とさない。
- * 4. Raw Event Lakeは読取り専用。affected HandIdのhands/phases/actionsだけを
- *    同一transactionでdelete-then-putし、消滅した旧pairやaction tailも除く。
+ * 1. 修復単位はhandではなくsession window。new rowが属するwindowを、検証済み
+ *    201（無ければLake先頭）から次の検証済み201（無ければLake末尾）まで
+ *    rebuild-styleで再導出する。handはDEAL時点のwindowへ所属させるため、hand内
+ *    201（MTT table move）でopening DEALを切らない。複数windowは独立に処理し、
+ *    対象外sessionのbystanderはdeleteもputもしないのでbyte-identicalに残る。
+ * 2. 各handのsessionはDEAL前のwindow内容から作る。最新201はid/battleTypeを
+ *    設定してnameをresetし、その後の最新308はnameを設定する。201がなく308だけ
+ *    でも{name}を持つLake sessionとして扱う。Lake contextが一切ない場合だけ
+ *    empty/rebuild-styleとし、純粋なappend tailの未派生handに限りlive sessionを
+ *    seedする（#104）。
+ * 3. delete候補は対象windowのold/post DEAL→306 pairのHandId和集合。ただしpost
+ *    pairのraw rowsが現存するのにEntityConverterのsemantic guardが再出力を拒否
+ *    したHandIdは候補から除外し、legacy derived rowsを保存する。old pairがpost
+ *    pairingから消えた場合だけは論理raw handが消滅したためstale idを削除できる。
+ * 4. 境界・pair・contextは全て現行schemaで再検証し、compound key順で扱う。
+ *    Raw Event Lakeは読取り専用。replace対象だけを同一transactionで
+ *    delete-then-putし、session外の派生行には触れない。
+ *
+ * Decision matrix:
+ * - hand rows / both: そのrowを含むold/post pairのDEAL所属windowを全再導出。
+ * - session rows: 201は自身から、308はgoverning 201（無ければLake先頭）から
+ *   次boundaryまで全再導出。contextは201 / 308-only / noneを上記2で決定。
+ * - converter re-emits: delete-then-put。rejects + post pair persists: preserve。
+ *   old-only pair（postで論理rows-gone）: delete。これで全組合せを閉じる。
  */
 export const buildOverlapRepairPlan = async (
   db: PokerChaseDB,
@@ -123,59 +139,6 @@ export const buildOverlapRepairPlan = async (
     const parsed = parseApiEvent(row)
     return !!parsed && isApplicationApiEvent(parsed)
   }
-
-  let minNewKey = eventKey(newEvents[0]!)
-  let maxNewKey = minNewKey
-  for (const event of newEvents.slice(1)) {
-    const key = eventKey(event)
-    if (compareEventKeys(key, minNewKey) < 0) minNewKey = key
-    if (compareEventKeys(key, maxNewKey) > 0) maxNewKey = key
-  }
-
-  // 直前のvalid 306より後から読むと、new rowを含む旧handのopening DEALを
-  // 保持しつつ、pure appendでは過去session全体を読み直さない。
-  const previousResult = await db.apiEvents
-    .where('[timestamp+ApiTypeId]')
-    .below(minNewKey)
-    .reverse()
-    .filter(row => row.ApiTypeId === ApiType.EVT_HAND_RESULTS && isValidApplicationRow(row))
-    .first()
-
-  // 新viewの最初の306と、new rowを除いた旧viewの最初の306の遅い方まで読む。
-  // 新306が旧pairを早く閉じるcapture-gap修復でも、旧pairの末尾を含められる。
-  // 探索開始をmaxNewKeyそのものにするのがsame-ms tail inclusivityの要点。
-  const firstPostResult = await db.apiEvents
-    .where('[timestamp+ApiTypeId]')
-    .aboveOrEqual(maxNewKey)
-    .filter(row => row.ApiTypeId === ApiType.EVT_HAND_RESULTS && isValidApplicationRow(row))
-    .first()
-  const firstOldResult = await db.apiEvents
-    .where('[timestamp+ApiTypeId]')
-    .aboveOrEqual(maxNewKey)
-    .filter(row =>
-      row.ApiTypeId === ApiType.EVT_HAND_RESULTS &&
-      !newEventKeys.has(eventStorageKey(row)) &&
-      isValidApplicationRow(row)
-    )
-    .first()
-  const upperEvent = [firstPostResult, firstOldResult]
-    .filter((event): event is ApiEvent => event !== undefined)
-    .sort((left, right) => compareEventKeys(eventKey(right), eventKey(left)))[0]
-
-  const lowerKey = previousResult ? eventKey(previousResult) : undefined
-  const upperKey = upperEvent ? eventKey(upperEvent) : undefined
-  let rawRows: ApiEvent[]
-  if (lowerKey && upperKey) {
-    rawRows = await db.apiEvents.where('[timestamp+ApiTypeId]').between(lowerKey, upperKey, false, true).toArray()
-  } else if (lowerKey) {
-    rawRows = await db.apiEvents.where('[timestamp+ApiTypeId]').above(lowerKey).toArray()
-  } else if (upperKey) {
-    rawRows = await db.apiEvents.where('[timestamp+ApiTypeId]').belowOrEqual(upperKey).toArray()
-  } else {
-    rawRows = await db.apiEvents.orderBy('[timestamp+ApiTypeId]').toArray()
-  }
-  const events = await filterValidApplicationEvents(rawRows)
-  const oldEvents = events.filter(event => !newEventKeys.has(eventStorageKey(event)))
 
   const collectPairedHands = (candidateEvents: ApiEvent[]): PairedLakeHand[] => {
     const hands: PairedLakeHand[] = []
@@ -194,8 +157,7 @@ export const buildOverlapRepairPlan = async (
             handId: event.HandId,
             dealKey,
             resultKey,
-            pairKey: pairStorageKey(dealKey, resultKey),
-            events: candidateEvents.slice(openDealIndex, index + 1)
+            pairKey: pairStorageKey(dealKey, resultKey)
           })
         }
         openDealIndex = undefined
@@ -204,87 +166,131 @@ export const buildOverlapRepairPlan = async (
     return hands
   }
 
-  const oldHands = collectPairedHands(oldEvents)
-  const postHands = collectPairedHands(events)
+  // Session starts and hand pairings are the only global information needed.
+  // Loading these indexed event kinds avoids turning every overlap import into
+  // a full-Lake rebuild; complete raw rows are fetched only for affected windows.
+  const boundaryRows = await db.apiEvents
+    .where('ApiTypeId')
+    .anyOf([ApiType.EVT_ENTRY_QUEUED, ApiType.EVT_DEAL, ApiType.EVT_HAND_RESULTS])
+    .toArray()
+  const boundaryEvents = (await filterValidApplicationEvents(boundaryRows))
+    .sort((left, right) => compareEventKeys(eventKey(left), eventKey(right)))
+  const oldBoundaryEvents = boundaryEvents.filter(event => !newEventKeys.has(eventStorageKey(event)))
+  const oldHands = collectPairedHands(oldBoundaryEvents)
+  const postHands = collectPairedHands(boundaryEvents)
   const oldByPair = new Map(oldHands.map(hand => [hand.pairKey, hand]))
   const postByPair = new Map(postHands.map(hand => [hand.pairKey, hand]))
+  const sessionStarts = boundaryEvents.filter(event => isApiEventType(event, ApiType.EVT_ENTRY_QUEUED))
 
-  type LakeSession = Pick<Session, 'id' | 'battleType' | 'name'>
-  const sessionCache = new Map<string, LakeSession | undefined>()
-  const lakeSessionBeforeDeal = async (
-    dealKey: CompoundEventKey,
-    excludeNewRows: boolean
-  ): Promise<LakeSession | undefined> => {
-    const cacheKey = `${excludeNewRows ? 'old' : 'post'}:${dealKey[0]}-${dealKey[1]}`
-    if (sessionCache.has(cacheKey)) return sessionCache.get(cacheKey)
-
-    const anchorRow = await db.apiEvents
-      .where('[timestamp+ApiTypeId]')
-      .below(dealKey)
-      .reverse()
-      .filter(row =>
-        row.ApiTypeId === ApiType.EVT_ENTRY_QUEUED &&
-        (!excludeNewRows || !newEventKeys.has(eventStorageKey(row))) &&
-        isValidApplicationRow(row)
-      )
-      .first()
-    const anchor = anchorRow ? parseApiEvent(anchorRow) : null
-    if (!anchor || !isApiEventType(anchor, ApiType.EVT_ENTRY_QUEUED)) {
-      sessionCache.set(cacheKey, undefined)
-      return undefined
+  const sessionWindowForKey = (key: CompoundEventKey): SessionWindow => {
+    let low = 0
+    let high = sessionStarts.length
+    while (low < high) {
+      const middle = Math.floor((low + high) / 2)
+      if (compareEventKeys(eventKey(sessionStarts[middle]!), key) <= 0) low = middle + 1
+      else high = middle
     }
-
-    const contextRows = await db.apiEvents
-      .where('[timestamp+ApiTypeId]')
-      .between(eventKey(anchor), dealKey, true, false)
-      .filter(row =>
-        (!excludeNewRows || !newEventKeys.has(eventStorageKey(row))) &&
-        isValidApplicationRow(row)
-      )
-      .toArray()
-    let name: string | undefined
-    for (const rawContext of contextRows) {
-      const context = parseApiEvent(rawContext)
-      if (context && isApiEventType(context, ApiType.EVT_SESSION_DETAILS)) name = context.Name
-    }
-    const session = { id: anchor.Id, battleType: anchor.BattleType, name }
-    sessionCache.set(cacheKey, session)
-    return session
-  }
-
-  const sessionsEqual = (left: LakeSession | undefined, right: LakeSession | undefined): boolean =>
-    left?.id === right?.id && left?.battleType === right?.battleType && left?.name === right?.name
-  const containsNewKey = (hand: PairedLakeHand): boolean => newEvents.some(event => {
-    const key = eventKey(event)
-    return compareEventKeys(key, hand.dealKey) >= 0 && compareEventKeys(key, hand.resultKey) <= 0
-  })
-
-  const affectedOldPairs = new Set<string>()
-  const affectedPostPairs = new Set<string>()
-  for (const oldHand of oldHands) {
-    if (!postByPair.has(oldHand.pairKey) || containsNewKey(oldHand)) affectedOldPairs.add(oldHand.pairKey)
-  }
-  for (const postHand of postHands) {
-    if (!oldByPair.has(postHand.pairKey) || containsNewKey(postHand)) affectedPostPairs.add(postHand.pairKey)
-  }
-  for (const postHand of postHands) {
-    const oldHand = oldByPair.get(postHand.pairKey)
-    if (!oldHand) continue
-    const [oldSession, postSession] = await Promise.all([
-      lakeSessionBeforeDeal(oldHand.dealKey, true),
-      lakeSessionBeforeDeal(postHand.dealKey, false)
-    ])
-    if (!sessionsEqual(oldSession, postSession)) {
-      affectedOldPairs.add(oldHand.pairKey)
-      affectedPostPairs.add(postHand.pairKey)
+    const startIndex = low - 1
+    const startKey = startIndex >= 0 ? eventKey(sessionStarts[startIndex]!) : undefined
+    const endKey = startIndex + 1 < sessionStarts.length
+      ? eventKey(sessionStarts[startIndex + 1]!)
+      : undefined
+    return {
+      id: startKey ? `session:${startKey[0]}-${startKey[1]}` : 'lake-start',
+      startKey,
+      endKey
     }
   }
+  const affectedWindows = new Map<string, SessionWindow>()
+  const addWindowForKey = (key: CompoundEventKey): void => {
+    const window = sessionWindowForKey(key)
+    affectedWindows.set(window.id, window)
+  }
 
-  const affectedPostHands = postHands.filter(hand => affectedPostPairs.has(hand.pairKey))
-  const affectedHandIds = Array.from(new Set([
-    ...oldHands.filter(hand => affectedOldPairs.has(hand.pairKey)).map(hand => hand.handId),
-    ...affectedPostHands.map(hand => hand.handId)
-  ]))
+  const isSessionRow = (event: ApiEvent): boolean =>
+    event.ApiTypeId === ApiType.EVT_ENTRY_QUEUED ||
+    event.ApiTypeId === ApiType.EVT_SESSION_DETAILS
+  const sessionRows = newEvents.filter(isSessionRow)
+  for (const sessionRow of sessionRows) addWindowForKey(eventKey(sessionRow))
+
+  const handRows = newEvents
+    .filter(event => !isSessionRow(event))
+    .sort((left, right) => compareEventKeys(eventKey(left), eventKey(right)))
+  const pairedNewKeys = new Set<string>()
+  const addWindowsForPairedRows = (hands: PairedLakeHand[]): void => {
+    let handIndex = 0
+    for (const newEvent of handRows) {
+      const key = eventKey(newEvent)
+      while (handIndex < hands.length && compareEventKeys(hands[handIndex]!.resultKey, key) < 0) {
+        handIndex++
+      }
+      const hand = hands[handIndex]
+      if (hand && compareEventKeys(key, hand.dealKey) >= 0 && compareEventKeys(key, hand.resultKey) <= 0) {
+        addWindowForKey(hand.dealKey)
+        pairedNewKeys.add(eventStorageKey(newEvent))
+      }
+    }
+  }
+  addWindowsForPairedRows(oldHands)
+  addWindowsForPairedRows(postHands)
+
+  for (const newEvent of handRows) {
+    // Incomplete/orphan session-tail rows still belong to their surrounding
+    // window even though no complete DEAL→306 pair can claim them yet.
+    if (!pairedNewKeys.has(eventStorageKey(newEvent))) addWindowForKey(eventKey(newEvent))
+  }
+
+  // Pairing can change beyond the exact new key (capture-gap repair). Mark the
+  // session of every old-only/new-only pair so stale ids and replacement ids
+  // are handled together by one session rebuild.
+  for (const hand of oldHands) {
+    if (!postByPair.has(hand.pairKey)) addWindowForKey(hand.dealKey)
+  }
+  for (const hand of postHands) {
+    if (!oldByPair.has(hand.pairKey)) addWindowForKey(hand.dealKey)
+  }
+
+  const affectedWindowList = Array.from(affectedWindows.values())
+  const affectedOldHands = oldHands.filter(hand => affectedWindows.has(sessionWindowForKey(hand.dealKey).id))
+  const affectedPostHands = postHands.filter(hand => affectedWindows.has(sessionWindowForKey(hand.dealKey).id))
+  const affectedHandsByWindow = new Map<string, PairedLakeHand[]>()
+  for (const hand of [...affectedOldHands, ...affectedPostHands]) {
+    const windowId = sessionWindowForKey(hand.dealKey).id
+    const hands = affectedHandsByWindow.get(windowId) ?? []
+    hands.push(hand)
+    affectedHandsByWindow.set(windowId, hands)
+  }
+
+  const replayEventsByKey = new Map<string, ApiEvent>()
+  for (const window of affectedWindowList) {
+    const crossingResult = (affectedHandsByWindow.get(window.id) ?? [])
+      .map(hand => hand.resultKey)
+      .sort((left, right) => compareEventKeys(right, left))[0]
+    const upperKey = window.endKey && crossingResult && compareEventKeys(crossingResult, window.endKey) >= 0
+      ? crossingResult
+      : window.endKey
+    const includeUpper = !!(window.endKey && crossingResult && compareEventKeys(crossingResult, window.endKey) >= 0)
+
+    let rawRows: ApiEvent[]
+    if (window.startKey && upperKey) {
+      rawRows = await db.apiEvents
+        .where('[timestamp+ApiTypeId]')
+        .between(window.startKey, upperKey, true, includeUpper)
+        .toArray()
+    } else if (window.startKey) {
+      rawRows = await db.apiEvents.where('[timestamp+ApiTypeId]').aboveOrEqual(window.startKey).toArray()
+    } else if (upperKey) {
+      rawRows = includeUpper
+        ? await db.apiEvents.where('[timestamp+ApiTypeId]').belowOrEqual(upperKey).toArray()
+        : await db.apiEvents.where('[timestamp+ApiTypeId]').below(upperKey).toArray()
+    } else {
+      rawRows = await db.apiEvents.orderBy('[timestamp+ApiTypeId]').toArray()
+    }
+    const validRows = await filterValidApplicationEvents(rawRows)
+    for (const event of validRows) replayEventsByKey.set(eventStorageKey(event), event)
+  }
+  const replayEvents = Array.from(replayEventsByKey.values())
+    .sort((left, right) => compareEventKeys(eventKey(left), eventKey(right)))
 
   // Pure tail append = 今回の最古new application keyが、旧viewの最後のvalid
   // application keyより後。複数handを一度にappendしても同じ判定になる。
@@ -293,6 +299,11 @@ export const buildOverlapRepairPlan = async (
     .reverse()
     .filter(row => !newEventKeys.has(eventStorageKey(row)) && isValidApplicationRow(row))
     .first()
+  let minNewKey = eventKey(newEvents[0]!)
+  for (const event of newEvents.slice(1)) {
+    const key = eventKey(event)
+    if (compareEventKeys(key, minNewKey) < 0) minNewKey = key
+  }
   const isTailAppend = !lastOldApplicationEvent || compareEventKeys(minNewKey, eventKey(lastOldApplicationEvent)) > 0
   const existingAffectedHands = affectedPostHands.length > 0
     ? await db.hands.bulkGet(affectedPostHands.map(hand => hand.handId))
@@ -304,8 +315,19 @@ export const buildOverlapRepairPlan = async (
   )
 
   const entities: EntityBundle = { hands: [], phases: [], actions: [] }
+  const emittedHandIds = new Set<number>()
+  const rejectedPostHandIds = new Set<number>()
   for (const hand of affectedPostHands) {
-    const lakeSession = await lakeSessionBeforeDeal(hand.dealKey, false)
+    type LakeSession = Pick<Session, 'id' | 'battleType' | 'name'>
+    let lakeSession: LakeSession | undefined
+    for (const context of replayEvents) {
+      if (compareEventKeys(eventKey(context), hand.dealKey) >= 0) break
+      if (isApiEventType(context, ApiType.EVT_ENTRY_QUEUED)) {
+        lakeSession = { id: context.Id, battleType: context.BattleType, name: undefined }
+      } else if (isApiEventType(context, ApiType.EVT_SESSION_DETAILS)) {
+        lakeSession = { ...lakeSession, name: context.Name }
+      }
+    }
     const session = lakeSession
       ? { ...emptyImportSession(), ...lakeSession }
       : isTailAppend && !previouslyDerivedIds.has(hand.handId)
@@ -315,23 +337,42 @@ export const buildOverlapRepairPlan = async (
     // SessionはDEAL時点のLake文脈で固定する。hand内に割り込む201/308を
     // converterへ渡すとclose時のcurrentSessionへ反映されるため、派生に必要な
     // 303/304/305/306だけをhandごとに変換する。
-    const handEvents = hand.events.filter(event =>
+    const handEvents = replayEvents.filter(event =>
+      compareEventKeys(eventKey(event), hand.dealKey) >= 0 &&
+      compareEventKeys(eventKey(event), hand.resultKey) <= 0 &&
+      (
       event.ApiTypeId === ApiType.EVT_DEAL ||
       event.ApiTypeId === ApiType.EVT_ACTION ||
       event.ApiTypeId === ApiType.EVT_DEAL_ROUND ||
       event.ApiTypeId === ApiType.EVT_HAND_RESULTS
+      )
     )
     const bundle = new EntityConverter(session).convertEventsToEntities(handEvents)
+    if (bundle.hands.length === 0) {
+      rejectedPostHandIds.add(hand.handId)
+      continue
+    }
+    bundle.hands.forEach(entity => emittedHandIds.add(entity.id))
     entities.hands.push(...bundle.hands)
     entities.phases.push(...bundle.phases)
     entities.actions.push(...bundle.actions)
   }
 
+  const preserveHandIds = new Set(
+    Array.from(rejectedPostHandIds).filter(handId => !emittedHandIds.has(handId))
+  )
+  const replaceHandIds = Array.from(new Set([
+    ...affectedOldHands.map(hand => hand.handId),
+    ...affectedPostHands.map(hand => hand.handId)
+  ])).filter(handId => !preserveHandIds.has(handId))
+
   return {
     entities,
-    affectedHandIds,
-    replayEventCount: events.length,
-    repairedHandCount: affectedPostHands.length
+    replaceHandIds,
+    replayEventCount: replayEvents.length,
+    repairedHandCount: entities.hands.length,
+    affectedSessionCount: affectedWindowList.length,
+    preservedRejectedHandCount: preserveHandIds.size
   }
 }
 
@@ -592,7 +633,7 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
           if (hadPreexistingEvents) {
             repairPlan = await buildOverlapRepairPlan(db, allNewEvents, service.session)
             entities = repairPlan.entities
-            console.log(`[importData] Overlap import detected - inspected ${repairPlan.replayEventCount} Lake events and re-derived ${repairPlan.repairedHandCount} affected hand(s)`)
+            console.log(`[importData] Overlap import detected - rebuilt ${repairPlan.affectedSessionCount} session window(s), inspected ${repairPlan.replayEventCount} Lake events, re-derived ${repairPlan.repairedHandCount} hand(s), preserved ${repairPlan.preservedRejectedHandCount} converter-rejected hand(s)`)
           } else {
             entities = new EntityConverter(service.session).convertEventsToEntities(allNewEvents)
           }
@@ -604,15 +645,15 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
           }
 
           if (repairPlan) {
-            // putだけでは消滅した旧pair/action tailが残るため、affected IDsだけ
-            // 同一transactionでdelete-then-putする。replay中のbystanderは
-            // affectedHandIdsへ入らず、hands/phases/actions全て無変更。
-            const { affectedHandIds } = repairPlan
+            // putだけでは消滅した旧pair/action tailが残るため、replace IDsだけ
+            // 同一transactionでdelete-then-putする。対象session外のbystanderと、
+            // raw pairは残るがconverterが再出力できないlegacy handは全て無変更。
+            const { replaceHandIds } = repairPlan
             await db.transaction('rw', [db.hands, db.phases, db.actions], async () => {
-              const existingAffectedHands = affectedHandIds.length > 0
-                ? await db.hands.bulkGet(affectedHandIds)
+              const existingAffectedHands = replaceHandIds.length > 0
+                ? await db.hands.bulkGet(replaceHandIds)
                 : []
-              const staleHandIds = affectedHandIds.filter((_, index) => existingAffectedHands[index] !== undefined)
+              const staleHandIds = replaceHandIds.filter((_, index) => existingAffectedHands[index] !== undefined)
               if (staleHandIds.length > 0) {
                 console.log(`[importData] Removing ${staleHandIds.length} affected derived hand(s) before re-deriving`)
                 await db.hands.bulkDelete(staleHandIds)

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -160,12 +160,28 @@ export const clearImportSession = (): void => {
  * old Lake、新規import、Lake先頭fallbackのどこから来た201でも同じ定義になり、
  * 最初にハンド途中のACTION/306断片があっても、最初のopening DEALより前の
  * 201なら正しく数える。逆に最初のDEALより後のmid-hand 201は数えない。
+ *
+ * これに加え、rangeが「今回のインポートより前から存在した完全な
+ * DEAL→306ペア」を1つでも含む場合もhasSessionAnchorはtrueになる（7巡目
+ * レビューP2「Avoid live-session seeding for Lake-start replays」）。201が
+ * 全く見つからずLake先頭までfallbackするケースでは、range先頭の
+ * 「最初のDEAL」はしばしば今回のimportとは無関係な既存の古いハンドの
+ * ものであり、この修復はaccountされた既存ハンドをdelete-then-putで
+ * 丸ごと再導出するため、201の有無だけで判定すると、その古い（本来
+ * contextlessな）ハンドがライブセッションのid/battleType/nameで
+ * 上書きされてしまう。判定は削除対象の算出（下記`accountedHandIds`）と
+ * 同じ「今回のimportで新規保存された行を除いたevents」上でのDEAL→306
+ * ペアリングを再利用する——rangeにそのような既存ペアが1つも無ければ、
+ * range内のデータは今回importされた行だけで完結する真に新規の
+ * インクリメンタルハンドであり（例: ノイズ行に囲まれているだけ）、
+ * 書き換えられる既存の派生ハンドがそもそも無いため、従来通り直接経路と
+ * 同じくlive sessionをseedに使う。
  * 呼び出し元はhasSessionAnchorがtrueの場合のみコンバーターを空セッション
- * で初期化し、falseの場合（201無しの増分ハンド等）はライブの
- * service.sessionを初期値として使う——201がid/battleTypeを上書きしても
- * session.nameは消さないため、そうしないと308を持たないハンドの修復結果に
- * ライブのテーブル名が混入し得る（PR #203 codexレビューP2 / #104の
- * SessionState seedingリグレッション参照）。
+ * で初期化し、falseの場合（201無しかつ既存ペアも無い増分ハンド等）は
+ * ライブのservice.sessionを初期値として使う——201がid/battleTypeを
+ * 上書きしてもsession.nameは消さないため、そうしないと308を持たない
+ * ハンドの修復結果にライブのテーブル名が混入し得る（PR #203 codexレビュー
+ * P2 / #104のSessionState seedingリグレッション参照）。
  */
 export const collectOverlapRepairEvents = async (
   db: PokerChaseDB,
@@ -276,8 +292,22 @@ export const collectOverlapRepairEvents = async (
   const events = await filterValidApplicationEvents(rawRows)
 
   // Post-validation range invariants (the scan path is deliberately irrelevant):
-  // 1. Empty/rebuild-style converter seed iff a valid 201 precedes the range's
-  //    first opening DEAL. With no DEAL, no session seed is needed.
+  // 1. Empty/rebuild-style converter seed iff EITHER a valid 201 precedes the
+  //    range's first opening DEAL, OR the range already contains a complete
+  //    pre-existing (older than this import) DEAL->306 pair -- i.e. an
+  //    already-derived hand this repair is about to delete-then-put (PR #203
+  //    codex review pass 7, "Avoid live-session seeding for Lake-start
+  //    replays"). With no 201 anywhere, the Lake-start fallback's range can
+  //    start at an unrelated older hand's DEAL; seeding that whole replay
+  //    from the live session would stamp the live table's id/battleType/name
+  //    onto that older, previously-contextless hand -- and every accounted
+  //    hand in the range gets rewritten by the delete-then-put below, not
+  //    just the newly imported one. A range with no pre-existing paired hand
+  //    at all -- a genuinely new incremental hand, e.g. one surrounded only
+  //    by non-application noise -- has no existing derived hand to corrupt,
+  //    so it keeps live-session seeding, matching the direct empty-DB path
+  //    (see the "old" pairing reused below for `accountedHandIds`). With no
+  //    DEAL at all, no session seed is needed either way.
   // 2. Cleanup authority exists only for a valid 306 paired with an opening DEAL
   //    inside this range in either the old (new rows excluded) or repaired replay.
   //    This deletes old mis-pairings but never a leading orphan 306 fragment.
@@ -307,14 +337,22 @@ export const collectOverlapRepairEvents = async (
     }
     return handIds
   }
+  // "Old" view = range events minus this import's own new rows -- the same
+  // view rebuildAllData()/the pre-repair Lake would have exposed. A non-empty
+  // pairing here means the range contains at least one hand that was already
+  // fully derived (DEAL+306 both pre-existing) before this import touched
+  // anything, so seeding the whole replay from the live session would leak
+  // it into that older hand once the delete-then-put below rewrites it
+  // (invariant 1 above).
+  const oldPairedHandIds = collectPairedHandIds(events.filter(event => !newEventKeys.has(`${event.timestamp}-${event.ApiTypeId}`)))
   const accountedHandIds = Array.from(new Set([
-    ...collectPairedHandIds(events.filter(event => !newEventKeys.has(`${event.timestamp}-${event.ApiTypeId}`))),
+    ...oldPairedHandIds,
     ...collectPairedHandIds(events),
   ]))
 
   return {
     events,
-    hasSessionAnchor: sawFirstDeal && sawSessionAnchorBeforeFirstDeal,
+    hasSessionAnchor: sawFirstDeal && (sawSessionAnchorBeforeFirstDeal || oldPairedHandIds.length > 0),
     accountedHandIds
   }
 }
@@ -578,14 +616,21 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
           //   Lakeから読み直して既存行と新規行を合わせて再導出する
           //   （境界の決め方・冪等性はcollectOverlapRepairEvents()参照）。
           //   コンバーターの初期セッションは、検証済みrangeの最初のDEALより
-          //   前に検証済みEVT_ENTRY_QUEUEDがある場合のみrebuildAllData()と
-          //   同じ空のデフォルトセッションにする（range内容がセッション文脈を
-          //   自前で再構築でき、かつライブのservice.sessionの名前等が過去の
-          //   再導出ハンドに混入しない）。最初のDEALより前に201が無い増分ハンドの
-          //   インポートでは従来の直接経路と同じくservice.sessionを
-          //   初期値に使う —— さもないとhand.sessionが空になり、#104の
-          //   SessionState seedingリグレッションが守っている挙動が
-          //   overlap経路でだけ壊れる（PR #203 codexレビューP2）。
+          //   前に検証済みEVT_ENTRY_QUEUEDがあるか、rangeが今回のimportより前
+          //   から存在した完全なDEAL→306ペア（＝これから削除→再導出される
+          //   既存の派生ハンド）を含む場合にのみrebuildAllData()と同じ空の
+          //   デフォルトセッションにする（range内容がセッション文脈を自前で
+          //   再構築でき、かつライブのservice.sessionの名前等が過去の再導出
+          //   ハンドに混入しない。後者の条件が無いと、201が全く無いLakeで
+          //   fallbackした際にrange先頭の既存ハンドがライブセッションで
+          //   書き換わってしまう —— PR #203 codexレビューP2 7巡目「Avoid
+          //   live-session seeding for Lake-start replays」）。どちらにも
+          //   当てはまらない、既存の派生ハンドを含まない真に新規の増分ハンド
+          //   （ノイズ行のみに囲まれている等）のインポートでは従来の直接経路
+          //   と同じくservice.sessionを初期値に使う —— さもないと
+          //   hand.sessionが空になり、#104のSessionState seedingリグレッション
+          //   が守っている挙動がoverlap経路でだけ壊れる（PR #203 codex
+          //   レビューP2）。
           let entitySourceEvents: ApiEvent[] = allNewEvents
           let converterSession: Session = service.session
           let repairRange: Awaited<ReturnType<typeof collectOverlapRepairEvents>> | undefined

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -81,11 +81,17 @@ export const clearImportSession = (): void => {
  *   プレイヤー名）の両方が範囲に含まれる。201が見つからない場合（および
  *   完了ハンド境界自体が無い場合）はLake先頭から（rebuildAllDataと同じ
  *   条件で）変換する。
- * - 終了境界: maxNewTimestamp 以後で最初の「検証済み」EVT_HAND_RESULTS(306)
- *   （それ自身を含む）。新規イベントが既存ハンドの中間に挿入された場合、
- *   そのハンドのRESULTSまでを含める。306が無い場合（Lake末尾が未完了ハンド）
- *   はLake末尾まで —— 未完了ハンドはEntityConverterがHandId未設定として
- *   棄却するためゴミは生成されない。
+ * - 終了境界（PR #203 codexレビュー2巡目P2で修正）: maxNewTimestamp 以後で
+ *   最初の「検証済みかつ既存（今回のインポートで保存された行を除く）」
+ *   EVT_HAND_RESULTS(306)（それ自身を含む）。既存行に限るのは、修復前の
+ *   派生状態が「新規306の位置」ではなく「旧Lakeでの次の306」までを1ハンド
+ *   として束ねていた可能性があるため（キャプチャ欠落でDEALが後続の別306と
+ *   誤ペアリングされるケース）: 旧ペアリングの末尾まで範囲を広げないと、
+ *   その旧ハンドを削除した後に範囲内の再導出だけで正しく作り直せない
+ *   （下のstale削除ウィンドウ参照）。新規306で終わる正常な差分は、範囲が
+ *   その先の既存306（または Lake末尾）まで伸びるだけで、再導出は冪等。
+ *   既存306が無い場合はLake末尾まで —— 未完了ハンドはEntityConverterが
+ *   HandId未設定として棄却するためゴミは生成されない。
  *
  * どちらの境界も、候補行を現行Zodスキーマで検証してから採用する
  * （PR #203 codexレビューP2）: Raw LakeにはApiTypeIdが306/201でもパース
@@ -94,11 +100,23 @@ export const clearImportSession = (): void => {
  * filterValidApplicationEvents()でその行自体が除去されて本物のRESULTSが
  * 範囲外に残り、ハンドが未終了扱いで棄却される（修復が黙って失敗する）。
  *
- * 範囲内の既存ハンドを再導出しても重複は生じない: hands(id) / phases
- * ([handId+phase]) / actions([handId+index]) はいずれも決定的キーで、
- * saveEntities()のbulkPutが同キー行を上書きする（冪等）。範囲外の派生行には
- * 一切触れない。返す前にfilterValidApplicationEvents()で再検証するのは
- * rebuildAllData()と同じ理由（CLAUDE.md「Raw Event Lake」参照）。
+ * 範囲内の既存ハンドの再導出はbulkPut上書きで冪等（hands(id) /
+ * phases([handId+phase]) / actions([handId+index])は決定的キー）だが、
+ * 上書きだけでは「旧導出には存在したが新導出には存在しない」行が残る
+ * （PR #203 codexレビュー2巡目P2）: 誤ペアリングされていた旧ハンドの
+ * HandIdが新導出に現れない、旧導出の方がaction数が多い等。このため
+ * 呼び出し元は、保存前に「stale削除ウィンドウ」= approxTimestampが
+ * (staleWindowStartExclusive, staleWindowEndInclusive] に入る既存派生
+ * ハンド（とそのphases/actions）を同一トランザクション内で削除する。
+ * ウィンドウ下限が「直前の完了ハンド境界306」(exclusive)なのは、そこまでの
+ * ハンドは新旧の導出が一致していて触る必要がなく、かつ範囲開始（201
+ * anchor）をまたぐハンド —— ハンド中に割り込んだ201がanchorになった
+ * 場合、そのDEALは範囲外 —— を誤って削除して再導出できない事態を防ぐ
+ * ため。ウィンドウ内のハンドは定義上すべて範囲内のイベントだけから
+ * 再導出可能（DEALは境界306より後、306は終了境界以前）。範囲外の
+ * 派生行には一切触れない。返す前にfilterValidApplicationEvents()で
+ * 再検証するのはrebuildAllData()と同じ理由（CLAUDE.md「Raw Event
+ * Lake」参照）。
  *
  * 戻り値の`hasSessionAnchor`は「範囲が検証済みEVT_ENTRY_QUEUEDから始まって
  * いる = 範囲内のイベント列だけでセッション文脈を再構築できる」ことを示す。
@@ -110,8 +128,17 @@ export const clearImportSession = (): void => {
 export const collectOverlapRepairEvents = async (
   db: PokerChaseDB,
   minNewTimestamp: number,
-  maxNewTimestamp: number
-): Promise<{ events: ApiEvent[], hasSessionAnchor: boolean }> => {
+  maxNewTimestamp: number,
+  /** 今回のインポートで新規保存された行のキー（`${timestamp}-${ApiTypeId}`）。終了境界の探索から除外する */
+  newEventKeys: ReadonlySet<string>
+): Promise<{
+  events: ApiEvent[]
+  hasSessionAnchor: boolean
+  /** stale削除ウィンドウ下限（直前の完了ハンド境界306のtimestamp、exclusive）。無ければundefined = Lake先頭から */
+  staleWindowStartExclusive: number | undefined
+  /** stale削除ウィンドウ上限（終了境界306のtimestamp、inclusive）。無ければundefined = Lake末尾まで */
+  staleWindowEndInclusive: number | undefined
+}> => {
   // 境界候補は現行スキーマで検証してから採用する（doc comment参照）。
   // parseApiEventは同期のZodパースなのでDexieのfilterコールバック内で使える。
   const isValidApplicationRow = (row: ApiEvent): boolean => {
@@ -139,11 +166,16 @@ export const collectOverlapRepairEvents = async (
       .first()
     : undefined
 
-  // 終了境界: maxNewTimestamp以後（同時刻含む）で最初の検証済みEVT_HAND_RESULTS。
+  // 終了境界: maxNewTimestamp以後（同時刻含む）で最初の検証済み「既存」
+  // EVT_HAND_RESULTS（今回新規保存された306は除外 —— doc comment参照）。
   const endEvent = await db.apiEvents
     .where('[timestamp+ApiTypeId]')
     .aboveOrEqual([maxNewTimestamp, 0])
-    .filter(event => event.ApiTypeId === ApiType.EVT_HAND_RESULTS && isValidApplicationRow(event))
+    .filter(event =>
+      event.ApiTypeId === ApiType.EVT_HAND_RESULTS &&
+      !newEventKeys.has(`${event.timestamp}-${event.ApiTypeId}`) &&
+      isValidApplicationRow(event)
+    )
     .first()
 
   const lowerKey: [number, number] | undefined = anchorEvent
@@ -166,7 +198,9 @@ export const collectOverlapRepairEvents = async (
 
   return {
     events: await filterValidApplicationEvents(rawRows),
-    hasSessionAnchor: anchorEvent !== undefined
+    hasSessionAnchor: anchorEvent !== undefined,
+    staleWindowStartExclusive: prevHandBoundary?.timestamp,
+    staleWindowEndInclusive: endEvent?.timestamp
   }
 }
 
@@ -439,8 +473,10 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
           //   overlap経路でだけ壊れる（PR #203 codexレビューP2）。
           let entitySourceEvents: ApiEvent[] = allNewEvents
           let converterSession: Session = service.session
+          let repairRange: Awaited<ReturnType<typeof collectOverlapRepairEvents>> | undefined
           if (hadPreexistingEvents) {
-            const repairRange = await collectOverlapRepairEvents(db, minNewTimestamp, maxNewTimestamp)
+            const newEventKeys = new Set(allNewEvents.map(event => `${event.timestamp}-${event.ApiTypeId}`))
+            repairRange = await collectOverlapRepairEvents(db, minNewTimestamp, maxNewTimestamp, newEventKeys)
             entitySourceEvents = repairRange.events
             if (repairRange.hasSessionAnchor) {
               converterSession = {
@@ -460,12 +496,46 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
 
           console.log(`[importData] Generated entities - Hands: ${entities.hands.length}, Phases: ${entities.phases.length}, Actions: ${entities.actions.length}`)
 
-          // Save entities using common utility
-          await saveEntities(db, entities, {
-            onProgress: (counts) => {
-              console.log(`[importData] Saved/updated ${counts.hands} hands, ${counts.phases} phases, ${counts.actions} actions`)
-            }
-          })
+          const logSavedCounts = (counts: { hands: number, phases: number, actions: number }) => {
+            console.log(`[importData] Saved/updated ${counts.hands} hands, ${counts.phases} phases, ${counts.actions} actions`)
+          }
+
+          if (repairRange) {
+            // Overlap修復はbulkPut（上書き）だけでは足りない（PR #203 codex
+            // レビュー2巡目P2）: 旧導出には存在したが新導出には存在しない
+            // 派生行 —— 例: キャプチャ欠落で後続の306と誤ペアリングされて
+            // いた旧ハンド（HandIdが新導出に現れない）、旧導出の方が多かった
+            // action行（[handId+index]の末尾が残る）—— がそのまま残り、
+            // 統計が新旧両方を数えてしまう。stale削除ウィンドウ
+            // （collectOverlapRepairEvents()のdocコメント参照。ウィンドウ内の
+            // ハンドは定義上すべて範囲内から再導出可能）に入る既存派生
+            // ハンドとそのphases/actionsを、再導出バンドルの保存と同一
+            // トランザクションで先に削除する。Raw Event Lake（apiEvents）
+            // には一切触れない。
+            const { staleWindowStartExclusive, staleWindowEndInclusive } = repairRange
+            await db.transaction('rw', [db.hands, db.phases, db.actions], async () => {
+              const staleHandIds = await db.hands
+                .where('approxTimestamp')
+                .between(
+                  staleWindowStartExclusive ?? 0,
+                  staleWindowEndInclusive ?? Number.MAX_SAFE_INTEGER,
+                  staleWindowStartExclusive === undefined, // 下限は境界306自身のハンドを含めない（exclusive）。境界なしならLake先頭から（inclusive）
+                  true
+                )
+                .primaryKeys()
+              if (staleHandIds.length > 0) {
+                console.log(`[importData] Removing ${staleHandIds.length} stale derived hand(s) in the repair window before re-deriving`)
+                await db.hands.bulkDelete(staleHandIds)
+                await db.phases.where('handId').anyOf(staleHandIds).delete()
+                await db.actions.where('handId').anyOf(staleHandIds).delete()
+              }
+              // saveEntities()内のtransactionは同一テーブル集合の親トランザクションに合流する
+              await saveEntities(db, entities, { onProgress: logSavedCounts })
+            })
+          } else {
+            // Save entities using common utility
+            await saveEntities(db, entities, { onProgress: logSavedCounts })
+          }
 
           // Update metadata separately（lastProcessedTimestampは従来通り
           // 「今回のインポートで新規保存されたイベント」の最大timestamp。

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -15,6 +15,7 @@ import PokerChaseService, {
 import { EntityConverter } from '../entity-converter'
 import { saveEntities, findLatestPlayerDealEvent, filterValidApplicationEvents } from '../utils/database-utils'
 import { DATABASE_CONSTANTS } from '../constants/database'
+import type { Session } from '../types'
 import type {
   ExportProgressMessage,
   ImportProgressMessage,
@@ -49,6 +50,84 @@ export const addImportChunk = (chunkIndex: number, chunkData: string): void => {
 
 export const clearImportSession = (): void => {
   currentImportSession = null
+}
+
+/**
+ * 差分インポート（既存データがあるDBへのインポート）でエンティティ再導出の
+ * 対象にすべきイベントを、Raw Event Lake（apiEvents）から読み直して返す
+ * （独立監査finding #7）。
+ *
+ * 修正前は、インポートで「新規に保存された行」だけをEntityConverterへ渡して
+ * いた。EntityConverterはEVT_DEAL(303)〜EVT_HAND_RESULTS(306)のイベント列が
+ * 揃って初めて1ハンドを構成できるため、既存ハンドの一部（例: DEALとRESULTSは
+ * 保存済みだが中間のACTIONだけ欠けていたDBに、完全なエクスポートを再インポート
+ * したケース）では、新規行（ACTION単体）がduplicate除外されたDEAL/RESULTSと
+ * 切り離され、ハンド境界を構成できずに黙って捨てられていた —— Raw Lakeだけが
+ * 修復され、派生hands/phases/actionsと統計は古いまま残る。
+ *
+ * この関数は新規イベントのtimestamp範囲 [minNewTimestamp, maxNewTimestamp] を
+ * 以下の境界までLake上で拡張し、既存行と新規行を合わせた連続領域を返す:
+ *
+ * - 開始境界: minNewTimestamp 以前で最後の EVT_ENTRY_QUEUED(201)。201は
+ *   ハンド間（テーブル着席時）にのみ発行されるためハンド境界として安全で、
+ *   かつEntityConverterのセッション文脈（BattleType/Id、以降の313/301が
+ *   積むプレイヤー名）の起点でもある —— 新規イベントが属するハンドの
+ *   DEALが既存行だった場合も、そのDEALより前から変換を始められる。
+ *   201が見つからない場合はLake先頭から（rebuildAllDataと同じ条件で）変換する。
+ * - 終了境界: maxNewTimestamp 以後で最初の EVT_HAND_RESULTS(306)（それ自身を
+ *   含む）。新規イベントが既存ハンドの中間に挿入された場合、そのハンドの
+ *   RESULTSまでを含める。306が無い場合（Lake末尾が未完了ハンド）はLake末尾
+ *   まで —— 未完了ハンドはEntityConverterがHandId未設定として棄却するため
+ *   ゴミは生成されない。
+ *
+ * 範囲内の既存ハンドを再導出しても重複は生じない: hands(id) / phases
+ * ([handId+phase]) / actions([handId+index]) はいずれも決定的キーで、
+ * saveEntities()のbulkPutが同キー行を上書きする（冪等）。範囲外の派生行には
+ * 一切触れない。返す前にfilterValidApplicationEvents()で再検証するのは
+ * rebuildAllData()と同じ理由（Raw Lakeには非アプリケーション行・現行スキーマで
+ * パース不能な行が混在し得る。CLAUDE.md「Raw Event Lake」参照）。
+ */
+export const collectOverlapRepairEvents = async (
+  db: PokerChaseDB,
+  minNewTimestamp: number,
+  maxNewTimestamp: number
+): Promise<ApiEvent[]> => {
+  // 開始境界: minNewTimestamp以前（同時刻含む）で最後のEVT_ENTRY_QUEUED。
+  // ApiTypeIdは小さい正の整数のため、[minNewTimestamp, MAX_SAFE_INTEGER]を
+  // 上限にすればminNewTimestampと同時刻の行も全て走査対象に含まれる。
+  const anchorEvent = await db.apiEvents
+    .where('[timestamp+ApiTypeId]')
+    .belowOrEqual([minNewTimestamp, Number.MAX_SAFE_INTEGER])
+    .reverse()
+    .filter(event => event.ApiTypeId === ApiType.EVT_ENTRY_QUEUED)
+    .first()
+
+  // 終了境界: maxNewTimestamp以後（同時刻含む）で最初のEVT_HAND_RESULTS。
+  const endEvent = await db.apiEvents
+    .where('[timestamp+ApiTypeId]')
+    .aboveOrEqual([maxNewTimestamp, 0])
+    .filter(event => event.ApiTypeId === ApiType.EVT_HAND_RESULTS)
+    .first()
+
+  const lowerKey: [number, number] | undefined = anchorEvent
+    ? [anchorEvent.timestamp!, anchorEvent.ApiTypeId]
+    : undefined
+  const upperKey: [number, number] | undefined = endEvent
+    ? [endEvent.timestamp!, endEvent.ApiTypeId]
+    : undefined
+
+  let rawRows: ApiEvent[]
+  if (lowerKey && upperKey) {
+    rawRows = await db.apiEvents.where('[timestamp+ApiTypeId]').between(lowerKey, upperKey, true, true).toArray()
+  } else if (lowerKey) {
+    rawRows = await db.apiEvents.where('[timestamp+ApiTypeId]').aboveOrEqual(lowerKey).toArray()
+  } else if (upperKey) {
+    rawRows = await db.apiEvents.where('[timestamp+ApiTypeId]').belowOrEqual(upperKey).toArray()
+  } else {
+    rawRows = await db.apiEvents.orderBy('[timestamp+ApiTypeId]').toArray()
+  }
+
+  return await filterValidApplicationEvents(rawRows)
 }
 
 /**
@@ -90,6 +169,13 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
           })
         })
       console.log(`[importData] Loaded ${existingKeys.size} existing keys`)
+
+      // 既存データが1件でもあるインポートは「差分インポート」: 新規イベントが
+      // 既存ハンドの一部（欠落していた中間イベント等）を埋める可能性があり、
+      // 新規イベント単体ではエンティティを再導出できない（独立監査finding #7、
+      // collectOverlapRepairEvents()のdocコメント参照）。この判定は後続の
+      // ループでexistingKeysへ新規キーを追記する前に確定させておく。
+      const hadPreexistingEvents = existingKeys.size > 0
 
       // 行で分割し、空行をフィルタリング
       const lines = jsonlData.split('\n').filter(line => line.trim())
@@ -283,10 +369,46 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
         console.log(`[importData] Generating entities from ${allNewEvents.length} new events...`)
         const entityStartTime = performance.now()
 
+        // 新規イベントのtimestamp範囲。Math.maxでスプレッド演算子を使うと
+        // スタックオーバーフローになるため、単一ループで両端を求める
+        let minNewTimestamp = Number.POSITIVE_INFINITY
+        let maxNewTimestamp = 0
+        for (const event of allNewEvents) {
+          const timestamp = event.timestamp || 0
+          if (timestamp < minNewTimestamp) minNewTimestamp = timestamp
+          if (timestamp > maxNewTimestamp) maxNewTimestamp = timestamp
+        }
+
         try {
+          // エンティティ生成対象の決定（独立監査finding #7）:
+          // - 空のDBへのインポート（従来からの正常系）: 新規イベントが全て
+          //   なので、そのままEntityConverterへ渡す（従来経路そのまま）。
+          // - 既存データがあるDBへの差分インポート: 新規イベントが既存ハンドの
+          //   欠落部分を埋めた可能性がある。新規イベント単体ではハンド境界
+          //   （EVT_DEAL〜EVT_HAND_RESULTS）を構成できないため、影響範囲を
+          //   Lakeから読み直して既存行と新規行を合わせて再導出する
+          //   （境界の決め方・冪等性はcollectOverlapRepairEvents()参照）。
+          //   セッション文脈は範囲先頭のEVT_ENTRY_QUEUEDから再構築されるため、
+          //   rebuildAllData()と同じ空のデフォルトセッションを初期値にする
+          //   （ライブのservice.sessionを流用すると、現在のセッション名等が
+          //   過去の再導出ハンドに混入し得る）。
+          let entitySourceEvents: ApiEvent[] = allNewEvents
+          let converterSession: Session = service.session
+          if (hadPreexistingEvents) {
+            entitySourceEvents = await collectOverlapRepairEvents(db, minNewTimestamp, maxNewTimestamp)
+            converterSession = {
+              id: undefined,
+              battleType: undefined,
+              name: undefined,
+              players: new Map(),
+              reset: () => { }
+            }
+            console.log(`[importData] Overlap import detected - re-deriving entities from ${entitySourceEvents.length} Lake events covering the affected range`)
+          }
+
           // EntityConverterを使用してエンティティを生成
-          const converter = new EntityConverter(service.session)
-          const entities = converter.convertEventsToEntities(allNewEvents)
+          const converter = new EntityConverter(converterSession)
+          const entities = converter.convertEventsToEntities(entitySourceEvents)
 
           console.log(`[importData] Generated entities - Hands: ${entities.hands.length}, Phases: ${entities.phases.length}, Actions: ${entities.actions.length}`)
 
@@ -297,23 +419,19 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
             }
           })
 
-          // Update metadata separately
-          // Math.maxでスプレッド演算子を使うとスタックオーバーフローになるため、reduceを使用
-          const lastTimestamp = allNewEvents.reduce((max, event) => {
-            const timestamp = event.timestamp || 0
-            return timestamp > max ? timestamp : max
-          }, 0)
-
+          // Update metadata separately（lastProcessedTimestampは従来通り
+          // 「今回のインポートで新規保存されたイベント」の最大timestamp。
+          // overlap修復で再導出対象に含めた既存行は含めない）
           await db.meta.put({
             id: 'importStatus',
             value: {
-              lastProcessedTimestamp: lastTimestamp,
+              lastProcessedTimestamp: maxNewTimestamp,
               lastProcessedEventCount: allNewEvents.length,
               lastImportDate: new Date().toISOString()
             },
             updatedAt: Date.now()
           })
-          console.log(`[importData] Updated metadata - lastTimestamp: ${lastTimestamp}`)
+          console.log(`[importData] Updated metadata - lastTimestamp: ${maxNewTimestamp}`)
 
           const entityTime = ((performance.now() - entityStartTime) / 1000).toFixed(2)
           console.log(`[importData] Entity generation completed in ${entityTime}s`)


### PR DESCRIPTION
## Summary

Independent release-audit finding #7 (P2): a partially-overlapping import repaired the Raw Event Lake but left derived state (hands/phases/actions, and every stat computed from them) inconsistent.

`importData()` stored every new raw line into `apiEvents`, but the derived-entity pass fed **only the newly-stored events** to `EntityConverter`. The converter can only form a hand from a contiguous `EVT_DEAL(303) → ... → EVT_HAND_RESULTS(306)` run, so a hand split between existing and imported rows could never be derived from the new events alone. In the audit's scenario — a DB that already held a hand's DEAL and RESULTS but was missing the middle ACTIONs, receiving a re-import of a complete export — DEAL/RESULTS deduped away, the new ACTION rows alone formed no hand boundary, and the converter silently dropped them. The stale derived state persisted until a manual full rebuild.

## What changed

`src/background/import-export.ts`:

- **Empty-DB import (fresh)**: unchanged — new events go straight to `EntityConverter`, seeded with `service.session` as before.
- **Import into a DB that already had events (overlap import)**: the entity pass now re-reads the affected range from the Lake via the new `collectOverlapRepairEvents()` and re-derives entities from existing and new rows together. The range spans:
  - **back** to the last `EVT_ENTRY_QUEUED(201)` at/before the earliest new event — a between-hands boundary that is also the session-context start (BattleType/Id, plus the 313/301 player names that follow it), so a hand whose DEAL was a pre-existing row is converted with its full session context; falls back to the Lake start when no 201 precedes the range (same condition a full rebuild would replay);
  - **forward** to the first `EVT_HAND_RESULTS(306)` at/after the latest new event, so events inserted mid-hand pick up their closing RESULTS; when none exists (Lake ends mid-hand) the incomplete tail is read but rejected by the converter's existing HandId guard, producing nothing.
- The repair path re-validates the range with `filterValidApplicationEvents()` (same Raw Event Lake rule as `rebuildAllData()`) and seeds the converter with the same empty default session `rebuildAllData()` uses, so the live `service.session` cannot leak into re-derived history.
- `importStatus.lastProcessedTimestamp` keeps its existing meaning: max timestamp of the newly stored events only (the min/max loop replaces the previous reduce; same stack-overflow-avoidance rationale).

**Idempotency / non-duplication**: `hands` (`id`), `phases` (`[handId+phase]`) and `actions` (`[handId+index]`) all have deterministic keys and `saveEntities()` uses `bulkPut`, so re-deriving hands that already exist overwrites them in place; derived rows outside the affected range are never touched.

`CLAUDE.md`: documents the overlap-import semantics under "Import Processing".

## Tests

`src/background/import-export.overlap-repair.test.ts` (real Dexie + fake-indexeddb, end-to-end through `importData()`):

1. The audit's exact scenario: existing DEAL/RESULTS with missing ACTIONs, full-export re-import → derived state deep-equals a from-scratch control import (complete and non-duplicated), including session context recovered from the duplicate-excluded 201 anchor.
2. Appended import completing an unfinished tail hand (existing DEAL, imported ACTIONs+RESULTS).
3. Range scoping: a later, already-complete hand stays intact and non-duplicated.
4. Lake-start fallback when no 201 precedes the new events.
5. The unchanged empty-DB direct path.

4 of the 5 tests fail without the fix (verified by `git apply -R` of the fix hunks and re-running).

## Verification

- `npm run typecheck` — clean
- `npm test` — 115 suites / 1085 tests, run twice, fully green both times
- `npm run e2e:smoke` — 6/6 checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)