### PR TITLE
feat(hud): allow multiple recent-hand panels

### DIFF
--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -10,7 +10,7 @@ import type { ApiEvent } from '../types'
 // Mock components
 jest.mock('./Hud', () => ({
   __esModule: true,
-  default: ({ actualSeatIndex, stat, scale, statDisplayConfigs, realTimeStats, playerPotOdds, isPositionalPanelOpen, onTogglePositionalPanel, isRecentHandsPanelOpen, onToggleRecentHandsPanel, hudDisplayMode, hudColorCoding, isDimmed }: any) => (
+  default: ({ actualSeatIndex, stat, scale, statDisplayConfigs, realTimeStats, playerPotOdds, isPositionalPanelOpen, onTogglePositionalPanel, isRecentHandsPanelOpen, onToggleRecentHandsPanel, handEpoch, hudDisplayMode, hudColorCoding, isDimmed }: any) => (
     <div data-testid={`hud-${actualSeatIndex}`}>
       Player: {stat.playerId}
       Scale: {scale}
@@ -19,6 +19,7 @@ jest.mock('./Hud', () => ({
       PotOdds: {playerPotOdds ? 'yes' : 'no'}
       PositionalPanelOpen: {isPositionalPanelOpen ? 'yes' : 'no'}
       RecentHandsPanelOpen: {isRecentHandsPanelOpen ? 'yes' : 'no'}
+      HandEpoch: {handEpoch ?? 0}
       DisplayMode: {hudDisplayMode ?? 'undefined'}
       ColorCoding: {hudColorCoding === undefined ? 'undefined' : hudColorCoding ? 'yes' : 'no'}
       Dimmed: {isDimmed ? 'yes' : 'no'}
@@ -494,7 +495,7 @@ describe('App', () => {
       expect(screen.getByTestId('hud-1')).toHaveTextContent('PositionalPanelOpen: no')
     })
 
-    it('ポジション別パネルと直近ハンドパネルは互いに排他（同一プレイヤーでも別プレイヤーでも）', async () => {
+    it('直近ハンドは複数プレイヤーを同時に開け、同じトリガーはそのプレイヤーだけを閉じる', async () => {
       const user = userEvent.setup()
 
       render(<App />)
@@ -508,24 +509,159 @@ describe('App', () => {
       expect(screen.getByTestId('hud-0')).toHaveTextContent('PositionalPanelOpen: no')
       expect(screen.getByTestId('hud-0')).toHaveTextContent('RecentHandsPanelOpen: no')
 
-      // 席0のポジション別を開く
-      await user.click(screen.getByText('toggle-1'))
-      expect(screen.getByTestId('hud-0')).toHaveTextContent('PositionalPanelOpen: yes')
-      expect(screen.getByTestId('hud-0')).toHaveTextContent('RecentHandsPanelOpen: no')
-
-      // 同じプレイヤーの直近ハンドを開くと、ポジション別は自動的に閉じる
+      // 席0と席1の直近ハンドを順に開いても、先に開いた席0は閉じない。
       await user.click(screen.getByText('toggle-recent-1'))
-      expect(screen.getByTestId('hud-0')).toHaveTextContent('PositionalPanelOpen: no')
       expect(screen.getByTestId('hud-0')).toHaveTextContent('RecentHandsPanelOpen: yes')
+      expect(screen.getByTestId('hud-1')).toHaveTextContent('RecentHandsPanelOpen: no')
 
-      // 別プレイヤーのポジション別を開くと、席0の直近ハンドも自動的に閉じる
+      await user.click(screen.getByText('toggle-recent-2'))
+      expect(screen.getByTestId('hud-0')).toHaveTextContent('RecentHandsPanelOpen: yes')
+      expect(screen.getByTestId('hud-1')).toHaveTextContent('RecentHandsPanelOpen: yes')
+
+      // 同じプレイヤーをもう一度押すと、そのパネルだけ閉じる。
+      await user.click(screen.getByText('toggle-recent-1'))
+      expect(screen.getByTestId('hud-0')).toHaveTextContent('RecentHandsPanelOpen: no')
+      expect(screen.getByTestId('hud-1')).toHaveTextContent('RecentHandsPanelOpen: yes')
+    })
+
+    it('複数の直近ハンドパネルが開いたまま同じhandEpoch更新を受け取る', async () => {
+      const user = userEvent.setup()
+
+      render(<App />)
+
+      await act(async () => {
+        window.dispatchEvent(
+          new CustomEvent('PokerChaseServiceEvent', { detail: mockStatsData })
+        )
+      })
+
+      await user.click(screen.getByText('toggle-recent-1'))
+      await user.click(screen.getByText('toggle-recent-2'))
+
+      await act(async () => {
+        window.dispatchEvent(
+          new CustomEvent('PokerChaseServiceEvent', {
+            detail: { ...mockStatsData, handEpoch: 7 },
+          })
+        )
+      })
+
+      expect(screen.getByTestId('hud-0')).toHaveTextContent('RecentHandsPanelOpen: yes')
+      expect(screen.getByTestId('hud-1')).toHaveTextContent('RecentHandsPanelOpen: yes')
+      expect(screen.getByTestId('hud-0')).toHaveTextContent('HandEpoch: 7')
+      expect(screen.getByTestId('hud-1')).toHaveTextContent('HandEpoch: 7')
+    })
+
+    it('ポジション別パネルとの従来の種別間排他は維持する', async () => {
+      const user = userEvent.setup()
+
+      render(<App />)
+
+      await act(async () => {
+        window.dispatchEvent(
+          new CustomEvent('PokerChaseServiceEvent', { detail: mockStatsData })
+        )
+      })
+
+      await user.click(screen.getByText('toggle-recent-1'))
+      await user.click(screen.getByText('toggle-recent-2'))
+      expect(screen.getByTestId('hud-0')).toHaveTextContent('RecentHandsPanelOpen: yes')
+      expect(screen.getByTestId('hud-1')).toHaveTextContent('RecentHandsPanelOpen: yes')
+
+      // ポジション別を開くと、開いていた直近ハンド群は全て閉じる。
       await user.click(screen.getByText('toggle-2'))
       expect(screen.getByTestId('hud-0')).toHaveTextContent('RecentHandsPanelOpen: no')
+      expect(screen.getByTestId('hud-1')).toHaveTextContent('RecentHandsPanelOpen: no')
       expect(screen.getByTestId('hud-1')).toHaveTextContent('PositionalPanelOpen: yes')
 
-      // 同じトリガーをもう一度クリックすると閉じる
-      await user.click(screen.getByText('toggle-2'))
+      // 直近ハンドを開けばポジション別は閉じる。
+      await user.click(screen.getByText('toggle-recent-1'))
       expect(screen.getByTestId('hud-1')).toHaveTextContent('PositionalPanelOpen: no')
+      expect(screen.getByTestId('hud-0')).toHaveTextContent('RecentHandsPanelOpen: yes')
+    })
+
+    it('セッション終了でheroを含む全ての開状態をリセットする', async () => {
+      const user = userEvent.setup()
+
+      render(<App />)
+      await act(async () => {
+        window.dispatchEvent(
+          new CustomEvent('PokerChaseServiceEvent', { detail: mockStatsData })
+        )
+      })
+      await user.click(screen.getByText('toggle-recent-1'))
+      await user.click(screen.getByText('toggle-recent-2'))
+
+      await act(async () => {
+        window.dispatchEvent(new CustomEvent('PokerChaseSessionEndEvent'))
+      })
+
+      // heroのstats自体は残るが、パネルの一時UI状態はセッションをまたがない。
+      expect(screen.getByTestId('hud-0')).toHaveTextContent('Player: 1')
+      expect(screen.getByTestId('hud-0')).toHaveTextContent('RecentHandsPanelOpen: no')
+      expect(screen.getByTestId('hud-1')).toHaveTextContent('RecentHandsPanelOpen: no')
+    })
+
+    it('テーブル切替を検出したら、同じhero playerIdのパネルも含めてリセットする', async () => {
+      const user = userEvent.setup()
+
+      render(<App />)
+      await act(async () => {
+        window.dispatchEvent(
+          new CustomEvent('PokerChaseServiceEvent', { detail: mockStatsData })
+        )
+      })
+      await user.click(screen.getByText('toggle-recent-1'))
+      await user.click(screen.getByText('toggle-recent-2'))
+
+      const nextTableStats: StatsData['stats'] = mockStatsData.stats.map((stat, index) => (
+        index === 0 ? stat : { playerId: 100 + index, statResults: [] }
+      ))
+      await act(async () => {
+        window.dispatchEvent(
+          new CustomEvent('PokerChaseServiceEvent', { detail: { stats: nextTableStats } })
+        )
+      })
+
+      // hero(1)は新テーブルにも残るため単なる「非表示playerIdのprune」では
+      // 閉じない。table-change境界で全開状態を明示リセットすることを確認する。
+      expect(screen.getByTestId('hud-0')).toHaveTextContent('Player: 1')
+      expect(screen.getByTestId('hud-0')).toHaveTextContent('RecentHandsPanelOpen: no')
+    })
+
+    it('席交代で消えたplayerIdの開状態をpruneし、別席へ再登場しても勝手に再オープンしない', async () => {
+      const user = userEvent.setup()
+
+      render(<App />)
+      await act(async () => {
+        window.dispatchEvent(
+          new CustomEvent('PokerChaseServiceEvent', { detail: mockStatsData })
+        )
+      })
+      await user.click(screen.getByText('toggle-recent-2'))
+      expect(screen.getByTestId('hud-1')).toHaveTextContent('RecentHandsPanelOpen: yes')
+
+      const afterTakeover: StatsData['stats'] = mockStatsData.stats.map((stat, index) => (
+        index === 1 ? { playerId: 99, statResults: [] } : stat
+      ))
+      await act(async () => {
+        window.dispatchEvent(
+          new CustomEvent('PokerChaseServiceEvent', { detail: { stats: afterTakeover } })
+        )
+      })
+      expect(screen.getByTestId('hud-1')).toHaveTextContent('Player: 99')
+
+      const reappearedElsewhere: StatsData['stats'] = afterTakeover.map((stat, index) => (
+        index === 5 ? { playerId: 2, statResults: [] } : stat
+      ))
+      await act(async () => {
+        window.dispatchEvent(
+          new CustomEvent('PokerChaseServiceEvent', { detail: { stats: reappearedElsewhere } })
+        )
+      })
+
+      expect(screen.getByTestId('hud-5')).toHaveTextContent('Player: 2')
+      expect(screen.getByTestId('hud-5')).toHaveTextContent('RecentHandsPanelOpen: no')
     })
   })
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -82,11 +82,15 @@ const App = memo(() => {
     dimmedSeatIndicesRef.current = next
     setDimmedSeatIndices(next)
   }, [])
-  // ドリルダウンパネル（ポジション別 / 直近ハンド）: 開いているのは常にどちらか
-  // 一方、高々1プレイヤー分（HUDツリーにローカルなReact state。グローバル設定
-  // への永続化はv1では不要）。#128のポジション別ドリルダウンの単一state管理を
-  // 拡張し、パネル種別を持たせることで両パネルを互いに排他にしている。
-  const [openPanel, setOpenPanel] = useState<{ playerId: number, kind: 'positional' | 'recentHands' } | null>(null)
+  // ドリルダウンパネルはHUDツリーにローカルな一時状態（グローバル設定への
+  // 永続化は不要）。ポジション別は従来どおり高々1プレイヤー、直近ハンドは
+  // playerIdの集合で管理して複数プレイヤーを独立に開閉できる。
+  //
+  // パネル種別間の従来の排他は維持する: ポジション別を開けば直近ハンド群を
+  // 閉じ、直近ハンドを1つでも開けばポジション別を閉じる。今回外すのは
+  // 「直近ハンドAを開くと直近ハンドBが閉じる」という同種パネル間の排他だけ。
+  const [openPositionalPanelPlayerId, setOpenPositionalPanelPlayerId] = useState<number | null>(null)
+  const [openRecentHandsPanelPlayerIds, setOpenRecentHandsPanelPlayerIds] = useState<ReadonlySet<number>>(() => new Set())
   // 監査指摘11（P2）対応: 生きたハンドが1件完了するたびに増える「hand epoch」
   // （ports.tsの`liveBroadcastSequence`をそのまま反映、上のStatsDataWithHandEpoch
   // 参照）。Hud経由でドリルダウンパネルへpropとして渡し、そのフェッチeffectの
@@ -96,12 +100,47 @@ const App = memo(() => {
   const [handEpoch, setHandEpoch] = useState(0)
 
   const handleTogglePositionalPanel = useCallback((playerId: number) => {
-    setOpenPanel(prev => (prev?.kind === 'positional' && prev.playerId === playerId) ? null : { playerId, kind: 'positional' })
+    setOpenPositionalPanelPlayerId(prev => prev === playerId ? null : playerId)
+    setOpenRecentHandsPanelPlayerIds(new Set())
   }, [])
 
   const handleToggleRecentHandsPanel = useCallback((playerId: number) => {
-    setOpenPanel(prev => (prev?.kind === 'recentHands' && prev.playerId === playerId) ? null : { playerId, kind: 'recentHands' })
+    setOpenPositionalPanelPlayerId(null)
+    setOpenRecentHandsPanelPlayerIds(prev => {
+      const next = new Set(prev)
+      if (next.has(playerId)) next.delete(playerId)
+      else next.add(playerId)
+      return next
+    })
   }, [])
+
+  const closeAllDrillDownPanels = useCallback(() => {
+    setOpenPositionalPanelPlayerId(null)
+    setOpenRecentHandsPanelPlayerIds(new Set())
+  }, [])
+
+  // 表示中のラインナップからplayerIdが消える境界（席交代、非heroの
+  // セッション終了処理、batch refreshなど）で、その開状態もpruneする。
+  // これにより古いplayerIdが別席・別セッションで再登場しても勝手に
+  // 再オープンしない。bust済みプレイヤーはdimCache経由でstatsに残るため、
+  // 通常のセッション/テーブルリセットまでは開状態を維持する。
+  useEffect(() => {
+    const displayedPlayerIds = new Set(
+      stats.filter(isExistPlayerStats).map(stat => stat.playerId)
+    )
+    setOpenPositionalPanelPlayerId(prev => (
+      prev !== null && !displayedPlayerIds.has(prev) ? null : prev
+    ))
+    setOpenRecentHandsPanelPlayerIds(prev => {
+      let changed = false
+      const next = new Set<number>()
+      for (const playerId of prev) {
+        if (displayedPlayerIds.has(playerId)) next.add(playerId)
+        else changed = true
+      }
+      return changed ? next : prev
+    })
+  }, [stats])
 
   // 仕様（PR #191、オーナー承認の縮小スコープ、2026-07-20。sola:
   // 「それほど重要な機能ではないので、bで十分です」）:
@@ -292,6 +331,7 @@ const App = memo(() => {
       const isTableChange = conflictSeatCount >= 2 && !hasContinuitySeat
       if (isTableChange) {
         dimCache.clear()
+        closeAllDrillDownPanels()
       }
 
       const nextDimmedSeatIndices = new Set<number>()
@@ -315,7 +355,7 @@ const App = memo(() => {
       applyDimmedSeatIndices(nextDimmedSeatIndices)
       setStats(dimmedStats)
     },
-    [applyDimmedSeatIndices]
+    [applyDimmedSeatIndices, closeAllDrillDownPanels]
   )
 
   useEffect(() => {
@@ -350,6 +390,7 @@ const App = memo(() => {
   // 表示であり、セッションをまたいで残す理由が無いため。heroパネル(座席0)は#158の
   // 通りここでは一切触らない(pregameでのキャリア統計復元は別経路)。
   const handleSessionEnd = useCallback(() => {
+    closeAllDrillDownPanels()
     const dimCache = dimCacheRef.current
     // #179 post-merge review P2「Preserve the hero by player id at session
     // end」指摘: 直前の更新が観戦モードdeal（上のisSpectatorDeal分岐）だった
@@ -371,7 +412,7 @@ const App = memo(() => {
     setStats(prev => prev.map((stat, seatIndex) => (
       seatIndex === HERO_SEAT_INDEX ? (heroStat ?? stat) : { playerId: -1 }
     )))
-  }, [applyDimmedSeatIndices])
+  }, [applyDimmedSeatIndices, closeAllDrillDownPanels])
 
   useEffect(() => {
     window.addEventListener(POKER_CHASE_SESSION_END_EVENT, handleSessionEnd)
@@ -691,9 +732,9 @@ const App = memo(() => {
               statDisplayConfigs={statDisplayConfigs}
               realTimeStats={position.actualSeatIndex === 0 ? allPlayersRealTimeStats?.heroStats : undefined}
               playerPotOdds={allPlayersRealTimeStats?.playerStats[position.originalSeatIndex]}
-              isPositionalPanelOpen={openPanel?.kind === 'positional' && openPanel.playerId === position.stat.playerId}
+              isPositionalPanelOpen={openPositionalPanelPlayerId === position.stat.playerId}
               onTogglePositionalPanel={() => handleTogglePositionalPanel(position.stat.playerId)}
-              isRecentHandsPanelOpen={openPanel?.kind === 'recentHands' && openPanel.playerId === position.stat.playerId}
+              isRecentHandsPanelOpen={openRecentHandsPanelPlayerIds.has(position.stat.playerId)}
               onToggleRecentHandsPanel={() => handleToggleRecentHandsPanel(position.stat.playerId)}
               handEpoch={handEpoch}
               hudDisplayMode={uiConfig.hudDisplayMode}

--- a/src/components/Hud.test.tsx
+++ b/src/components/Hud.test.tsx
@@ -562,6 +562,65 @@ describe('Hud', () => {
       })
     })
 
+    it('複数プレイヤーのパネルを同時表示し、handEpoch更新時にそれぞれ再フェッチする', async () => {
+      (chrome.runtime.sendMessage as jest.Mock).mockImplementation(
+        (_message: unknown, callback: (response: unknown) => void) => {
+          callback({
+            success: true,
+            recentHands: { computedAt: Date.now(), hands: [] },
+          })
+        }
+      )
+      const secondPlayerStats: PlayerStats = {
+        playerId: 456,
+        statResults: [
+          { id: 'playerName', name: 'Name', value: 'SecondPlayer', formatted: 'SecondPlayer' },
+        ],
+      }
+      const renderBoth = (handEpoch: number) => (
+        <>
+          <Hud
+            actualSeatIndex={0}
+            stat={mockPlayerStats}
+            scale={1}
+            statDisplayConfigs={mockStatDisplayConfigs}
+            onToggleRecentHandsPanel={jest.fn()}
+            isRecentHandsPanelOpen={true}
+            handEpoch={handEpoch}
+          />
+          <Hud
+            actualSeatIndex={1}
+            stat={secondPlayerStats}
+            scale={1}
+            statDisplayConfigs={mockStatDisplayConfigs}
+            onToggleRecentHandsPanel={jest.fn()}
+            isRecentHandsPanelOpen={true}
+            handEpoch={handEpoch}
+          />
+        </>
+      )
+
+      const { rerender } = render(renderBoth(1))
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('recent-hands-panel')).toHaveLength(2)
+      })
+      expect(screen.getAllByTestId('recent-hands-panel').map(panel => panel.dataset.playerId)).toEqual(['123', '456'])
+      expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+        { action: 'getRecentHands', playerId: 123 },
+        expect.any(Function)
+      )
+      expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+        { action: 'getRecentHands', playerId: 456 },
+        expect.any(Function)
+      )
+
+      rerender(renderBoth(2))
+      await waitFor(() => {
+        expect(chrome.runtime.sendMessage).toHaveBeenCalledTimes(4)
+      })
+    })
+
     it('ポジション別トリガーと同時に表示しても両方独立してクリックできる', async () => {
       const handleTogglePositional = jest.fn()
       const handleToggleRecentHands = jest.fn()

--- a/src/components/Hud.tsx
+++ b/src/components/Hud.tsx
@@ -35,11 +35,11 @@ interface HudProps {
   statDisplayConfigs: StatDisplayConfig[]
   realTimeStats?: RealTimeStats
   playerPotOdds?: PlayerPotOdds
-  /** ポジション別ドリルダウンパネルが開いているか（Appが単一のopenPlayerIdで管理） */
+  /** ポジション別ドリルダウンパネルが開いているか（Appが単一playerIdで管理） */
   isPositionalPanelOpen?: boolean
   /** ドリルダウンパネルの開閉トグル。渡された時のみヘッダーにトリガーを表示する */
   onTogglePositionalPanel?: () => void
-  /** 直近ハンド・ドリルダウンパネルが開いているか（Appが単一のopenPanelで管理、ポジション別と排他） */
+  /** 直近ハンド・ドリルダウンパネルが開いているか（AppがplayerId集合で管理） */
   isRecentHandsPanelOpen?: boolean
   /** 直近ハンド・ドリルダウンパネルの開閉トグル。渡された時のみヘッダーにトリガーを表示する */
   onToggleRecentHandsPanel?: () => void

--- a/src/components/hud/HudHeader.test.tsx
+++ b/src/components/hud/HudHeader.test.tsx
@@ -182,7 +182,7 @@ describe('HudHeader', () => {
       expect(handleToggle).toHaveBeenCalledTimes(1)
     })
 
-    it('isRecentHandsPanelOpenに応じてaria-expandedが変わる', () => {
+    it('isRecentHandsPanelOpenに応じてaria-expandedが変わり、対応パネルをaria-controlsで示す', () => {
       const { rerender } = render(
         <HudHeader
           playerName="TestPlayer"
@@ -194,6 +194,7 @@ describe('HudHeader', () => {
 
       const trigger = screen.getByTitle('直近ハンド')
       expect(trigger).toHaveAttribute('aria-expanded', 'false')
+      expect(trigger).toHaveAttribute('aria-controls', 'recent-hands-panel-123')
 
       rerender(
         <HudHeader
@@ -205,6 +206,23 @@ describe('HudHeader', () => {
       )
 
       expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('native buttonとしてキーボードのEnterで開閉できる', async () => {
+      const handleToggle = jest.fn()
+      render(
+        <HudHeader
+          playerName="TestPlayer"
+          playerId={123}
+          onToggleRecentHandsPanel={handleToggle}
+        />
+      )
+
+      const trigger = screen.getByTitle('直近ハンド')
+      trigger.focus()
+      await userEvent.keyboard('{Enter}')
+
+      expect(handleToggle).toHaveBeenCalledTimes(1)
     })
 
     it('両トリガーが同時に表示されても独立している', async () => {

--- a/src/components/hud/RecentHandsPanel.test.tsx
+++ b/src/components/hud/RecentHandsPanel.test.tsx
@@ -64,6 +64,16 @@ describe('RecentHandsPanel', () => {
     })
   })
 
+  it('triggerから参照できるplayer固有regionとして公開する', () => {
+    mockSendMessage.mockImplementation(() => {})
+
+    render(<RecentHandsPanel playerId={999} />)
+
+    const panel = screen.getByRole('region', { name: 'Player 999の直近ハンド' })
+    expect(panel).toHaveAttribute('id', 'recent-hands-panel-999')
+    expect(panel).toHaveAttribute('data-player-id', '999')
+  })
+
   it('新しい順（ハンドID降順）に表示する', async () => {
     mockSendMessage.mockImplementation((_message: unknown, callback: (response: unknown) => void) => {
       callback({ success: true, recentHands: buildResult() })

--- a/src/components/hud/RecentHandsPanel.tsx
+++ b/src/components/hud/RecentHandsPanel.tsx
@@ -134,6 +134,13 @@ const styles = {
 export const RecentHandsPanel = memo(({ playerId, handEpoch }: RecentHandsPanelProps) => {
   const [status, setStatus] = useState<FetchStatus>('loading')
   const [data, setData] = useState<RecentHandsResult | undefined>(undefined)
+  const panelProps = {
+    id: `recent-hands-panel-${playerId}`,
+    role: 'region',
+    'aria-label': `Player ${playerId}の直近ハンド`,
+    'data-testid': 'recent-hands-panel',
+    'data-player-id': playerId,
+  } as const
 
   useEffect(() => {
     let cancelled = false
@@ -165,7 +172,7 @@ export const RecentHandsPanel = memo(({ playerId, handEpoch }: RecentHandsPanelP
 
   if (status === 'loading') {
     return (
-      <div style={styles.panel} data-testid="recent-hands-panel">
+      <div style={styles.panel} {...panelProps}>
         <div style={styles.placeholder}>Loading hands…</div>
       </div>
     )
@@ -173,7 +180,7 @@ export const RecentHandsPanel = memo(({ playerId, handEpoch }: RecentHandsPanelP
 
   if (status === 'error' || !data) {
     return (
-      <div style={styles.panel} data-testid="recent-hands-panel">
+      <div style={styles.panel} {...panelProps}>
         <div style={styles.placeholder}>—</div>
       </div>
     )
@@ -181,7 +188,7 @@ export const RecentHandsPanel = memo(({ playerId, handEpoch }: RecentHandsPanelP
 
   if (data.hands.length === 0) {
     return (
-      <div style={styles.panel} data-testid="recent-hands-panel">
+      <div style={styles.panel} {...panelProps}>
         <div style={styles.placeholder}>No hands yet</div>
       </div>
     )
@@ -190,7 +197,7 @@ export const RecentHandsPanel = memo(({ playerId, handEpoch }: RecentHandsPanelP
   const now = Date.now()
 
   return (
-    <div style={styles.panel} data-testid="recent-hands-panel">
+    <div style={styles.panel} {...panelProps}>
       <table style={styles.table}>
         <thead>
           <tr>

--- a/src/components/hud/RecentHandsPanelTrigger.tsx
+++ b/src/components/hud/RecentHandsPanelTrigger.tsx
@@ -39,6 +39,7 @@ export const RecentHandsPanelTrigger = memo(({ playerName, playerId, isOpen, onT
     title="直近ハンド"
     aria-label={`${playerName || `Player ${playerId}`}の直近ハンドを${isOpen ? '閉じる' : '開く'}`}
     aria-expanded={isOpen ?? false}
+    aria-controls={`recent-hands-panel-${playerId}`}
     onMouseDown={(e) => e.stopPropagation()}
     onClick={(e) => {
       e.stopPropagation()


### PR DESCRIPTION
## Summary
- track open recent-hand histories by player ID so several HUDs can remain expanded
- keep each player toggle independent while preserving cross-type exclusivity with positional details
- clear stale open state on player removal, table change, and session end
- connect each native trigger to a player-specific accessible region

## Validation
- `npm test -- --runInBand`
- `npm test -- --runInBand src/components/App.test.tsx src/components/Hud.test.tsx src/components/hud/HudHeader.test.tsx src/components/hud/RecentHandsPanel.test.tsx` (109 tests)
- `npm run typecheck`
- `npm run build`
- `npm run e2e:smoke` (6 checks)
- manual 1920x1080 fixture check: two histories stayed open, fully inside the viewport, without overlapping each other

## Head
`23941487db87c52e15d16e10cac5136293dcef7a`