### PR TITLE
test: fix order-dependent test-isolation leaks under jest --randomize

### DIFF
--- a/src/background/import-export.export-handoff.test.ts
+++ b/src/background/import-export.export-handoff.test.ts
@@ -267,7 +267,12 @@ describe('export download-handoff completion', () => {
     ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => {
       setTimeout(() => callback([]), 0) // no matching tabs -- forces the chrome.downloads fallback
     })
-    ;(chrome.downloads.download as jest.Mock).mockImplementation((_options, callback) => {
+    // mockImplementationOnce, NOT mockImplementation: chrome.downloads.download
+    // is a shared jest.fn from test-setup.ts, and neither clearAllMocks (call
+    // history only) nor restoreAllMocks (spyOn spies only) removes a permanent
+    // implementation override -- it would leak USER_CANCELED into whichever
+    // test in this file next hits the fallback path under `jest --randomize`.
+    ;(chrome.downloads.download as jest.Mock).mockImplementationOnce((_options, callback) => {
       ;(chrome.runtime as any).lastError = { message: 'USER_CANCELED' }
       callback?.(undefined)
       delete (chrome.runtime as any).lastError

--- a/src/background/message-router.positional-stats.test.ts
+++ b/src/background/message-router.positional-stats.test.ts
@@ -6,6 +6,7 @@
  * given { action: 'getPositionalStats', playerId }, calls the positional
  * stats service and responds with { success: true, positionalStats }.
  */
+import { waitFor } from '@testing-library/dom'
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
 import PokerChaseService, { PokerChaseDB } from '../app'
 import { registerMessageRouter } from './message-router'
@@ -73,8 +74,11 @@ describe('message-router getPositionalStats', () => {
 
     expect(handled).toBe(true) // async response signaled
 
-    // Let the underlying promise chain resolve.
-    await new Promise(resolve => setTimeout(resolve, 0))
+    // Let the underlying promise chain resolve. Poll instead of a single
+    // setTimeout(0): the chain includes fake-indexeddb reads that can take
+    // more than one macrotask to settle on a loaded machine (observed as a
+    // rare flake during `jest --randomize` seed sweeps, 2026-07-21).
+    await waitFor(() => expect(sendResponse).toHaveBeenCalledTimes(1))
 
     expect(sendResponse).toHaveBeenCalledTimes(1)
     const response = sendResponse.mock.calls[0][0]

--- a/src/components/HandLog.test.tsx
+++ b/src/components/HandLog.test.tsx
@@ -35,11 +35,6 @@ jest.mock('react-window', () => {
 
 // Mock navigator.clipboard
 const mockWriteText = jest.fn()
-Object.assign(navigator, {
-  clipboard: {
-    writeText: mockWriteText,
-  },
-})
 
 describe('HandLog', () => {
   const mockEntries: HandLogEntry[] = [
@@ -78,6 +73,16 @@ describe('HandLog', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockWriteText.mockResolvedValue(undefined)
+    // Re-install the clipboard mock every test: `userEvent.setup()` (used by
+    // the double-click test) unconditionally replaces `navigator.clipboard`
+    // with user-event's own ClipboardStub (a configurable getter), so under
+    // `jest --randomize` any test running after it would otherwise assert
+    // against the stub instead of this mock. defineProperty (not
+    // Object.assign) because the stub property is getter-only.
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: mockWriteText },
+      configurable: true,
+    })
   })
 
   it('コンフィグが無効の場合は何も表示されない', () => {

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -16,6 +16,18 @@ const chromeStorageMockData = {
 // chrome.storage.onChanged listeners (fired by the local/sync `set` mocks below)
 const storageChangeListeners: Array<(changes: Record<string, { oldValue?: any, newValue?: any }>, areaName: string) => void> = []
 
+// The mock storage above is module-scoped, so without a per-test reset any
+// key a test writes leaks into every later test in the same file — an
+// order-dependence that only surfaces under `jest --randomize` (e.g. a
+// leftover legacy `autoSyncLastTime` makes AutoSyncService.initialize()
+// conclude "already synced" and skip the first sync another test asserts on).
+// Listeners are intentionally NOT cleared: module singletons register
+// chrome.storage.onChanged listeners as import-time side effects (once per
+// file), and clearing them here would desubscribe them for every test after
+// the first in a way real Chrome never would. The reset itself is registered
+// in the beforeEach at the bottom of this file, alongside the chrome-mock
+// implementation restore.
+
 const fireStorageChange = (areaName: 'sync' | 'local', items: Record<string, any>) => {
   const changes: Record<string, { oldValue?: any, newValue?: any }> = {}
   for (const key of Object.keys(items)) {
@@ -177,6 +189,43 @@ global.chrome = {
     }),
   },
 } as any
+
+// Per-test isolation for the shared chrome mock above.
+//
+// `jest.clearAllMocks()` clears call history but NOT implementations, and
+// `jest.restoreAllMocks()` only covers `jest.spyOn` spies — so a test that
+// calls `mockImplementation()`/`mockReturnValue()` on one of these shared
+// jest.fn()s would otherwise leak that override into every later test in the
+// same file (order-dependent failures under `jest --randomize`). Snapshot
+// each mock's default implementation once at setup, then reset and re-install
+// it before every test. File-level `beforeEach` hooks run after this root
+// one, so per-file overrides installed there keep working unchanged.
+const chromeMockDefaults: Array<{ fn: jest.Mock, impl: ((...args: any[]) => any) | undefined }> = []
+const collectMockDefaults = (obj: Record<string, any>) => {
+  for (const value of Object.values(obj)) {
+    if (jest.isMockFunction(value)) {
+      chromeMockDefaults.push({ fn: value as jest.Mock, impl: (value as jest.Mock).getMockImplementation() })
+    } else if (value && typeof value === 'object') {
+      collectMockDefaults(value)
+    }
+  }
+}
+collectMockDefaults(global.chrome)
+
+beforeEach(() => {
+  chromeStorageMockData.sync = {}
+  chromeStorageMockData.local = {}
+  // Some test files replace global.chrome wholesale with a minimal stub
+  // (e.g. useDraggable.test.ts) — guard, and only clean lastError when the
+  // runtime namespace actually exists.
+  if ((global.chrome as any)?.runtime) {
+    delete (global.chrome.runtime as any).lastError
+  }
+  for (const { fn, impl } of chromeMockDefaults) {
+    fn.mockReset()
+    if (impl) fn.mockImplementation(impl)
+  }
+})
 
 // Mock document.body.style for dragging tests
 if (typeof document !== 'undefined') {


### PR DESCRIPTION
## Summary

The full jest suite passed in declaration order but failed under `npx jest --randomize` with certain seeds (20331, 20332 observed 2026-07-21; a 1-40 seed sweep reproduced more). All failures were pre-existing test-isolation leaks — `--randomize` shuffles test order *within* each file, so intra-file shared state that declaration order happened to mask became visible. Four leaks fixed, no assertions weakened.

## The leaks

**1. `chromeStorageMockData` persisted across tests within a file** (`src/test-setup.ts`)
The chrome storage mock's backing object is module-scoped, so any key a test writes leaks into every later test in the same file. Concretely: `auto-sync-service.test.ts`'s migration-blocked test (codex review r3615389121) deliberately leaves the legacy `autoSyncLastTime` key behind as its own assertion; when randomize ran it before the two `initialize()` first-sync tests, they migrated the leftover key, concluded "already synced", and never issued the `performSync()` call they assert on. Fixed with a root-level `beforeEach` reset of both storage areas. `onChanged` listeners are intentionally NOT cleared — module singletons register them as import-time side effects (once per file), and clearing would desubscribe them in a way real Chrome never would.

**2. Implementation overrides on shared chrome jest.fn()s outlived their test** (`src/test-setup.ts`)
`jest.clearAllMocks()` clears call history but not implementations; `jest.restoreAllMocks()` only covers `jest.spyOn` spies. So `(chrome.downloads.download as jest.Mock).mockImplementation(...)` persisted for the rest of the file. Fixed generically: each chrome mock's default implementation is snapshotted once at setup and reset+re-installed before every test. File-level `beforeEach` overrides still work unchanged (root hooks run first). The reset guards against files that replace `global.chrome` wholesale with a minimal stub (e.g. `useDraggable.test.ts`).

**3. `userEvent.setup()` clobbers the `navigator.clipboard` mock** (`src/components/HandLog.test.tsx`)
user-event's `setupMain` unconditionally replaces `navigator.clipboard` with its own `ClipboardStub` (a configurable getter). When the double-click test (which calls `userEvent.setup()`) ran before the click-to-copy test, the copy test asserted against the stub's plain `writeText` function instead of the jest mock — "received value must be a mock or spy function". The mock is now re-installed per test via `Object.defineProperty` (`Object.assign` can't overwrite a getter-only property).

**4. `USER_CANCELED` download mock leaked into the fallback test** (`src/background/import-export.export-handoff.test.ts`)
The lastError-path test's permanent `mockImplementation` on `chrome.downloads.download` (leak class #2) made the "falls back to a data-URL download" test fail with `USER_CANCELED` whenever it ran later. Now `mockImplementationOnce`, consumed within its own test (guaranteed by its `rejects.toThrow(/USER_CANCELED/)` assertion).

**Bonus hardening** (`src/background/message-router.positional-stats.test.ts`): not an ordering leak, but its single `setTimeout(0)` wait for a fake-indexeddb-backed promise chain flaked once under CPU load during the seed sweeps. Replaced with a bounded `waitFor` poll on the same assertion.

## Verification

- `npx jest` (declaration order): 119 suites / 1141 tests green
- `npx jest --randomize --seed N` for N ∈ {20331, 20332, 1..40}: all 42 runs green (1141/1141 each)
- `npx tsc --noEmit`: clean

The previously-failing seeds are all included: 20331/20332 (HandLog + auto-sync ×2), and from the pre-fix sweep 1-10/16 (export-handoff, HandLog, auto-sync in various combinations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)