### PR TITLE
fix(background): handle missing hand-log receivers

### DIFF
--- a/src/background/ports.hand-log-delivery.test.ts
+++ b/src/background/ports.hand-log-delivery.test.ts
@@ -1,0 +1,68 @@
+import type PokerChaseService from '../services/poker-chase-service'
+import type { HandLogEvent } from '../types/hand-log'
+import { registerStreamSubscriptions } from './ports'
+
+describe('ports.ts hand-log delivery', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('consumes a missing content-script receiver rejection', async () => {
+    const listeners: Record<string, (value: unknown) => void> = {}
+    const stream = (name: string) => ({
+      on: jest.fn((_event: 'data', listener: (value: unknown) => void) => {
+        listeners[name] = listener
+      })
+    })
+    const service = {
+      realTimeStatsStream: stream('realTimeStats'),
+      statsOutputStream: stream('statsOutput'),
+      writeEntityStream: stream('writeEntity'),
+      handLogStream: stream('handLog')
+    } as unknown as PokerChaseService
+
+    const missingReceiver = new Error('Could not establish connection. Receiving end does not exist.')
+    ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => callback([{ id: 42 }]))
+    ;(chrome.tabs.sendMessage as jest.Mock).mockRejectedValue(missingReceiver)
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    registerStreamSubscriptions(service, 'https://game.poker-chase.com/*')
+    listeners.handLog!({ type: 'clear' } satisfies HandLogEvent)
+    await Promise.resolve()
+
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+      action: 'handLogEvent',
+      event: { type: 'clear' }
+    })
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  test('reports unexpected delivery failures without leaving a rejected Promise', async () => {
+    const listeners: Record<string, (value: unknown) => void> = {}
+    const stream = (name: string) => ({
+      on: jest.fn((_event: 'data', listener: (value: unknown) => void) => {
+        listeners[name] = listener
+      })
+    })
+    const service = {
+      realTimeStatsStream: stream('realTimeStats'),
+      statsOutputStream: stream('statsOutput'),
+      writeEntityStream: stream('writeEntity'),
+      handLogStream: stream('handLog')
+    } as unknown as PokerChaseService
+
+    const unexpectedError = new Error('Unexpected delivery failure')
+    ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => callback([{ id: 7 }]))
+    ;(chrome.tabs.sendMessage as jest.Mock).mockRejectedValue(unexpectedError)
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    registerStreamSubscriptions(service, 'https://game.poker-chase.com/*')
+    listeners.handLog!({ type: 'clear' } satisfies HandLogEvent)
+    await Promise.resolve()
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[background] Failed to deliver hand log event to tab 7:',
+      unexpectedError
+    )
+  })
+})

--- a/src/background/ports.ts
+++ b/src/background/ports.ts
@@ -184,6 +184,15 @@ export const registerStreamSubscriptions = (service: PokerChaseService, gameUrlP
           chrome.tabs.sendMessage<HandLogEventMessage>(tab.id, {
             action: 'handLogEvent',
             event: event
+          }).catch(error => {
+            // A matching game tab can temporarily have no content-script
+            // receiver (for example after an extension update until the tab
+            // is reloaded, or while the tab is navigating). Hand-log delivery
+            // is best-effort, so consume that expected Promise rejection
+            // instead of surfacing one unhandled error for every log event.
+            if (!(error instanceof Error) || !error.message.includes('Receiving end does not exist')) {
+              console.warn(`[background] Failed to deliver hand log event to tab ${tab.id}:`, error)
+            }
           })
         }
       })


### PR DESCRIPTION
## Scope

- Handle the rejected Promise from best-effort hand-log delivery when a matching game tab has no active content-script receiver.
- Keep unexpected delivery failures visible as warnings.
- Add focused regression coverage for both paths.

## Intent

A game tab can still match `https://game.poker-chase.com/*` while its content script is absent during extension update/reload or navigation. Each hand-log event previously produced an unhandled `chrome.tabs.sendMessage()` rejection in the Service Worker console. This change consumes only the expected missing-receiver lifecycle race.

## Validation

- `npm test -- --runInBand src/background/ports.hand-log-delivery.test.ts`
- `npm test -- --runInBand`
- `npm run typecheck`
- `npm run build`

Head SHA: `da53795729854526306bbdb94b8d625abe1641d7`