### PR TITLE
fix: preserve MTT hand receive chronology

### DIFF
--- a/src/services/positional-stats-service.test.ts
+++ b/src/services/positional-stats-service.test.ts
@@ -262,11 +262,12 @@ describe('PositionalStatsService', () => {
     }
   })
 
-  test('handLimitFilter keeps only the most recent N hands, sorted by id desc like calcStats', async () => {
+  test('handLimitFilter keeps the most recent N legacy hands with deterministic HandId fallback', async () => {
     service.handLimitFilter = 3
     const result = await getPositionalStats(db, service, PLAYER_ID)
 
-    // Top 3 hands by id: 10 (BTN), 9 (BTN), 8 (HJ)
+    // These legacy fixtures omit approxTimestamp, so the documented fallback
+    // keeps the prior HandId order: 10 (BTN), 9 (BTN), 8 (HJ).
     const btn = bucketOf(result, Position.BTN)
     expect(btn.handsN).toBe(2)
     expect(btn.stats.vpip).toEqual([2, 2])

--- a/src/services/positional-stats-service.ts
+++ b/src/services/positional-stats-service.ts
@@ -30,6 +30,7 @@ import type { PokerChaseDB } from '../db/poker-chase-db'
 import type PokerChaseService from './poker-chase-service'
 import { defaultRegistry } from '../stats'
 import { matchesTableSizeFilter } from '../utils/table-size'
+import { compareHandsNewestFirst } from '../utils/hand-order'
 
 /** Bucket display order: standard late→early preflop order, blinds, then unknown. */
 const POSITION_BUCKETS: PositionalStatsBucketId[] = [
@@ -223,7 +224,7 @@ export async function getPositionalStats(
 
   if (service.handLimitFilter !== undefined && service.handLimitFilter > 0) {
     allPlayerHands = [...allPlayerHands]
-      .sort((a, b) => b.id - a.id)
+      .sort(compareHandsNewestFirst)
       .slice(0, service.handLimitFilter)
   }
 

--- a/src/services/recent-hands-service.test.ts
+++ b/src/services/recent-hands-service.test.ts
@@ -125,7 +125,7 @@ describe('RecentHandsService', () => {
       await db.hands.bulkAdd(hands)
     })
 
-    test('returns hands newest-first (by hand id) and applies the limit', async () => {
+    test('returns timestamped hands newest-first and applies the limit', async () => {
       const result = await getRecentHands(db, service, PLAYER_ID, 3)
       expect(result.hands.map(h => h.handId)).toEqual([5, 4, 3])
       expect(typeof result.computedAt).toBe('number')

--- a/src/services/recent-hands-service.ts
+++ b/src/services/recent-hands-service.ts
@@ -28,6 +28,7 @@ import type { PokerChaseDB } from '../db/poker-chase-db'
 import type PokerChaseService from './poker-chase-service'
 import { matchesTableSizeFilter } from '../utils/table-size'
 import { formatCardsArray } from '../utils/card-utils'
+import { compareHandsNewestFirst } from '../utils/hand-order'
 
 /** デフォルトの取得件数（「直近10ハンド」）。 */
 export const DEFAULT_RECENT_HANDS_LIMIT = 10
@@ -256,7 +257,7 @@ export async function getRecentHands(
   // handLimitFilterは意図的に適用しない（このパネル自体の「直近N件」が
   // 独立したlimitのため、仕様通り）。新しいハンドから優先して上位limit件を選ぶ。
   const recentHands = [...allPlayerHands]
-    .sort((a, b) => b.id - a.id)
+    .sort(compareHandsNewestFirst)
     .slice(0, effectiveLimit)
 
   if (recentHands.length === 0) {

--- a/src/streams/mtt-table-move-lifecycle.test.ts
+++ b/src/streams/mtt-table-move-lifecycle.test.ts
@@ -1,0 +1,124 @@
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { getPositionalStats, clearPositionalStatsCache } from '../services/positional-stats-service'
+import { getRecentHands, clearRecentHandsCache } from '../services/recent-hands-service'
+import { MTT_TABLE_MOVE_FIXTURE } from '../test-fixtures/mtt-table-move-lifecycle'
+import { ApiType, apiEventSchemas } from '../types/api'
+import { Position } from '../types/game'
+import type { ApiEvent } from '../types/api'
+import { HandLogExporter } from '../utils/hand-log-exporter'
+
+describe('sanitized MTT table-move lifecycle fixture', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+
+  beforeEach(async () => {
+    clearPositionalStatsCache()
+    clearRecentHandsCache()
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    service = new PokerChaseService({ db })
+    await service.ready
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    db.close()
+    await db.delete()
+  })
+
+  test('contains schema-valid events with only synthetic/redacted identity fields', () => {
+    for (const event of MTT_TABLE_MOVE_FIXTURE.events) {
+      expect(() => apiEventSchemas[event.ApiTypeId]!.parse(event)).not.toThrow()
+    }
+
+    const entryIds = MTT_TABLE_MOVE_FIXTURE.events
+      .filter((event): event is ApiEvent<ApiType.EVT_ENTRY_QUEUED> => event.ApiTypeId === ApiType.EVT_ENTRY_QUEUED)
+      .map(event => event.Id)
+    expect(entryIds).toEqual(['redacted', 'redacted', 'redacted'])
+
+    const tableUsers = MTT_TABLE_MOVE_FIXTURE.events
+      .filter((event): event is ApiEvent<ApiType.EVT_PLAYER_SEAT_ASSIGNED> => event.ApiTypeId === ApiType.EVT_PLAYER_SEAT_ASSIGNED)
+      .flatMap(event => event.TableUsers)
+    expect(tableUsers.every(user => user.UserName === '')).toBe(true)
+    expect(tableUsers.every(user => user.UserId >= 1000 && user.UserId <= 4000)).toBe(true)
+  })
+
+  test('rejects the chimera, re-anchors HUD seat context, and retains receive chronology across HandId inversion', async () => {
+    const acceptedLineups: number[][] = []
+    service.writeEntityStream.on('data', lineup => acceptedLineups.push([...lineup]))
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+    // HandLogExporter reads the raw event lake rather than the live stream.
+    await db.apiEvents.bulkPut(MTT_TABLE_MOVE_FIXTURE.events.map(event => ({ ...event, sequence: 0 })))
+
+    for (const event of MTT_TABLE_MOVE_FIXTURE.events) {
+      service.handAggregateStream.write(event)
+    }
+    await service.handAggregateStream.whenIdle()
+
+    const storedHands = await db.hands.toArray()
+    expect(storedHands.map(hand => hand.id).sort((a, b) => a - b)).toEqual([
+      MTT_TABLE_MOVE_FIXTURE.handIds.invertedAccepted,
+      MTT_TABLE_MOVE_FIXTURE.handIds.oldAccepted,
+      MTT_TABLE_MOVE_FIXTURE.handIds.newAccepted
+    ].sort((a, b) => a - b))
+    expect(await db.hands.get(MTT_TABLE_MOVE_FIXTURE.handIds.rejectedChimera)).toBeUndefined()
+    expect(await db.actions.where('handId').equals(MTT_TABLE_MOVE_FIXTURE.handIds.rejectedChimera).count()).toBe(0)
+    expect(await db.phases.where('handId').equals(MTT_TABLE_MOVE_FIXTURE.handIds.rejectedChimera).count()).toBe(0)
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining(
+      `Rejected chimera hand (HandId=${MTT_TABLE_MOVE_FIXTURE.handIds.rejectedChimera})`
+    ))
+
+    expect(acceptedLineups).toEqual([
+      MTT_TABLE_MOVE_FIXTURE.oldLineup,
+      MTT_TABLE_MOVE_FIXTURE.middleLineup,
+      MTT_TABLE_MOVE_FIXTURE.newLineup
+    ])
+    expect(service.playerId).toBe(MTT_TABLE_MOVE_FIXTURE.heroId)
+    expect(service.latestEvtDeal?.SeatUserIds).toEqual(MTT_TABLE_MOVE_FIXTURE.newLineup)
+    expect(service.latestEvtDeal?.Player?.SeatIndex).toBe(MTT_TABLE_MOVE_FIXTURE.newHeroSeat)
+    expect(service.liveEvtDeal?.SeatUserIds).toEqual(MTT_TABLE_MOVE_FIXTURE.newLineup)
+    expect(service.liveEvtDeal?.Player?.SeatIndex).toBe(MTT_TABLE_MOVE_FIXTURE.newHeroSeat)
+    expect([...service.session.players.keys()].sort((a, b) => a - b)).toEqual(
+      [...MTT_TABLE_MOVE_FIXTURE.newLineup].sort((a, b) => a - b)
+    )
+    for (const oldPlayerId of MTT_TABLE_MOVE_FIXTURE.oldLineup) {
+      if (oldPlayerId !== MTT_TABLE_MOVE_FIXTURE.heroId) {
+        expect(service.session.players.has(oldPlayerId)).toBe(false)
+      }
+    }
+
+    // Recent means receive chronology, not numeric HandId order. In particular,
+    // 288331101 arrived after 288331102 in this MTT table-move sequence.
+    const recent = await getRecentHands(db, service, MTT_TABLE_MOVE_FIXTURE.heroId, 3)
+    expect(recent.hands.map(hand => hand.handId)).toEqual([
+      MTT_TABLE_MOVE_FIXTURE.handIds.newAccepted,
+      MTT_TABLE_MOVE_FIXTURE.handIds.invertedAccepted,
+      MTT_TABLE_MOVE_FIXTURE.handIds.oldAccepted
+    ])
+
+    // The newest two accepted hands were both played from the BB. Numeric
+    // HandId sorting would incorrectly select the old-table CO hand (102)
+    // instead of the later destination-table BB hand (101).
+    service.handLimitFilter = 2
+    clearPositionalStatsCache()
+    const positional = await getPositionalStats(db, service, MTT_TABLE_MOVE_FIXTURE.heroId)
+    expect(positional.positions.find(bucket => bucket.position === Position.BB)?.handsN).toBe(2)
+    expect(positional.positions.find(bucket => bucket.position === Position.CO)?.handsN).toBe(0)
+
+    const hudStats = await service.statsOutputStream.calcStats([MTT_TABLE_MOVE_FIXTURE.heroId])
+    const heroStats = hudStats.find(stats => stats.playerId === MTT_TABLE_MOVE_FIXTURE.heroId)
+    expect(heroStats && 'statResults' in heroStats
+      ? heroStats.statResults?.find(stat => stat.id === 'vpip')?.value
+      : undefined).toEqual([0, 2])
+
+    const exported = await HandLogExporter.exportRecentHands(db, undefined, 3)
+    const newestIndex = exported.indexOf(`PokerStars Hand #${MTT_TABLE_MOVE_FIXTURE.handIds.newAccepted}`)
+    const invertedIndex = exported.indexOf(`PokerStars Hand #${MTT_TABLE_MOVE_FIXTURE.handIds.invertedAccepted}`)
+    const oldIndex = exported.indexOf(`PokerStars Hand #${MTT_TABLE_MOVE_FIXTURE.handIds.oldAccepted}`)
+    expect(newestIndex).toBeGreaterThanOrEqual(0)
+    expect(invertedIndex).toBeGreaterThan(newestIndex)
+    expect(oldIndex).toBeGreaterThan(invertedIndex)
+  })
+})

--- a/src/streams/read-entity-stream.ts
+++ b/src/streams/read-entity-stream.ts
@@ -13,6 +13,7 @@ import { ErrorHandler } from '../utils/error-handler'
 import { defaultRegistry, defaultStatDisplayConfigs } from '../stats'
 import { COMPACT_REQUIRED_STAT_IDS, CLASSIFIER_REQUIRED_STAT_IDS } from '../stats/compactStats'
 import { matchesTableSizeFilter } from '../utils/table-size'
+import { compareHandsNewestFirst } from '../utils/hand-order'
 import type { ErrorContext } from '../types/errors'
 
 /**
@@ -220,8 +221,8 @@ export class ReadEntityStream extends SimpleTransform<number[], PlayerStats[]> {
 
       // 最後にハンド制限フィルターを適用（フィルタ後にlimit、既存の順序を維持）
       if (this.service.handLimitFilter !== undefined && this.service.handLimitFilter > 0) {
-        // 最新のハンドを取得するためハンドIDでソート（降順）
-        allPlayerHands.sort((a, b) => b.id - a.id)
+        // MTTのテーブル移動ではHandIdが局所逆転するため、受信時刻で最新順にする。
+        allPlayerHands.sort(compareHandsNewestFirst)
         allPlayerHands = allPlayerHands.slice(0, this.service.handLimitFilter)
       }
 

--- a/src/test-fixtures/mtt-table-move-lifecycle.ts
+++ b/src/test-fixtures/mtt-table-move-lifecycle.ts
@@ -1,0 +1,246 @@
+import type { ApiEvent } from '../types/api'
+import { ApiType } from '../types/api'
+import { ActionType, BattleType, BetStatusType, PhaseType, RankType } from '../types/game'
+
+/**
+ * Sanitized lifecycle derived from BattleType audit_ref=952005e4927c.
+ *
+ * The structural facts retained from the capture are:
+ * - repeated 201 -> 308 -> 313 table-move announcements;
+ * - hero seat changes from 5 to 2 with a completely different lineup;
+ * - an old-table 303 buffer receives a new-table 306 and must be rejected;
+ * - accepted HandIds arrive as 288331102 -> 288331101 -> 288331638;
+ * - a later old-table 303/new-table 306 boundary is rejected as a chimera.
+ *
+ * The rejected boundary HandId is synthetic because the audit published only
+ * the rejected count, not those identifiers. All user IDs below are synthetic
+ * small integers. Display names, observer, tournament, room, and other private
+ * identifiers are omitted or redacted.
+ */
+
+const HERO_ID = 1006
+const OLD_LINEUP = [1001, 1002, 1003, 1004, 1005, HERO_ID] as const
+const MIDDLE_LINEUP = [2001, 2002, HERO_ID, 2004, 2005, 2006] as const
+const NEW_LINEUP = [3001, 3002, HERO_ID, 3004, 3005, 3006] as const
+
+const BASE_TIMESTAMP = 1_700_000_000_000
+
+const rank = {
+  RankId: 'redacted',
+  RankName: '',
+  RankLvId: 'redacted',
+  RankLvName: ''
+}
+
+const tableUser = (userId: number) => ({
+  UserId: userId,
+  UserName: '',
+  FavoriteCharaId: '',
+  CostumeId: '',
+  EmblemId: '',
+  IsCpu: false,
+  IsOfficial: false,
+  SettingDecoIds: ['', '', '', '', '', '', ''],
+  Rank: rank
+})
+
+const entry = (timestamp: number): ApiEvent<ApiType.EVT_ENTRY_QUEUED> => ({
+  ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+  timestamp,
+  BattleType: BattleType.TOURNAMENT,
+  Code: 0,
+  Id: 'redacted',
+  IsRetire: false
+})
+
+const details = (timestamp: number): ApiEvent<ApiType.EVT_SESSION_DETAILS> => ({
+  ApiTypeId: ApiType.EVT_SESSION_DETAILS,
+  timestamp,
+  BlindStructures: [{ ActiveMinutes: 5, Ante: 50, BigBlind: 200, Lv: 1 }],
+  CoinNum: -1,
+  DefaultChip: 20_000,
+  IsReplay: false,
+  Items: [],
+  LimitSeconds: 10,
+  MoneyList: [],
+  Name: '',
+  Name2: ''
+})
+
+const seatAssigned = (
+  timestamp: number,
+  processType: 1 | 2 | 4,
+  lineup: readonly number[]
+): ApiEvent<ApiType.EVT_PLAYER_SEAT_ASSIGNED> => ({
+  ApiTypeId: ApiType.EVT_PLAYER_SEAT_ASSIGNED,
+  timestamp,
+  IsLeave: false,
+  IsRetire: false,
+  ProcessType: processType,
+  SeatUserIds: [...lineup],
+  TableUsers: lineup.map(tableUser)
+})
+
+const deal = (
+  timestamp: number,
+  lineup: readonly number[],
+  heroSeat: 2 | 5
+): ApiEvent<ApiType.EVT_DEAL> => ({
+  ApiTypeId: ApiType.EVT_DEAL,
+  timestamp,
+  SeatUserIds: [...lineup],
+  Game: {
+    CurrentBlindLv: 1,
+    NextBlindUnixSeconds: Math.floor(timestamp / 1000) + 300,
+    Ante: 50,
+    SmallBlind: 100,
+    BigBlind: 200,
+    ButtonSeat: 0,
+    SmallBlindSeat: 1,
+    BigBlindSeat: 2
+  },
+  Player: {
+    SeatIndex: heroSeat,
+    BetStatus: BetStatusType.BET_ABLE,
+    HoleCards: [0, 5],
+    Chip: 19_750,
+    BetChip: heroSeat === 2 ? 200 : 0
+  },
+  OtherPlayers: lineup
+    .map((_, SeatIndex) => SeatIndex)
+    .filter(SeatIndex => SeatIndex !== heroSeat)
+    .map(SeatIndex => ({
+      SeatIndex: SeatIndex as 0 | 1 | 2 | 3 | 4 | 5,
+      Status: 0 as const,
+      BetStatus: BetStatusType.BET_ABLE,
+      Chip: 19_950,
+      BetChip: SeatIndex === 1 ? 100 : 0,
+      IsSafeLeave: false
+    })),
+  Progress: {
+    Phase: PhaseType.PREFLOP,
+    NextActionSeat: heroSeat,
+    NextActionTypes: [ActionType.FOLD, ActionType.CALL, ActionType.RAISE, ActionType.ALL_IN],
+    NextExtraLimitSeconds: 1,
+    MinRaise: 400,
+    Pot: 600,
+    SidePot: []
+  }
+})
+
+const results = (
+  timestamp: number,
+  handId: number,
+  lineup: readonly number[],
+  heroSeat: 2 | 5
+): ApiEvent<ApiType.EVT_HAND_RESULTS> => ({
+  ApiTypeId: ApiType.EVT_HAND_RESULTS,
+  timestamp,
+  CommunityCards: [],
+  Pot: 600,
+  SidePot: [],
+  ResultType: 0,
+  DefeatStatus: 0,
+  HandId: handId,
+  HandLog: '',
+  Results: [{
+    UserId: lineup[0]!,
+    HoleCards: [],
+    RankType: RankType.NO_CALL,
+    Hands: [],
+    HandRanking: 1,
+    Ranking: -2,
+    RewardChip: 600
+  }],
+  Player: {
+    SeatIndex: heroSeat,
+    BetStatus: BetStatusType.HAND_ENDED,
+    Chip: 19_750,
+    BetChip: 0
+  },
+  OtherPlayers: lineup
+    .map((_, SeatIndex) => SeatIndex)
+    .filter(SeatIndex => SeatIndex !== heroSeat)
+    .map(SeatIndex => ({
+      SeatIndex: SeatIndex as 0 | 1 | 2 | 3 | 4 | 5,
+      Status: 0 as const,
+      BetStatus: BetStatusType.HAND_ENDED as const,
+      Chip: 19_950,
+      BetChip: 0 as const,
+      IsSafeLeave: false
+    }))
+})
+
+const action = (
+  timestamp: number,
+  heroSeat: 2 | 5,
+  actionType: ActionType.CALL | ActionType.FOLD
+): ApiEvent<ApiType.EVT_ACTION> => ({
+  ApiTypeId: ApiType.EVT_ACTION,
+  timestamp,
+  SeatIndex: heroSeat,
+  ActionType: actionType,
+  Chip: actionType === ActionType.CALL ? 19_600 : 19_750,
+  BetChip: actionType === ActionType.CALL ? 400 : 0,
+  Progress: {
+    Phase: PhaseType.PREFLOP,
+    NextActionSeat: -2,
+    NextActionTypes: [],
+    NextExtraLimitSeconds: 0,
+    MinRaise: 0,
+    Pot: 600,
+    SidePot: []
+  }
+})
+
+export const MTT_TABLE_MOVE_FIXTURE = {
+  heroId: HERO_ID,
+  oldHeroSeat: 5,
+  newHeroSeat: 2,
+  oldLineup: [...OLD_LINEUP],
+  middleLineup: [...MIDDLE_LINEUP],
+  newLineup: [...NEW_LINEUP],
+  handIds: {
+    oldAccepted: 288331102,
+    invertedAccepted: 288331101,
+    rejectedChimera: 288331500,
+    newAccepted: 288331638
+  },
+  timestamps: {
+    oldAcceptedDeal: BASE_TIMESTAMP + 3,
+    invertedAcceptedDeal: BASE_TIMESTAMP + 9,
+    oldTailDeal: BASE_TIMESTAMP + 12,
+    rejectedChimeraResult: BASE_TIMESTAMP + 16,
+    newAcceptedDeal: BASE_TIMESTAMP + 17
+  },
+  events: [
+    entry(BASE_TIMESTAMP),
+    details(BASE_TIMESTAMP + 1),
+    seatAssigned(BASE_TIMESTAMP + 2, 1, OLD_LINEUP),
+    deal(BASE_TIMESTAMP + 3, OLD_LINEUP, 5),
+    action(BASE_TIMESTAMP + 4, 5, ActionType.CALL),
+    results(BASE_TIMESTAMP + 5, 288331102, OLD_LINEUP, 5),
+
+    // First move: the next accepted hand arrives with a lower HandId.
+    entry(BASE_TIMESTAMP + 6),
+    details(BASE_TIMESTAMP + 7),
+    seatAssigned(BASE_TIMESTAMP + 8, 2, MIDDLE_LINEUP),
+    deal(BASE_TIMESTAMP + 9, MIDDLE_LINEUP, 2),
+    action(BASE_TIMESTAMP + 10, 2, ActionType.FOLD),
+    results(BASE_TIMESTAMP + 11, 288331101, MIDDLE_LINEUP, 2),
+
+    // Second move: a tail from the previous table is buffered before the
+    // destination-table result arrives. The mixed buffer must be rejected.
+    deal(BASE_TIMESTAMP + 12, MIDDLE_LINEUP, 2),
+    entry(BASE_TIMESTAMP + 13),
+    details(BASE_TIMESTAMP + 14),
+    seatAssigned(BASE_TIMESTAMP + 15, 4, NEW_LINEUP),
+    results(BASE_TIMESTAMP + 16, 288331500, NEW_LINEUP, 2),
+
+    // The first complete destination-table hand must be accepted and replace
+    // every old lineup/hero-seat display context.
+    deal(BASE_TIMESTAMP + 17, NEW_LINEUP, 2),
+    action(BASE_TIMESTAMP + 18, 2, ActionType.FOLD),
+    results(BASE_TIMESTAMP + 19, 288331638, NEW_LINEUP, 2)
+  ] as ApiEvent[]
+} as const

--- a/src/utils/hand-log-exporter.ts
+++ b/src/utils/hand-log-exporter.ts
@@ -17,6 +17,7 @@ import {
   getApiEventKey,
   type ApiEventKey
 } from './api-event-key'
+import { compareHandsNewestFirst } from './hand-order'
 
 export class HandLogExporter {
   // Cache for player names across all exports
@@ -236,15 +237,16 @@ export class HandLogExporter {
     console.log(`[HandLogExporter] Prefetched ${allEvents.length} events (${rawEvents.length} raw)`)
 
     // 5. Process each hand using the prefetched events
-    // プリパス: セッションごとの最小ハンドIDを確定（トーナメントID用）
-    const sessionFirstHandId = new Map<string | undefined, number>()
+    // プリパス: セッションごとの最小ハンドIDを確定（トーナメントID用の
+    // deterministic valueであり、受信順の「先頭」を意味しない）。
+    const sessionMinHandId = new Map<string | undefined, number>()
     for (const handId of handIds) {
       const hand = handMap.get(handId)
       if (!hand) continue
       const sessionId = hand.session.id
-      const currentMin = sessionFirstHandId.get(sessionId)
+      const currentMin = sessionMinHandId.get(sessionId)
       if (currentMin === undefined || handId < currentMin) {
-        sessionFirstHandId.set(sessionId, handId)
+        sessionMinHandId.set(sessionId, handId)
       }
     }
     
@@ -268,8 +270,8 @@ export class HandLogExporter {
         }
 
         // Build hand text using already-cached player map
-        const firstHandId = sessionFirstHandId.get(hand.session.id)
-        const handText = this.processHandToText(hand, handEvents, globalPlayerMap, firstHandId)
+        const minHandId = sessionMinHandId.get(hand.session.id)
+        const handText = this.processHandToText(hand, handEvents, globalPlayerMap, minHandId)
         results.push(handText)
       } catch (error) {
         console.warn(`[HandLogExporter] Skipped hand ${handId}:`, error instanceof Error ? error.message : error)
@@ -343,7 +345,7 @@ export class HandLogExporter {
     hand: Hand,
     events: ApiEvent[],
     globalPlayerMap: Map<number, { name: string, rank: string }>,
-    firstHandId?: number
+    sessionMinHandId?: number
   ): string {
     // Built as a plain, mutable Map first since Session.players is exposed
     // as a ReadonlyMap once assigned below.
@@ -376,7 +378,7 @@ export class HandLogExporter {
       session,
       handLogConfig: DEFAULT_HAND_LOG_CONFIG,
       handTimestamp: hand.approxTimestamp,
-      firstHandId
+      firstHandId: sessionMinHandId
     }
 
     const processor = new HandLogProcessor(context)
@@ -477,13 +479,25 @@ export class HandLogExporter {
         .toArray()
         .then((allHands: Hand[]) =>
           allHands.filter((h: Hand) => h.session.id === sessionId)
-            .sort((a, b) => b.id - a.id)
+            .sort(compareHandsNewestFirst)
             .slice(0, limit)
         )
     } else {
-      // Get all hands (or limited if specified)
-      const query = db.hands.orderBy('id').reverse()
-      hands = limit ? await query.limit(limit).toArray() : await query.toArray()
+      // HandId can locally invert after an MTT table move. Prefer the existing
+      // timestamp index for the common limited export, while retaining a full
+      // scan fallback when legacy rows without approxTimestamp must be filled.
+      if (limit) {
+        const timestampedHands = await db.hands
+          .orderBy('approxTimestamp')
+          .reverse()
+          .limit(limit)
+          .toArray()
+        hands = timestampedHands.length === limit
+          ? timestampedHands.sort(compareHandsNewestFirst)
+          : (await db.hands.toArray()).sort(compareHandsNewestFirst).slice(0, limit)
+      } else {
+        hands = (await db.hands.toArray()).sort(compareHandsNewestFirst)
+      }
     }
 
     if (hands.length === 0) {

--- a/src/utils/hand-order.test.ts
+++ b/src/utils/hand-order.test.ts
@@ -1,0 +1,30 @@
+import { compareHandsNewestFirst } from './hand-order'
+
+describe('compareHandsNewestFirst', () => {
+  test('uses receive timestamps when MTT HandIds locally invert', () => {
+    const hands = [
+      { id: 288331102, approxTimestamp: 1000 },
+      { id: 288331101, approxTimestamp: 2000 },
+      { id: 288331638, approxTimestamp: 3000 }
+    ]
+
+    expect(hands.sort(compareHandsNewestFirst).map(hand => hand.id)).toEqual([
+      288331638,
+      288331101,
+      288331102
+    ])
+  })
+
+  test('keeps deterministic HandId fallback for legacy records without timestamps', () => {
+    const hands = [{ id: 8 }, { id: 10 }, { id: 9 }]
+    expect(hands.sort(compareHandsNewestFirst).map(hand => hand.id)).toEqual([10, 9, 8])
+  })
+
+  test('places current timestamped records before legacy records', () => {
+    const hands = [
+      { id: 999999999 },
+      { id: 1, approxTimestamp: 1000 }
+    ]
+    expect(hands.sort(compareHandsNewestFirst).map(hand => hand.id)).toEqual([1, 999999999])
+  })
+})

--- a/src/utils/hand-order.ts
+++ b/src/utils/hand-order.ts
@@ -1,0 +1,28 @@
+import type { Hand } from '../types/entities'
+
+type OrderableHand = Pick<Hand, 'id' | 'approxTimestamp'>
+
+/**
+ * Compare persisted hands by receive chronology, newest first.
+ *
+ * HandId is assigned by the table that completed the hand. In an MTT, a
+ * player can move between independently progressing tables, so the receive
+ * sequence can legitimately contain a local inversion such as
+ * 288331102 -> 288331101. `approxTimestamp` comes from the EVT_DEAL receive
+ * timestamp and is therefore the ordering signal for current records.
+ *
+ * Legacy records may predate `approxTimestamp`. Keep their previous HandId
+ * ordering as a deterministic fallback, and put timestamped records ahead of
+ * legacy records because newly written hands always have a timestamp.
+ */
+export function compareHandsNewestFirst(a: OrderableHand, b: OrderableHand): number {
+  const aHasTimestamp = Number.isFinite(a.approxTimestamp)
+  const bHasTimestamp = Number.isFinite(b.approxTimestamp)
+
+  if (aHasTimestamp && bHasTimestamp && a.approxTimestamp !== b.approxTimestamp) {
+    return b.approxTimestamp! - a.approxTimestamp!
+  }
+  if (aHasTimestamp !== bHasTimestamp) return aHasTimestamp ? -1 : 1
+
+  return b.id - a.id
+}


### PR DESCRIPTION
## Summary

- add a schema-valid, sanitized MTT table-move fixture derived from audit_ref 952005e4927c
- cover repeated 201/308/313 moves, hero seat 5 to 2, an old-table 303/new-table 306 chimera boundary, and accepted HandId order 288331102 to 288331101 to 288331638
- verify the chimera writes no hand/action/phase, the destination lineup replaces old session and HUD seat context, and current hands remain in receive chronology
- order hand-limit HUD stats, positional stats, Recent Hands, and recent hand exports by persisted EVT_DEAL receive timestamp; retain HandId only as the deterministic legacy fallback

## Evidence and privacy

The fixture preserves only event shape, ProcessType transitions, documented HandIds, and relative ordering from PR #225. Player IDs are synthetic small integers. User names are empty, and observer, tournament, room, and other private identifiers are omitted or redacted. The rejected chimera HandId is synthetic because the audit published the rejected count but not those identifiers.

## Validation

- npm test -- --runInBand (125 suites, 1189 tests)
- npm run typecheck
- npm run build
- targeted lifecycle/order suite: 7 suites, 99 tests

Head: a09062dbc73dbb495e9f532785891fd4b0c96bce