### PR TITLE
feat(logging): show hand histories in worker console

### DIFF
--- a/src/background/ports.hand-log-console.test.ts
+++ b/src/background/ports.hand-log-console.test.ts
@@ -1,0 +1,53 @@
+import { HandLogEntryType, type HandLogEvent } from '../types/hand-log'
+import { logCompletedHandToConsole } from './ports'
+
+const completedHand: HandLogEvent = {
+  type: 'update',
+  handId: 123456,
+  entries: [
+    {
+      id: 'header',
+      handId: 123456,
+      timestamp: 1,
+      text: "PokerStars Hand #123456: Hold'em No Limit (100/200) - 2026/07/22 10:00:00 JST",
+      type: HandLogEntryType.HEADER
+    },
+    {
+      id: 'summary',
+      handId: 123456,
+      timestamp: 2,
+      text: '*** SUMMARY ***',
+      type: HandLogEntryType.SUMMARY
+    }
+  ]
+}
+
+describe('Service Worker completed-hand console log', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('logs the completed hand once in the same PokerStars line order as the HUD', () => {
+    const info = jest.spyOn(console, 'info').mockImplementation(() => undefined)
+
+    logCompletedHandToConsole(completedHand)
+
+    expect(info).toHaveBeenCalledTimes(1)
+    expect(info).toHaveBeenCalledWith([
+      "PokerStars Hand #123456: Hold'em No Limit (100/200) - 2026/07/22 10:00:00 JST",
+      '*** SUMMARY ***'
+    ].join('\n'))
+  })
+
+  test.each<HandLogEvent>([
+    { type: 'add', entries: completedHand.entries },
+    { type: 'removeIncomplete' },
+    { type: 'update', handId: 123456, entries: [] }
+  ])('does not log incomplete or empty hand-log events: $type', event => {
+    const info = jest.spyOn(console, 'info').mockImplementation(() => undefined)
+
+    logCompletedHandToConsole(event)
+
+    expect(info).not.toHaveBeenCalled()
+  })
+})

--- a/src/background/ports.ts
+++ b/src/background/ports.ts
@@ -4,6 +4,7 @@ import type { ApiEvent, ApiType, PlayerStats } from '../app'
 import type { AllPlayersRealTimeStats } from '../realtime-stats/realtime-stats-service'
 import type { HandLogEvent } from '../types/hand-log'
 import type { HandLogEventMessage } from '../types/messages'
+import { formatHandLogEntries } from '../utils/hand-log-text'
 
 const PING_INTERVAL_MS = 10 * 1000
 
@@ -65,6 +66,13 @@ export const getLatestRealTimeStats = (): AllPlayersRealTimeStats | undefined =>
  * ストリームイベントをブロードキャストする際の送信先として利用する
  */
 export const connectedPorts = new Set<chrome.runtime.Port>()
+
+/** 完了済みハンドだけをHUDと同じPokerStars形式でService Worker consoleへ出す。 */
+export const logCompletedHandToConsole = (event: HandLogEvent): void => {
+  if (event.type === 'update' && event.entries && event.entries.length > 0) {
+    console.info(formatHandLogEntries(event.entries))
+  }
+}
 
 /**
  * 接続中の全ポートにメッセージをブロードキャストする
@@ -177,6 +185,10 @@ export const registerStreamSubscriptions = (service: PokerChaseService, gameUrlP
 
   // Handle hand log events
   service.handLogStream.on('data', (event: HandLogEvent) => {
+    // 進行中のaddイベントは出さず、1ハンドを1ログにまとめることで、
+    // イベント単位の既存rawログから完成形を探す手間を省く。
+    logCompletedHandToConsole(event)
+
     // Send to all tabs with the game
     chrome.tabs.query({ url: gameUrlPattern }, tabs => {
       tabs.forEach(tab => {

--- a/src/components/HandLog.tsx
+++ b/src/components/HandLog.tsx
@@ -11,6 +11,7 @@ import {
   HandLogConfig,
   DEFAULT_HAND_LOG_CONFIG
 } from '../types/hand-log'
+import { formatHandLogEntries } from '../utils/hand-log-text'
 
 interface HandLogProps {
   entries: HandLogEntry[]
@@ -230,7 +231,7 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
         return
       }
 
-      const logText = handEntries.map(e => e.text).join('\n')
+      const logText = formatHandLogEntries(handEntries)
 
       await navigator.clipboard.writeText(logText)
       setCopiedHandId(handId)

--- a/src/utils/hand-log-exporter.ts
+++ b/src/utils/hand-log-exporter.ts
@@ -7,6 +7,7 @@ import type { PokerChaseDB } from '../app'
 import type { ApiEvent, Hand, Session } from '../types'
 import { ApiType, isApiEventType } from '../types/api'
 import { HandLogProcessor, HandLogContext } from './hand-log-processor'
+import { formatHandLogEntries } from './hand-log-text'
 import { DEFAULT_HAND_LOG_CONFIG } from '../types/hand-log'
 import { DATABASE_CONSTANTS } from '../constants/database'
 import { processInChunks, filterValidApplicationEvents } from '../utils/database-utils'
@@ -172,7 +173,7 @@ export class HandLogExporter {
     const entries = processor.processEvents(events)
 
     // Convert entries to text format
-    const handText = entries.map(entry => entry.text).join('\n')
+    const handText = formatHandLogEntries(entries)
 
     // Generated log entries for hand
     return handText
@@ -380,7 +381,7 @@ export class HandLogExporter {
 
     const processor = new HandLogProcessor(context)
     const entries = processor.processEvents(events)
-    return entries.map(entry => entry.text).join('\n')
+    return formatHandLogEntries(entries)
   }
 
   /**

--- a/src/utils/hand-log-text.ts
+++ b/src/utils/hand-log-text.ts
@@ -1,0 +1,9 @@
+import type { HandLogEntry } from '../types/hand-log'
+
+/**
+ * HandLogProcessor が生成した行を PokerStars 形式の1ハンドへ直列化する。
+ * HUDのコピー、エクスポート、Service Worker consoleで同じ行順・改行を使う。
+ */
+export const formatHandLogEntries = (
+  entries: ReadonlyArray<Pick<HandLogEntry, 'text'>>
+): string => entries.map(entry => entry.text).join('\n')


### PR DESCRIPTION
## Scope

- Log each completed hand once in the Service Worker console using the same PokerStars-formatted entries shown and copied by the HUD.
- Share the final line serialization across HUD copy, export, and worker logging.
- Ignore in-progress and empty hand-log events; no raw event payloads, tokens, or additional private fields are exposed.
- This PR is limited to a3 observability and does not change sync counts or extension messaging behavior.

## Intent

Make completed hands easy to inspect from the Service Worker console without reconstructing them from per-event raw logs or duplicating the PokerStars formatter.

## Validation

- `npm test -- --runInBand` (108 suites, 1003 tests)
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Head

`bbcfc7b6565b14b2bfa2dc036687545199c09b22`