### PR TITLE
fix(hud): improve muted text contrast

### DIFF
--- a/src/components/Hud.test.tsx
+++ b/src/components/Hud.test.tsx
@@ -106,7 +106,7 @@ describe('Hud', () => {
       />
     )
 
-    expect(screen.getByText('Waiting for Hand...')).toBeInTheDocument()
+    expect(screen.getByText('Waiting for Hand...')).toHaveStyle({ color: '#b8b8b8' })
   })
 
   it('プレイヤーがいるがデータがない場合は"No Data"を表示', () => {
@@ -124,7 +124,7 @@ describe('Hud', () => {
       />
     )
 
-    expect(screen.getByText('No Data')).toBeInTheDocument()
+    expect(screen.getByText('No Data')).toHaveStyle({ color: '#b8b8b8' })
   })
 
   it('プレイヤー名と統計を表示', () => {

--- a/src/components/Hud.tsx
+++ b/src/components/Hud.tsx
@@ -14,6 +14,7 @@ import { PositionalStatsPanel } from './hud/PositionalStatsPanel'
 import { PositionalPanelTrigger } from './hud/PositionalPanelTrigger'
 import { RecentHandsPanel } from './hud/RecentHandsPanel'
 import { RecentHandsPanelTrigger } from './hud/RecentHandsPanelTrigger'
+import { HUD_MUTED_TEXT_COLOR } from './hud/hudColors'
 
 // Types
 interface PlayerPotOdds {
@@ -317,7 +318,7 @@ const Hud = memo((props: HudProps) => {
         >
           <DragHandle isHovering={isHovering} onMouseDown={handleMouseDown} />
           <div style={styles.header}>
-            <span style={{ ...styles.playerName, color: '#888888', fontStyle: 'italic' }}>
+            <span style={{ ...styles.playerName, color: HUD_MUTED_TEXT_COLOR, fontStyle: 'italic' }}>
               Waiting for Hand...
             </span>
             <PlayerTypeIcons />
@@ -340,7 +341,7 @@ const Hud = memo((props: HudProps) => {
         >
           <DragHandle isHovering={isHovering} onMouseDown={handleMouseDown} />
           <div style={styles.header}>
-            <span style={{ ...styles.playerName, color: '#888888' }}>
+            <span style={{ ...styles.playerName, color: HUD_MUTED_TEXT_COLOR }}>
               {playerName || `Player ${props.stat.playerId}`}
             </span>
             <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
@@ -369,7 +370,7 @@ const Hud = memo((props: HudProps) => {
             textAlign: 'center',
             minHeight: '20px',
           }}>
-            <span style={{ color: '#888888', fontSize: '9px' }}>No Data</span>
+            <span style={{ color: HUD_MUTED_TEXT_COLOR, fontSize: '9px' }}>No Data</span>
           </div>
           {props.isPositionalPanelOpen && (
             <PositionalStatsPanel playerId={props.stat.playerId} handEpoch={props.handEpoch} />

--- a/src/components/hud/CompactStatDisplay.test.tsx
+++ b/src/components/hud/CompactStatDisplay.test.tsx
@@ -78,7 +78,7 @@ describe('CompactStatDisplay', () => {
     )
 
     const vpipSegment = screen.getByText('50')
-    expect(vpipSegment).toHaveStyle({ color: '#888888' })
+    expect(vpipSegment).toHaveStyle({ color: '#b8b8b8' })
   })
 
   it('各セグメントに統計名+値+一言説明を含むtitleが付与される', () => {

--- a/src/components/hud/HudHeader.test.tsx
+++ b/src/components/hud/HudHeader.test.tsx
@@ -82,7 +82,7 @@ describe('HudHeader', () => {
     )
 
     const potOddsElement = screen.getByText('100/20 (17%)')
-    expect(potOddsElement).toHaveStyle({ color: '#888' })
+    expect(potOddsElement).toHaveStyle({ color: '#b8b8b8' })
   })
 
   it('ポットオッズがない場合は表示しない', () => {

--- a/src/components/hud/HudHeader.tsx
+++ b/src/components/hud/HudHeader.tsx
@@ -4,6 +4,7 @@ import type { StatResult } from '../../types/stats'
 import { PlayerTypeIcons } from './PlayerTypeIcons'
 import { PositionalPanelTrigger } from './PositionalPanelTrigger'
 import { RecentHandsPanelTrigger } from './RecentHandsPanelTrigger'
+import { HUD_MUTED_TEXT_COLOR } from './hudColors'
 
 interface PlayerPotOdds {
   spr?: number
@@ -94,7 +95,7 @@ export const HudHeader = memo(({ playerName, playerId, playerPotOdds, isPosition
           )}
           {hasPotOdds && (
             <span style={{ 
-              color: playerPotOdds.potOdds!.isPlayerTurn ? '#00ff00' : '#888',
+              color: playerPotOdds.potOdds!.isPlayerTurn ? '#00ff00' : HUD_MUTED_TEXT_COLOR,
               fontWeight: playerPotOdds.potOdds!.isPlayerTurn ? 'bold' : 'normal',
               whiteSpace: 'nowrap'
             }}>

--- a/src/components/hud/PositionalStatsPanel.test.tsx
+++ b/src/components/hud/PositionalStatsPanel.test.tsx
@@ -99,7 +99,7 @@ describe('PositionalStatsPanel', () => {
     const lowSampleCells = hjRow.querySelectorAll('[data-low-sample="true"]')
     expect(lowSampleCells.length).toBeGreaterThan(0)
     lowSampleCells.forEach(cell => {
-      expect(cell).toHaveStyle({ color: '#666666' })
+      expect(cell).toHaveStyle({ color: '#b8b8b8' })
     })
 
     // BTN行: vpip is [10,42] -> den=42 >= 10, not dimmed

--- a/src/components/hud/PositionalStatsPanel.tsx
+++ b/src/components/hud/PositionalStatsPanel.tsx
@@ -4,6 +4,7 @@ import { Position } from '../../types/game'
 import type { PositionalStatId, PositionalStatsBucketId, PositionalStatsResult } from '../../types/stats'
 import type { GetPositionalStatsMessage, PositionalStatsResponse, ErrorResponse } from '../../types/messages'
 import { sendMessageWithTimeout } from '../popup/send-message'
+import { HUD_MUTED_TEXT_COLOR } from './hudColors'
 
 interface PositionalStatsPanelProps {
   playerId: number
@@ -54,7 +55,7 @@ const styles = {
   placeholder: {
     padding: '6px 0',
     textAlign: 'center' as const,
-    color: '#888888',
+    color: HUD_MUTED_TEXT_COLOR,
     fontSize: '9px',
   } as CSSProperties,
 
@@ -91,7 +92,7 @@ const styles = {
   } as CSSProperties,
 
   lowSample: {
-    color: '#666666',
+    color: HUD_MUTED_TEXT_COLOR,
   } as CSSProperties,
 }
 

--- a/src/components/hud/RealTimeStatsDisplay.test.tsx
+++ b/src/components/hud/RealTimeStatsDisplay.test.tsx
@@ -65,7 +65,7 @@ describe('RealTimeStatsDisplay', () => {
 
     // Three of a Kindは0%でも表示される
     expect(screen.getByText('Three of a Kind')).toBeInTheDocument()
-    expect(screen.getByText('0.0%')).toBeInTheDocument()
+    expect(screen.getByText('0.0%')).toHaveStyle({ color: '#b8b8b8' })
   })
 
   it('手札改善情報がない場合は表示しない', () => {

--- a/src/components/hud/RealTimeStatsDisplay.tsx
+++ b/src/components/hud/RealTimeStatsDisplay.tsx
@@ -4,6 +4,7 @@ import type { RealTimeStats } from '../../realtime-stats/realtime-stats-service'
 import { getStartingHandRanking } from '../../utils/starting-hand-rankings'
 import { useDraggable } from './hooks/useDraggable'
 import { DragHandle } from './DragHandle'
+import { HUD_MUTED_TEXT_COLOR } from './hudColors'
 
 interface RealTimeStatsDisplayProps {
   stats: RealTimeStats
@@ -138,7 +139,7 @@ export const RealTimeStatsDisplay = memo(({ stats, seatIndex }: RealTimeStatsDis
               const probabilityColor = isComplete ? '#00ff00' : 
                                      isWaitingForAction ? '#cccccc' :  // Neutral color when waiting
                                      hasGoodOdds ? '#00ff00' : 
-                                     probability > 0 ? '#ff6666' : '#666'
+                                     probability > 0 ? '#ff6666' : HUD_MUTED_TEXT_COLOR
               
               return (
                 <tr key={improvement.rank} style={rowStyle}>

--- a/src/components/hud/RecentHandsPanel.test.tsx
+++ b/src/components/hud/RecentHandsPanel.test.tsx
@@ -40,7 +40,7 @@ describe('RecentHandsPanel', () => {
 
     render(<RecentHandsPanel playerId={123} />)
 
-    expect(screen.getByText('Loading hands…')).toBeInTheDocument()
+    expect(screen.getByText('Loading hands…')).toHaveStyle({ color: '#b8b8b8' })
 
     await waitFor(() => {
       expect(screen.getAllByTestId('recent-hands-row')).toHaveLength(3)
@@ -105,6 +105,7 @@ describe('RecentHandsPanel', () => {
     expect(rows[0]).toHaveTextContent('●')
     expect(rows[1]).not.toHaveTextContent('●')
     expect(rows[1]).toHaveTextContent('-')
+    expect(rows[1]!.querySelector('td:last-child span')).toHaveStyle({ color: '#b8b8b8' })
   })
 
   it('プリフロップ・ラインとポジションを表示する（nullは"—"）', async () => {

--- a/src/components/hud/RecentHandsPanel.tsx
+++ b/src/components/hud/RecentHandsPanel.tsx
@@ -5,6 +5,7 @@ import type { RecentHandEntry, RecentHandsResult } from '../../types/stats'
 import type { GetRecentHandsMessage, RecentHandsResponse, ErrorResponse } from '../../types/messages'
 import { sendMessageWithTimeout } from '../popup/send-message'
 import { isRedSuit } from '../../utils/card-utils'
+import { HUD_MUTED_TEXT_COLOR } from './hudColors'
 
 interface RecentHandsPanelProps {
   playerId: number
@@ -63,7 +64,7 @@ const styles = {
   placeholder: {
     padding: '6px 0',
     textAlign: 'center' as const,
-    color: '#888888',
+    color: HUD_MUTED_TEXT_COLOR,
     fontSize: '9px',
   } as CSSProperties,
 
@@ -103,7 +104,7 @@ const styles = {
   } as CSSProperties,
 
   notWon: {
-    color: '#888888',
+    color: HUD_MUTED_TEXT_COLOR,
   } as CSSProperties,
 
   showdownMarker: {

--- a/src/components/hud/StatDisplay.test.tsx
+++ b/src/components/hud/StatDisplay.test.tsx
@@ -112,7 +112,7 @@ describe('StatDisplay', () => {
 
       render(<StatDisplay displayStats={lowSample} formatValue={mockFormatValue} colorCoding />)
 
-      expect(screen.getByText('50.0% (5/10)')).toHaveStyle({ color: '#888888' })
+      expect(screen.getByText('50.0% (5/10)')).toHaveStyle({ color: '#b8b8b8' })
     })
 
     it('しきい値ルールのない統計はcolorCoding有効でも既定色のまま', () => {

--- a/src/components/hud/hudColors.test.ts
+++ b/src/components/hud/hudColors.test.ts
@@ -1,0 +1,35 @@
+import { HUD_MUTED_TEXT_COLOR } from './hudColors'
+
+const srgbChannelToLinear = (channel: number): number => {
+  const normalized = channel / 255
+  return normalized <= 0.04045
+    ? normalized / 12.92
+    : ((normalized + 0.055) / 1.055) ** 2.4
+}
+
+const relativeLuminance = (hex: string): number => {
+  const [red, green, blue] = [1, 3, 5].map(offset => Number.parseInt(hex.slice(offset, offset + 2), 16))
+  return (
+    0.2126 * srgbChannelToLinear(red!) +
+    0.7152 * srgbChannelToLinear(green!) +
+    0.0722 * srgbChannelToLinear(blue!)
+  )
+}
+
+const contrastRatio = (foreground: string, background: string): number => {
+  const lighter = Math.max(relativeLuminance(foreground), relativeLuminance(background))
+  const darker = Math.min(relativeLuminance(foreground), relativeLuminance(background))
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+describe('HUD text contrast', () => {
+  test('muted text meets WCAG AA on the bright representative normal-panel background', () => {
+    // Conservative 95th-percentile bright background sampled from normal HUD
+    // panels in docs/store-assets/store-1-hud.png. The old #888888 token was
+    // only 2.61:1 here; #b8b8b8 is 4.67:1 while remaining below #dddddd.
+    const representativeBrightPanelBackground = '#414946'
+
+    expect(contrastRatio(HUD_MUTED_TEXT_COLOR, representativeBrightPanelBackground)).toBeGreaterThanOrEqual(4.5)
+    expect(relativeLuminance(HUD_MUTED_TEXT_COLOR)).toBeLessThan(relativeLuminance('#dddddd'))
+  })
+})

--- a/src/components/hud/hudColors.ts
+++ b/src/components/hud/hudColors.ts
@@ -1,0 +1,6 @@
+/**
+ * Muted HUD text stays visibly subordinate to the default `#dddddd` values,
+ * while remaining readable where the translucent panel crosses bright table
+ * artwork. See hudColors.test.ts for the WCAG contrast regression baseline.
+ */
+export const HUD_MUTED_TEXT_COLOR = '#b8b8b8'

--- a/src/components/hud/statColorRules.ts
+++ b/src/components/hud/statColorRules.ts
@@ -13,12 +13,13 @@
  * dimmed gray used for low-confidence stats.
  */
 import type { StatValue } from '../../types/stats'
+import { HUD_MUTED_TEXT_COLOR } from './hudColors'
 
 /** Minimum opportunities (StatValue denominator) before a stat gets colored instead of dimmed gray. */
 export const MIN_DENOMINATOR_FOR_COLOR = 20
 
 /** Dimmed color shown for stats below {@link MIN_DENOMINATOR_FOR_COLOR}, matching StatDisplay's existing low-confidence style. */
-export const LOW_SAMPLE_COLOR = '#888888'
+export const LOW_SAMPLE_COLOR = HUD_MUTED_TEXT_COLOR
 
 /** One color band: values at or below `upTo` (inclusive) get `color`; `null` means "leave the default text color". A boundary value belongs to the band whose `upTo` it matches, not the next band up. */
 interface ColorBand {


### PR DESCRIPTION
## Scope

- Introduce one shared `#b8b8b8` muted HUD text token.
- Apply it to low-sample statistics, passive pot odds, waiting/no-data states, positional low-sample cells, recent-hand non-wins, and zero-probability realtime rows.
- Keep primary values (`#dddddd`), labels (`#aaaaaa`), threshold colors, normal/hover backgrounds, and dimmed-panel behavior unchanged.

## Contrast

The normal HUD panel is translucent (`rgba(0, 0, 0, 0.5)`), so the visible background varies with the table artwork. Using the conservative 95th-percentile bright panel background sampled from `docs/store-assets/store-1-hud.png` (`rgb(65, 73, 70)` / `#414946`):

- Before: `#888888` = **2.61:1**
- Before positional/zero state: `#666666` = **1.67:1**
- After: `#b8b8b8` = **4.67:1** (WCAG AA for normal text)

The new muted token remains below the `#dddddd` primary-value luminance, preserving information hierarchy. Hover uses the existing darker `rgba(0, 0, 0, 0.7)` background, and dimmed panels still restore full opacity on hover.

## Validation

- `npm test -- --runInBand` (121 suites / 1162 tests)
- `npm run typecheck`
- `npm run build`
- `npm run e2e:smoke` (6/6 checks)
- Visually inspected `e2e/out/smoke-hud.png` against the existing `docs/store-assets/store-1-hud.png` reference

Head SHA: `8f4cb5bd2a50b90941bfe2228f84ddff96dcf41c`