### PR TITLE
feat(popup): compact update disclosures

### DIFF
--- a/e2e/scenarios/smoke.ts
+++ b/e2e/scenarios/smoke.ts
@@ -155,6 +155,21 @@ const run = async (): Promise<void> => {
     check('popup renders content', popupHasContent)
     check('popup has no uncaught render error', !popupError, popupError?.message)
 
+    // Chromeのextension popupは約600pxで高さが頭打ちになる。更新情報が長くても、
+    // 最初のHUD設定カードがその初期viewport内に入り、設定操作を始めるために
+    // 更新履歴全体をスクロールしなくてよいことを実レイアウトで確認する。
+    const firstConfigTop = await popup.evaluate(() => {
+      const displayMode = document.querySelector('[aria-label="HUD表示モード"]')
+      return displayMode?.closest('.MuiPaper-root')?.getBoundingClientRect().top
+    })
+    check(
+      'first HUD config stays within the initial popup viewport',
+      // 600pxぎりぎりでは操作部が数pxしか見えないため、少なくとも50pxの
+      // 余裕を確保する。
+      typeof firstConfigTop === 'number' && firstConfigTop < 550,
+      `top = ${String(firstConfigTop)}px`
+    )
+
     const failures = checks.filter((c) => !c.pass)
     if (failures.length > 0) {
       await dumpFailureEvidence(harness, screenshotDir, 'summary')

--- a/src/components/popup/WhatsNewSection.test.tsx
+++ b/src/components/popup/WhatsNewSection.test.tsx
@@ -1,7 +1,14 @@
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { WhatsNewSection } from './WhatsNewSection'
-import { WHATS_NEW_ENTRIES, GITHUB_RELEASES_URL } from '../../constants/whats-new'
-import { compareVersions } from '../../utils/version-compare'
+import { WHATS_NEW_ENTRIES, GITHUB_RELEASES_URL, type WhatsNewEntry } from '../../constants/whats-new'
+
+const syntheticEntry = (version: string, pointCount: number): WhatsNewEntry => ({
+  version,
+  date: '2026-07-22',
+  title: `v${version} updates`,
+  points: Array.from({ length: pointCount }, (_, index) => ({ text: `${version} point ${index + 1}` })),
+})
 
 describe('WhatsNewSection', () => {
   let mockSendMessage: jest.Mock
@@ -22,27 +29,101 @@ describe('WhatsNewSection', () => {
     } as any
   })
 
-  it('renders the entry matching the current manifest version, its points, and the GitHub Releases link', async () => {
+  it('shows the newest two eligible versions initially and keeps older versions collapsed', () => {
     render(<WhatsNewSection />)
 
-    const current = WHATS_NEW_ENTRIES[0]!
     expect(screen.getByText('更新情報')).toBeInTheDocument()
-    expect(screen.getByText(new RegExp(`v${current.version.replace(/\./g, '\\.')}`))).toBeInTheDocument()
-    expect(screen.getByText(current.points[0]!.text)).toBeInTheDocument()
+    expect(screen.getByText(/v5\.2\.0/)).toBeVisible()
+    expect(screen.getByText(/v5\.1\.0/)).toBeVisible()
+    expect(screen.getByText(/v5\.0\.0/)).not.toBeVisible()
 
-    const link = screen.getByRole('link', { name: /すべての変更を見る/ })
-    expect(link).toHaveAttribute('href', GITHUB_RELEASES_URL)
-    expect(link).toHaveAttribute('target', '_blank')
-    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
+    const history = screen.getByRole('button', { name: new RegExp(`過去の更新情報（${WHATS_NEW_ENTRIES.length - 2}件）`) })
+    expect(history).toHaveAttribute('aria-expanded', 'false')
   })
 
-  it('falls back to the newest entry <= current version when there is no exact-match curated entry', async () => {
-    mockGetManifest.mockReturnValue({ version: '5.2.99' }) // uncurated patch bump above the newest entry
+  it('shows a short newest release in full while truncating the long second release', () => {
+    const entries = [syntheticEntry('5.3.0', 2), syntheticEntry('5.2.0', 6), syntheticEntry('5.1.0', 1)]
+    mockGetManifest.mockReturnValue({ version: '5.3.0' })
+
+    render(<WhatsNewSection entries={entries} />)
+
+    expect(screen.getByText('5.3.0 point 1')).toBeVisible()
+    expect(screen.getByText('5.3.0 point 2')).toBeVisible()
+    expect(screen.queryByRole('button', { name: /v5\.3\.0の更新情報を続きを読む/ })).not.toBeInTheDocument()
+    expect(screen.getByText('5.2.0 point 2')).toBeVisible()
+    expect(screen.queryByText('5.2.0 point 3')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /v5\.2\.0の更新情報を続きを読む/ })).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('expands and collapses a long release with an accessible button', async () => {
+    const user = userEvent.setup()
+    const entries = [syntheticEntry('5.3.0', 1), syntheticEntry('5.2.0', 6)]
+    mockGetManifest.mockReturnValue({ version: '5.3.0' })
+
+    render(<WhatsNewSection entries={entries} />)
+
+    const readMore = screen.getByRole('button', { name: /v5\.2\.0の更新情報を続きを読む/ })
+    expect(readMore).toHaveAttribute('aria-expanded', 'false')
+    expect(readMore).toHaveAttribute('aria-controls')
+    expect(screen.queryByText('5.2.0 point 6')).not.toBeInTheDocument()
+
+    await user.click(readMore)
+
+    expect(screen.getByText('5.2.0 point 6')).toBeVisible()
+    const collapse = screen.getByRole('button', { name: /v5\.2\.0の更新情報を折りたたむ/ })
+    expect(collapse).toHaveAttribute('aria-expanded', 'true')
+
+    await user.click(collapse)
+
+    expect(screen.queryByText('5.2.0 point 6')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /v5\.2\.0の更新情報を続きを読む/ })).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('expands and collapses the third and older releases as one accessible disclosure', async () => {
+    const user = userEvent.setup()
+    render(<WhatsNewSection />)
+
+    const history = screen.getByRole('button', { name: /過去の更新情報/ })
+    const controlledId = history.getAttribute('aria-controls')
+    expect(controlledId).toBeTruthy()
+    expect(history).toHaveTextContent(/^▶ 過去の更新情報/)
+    expect(history).toHaveAttribute('aria-expanded', 'false')
+    expect(document.getElementById(controlledId!)).toHaveAttribute('hidden')
+
+    await user.click(history)
+
+    expect(screen.getByRole('button', { name: /過去の更新情報/ })).toHaveTextContent(/^▼ 過去の更新情報/)
+    expect(screen.getByRole('button', { name: /過去の更新情報/ })).toHaveAttribute('aria-expanded', 'true')
+    expect(document.getElementById(controlledId!)).not.toHaveAttribute('hidden')
+    expect(screen.getByText(/v5\.0\.0/)).toBeVisible()
+
+    await user.click(screen.getByRole('button', { name: /過去の更新情報/ }))
+
+    expect(screen.getByRole('button', { name: /過去の更新情報/ })).toHaveAttribute('aria-expanded', 'false')
+    expect(document.getElementById(controlledId!)).toHaveAttribute('hidden')
+  })
+
+  it.each([
+    { entries: [syntheticEntry('5.3.0', 1)], expectedVersions: ['5.3.0'] },
+    { entries: [syntheticEntry('5.3.0', 1), syntheticEntry('5.2.0', 1)], expectedVersions: ['5.3.0', '5.2.0'] },
+  ])('handles $expectedVersions.length eligible entries without an empty history disclosure', ({ entries, expectedVersions }) => {
+    mockGetManifest.mockReturnValue({ version: '5.3.0' })
+
+    render(<WhatsNewSection entries={entries} />)
+
+    for (const version of expectedVersions) {
+      expect(screen.getByText(new RegExp(`v${version.replace(/\./g, '\\.')}`))).toBeVisible()
+    }
+    expect(screen.queryByRole('button', { name: /過去の更新情報/ })).not.toBeInTheDocument()
+  })
+
+  it('falls back to the newest entry <= current version when there is no exact curated entry', () => {
+    mockGetManifest.mockReturnValue({ version: '5.2.99' })
 
     render(<WhatsNewSection />)
 
-    const newest = WHATS_NEW_ENTRIES[0]!
-    expect(screen.getByText(new RegExp(`v${newest.version.replace(/\./g, '\\.')}`))).toBeInTheDocument()
+    expect(screen.getByText(/v5\.2\.0/)).toBeVisible()
+    expect(screen.getByText(/v5\.1\.0/)).toBeVisible()
   })
 
   it('renders nothing when the current version predates every curated entry', () => {
@@ -53,48 +134,26 @@ describe('WhatsNewSection', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('excludes future entries from both the primary slot and the history disclosure (codex review, PR #172)', () => {
-    // Regression for: manifest.json/package.json still at 5.1.0 while
-    // WHATS_NEW_ENTRIES[0] is the newer, not-yet-released 5.2.0 (this repo's
-    // actual state right now -- the whats-new copy for a release is added
-    // ahead of release-please bumping the manifest, see whats-new.ts's
-    // header comment). An entry newer than the running version must never
-    // render anywhere, including tucked away in "過去の更新情報".
-    expect(WHATS_NEW_ENTRIES[0]!.version).toBe('5.2.0')
+  it('excludes future entries from featured releases and history', async () => {
+    const user = userEvent.setup()
     mockGetManifest.mockReturnValue({ version: '5.1.0' })
 
     render(<WhatsNewSection />)
 
-    // Primary: the 5.1.0 entry (exact match), never the future 5.2.0 one.
-    expect(screen.getByText(/v5\.1\.0/)).toBeInTheDocument()
     expect(screen.queryByText(/v5\.2\.0/)).not.toBeInTheDocument()
-
-    // History: every curated entry strictly older than the selected 5.1.0
-    // entry (5.0.0 and all earlier releases) -- the future 5.2.0 entry must
-    // be filtered out, not merely deduplicated against the primary entry.
-    // Count is derived rather than hardcoded so it doesn't rot as sola adds
-    // more curated history to WHATS_NEW_ENTRIES.
-    const expectedOlderCount = WHATS_NEW_ENTRIES.filter(entry => compareVersions(entry.version, '5.1.0') === -1).length
-    expect(
-      screen.getByText(new RegExp(`過去の更新情報（${expectedOlderCount}件）`))
-    ).toBeInTheDocument()
-    expect(screen.getByText(/v5\.0\.0/)).toBeInTheDocument()
+    expect(screen.getByText(/v5\.1\.0/)).toBeVisible()
+    expect(screen.getByText(/v5\.0\.0/)).toBeVisible()
+    await user.click(screen.getByRole('button', { name: /過去の更新情報/ }))
     expect(screen.queryByText(/v5\.2\.0/)).not.toBeInTheDocument()
   })
 
-  it('collapses older entries under a <details> disclosure and lists them all', () => {
+  it('renders the GitHub Releases link', () => {
     render(<WhatsNewSection />)
 
-    const olderCount = WHATS_NEW_ENTRIES.length - 1
-    if (olderCount > 0) {
-      const summary = screen.getByText(new RegExp(`過去の更新情報（${olderCount}件）`))
-      expect(summary).toBeInTheDocument()
-      expect(summary.closest('summary')).toBeInTheDocument()
-
-      for (const entry of WHATS_NEW_ENTRIES.slice(1)) {
-        expect(screen.getByText(new RegExp(`v${entry.version.replace(/\./g, '\\.')}`))).toBeInTheDocument()
-      }
-    }
+    const link = screen.getByRole('link', { name: /すべての変更を見る/ })
+    expect(link).toHaveAttribute('href', GITHUB_RELEASES_URL)
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
   })
 
   it('sends acknowledgeWhatsNew on mount so the background can clear the badge', async () => {

--- a/src/components/popup/WhatsNewSection.test.tsx
+++ b/src/components/popup/WhatsNewSection.test.tsx
@@ -33,9 +33,12 @@ describe('WhatsNewSection', () => {
     render(<WhatsNewSection />)
 
     expect(screen.getByText('更新情報')).toBeInTheDocument()
-    expect(screen.getByText(/v5\.2\.0/)).toBeVisible()
-    expect(screen.getByText(/v5\.1\.0/)).toBeVisible()
-    expect(screen.getByText(/v5\.0\.0/)).not.toBeVisible()
+    for (const entry of WHATS_NEW_ENTRIES.slice(0, 2)) {
+      expect(screen.getByText(new RegExp(`v${entry.version.replace(/\./g, '\\.')}`))).toBeVisible()
+    }
+    expect(
+      screen.getByText(new RegExp(`v${WHATS_NEW_ENTRIES[2]!.version.replace(/\./g, '\\.')}`)),
+    ).not.toBeVisible()
 
     const history = screen.getByRole('button', { name: new RegExp(`過去の更新情報（${WHATS_NEW_ENTRIES.length - 2}件）`) })
     expect(history).toHaveAttribute('aria-expanded', 'false')

--- a/src/components/popup/WhatsNewSection.tsx
+++ b/src/components/popup/WhatsNewSection.tsx
@@ -1,7 +1,8 @@
 import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
 import Link from '@mui/material/Link'
 import Typography from '@mui/material/Typography'
-import { useEffect, useMemo } from 'react'
+import { useEffect, useId, useMemo, useState } from 'react'
 import {
   GITHUB_RELEASES_URL,
   WHATS_NEW_ENTRIES,
@@ -14,8 +15,25 @@ import { SectionCard } from './SectionCard'
 import { SectionHeading } from './SectionHeading'
 import { sendMessageWithTimeout } from './send-message'
 
-const EntryHeader = ({ entry }: { entry: WhatsNewEntry }) => (
-  <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+const FEATURED_ENTRY_COUNT = 2
+const COLLAPSED_POINT_COUNT = 2
+
+interface WhatsNewSectionProps {
+  /** Test seam; production always uses the curated newest-first list. */
+  entries?: WhatsNewEntry[]
+}
+
+const disclosureButtonSx = {
+  minWidth: 0,
+  p: 0,
+  mt: 0.5,
+  fontSize: '0.75rem',
+  lineHeight: 1.4,
+  textTransform: 'none',
+}
+
+const EntryHeader = ({ entry, id }: { entry: WhatsNewEntry, id?: string }) => (
+  <Typography id={id} variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
     v{entry.version}（{entry.date}）{entry.title}
   </Typography>
 )
@@ -35,18 +53,51 @@ const EntryPoints = ({ points }: { points: WhatsNewEntry['points'] }) => (
   </Box>
 )
 
+const FeaturedEntry = ({ entry, isFirst }: { entry: WhatsNewEntry, isFirst: boolean }) => {
+  const [expanded, setExpanded] = useState(false)
+  const headingId = useId()
+  const pointsId = useId()
+  const isLong = entry.points.length > COLLAPSED_POINT_COUNT
+  const visiblePoints = isLong && !expanded
+    ? entry.points.slice(0, COLLAPSED_POINT_COUNT)
+    : entry.points
+
+  return (
+    <Box component="article" aria-labelledby={headingId} sx={{ mt: isFirst ? 0 : 1.5 }}>
+      <EntryHeader entry={entry} id={headingId} />
+      <Box id={pointsId}>
+        <EntryPoints points={visiblePoints} />
+      </Box>
+      {isLong && (
+        <Button
+          size="small"
+          variant="text"
+          aria-expanded={expanded}
+          aria-controls={pointsId}
+          aria-label={`v${entry.version}の更新情報を${expanded ? '折りたたむ' : '続きを読む'}`}
+          onClick={() => setExpanded(current => !current)}
+          sx={disclosureButtonSx}
+        >
+          {expanded ? '折りたたむ' : '続きを読む'}
+        </Button>
+      )}
+    </Box>
+  )
+}
+
 /**
- * 更新情報（What's New）セクション。バージョンごとにキュレーションされた
- * 変更点（`src/constants/whats-new.ts`のWHATS_NEW_ENTRIES）を、現在の
- * `chrome.runtime.getManifest().version`に対応するエントリを中心に表示する。
- * 過去のエントリは`<details>`で折りたたみ、フッターにGitHub Releasesへの
- * リンクを置く。
+ * 更新情報（What's New）セクション。実行中バージョン以下の最新2件を最初から
+ * 表示し、長い本文だけをエントリ内の「続きを読む」で省略する。3件目以前は
+ * 「過去の更新情報」にまとめ、設定操作へ早く到達できる初期高さを保つ。
  *
  * マウント時に`acknowledgeWhatsNew`メッセージ（`message-router.ts`→
  * `src/background/whats-new-badge.ts`）を送り、拡張機能アイコンのバッジ
  * （未読があれば）を解消する。未読が無い状態で送っても副作用は無い（冪等）。
  */
-export const WhatsNewSection = () => {
+export const WhatsNewSection = ({ entries = WHATS_NEW_ENTRIES }: WhatsNewSectionProps) => {
+  const [historyExpanded, setHistoryExpanded] = useState(false)
+  const historyId = useId()
+
   useEffect(() => {
     // Popupが開かれた = ユーザーが更新情報を目にする機会があった、という
     // ことなのでバッジを解消する。応答は使わないので待たない（fire-and-forget）。
@@ -54,49 +105,52 @@ export const WhatsNewSection = () => {
   }, [])
 
   const currentVersion = useMemo(() => chrome.runtime.getManifest().version, [])
-  const current = useMemo(() => selectWhatsNewEntry(currentVersion), [currentVersion])
-  // 過去の更新情報は`current`（実行中バージョン以下で選ばれたエントリ）より
-  // 厳密に古いものだけに絞る。`current.version !== entry.version`だけでは
-  // 不十分 -- マニフェストがまだ更新エントリより古い版の場合（例:
-  // manifest=5.1.0だがWHATS_NEW_ENTRIES[0]は未リリースの5.2.0）、単純な
-  // 「currentと違う」フィルタだと未来のエントリまで「過去の更新情報」の
-  // 折りたたみに紛れ込んでしまう（codex review, PR #172）。
-  const olderEntries = useMemo(
-    () =>
-      WHATS_NEW_ENTRIES.filter(entry => {
-        if (!current) return false
-        const cmp = compareVersions(entry.version, current.version)
-        return cmp !== null && cmp < 0
-      }),
-    [current]
+  const current = useMemo(() => selectWhatsNewEntry(currentVersion, entries), [currentVersion, entries])
+  // current以下だけを残すことで、リリース前に先行追加された未来のエントリを
+  // 最新2件にも過去の折りたたみにも混ぜない（PR #172のfuture-entry guard）。
+  const availableEntries = useMemo(
+    () => entries.filter(entry => {
+      if (!current) return false
+      const cmp = compareVersions(entry.version, current.version)
+      return cmp !== null && cmp <= 0
+    }),
+    [current, entries]
   )
+  const featuredEntries = availableEntries.slice(0, FEATURED_ENTRY_COUNT)
+  const historyEntries = availableEntries.slice(FEATURED_ENTRY_COUNT)
 
-  // キュレーション済みエントリが無い（例: 新しすぎるバージョンでこのファイルへ
-  // まだ追記されていない）場合は何も描画しない -- 空のカードを見せるより、
-  // セクションごと出さない方が誠実
+  // キュレーション済みエントリが無い（例: 全エントリより古いバージョン）の
+  // 場合は空のカードを描画しない。
   if (!current) return null
 
   return (
     <SectionCard>
       <SectionHeading>更新情報</SectionHeading>
 
-      <EntryHeader entry={current} />
-      <EntryPoints points={current.points} />
+      {featuredEntries.map((entry, index) => (
+        <FeaturedEntry key={entry.version} entry={entry} isFirst={index === 0} />
+      ))}
 
-      {olderEntries.length > 0 && (
-        <Box component="details" sx={{ mt: 1.5 }}>
-          <Box
-            component="summary"
-            sx={{ cursor: 'pointer', fontSize: '0.8125rem', color: 'text.secondary', userSelect: 'none' }}
+      {historyEntries.length > 0 && (
+        <Box sx={{ mt: 1.5 }}>
+          <Button
+            size="small"
+            variant="text"
+            aria-expanded={historyExpanded}
+            aria-controls={historyId}
+            onClick={() => setHistoryExpanded(currentExpanded => !currentExpanded)}
+            sx={{ ...disclosureButtonSx, mt: 0 }}
           >
-            過去の更新情報（{olderEntries.length}件）
+            {historyExpanded ? '▼' : '▶'} 過去の更新情報（{historyEntries.length}件）
+          </Button>
+          <Box id={historyId} hidden={!historyExpanded}>
+            {historyEntries.map(entry => (
+              <Box component="article" key={entry.version} sx={{ mt: 1 }}>
+                <EntryHeader entry={entry} />
+                <EntryPoints points={entry.points} />
+              </Box>
+            ))}
           </Box>
-          {olderEntries.map(entry => (
-            <Box key={entry.version} sx={{ mt: 1 }}>
-              <EntryHeader entry={entry} />
-              <EntryPoints points={entry.points} />
-            </Box>
-          ))}
         </Box>
       )}
 


### PR DESCRIPTION
## Scope

- Show the two newest eligible release-note versions in the initial popup view.
- Render short releases in full and collapse long featured releases after two points behind an accessible `続きを読む` / `折りたたむ` button.
- Fold the third and older releases behind an accessible `▶ 過去の更新情報` disclosure.
- Preserve future-entry filtering, fallback version selection, badge acknowledgement, and the GitHub Releases link.
- Keep this PR limited to b1 popup layout and its regression coverage.

## Intent

Keep release notes discoverable without forcing users to scroll through the long v5.2.0 body before reaching HUD configuration. The future short v5.3.0 entry remains fully visible while v5.2.0 stays one click away.

## Validation

- `npm test -- --runInBand` (120 suites, 1166 tests)
- `npm run typecheck`
- `npm test -- --runInBand src/components/popup/WhatsNewSection.test.tsx` (review fix; 11 tests)
- `git diff --check` (review fix)
- `npm run build`
- `npm run e2e:smoke` (7 checks; first HUD config top = 511.05px, below the 550px guard)
- Visual inspection: `e2e/out/smoke-popup.png`
- `git diff --check`

## Head

`0fb2f115710aabbb3c0507f37231662a09e01ce6`