### PR TITLE
fix(sync): make upload count reporting explicit

### DIFF
--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -230,6 +230,104 @@ describe('AutoSyncService cloud downloads', () => {
     expect(service.getSyncState().status).toBe('success')
   }, 15000)
 
+  test('upload: reports raw, valid, filtered, deferred, and acknowledged counts without implying data loss', async () => {
+    const validEvents = [100, 500].map(timestamp => ({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Code: 0,
+      BattleType: BattleType.SIT_AND_GO,
+      Id: `stage-${timestamp}`,
+      IsRetire: false,
+      timestamp
+    } as ApiEvent))
+    const nonApplicationNoise = [
+      { ApiTypeId: 202, Code: 0, timestamp: 200 },
+      { ApiTypeId: 311, NotifyCode: 1, timestamp: 300 }
+    ]
+    const unparseableApplicationEvent = {
+      ApiTypeId: ApiType.EVT_SESSION_RESULTS,
+      timestamp: 400
+    }
+    await db.apiEvents.bulkAdd([
+      validEvents[0],
+      nonApplicationNoise[0],
+      nonApplicationNoise[1],
+      unparseableApplicationEvent,
+      validEvents[1]
+    ] as any)
+
+    jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockResolvedValue(null)
+    jest.spyOn(firestoreBackupService, 'syncToCloudBatch')
+      .mockResolvedValue({ totalEvents: 2, syncedEvents: 2, lastSyncTime: new Date() })
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+    const service = new AutoSyncService(db)
+    await service.performSync('upload')
+
+    expect(logSpy).toHaveBeenCalledWith(
+      '[AutoSync] Upload scan snapshot has 5 raw events; application-event validation runs per chunk'
+    )
+    expect(logSpy).toHaveBeenCalledWith(
+      '[AutoSync] Upload pass complete: scanned raw=5; valid application=2; ' +
+      'acknowledged Firestore writes=2; filtered non-application/unknown=2; ' +
+      'deferred unparseable application=1'
+    )
+    expect(service.getSyncState().progress).toEqual({
+      current: 5,
+      total: 5,
+      direction: 'upload'
+    })
+    expect((await db.meta.get('syncUnparseableFloor'))?.value).toBe(400)
+  })
+
+  test('upload: distinguishes the trigger snapshot from raw events arriving during the cloud watermark read', async () => {
+    const initialEvents = [100, 200, 300].map(timestamp => ({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Code: 0,
+      BattleType: BattleType.SIT_AND_GO,
+      Id: `stage-${timestamp}`,
+      IsRetire: false,
+      timestamp
+    } as ApiEvent))
+    await db.apiEvents.bulkAdd(initialEvents)
+
+    jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue({ uid: 'test-user' } as any)
+    jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp')
+      .mockImplementationOnce(async () => {
+        // Mirrors the reported runtime ordering: the trigger count is logged,
+        // then more raw WebSocket events land while Firestore's watermark is
+        // being fetched. The later upload scan correctly sees both snapshots.
+        await db.apiEvents.bulkAdd([
+          { ApiTypeId: 202, Code: 0, timestamp: 400 },
+          { ApiTypeId: 311, NotifyCode: 1, timestamp: 500 }
+        ] as any)
+        return null
+      })
+      .mockResolvedValue(null)
+    jest.spyOn(firestoreBackupService, 'syncToCloudBatch')
+      .mockImplementation(async (events: ApiEvent[]) => ({
+        totalEvents: events.length,
+        syncedEvents: events.length,
+        lastSyncTime: new Date()
+      }))
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+    const service = new AutoSyncService(db)
+    ;(service as any).EVENTS_THRESHOLD = 3
+    await service.onGameSessionEnd()
+
+    expect(logSpy).toHaveBeenCalledWith(
+      '[AutoSync] Game ended with 3 raw events since the last completed sync, performing upload sync...'
+    )
+    expect(logSpy).toHaveBeenCalledWith(
+      '[AutoSync] Upload scan snapshot has 5 raw events; application-event validation runs per chunk'
+    )
+    expect(logSpy).toHaveBeenCalledWith(
+      '[AutoSync] Upload pass complete: scanned raw=5; valid application=3; ' +
+      'acknowledged Firestore writes=3; filtered non-application/unknown=2; ' +
+      'deferred unparseable application=0'
+    )
+  })
+
   test('upload: a normal chunk of only valid application events uploads and advances the cloud watermark past every event (unaffected by the unparseable-row guard)', async () => {
     const firstEntry = {
       ApiTypeId: ApiType.EVT_ENTRY_QUEUED,

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -927,7 +927,7 @@ export class AutoSyncService {
       : await this.db.apiEvents.count()
 
     if (totalCount === 0) {
-      console.log('[AutoSync] No new events to sync')
+      console.log('[AutoSync] Upload scan snapshot has no raw events')
       // Nothing at all above the floor -- if a marker was pending, its row no
       // longer exists locally (e.g. local data was cleared). Nothing left to
       // recover, so clear the stale marker rather than rewinding forever.
@@ -937,12 +937,15 @@ export class AutoSyncService {
       return
     }
 
-    console.log(`[AutoSync] Found ${totalCount} new events to sync`)
+    console.log(`[AutoSync] Upload scan snapshot has ${totalCount} raw events; application-event validation runs per chunk`)
 
     // Process in chunks to avoid memory issues
     const CHUNK_SIZE = DATABASE_CONSTANTS.SYNC_CHUNK_SIZE
     let processed = 0
     let synced = 0
+    let validApplicationEvents = 0
+    let filteredNonApplicationEvents = 0
+    let deferredUnparseableApplicationEvents = 0
     // Compound cursor: all THREE components must track the actual last-processed
     // row between chunks (see fix (a) above). Starts at `scanFloor`'s own
     // millisecond with the sentinel ApiTypeId (see fix (b) above).
@@ -993,17 +996,22 @@ export class AutoSyncService {
       // noise, otherwise a chunk containing only non-application events would never
       // advance the cursor and the loop would refetch it forever.
       const chunk = rawChunk.filter(isApplicationApiEvent)
+      validApplicationEvents += chunk.length
 
       // Find any application-typed rows in THIS raw chunk that still can't
       // parse (see watermark guard above).
       let earliestUnparseableThisChunk: number | null = null
+      let unparseableApplicationEventsInChunk = 0
       for (const raw of rawChunk) {
         if (isUnparseableApplicationEvent(raw) && typeof raw.timestamp === 'number') {
+          unparseableApplicationEventsInChunk++
           earliestUnparseableThisChunk = earliestUnparseableThisChunk === null
             ? raw.timestamp
             : Math.min(earliestUnparseableThisChunk, raw.timestamp)
         }
       }
+      deferredUnparseableApplicationEvents += unparseableApplicationEventsInChunk
+      filteredNonApplicationEvents += rawChunk.length - chunk.length - unparseableApplicationEventsInChunk
 
       if (earliestUnparseableThisChunk !== null) {
         earliestUnparseableThisPass = earliestUnparseableThisPass === null
@@ -1081,6 +1089,26 @@ export class AutoSyncService {
       }
 
       processed += rawChunk.length
+      // Upload progress is measured against raw scan rows, because `totalCount`
+      // is a raw-Lake count. The Firestore callback above reports progress only
+      // within the valid application subset, so a mixed chunk would otherwise
+      // leave the popup at e.g. 695/1023 even after all 1023 raw rows had been
+      // examined. Publishing the raw chunk boundary makes the numerator and
+      // denominator use the same population and reaches 100% without implying
+      // that filtered noise was uploaded.
+      this.updateSyncState({
+        progress: {
+          current: processed,
+          // `totalCount` is a snapshot. Rows can continue arriving while a
+          // sync is in flight and a later page can therefore contain more
+          // rows than that snapshot. Grow the display total with the actual
+          // processed boundary so progress remains truthful and never exceeds
+          // 100%; rows beyond the last page reached stay pending for the next
+          // sync pass as before.
+          total: Math.max(totalCount, processed),
+          direction: 'upload'
+        }
+      })
 
       // Update the compound cursor for next chunk (based on the raw chunk's
       // actual last row's FULL [timestamp, ApiTypeId, sequence] key. Tracking
@@ -1104,7 +1132,12 @@ export class AutoSyncService {
     // ACCOUNT-SCOPING INVARIANTS spec's invariant (2).)
     await this.persistUnparseableSyncFloor(earliestUnparseableThisPass, identity)
 
-    console.log(`[AutoSync] Uploaded ${synced} new events to cloud`)
+    console.log(
+      `[AutoSync] Upload pass complete: scanned raw=${processed}; ` +
+      `valid application=${validApplicationEvents}; acknowledged Firestore writes=${synced}; ` +
+      `filtered non-application/unknown=${filteredNonApplicationEvents}; ` +
+      `deferred unparseable application=${deferredUnparseableApplicationEvents}`
+    )
   }
 
   /**
@@ -1622,10 +1655,10 @@ export class AutoSyncService {
         .count()
 
       if (newEventsCount >= this.EVENTS_THRESHOLD) {
-        console.log(`[AutoSync] ${trigger} with ${newEventsCount} new events, performing upload sync...`)
+        console.log(`[AutoSync] ${trigger} with ${newEventsCount} raw events since the last completed sync, performing upload sync...`)
         await this.performSync('upload')
       } else {
-        console.log(`[AutoSync] ${trigger} with only ${newEventsCount} new events, skipping sync (threshold: ${this.EVENTS_THRESHOLD})`)
+        console.log(`[AutoSync] ${trigger} with only ${newEventsCount} raw events since the last completed sync, skipping sync (threshold: ${this.EVENTS_THRESHOLD})`)
       }
     } catch (error) {
       console.error(`[AutoSync] Error checking event count (${trigger}):`, error)

--- a/src/services/firestore-backup-service.ts
+++ b/src/services/firestore-backup-service.ts
@@ -191,13 +191,13 @@ export class FirestoreBackupService {
       let processed = 0
       let synced = 0
 
-      console.log(`[Firestore] Processing batch of ${apiEvents.length} events...`)
+      console.log(`[Firestore] Processing batch of ${apiEvents.length} upload candidates...`)
 
       const newEvents = cloudMaxTimestamp
         ? apiEvents.filter(event => (event.timestamp || 0) > cloudMaxTimestamp)
         : apiEvents
 
-      console.log(`[Firestore] ${newEvents.length} new events in this batch`)
+      console.log(`[Firestore] ${newEvents.length} events remain after the upload watermark filter`)
 
       const PARALLEL_BATCHES = DATABASE_CONSTANTS.FIRESTORE_PARALLEL_BATCHES
       for (let i = 0; i < newEvents.length; i += this.BATCH_SIZE * PARALLEL_BATCHES) {


### PR DESCRIPTION
## Summary

The reported `1021 -> 1023 -> 695` sequence combines three different populations:

- `1021` was the raw-Lake backlog snapshot taken by the session-end trigger.
- `1023` was a later raw-Lake upload-scan snapshot, after two more WebSocket rows could arrive while the cloud watermark was being fetched.
- `695` was the schema-valid application-event subset offered to Firestore. Non-application/unknown rows are intentionally excluded; application-typed rows that currently fail schema validation are excluded from this write pass but retained locally and protected by the durable unparseable-row floor for retry.

The upload path did not expose those definitions, and upload progress mixed a raw-row denominator with an application-event numerator, making normal filtering look like silent data loss.

## Changes

- Label trigger and upload-scan counts as raw-event snapshots.
- Report one explicit end-of-pass breakdown: raw rows scanned, valid application events, acknowledged Firestore writes, filtered non-application/unknown rows, and deferred unparseable application rows.
- Describe Firestore batch inputs as upload candidates and its timestamp filter separately; acknowledged writes are not claimed to be newly-created documents because boundary re-offers are idempotent.
- Advance upload progress on raw chunk boundaries so a mixed `695 / 1023` pass completes at `1023 / 1023` without implying that filtered rows were uploaded. The total grows if rows arrive after the initial scan snapshot, preventing progress above 100%.
- Add regression coverage for both mixed raw/application populations and the trigger-snapshot race (`3 -> 5`, mirroring `1021 -> 1023`).

## Scope

This PR addresses Service Worker item **a2** only. It does not include the connection-error work (a1) or Stars-format worker hand logs (a3).

## Validation

- `npm test -- --runInBand` — 120 suites / 1163 tests passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `npm run e2e:smoke` — all 6 checks passed
- `git diff --check` — passed

## Head

`933db3141cbd35d5f43e319ff60d77fe480466c6`
