### PR TITLE
ci(release): sign Chrome Web Store CRX uploads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,9 +57,23 @@ jobs:
       - name: Build extension
         run: npm run build
 
+      - name: Build signed CRX
+        env:
+          CWS_CRX_PRIVATE_KEY: ${{ secrets.CWS_CRX_PRIVATE_KEY }}
+        run: |
+          if [[ -z "$CWS_CRX_PRIVATE_KEY" ]]; then
+            echo "CWS_CRX_PRIVATE_KEY is not configured" >&2
+            exit 1
+          fi
+
+          key_file=$(mktemp)
+          trap 'rm -f "$key_file"' EXIT
+          chmod 600 "$key_file"
+          printf '%s' "$CWS_CRX_PRIVATE_KEY" > "$key_file"
+          npm run pack:crx -- "$key_file"
+
       - name: Upload Release Asset
         run: |
-          gh release upload ${{ needs.release-please.outputs.tag_name }} extension.zip --clobber
+          gh release upload ${{ needs.release-please.outputs.tag_name }} extension.zip extension.crx --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
           trap 'rm -f "$key_file"' EXIT
           chmod 600 "$key_file"
           printf '%s' "$CWS_CRX_PRIVATE_KEY" > "$key_file"
-          npm run pack:crx -- "$key_file"
+          xvfb-run -a npm run pack:crx -- "$key_file"
 
       - name: Upload Release Asset
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,15 @@ jobs:
 
     - name: Run tests
       run: npm test
+
+    - name: Build extension
+      run: npm run build
+
+    - name: Smoke test CRX packaging
+      run: |
+        key_file=$(mktemp)
+        crx_file=$(mktemp --suffix=.crx)
+        trap 'rm -f "$key_file" "$crx_file"' EXIT
+        openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$key_file" 2>/dev/null
+        xvfb-run -a npm run pack:crx -- "$key_file" "$crx_file"
+        test -s "$crx_file"

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ coverage/
 *.log
 *.zip
 *.crx
+*.pem
 .DS_Store
 .mcp.json
 *.ndjson

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ output/playwright/
 coverage/
 *.log
 *.zip
+*.crx
 .DS_Store
 .mcp.json
 *.ndjson

--- a/docs/chrome-web-store-release.md
+++ b/docs/chrome-web-store-release.md
@@ -1,0 +1,38 @@
+# Chrome Web Store release
+
+Chrome Web Store の「検証済み CRX アップロード」を有効にした後は、すべての
+パッケージ更新を登録済みの RSA 秘密鍵で署名した CRX として提出する。
+
+## Signing key
+
+- 秘密鍵はリポジトリや Google アカウントに保存しない。
+- GitHub Actions では repository secret `CWS_CRX_PRIVATE_KEY` から読み込む。
+- Developer Dashboard の **Package > Verified CRX Uploads** には、対応する公開鍵だけを登録する。
+- 秘密鍵を紛失すると Chrome Web Store support に鍵の交換を依頼する必要があるため、
+  GitHub Actions とは別の安全な keystore にもバックアップする。
+
+2048-bit RSA 鍵と公開鍵は次のように生成できる。
+
+```sh
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out privatekey.pem
+openssl rsa -in privatekey.pem -pubout -out publickey.pem
+```
+
+秘密鍵を repository secret に登録する。
+
+```sh
+gh secret set CWS_CRX_PRIVATE_KEY < privatekey.pem
+```
+
+## Release artifact
+
+Release Please がリリースを作成すると、workflow は通常の `extension.zip` に加えて
+署名済みの `extension.crx` を GitHub Release に添付する。Chrome Web Store の更新には
+`extension.crx` をアップロードする。
+
+ローカルで同じ CRX を作成する場合は、先に通常の build を行い、秘密鍵のパスを渡す。
+
+```sh
+npm run build
+npm run pack:crx -- /path/to/privatekey.pem
+```

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.1.0",
   "scripts": {
     "build": "tsx esbuild.config.ts",
+    "pack:crx": "bash scripts/pack-crx.sh",
     "mockup": "tsx mockup.config.ts --serve",
     "mockup:build": "tsx mockup.config.ts",
     "postbuild": "zip -r extension.zip dist/ icons/ manifest.json",

--- a/scripts/pack-crx.sh
+++ b/scripts/pack-crx.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <private-key.pem> [output.crx]" >&2
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage
+  exit 2
+fi
+
+private_key=$1
+output_path=${2:-extension.crx}
+
+if [[ ! -f "$private_key" ]]; then
+  echo "CRX signing key not found: $private_key" >&2
+  exit 1
+fi
+
+for required_path in dist icons manifest.json; do
+  if [[ ! -e "$required_path" ]]; then
+    echo "Build input not found: $required_path" >&2
+    exit 1
+  fi
+done
+
+if [[ -n "${CHROME_BINARY:-}" ]]; then
+  chrome_binary=$CHROME_BINARY
+elif command -v google-chrome >/dev/null 2>&1; then
+  chrome_binary=$(command -v google-chrome)
+elif command -v google-chrome-stable >/dev/null 2>&1; then
+  chrome_binary=$(command -v google-chrome-stable)
+elif [[ -x "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" ]]; then
+  chrome_binary="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+else
+  echo "Google Chrome was not found. Set CHROME_BINARY to its executable." >&2
+  exit 1
+fi
+
+work_parent=${TMPDIR:-/tmp}
+work_dir=$(mktemp -d "$work_parent/pokerchase-hud-crx.XXXXXX")
+extension_dir="$work_dir/extension"
+
+cleanup() {
+  if [[ "$work_dir" == "$work_parent"/pokerchase-hud-crx.* ]]; then
+    rm -rf -- "$work_dir"
+  fi
+}
+trap cleanup EXIT
+
+mkdir "$extension_dir"
+cp -R dist icons manifest.json "$extension_dir/"
+
+"$chrome_binary" \
+  --pack-extension="$extension_dir" \
+  --pack-extension-key="$private_key" \
+  --no-message-box
+
+if [[ ! -f "$work_dir/extension.crx" ]]; then
+  echo "Chrome did not create the expected CRX package." >&2
+  exit 1
+fi
+
+cp "$work_dir/extension.crx" "$output_path"
+echo "Created $output_path"


### PR DESCRIPTION
## Summary

- add deterministic Chrome CRX3 packaging from the built extension
- read the signing key only from the `CWS_CRX_PRIVATE_KEY` Actions secret
- run Linux Chrome packaging under Xvfb
- smoke-test CRX packaging in PR CI with a throwaway RSA key
- attach `extension.crx` alongside `extension.zip` on each Release Please release
- keep PEM signing keys out of git and document the Verified CRX Uploads recovery boundary

## Verification

- `bash -n scripts/pack-crx.sh`
- workflow YAML parsed successfully
- `npm run build`
- local CRX3 packaging with a newly generated RSA key and the existing fixed manifest `key`
- PR CI run `29811689827`: typecheck, tests, build, and Ubuntu/Xvfb CRX packaging smoke passed

## Head

`4015021`