### PR TITLE
docs: use marquee tile as README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An unofficial Chrome extension providing real-time poker statistics and hand history tracking.
 
-![PokerChase HUD](./README.png)
+![PokerChase HUD marquee promotional tile](./docs/store-assets/promo-marquee-1400x560.png)
 
 > **Note**: This codebase was primarily written by [Claude Code](https://claude.ai/code), demonstrating AI-assisted software development capabilities.
 


### PR DESCRIPTION
## Summary

- Replaces only the README top/hero image reference with the existing Chrome Web Store marquee promotional tile.
- Updates the image alt text to identify the asset as the PokerChase HUD marquee promotional tile.
- Preserves `README.png` and every existing store asset.

## Asset provenance

- Source: `docs/store-assets/promo-marquee-1400x560.png`, introduced by merged PR #205 (`fb0422c`).
- Verified dimensions/format: 1400x560, 8-bit RGB PNG, no alpha channel.
- SHA-256: `0d285065eb02063369cfb1406af34af7595d00f4fad0af208904748d0ab279ee`.
- Visually inspected at original resolution: branded left panel plus anonymized real-gameplay HUD composition; no replacement image was generated.

## Validation

- README relative image link resolves with exact path and case.
- `file` and `sips` successfully parse the PNG and confirm dimensions/format/no alpha.
- Local Markdown source and the referenced image were visually inspected.
- `git diff --check`
- `npm run typecheck`
- `npm run build`

## Head

- `605efa74c7c4f26c5a146bf9ea72992f692aab43`

Codex session: `019f8719-f926-7e81-ae3a-3924c8efbfe9`