### PR TITLE
fix(hud): show pot odds before SPR

### DIFF
--- a/src/components/Hud.test.tsx
+++ b/src/components/Hud.test.tsx
@@ -144,7 +144,7 @@ describe('Hud', () => {
     expect(screen.getByText('20.0% (20/100)')).toBeInTheDocument()
   })
 
-  it('ポットオッズとSPRを表示', () => {
+  it.each(['full', 'compact'] as const)('%s HUDでポットオッズをSPRより先に表示', (hudDisplayMode) => {
     render(
       <Hud
         actualSeatIndex={0}
@@ -152,11 +152,14 @@ describe('Hud', () => {
         scale={1}
         statDisplayConfigs={mockStatDisplayConfigs}
         playerPotOdds={mockPlayerPotOdds}
+        hudDisplayMode={hudDisplayMode}
       />
     )
 
-    expect(screen.getByText('100/20 (17%)')).toBeInTheDocument()
-    expect(screen.getByText('SPR:10.5')).toBeInTheDocument()
+    const potOdds = screen.getByText('100/20 (17%)')
+    const spr = screen.getByText('SPR:10.5')
+
+    expect(potOdds.compareDocumentPosition(spr) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 
   it('ヒーロー（席0）の場合はリアルタイム統計を表示', () => {

--- a/src/components/hud/HudHeader.test.tsx
+++ b/src/components/hud/HudHeader.test.tsx
@@ -13,7 +13,7 @@ describe('HudHeader', () => {
     expect(screen.getByText('Player 123')).toBeInTheDocument()
   })
 
-  it('ポットオッズを表示', () => {
+  it('ポットオッズをSPRより先に表示し、各値の対応を維持する', () => {
     const playerPotOdds = {
       spr: 10.5,
       potOdds: {
@@ -33,8 +33,12 @@ describe('HudHeader', () => {
       />
     )
 
-    expect(screen.getByText('100/20 (17%)')).toBeInTheDocument()
-    expect(screen.getByText('SPR:10.5')).toBeInTheDocument()
+    const potOdds = screen.getByText('100/20 (17%)')
+    const spr = screen.getByText('SPR:10.5')
+
+    expect(potOdds).toBeInTheDocument()
+    expect(spr).toBeInTheDocument()
+    expect(potOdds.compareDocumentPosition(spr) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 
   it('プレイヤーのターンの場合はポットオッズがハイライトされる', () => {

--- a/src/components/hud/HudHeader.tsx
+++ b/src/components/hud/HudHeader.tsx
@@ -88,11 +88,6 @@ export const HudHeader = memo(({ playerName, playerId, playerPotOdds, isPosition
               離席
             </span>
           )}
-          {hasSpr && (
-            <span style={{ color: '#ffcc00', fontWeight: 'bold', whiteSpace: 'nowrap' }}>
-              SPR:{playerPotOdds.spr}
-            </span>
-          )}
           {hasPotOdds && (
             <span style={{ 
               color: playerPotOdds.potOdds!.isPlayerTurn ? '#00ff00' : HUD_MUTED_TEXT_COLOR,
@@ -100,6 +95,11 @@ export const HudHeader = memo(({ playerName, playerId, playerPotOdds, isPosition
               whiteSpace: 'nowrap'
             }}>
               {playerPotOdds.potOdds!.pot}/{playerPotOdds.potOdds!.call} ({playerPotOdds.potOdds!.percentage.toFixed(0)}%)
+            </span>
+          )}
+          {hasSpr && (
+            <span style={{ color: '#ffcc00', fontWeight: 'bold', whiteSpace: 'nowrap' }}>
+              SPR:{playerPotOdds.spr}
             </span>
           )}
           {onTogglePositionalPanel && (


### PR DESCRIPTION
## Summary
- render pot odds before SPR in the shared HUD header
- preserve each metric's value, color, font weight, spacing, calculation, and update flow
- lock the DOM order in the shared header and in both full and compact HUD modes

All seat positions and display densities use the same `HudHeader`, so this single visual-order change applies consistently without branching layout behavior.

## Validation
- `npm test -- --runInBand src/components/hud/HudHeader.test.tsx src/components/Hud.test.tsx` (52 tests)
- `npm test -- --runInBand` (123 suites, 1184 tests)
- `npm run typecheck`
- `npm run build`
- `npm run e2e:smoke` (7 checks)
- Playwright Visual Mockup at 1920x1080 and 800x600: verified `1740/640 (27%)` precedes `SPR:2.7`, both remain on one line with the existing 4px gap/colors/weights, and the page has no horizontal overflow

## Head
`a2292f4e8347d9f9b6af7c4824cb9a333bdb54c9`