### PR TITLE
test: cover private MTT rebuy lifecycle

### DIFF
--- a/src/streams/private-mtt-lifecycle.test.ts
+++ b/src/streams/private-mtt-lifecycle.test.ts
@@ -1,0 +1,181 @@
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import { PokerChaseDB } from '../db/poker-chase-db'
+import { EntityConverter } from '../entity-converter'
+import PokerChaseService from '../services/poker-chase-service'
+import { clearRecentHandsCache, getRecentHands } from '../services/recent-hands-service'
+import { PRIVATE_MTT_LIFECYCLE_FIXTURE } from '../test-fixtures/private-mtt-lifecycle'
+import {
+  ApiType,
+  BattleType,
+  parseApiEvent,
+} from '../types'
+import type { ApiEvent, PlayerStats, Session, StatResult } from '../types'
+import { HandLogExporter } from '../utils/hand-log-exporter'
+
+const EMPTY_SESSION: Session = {
+  id: undefined,
+  battleType: undefined,
+  name: undefined,
+  players: new Map(),
+  reset: () => {},
+}
+
+function handsStat(stats: PlayerStats[], playerId: number): StatResult | undefined {
+  const player = stats.find(stat => stat.playerId === playerId)
+  if (!player || !('statResults' in player) || !player.statResults) return undefined
+  return player.statResults.find(stat => stat.id === 'hands')
+}
+
+describe('private MTT rebuy/table-move lifecycle (audit_ref b1feff03635a)', () => {
+  let db: PokerChaseDB
+
+  beforeEach(async () => {
+    clearRecentHandsCache()
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+  })
+
+  afterEach(async () => {
+    db.close()
+    await db.delete()
+    clearRecentHandsCache()
+  })
+
+  test('keeps only structural evidence and remains schema-valid', () => {
+    const { events, intermediateResults, finalResult } = PRIVATE_MTT_LIFECYCLE_FIXTURE
+
+    expect(events.filter(event => parseApiEvent(event) === null).map(event => event.ApiTypeId)).toEqual([])
+    expect(events.filter(event => event.ApiTypeId === ApiType.EVT_ENTRY_QUEUED)).toHaveLength(3)
+    expect(events.filter(event => event.ApiTypeId === ApiType.EVT_SESSION_DETAILS)).toHaveLength(3)
+    expect(events.filter(event => event.ApiTypeId === ApiType.EVT_PLAYER_SEAT_ASSIGNED)).toHaveLength(2)
+    expect(events.filter(event => event.ApiTypeId === ApiType.EVT_HAND_RESULTS)).toHaveLength(5)
+    expect(events.filter(event => event.ApiTypeId === ApiType.EVT_SESSION_RESULTS)).toHaveLength(3)
+
+    const entries = events.filter((event): event is ApiEvent<ApiType.EVT_ENTRY_QUEUED> =>
+      event.ApiTypeId === ApiType.EVT_ENTRY_QUEUED
+    )
+    expect(new Set(entries.map(event => event.Id))).toEqual(new Set([
+      PRIVATE_MTT_LIFECYCLE_FIXTURE.tournamentId,
+    ]))
+    expect(entries.every(event => event.BattleType === BattleType.TOURNAMENT)).toBe(true)
+    expect(entries.every(event => event.BattleType !== BattleType.FRIEND_SIT_AND_GO)).toBe(true)
+    expect(entries.every(event => event.BattleType !== BattleType.CLUB_MATCH)).toBe(true)
+
+    expect(intermediateResults.map(event => [event.IsRebuy, event.Ranking])).toEqual([
+      [true, -1],
+      [true, -1],
+    ])
+    expect([finalResult.IsRebuy, finalResult.Ranking]).toEqual([false, 3])
+
+    const tableUsers = events
+      .filter((event): event is ApiEvent<ApiType.EVT_PLAYER_SEAT_ASSIGNED> =>
+        event.ApiTypeId === ApiType.EVT_PLAYER_SEAT_ASSIGNED
+      )
+      .flatMap(event => event.TableUsers)
+    expect(tableUsers.every(user => user.UserName === '')).toBe(true)
+    expect(events.some(event => JSON.stringify(event).includes('ticket'))).toBe(false)
+  })
+
+  test('continues after rebuy results, re-anchors seats, and preserves one tournament grouping', async () => {
+    const fixture = PRIVATE_MTT_LIFECYCLE_FIXTURE
+    const service = new PokerChaseService({ db })
+    await service.ready
+
+    const completedLineups: number[][] = []
+    service.writeEntityStream.on('data', lineup => completedLineups.push([...lineup]))
+
+    await db.apiEvents.bulkPut(fixture.events.map(event => ({ ...event, sequence: 0 })))
+
+    const writeThrough = async (events: readonly ApiEvent[]) => {
+      for (const event of events) {
+        service.handAggregateStream.write(event)
+        await service.handAggregateStream.whenIdle()
+        await service.writeEntityStream.whenIdle()
+      }
+    }
+
+    const firstRebuyIndex = fixture.events.indexOf(fixture.intermediateResults[0])
+    const secondRebuyIndex = fixture.events.indexOf(fixture.intermediateResults[1])
+
+    await writeThrough(fixture.events.slice(0, firstRebuyIndex + 1))
+    expect((await db.hands.toArray()).map(hand => hand.id)).toEqual([fixture.handIds[0]])
+    expect(service.session.battleType).toBe(BattleType.TOURNAMENT)
+
+    await writeThrough(fixture.events.slice(firstRebuyIndex + 1, secondRebuyIndex + 1))
+    expect((await db.hands.toArray()).map(hand => hand.id).sort((a, b) => a - b)).toEqual(
+      fixture.handIds.slice(0, 3).sort((a, b) => a - b)
+    )
+    expect(service.session.battleType).toBe(BattleType.TOURNAMENT)
+
+    await writeThrough(fixture.events.slice(secondRebuyIndex + 1))
+
+    const hands = await db.hands.toArray()
+    expect(hands).toHaveLength(5)
+    expect(new Set(hands.map(hand => hand.id))).toEqual(new Set(fixture.handIds))
+    expect(completedLineups).toEqual([
+      fixture.lineups.first,
+      fixture.lineups.second,
+      fixture.lineups.secondPreMove,
+      fixture.lineups.final,
+      fixture.lineups.final,
+    ])
+
+    const handsById = new Map(hands.map(hand => [hand.id, hand]))
+    expect(handsById.get(fixture.handIds[0])?.seatUserIds).toEqual(fixture.lineups.first)
+    expect(handsById.get(fixture.handIds[1])?.seatUserIds).toEqual(fixture.lineups.second)
+    expect(handsById.get(fixture.handIds[2])?.seatUserIds).toEqual(fixture.lineups.secondPreMove)
+    expect(handsById.get(fixture.handIds[3])?.seatUserIds).toEqual(fixture.lineups.final)
+    expect(handsById.get(fixture.handIds[4])?.seatUserIds).toEqual(fixture.lineups.final)
+    for (const hand of hands) {
+      expect(hand.results.every(result => hand.seatUserIds.includes(result.UserId))).toBe(true)
+      expect(hand.session.id).toBe(fixture.tournamentId)
+      expect(hand.session.battleType).toBe(BattleType.TOURNAMENT)
+      expect(hand.session.name).toBe(fixture.tournamentName)
+    }
+
+    const phases = await db.phases.toArray()
+    expect(phases).toHaveLength(5)
+    expect(new Set(phases.map(phase => phase.handId))).toEqual(new Set(fixture.handIds))
+
+    expect(service.playerId).toBe(fixture.heroId)
+    expect(service.latestEvtDeal).toEqual(fixture.finalDeal)
+    expect(service.latestEvtDeal?.Player?.SeatIndex).toBe(2)
+    expect(service.liveEvtDeal?.SeatUserIds).toEqual(fixture.lineups.final)
+    expect([...service.session.players.keys()].sort((a, b) => a - b)).toEqual(
+      [...fixture.lineups.final].sort((a, b) => a - b)
+    )
+    for (const oldPlayerId of fixture.lineups.first) {
+      if (oldPlayerId !== fixture.heroId) expect(service.session.players.has(oldPlayerId)).toBe(false)
+    }
+
+    service.battleTypeFilter = [BattleType.TOURNAMENT]
+    expect(handsStat(await service.statsOutputStream.calcStats([fixture.heroId]), fixture.heroId)?.value).toBe(5)
+
+    service.battleTypeFilter = [BattleType.FRIEND_SIT_AND_GO, BattleType.CLUB_MATCH]
+    const nonMttStats = await service.statsOutputStream.calcStats([fixture.heroId])
+    expect(nonMttStats[0] && 'statResults' in nonMttStats[0] ? nonMttStats[0].statResults : undefined).toEqual([])
+
+    service.battleTypeFilter = [BattleType.TOURNAMENT]
+    const recent = await getRecentHands(db, service, fixture.heroId, 5)
+    expect(recent.hands.map(hand => hand.handId)).toEqual([...fixture.handIds].reverse())
+
+    const exported = await HandLogExporter.exportRecentHands(db, undefined, 5)
+    for (const handId of fixture.handIds) {
+      expect(exported.match(new RegExp(`PokerStars Hand #${handId}`, 'g'))).toHaveLength(1)
+    }
+    const exportOffsets = [...fixture.handIds].reverse().map(handId => exported.indexOf(`PokerStars Hand #${handId}`))
+    expect(exportOffsets.every(offset => offset >= 0)).toBe(true)
+    expect(exportOffsets).toEqual([...exportOffsets].sort((a, b) => a - b))
+
+    // Batch parser/sessionizer parity: repeated 201/308/313 and intermediate
+    // IsRebuy=true results must not duplicate hands or split one private MTT
+    // into Friend/Club SNG sessions.
+    const rebuilt = new EntityConverter(EMPTY_SESSION).convertEventsToEntities(fixture.events)
+    expect(rebuilt.hands).toHaveLength(5)
+    expect(rebuilt.hands.map(hand => hand.id)).toEqual(fixture.handIds)
+    expect(rebuilt.hands.map(hand => hand.seatUserIds)).toEqual(completedLineups)
+    expect(rebuilt.hands.every(hand => hand.session.id === fixture.tournamentId)).toBe(true)
+    expect(rebuilt.hands.every(hand => hand.session.battleType === BattleType.TOURNAMENT)).toBe(true)
+    expect(rebuilt.hands.every(hand => hand.session.name === fixture.tournamentName)).toBe(true)
+  })
+})

--- a/src/test-fixtures/private-mtt-lifecycle.ts
+++ b/src/test-fixtures/private-mtt-lifecycle.ts
@@ -1,0 +1,272 @@
+import type { ApiEvent } from '../types/api'
+import { ApiType } from '../types/api'
+import { BattleType, BetStatusType, PhaseType, RankType } from '../types/game'
+
+/**
+ * Sanitized private-MTT lifecycle derived from audit_ref=b1feff03635a.
+ *
+ * Retained production facts:
+ * - the same private tournament identity is announced by 201/308 three times;
+ * - two 309 events have IsRebuy=true and are followed by another entry/hand;
+ * - two 313 table moves re-anchor the hero to a different seat/lineup;
+ * - the four HandIds bracketing those moves and one late HandId are real;
+ * - the final 309 is Ranking=3, IsRebuy=false.
+ *
+ * The 220-hand production capture is condensed to five representative hands.
+ * Timestamps, cards, stacks, tournament name, and all user/display/private ids
+ * are synthetic or redacted. Entry Codes and private ticket markers are not
+ * retained.
+ */
+
+const HERO_ID = 100
+const FIRST_LINEUP = [HERO_ID, 101, 102, 103, 104, 105] as const
+const SECOND_LINEUP = [201, 202, 203, 204, 205, HERO_ID] as const
+// The long capture contained intervening hands/tables. Keep the same players
+// but rotate their observed seats to preserve the audited pre-move hero seat.
+const SECOND_PRE_MOVE_LINEUP = [202, HERO_ID, 203, 204, 205, 201] as const
+const FINAL_LINEUP = [301, 302, HERO_ID, 303, 304, 305] as const
+
+const TOURNAMENT_ID = 'private-mtt-redacted'
+const TOURNAMENT_NAME = 'Private MTT [redacted]'
+const BASE_TIMESTAMP = 1_720_000_000_000
+
+const rank = {
+  RankId: 'redacted',
+  RankName: '',
+  RankLvId: 'redacted',
+  RankLvName: ''
+}
+
+const tableUser = (userId: number) => ({
+  UserId: userId,
+  UserName: '',
+  FavoriteCharaId: '',
+  CostumeId: '',
+  EmblemId: '',
+  IsCpu: false,
+  IsOfficial: false,
+  SettingDecoIds: ['', '', '', '', '', '', ''],
+  Rank: rank
+})
+
+const entry = (timestamp: number): ApiEvent<ApiType.EVT_ENTRY_QUEUED> => ({
+  ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+  timestamp,
+  BattleType: BattleType.TOURNAMENT,
+  Code: 0,
+  Id: TOURNAMENT_ID,
+  IsRetire: false
+})
+
+const details = (timestamp: number): ApiEvent<ApiType.EVT_SESSION_DETAILS> => ({
+  ApiTypeId: ApiType.EVT_SESSION_DETAILS,
+  timestamp,
+  BlindStructures: [{ ActiveMinutes: 5, Ante: 50, BigBlind: 200, Lv: 1 }],
+  CoinNum: -1,
+  DefaultChip: 20_000,
+  IsReplay: false,
+  Items: [],
+  LimitSeconds: 10,
+  MoneyList: [],
+  Name: TOURNAMENT_NAME,
+  Name2: ''
+})
+
+const seatAssigned = (
+  timestamp: number,
+  lineup: readonly number[]
+): ApiEvent<ApiType.EVT_PLAYER_SEAT_ASSIGNED> => ({
+  ApiTypeId: ApiType.EVT_PLAYER_SEAT_ASSIGNED,
+  timestamp,
+  IsLeave: false,
+  IsRetire: false,
+  ProcessType: 1,
+  SeatUserIds: [...lineup],
+  TableUsers: lineup.map(tableUser)
+})
+
+const deal = (
+  timestamp: number,
+  lineup: readonly number[],
+  heroSeat: 0 | 1 | 2 | 5
+): ApiEvent<ApiType.EVT_DEAL> => ({
+  ApiTypeId: ApiType.EVT_DEAL,
+  timestamp,
+  SeatUserIds: [...lineup],
+  Game: {
+    CurrentBlindLv: 1,
+    NextBlindUnixSeconds: Math.floor(timestamp / 1000) + 300,
+    Ante: 50,
+    SmallBlind: 100,
+    BigBlind: 200,
+    ButtonSeat: 3,
+    SmallBlindSeat: 4,
+    BigBlindSeat: 5
+  },
+  Player: {
+    SeatIndex: heroSeat,
+    BetStatus: BetStatusType.BET_ABLE,
+    HoleCards: [0, 5],
+    Chip: 19_950,
+    BetChip: heroSeat === 5 ? 200 : 0
+  },
+  OtherPlayers: lineup
+    .map((_, SeatIndex) => SeatIndex)
+    .filter(SeatIndex => SeatIndex !== heroSeat)
+    .map(SeatIndex => ({
+      SeatIndex: SeatIndex as 0 | 1 | 2 | 3 | 4 | 5,
+      Status: 0 as const,
+      BetStatus: BetStatusType.BET_ABLE,
+      Chip: 19_950,
+      BetChip: SeatIndex === 4 ? 100 : SeatIndex === 5 ? 200 : 0,
+      IsSafeLeave: false
+    })),
+  Progress: {
+    Phase: PhaseType.PREFLOP,
+    NextActionSeat: heroSeat,
+    NextActionTypes: [2, 3, 4, 5],
+    NextExtraLimitSeconds: 1,
+    MinRaise: 400,
+    Pot: 350,
+    SidePot: []
+  }
+})
+
+const results = (
+  timestamp: number,
+  handId: number,
+  lineup: readonly number[],
+  heroSeat: 0 | 1 | 2 | 5,
+  finalPlacement = false
+): ApiEvent<ApiType.EVT_HAND_RESULTS> => {
+  const winnerId = lineup.find(userId => userId !== HERO_ID)!
+  return {
+    ApiTypeId: ApiType.EVT_HAND_RESULTS,
+    timestamp,
+    CommunityCards: [],
+    Pot: 350,
+    SidePot: [],
+    ResultType: finalPlacement ? 1 : 0,
+    DefeatStatus: 0,
+    HandId: handId,
+    HandLog: '',
+    Results: [
+      {
+        UserId: winnerId,
+        HoleCards: [],
+        RankType: RankType.NO_CALL,
+        Hands: [],
+        HandRanking: 1,
+        Ranking: -2,
+        RewardChip: 350
+      },
+      ...(finalPlacement
+        ? [{
+            UserId: HERO_ID,
+            HoleCards: [] as number[],
+            RankType: RankType.NO_CALL,
+            Hands: [] as number[],
+            HandRanking: -1 as const,
+            Ranking: 3 as const,
+            RewardChip: 0
+          }]
+        : [])
+    ],
+    Player: {
+      SeatIndex: heroSeat,
+      BetStatus: finalPlacement ? BetStatusType.ELIMINATED : BetStatusType.HAND_ENDED,
+      Chip: finalPlacement ? 0 : 19_950,
+      BetChip: 0
+    },
+    OtherPlayers: lineup
+      .map((_, SeatIndex) => SeatIndex)
+      .filter(SeatIndex => SeatIndex !== heroSeat)
+      .map(SeatIndex => ({
+        SeatIndex: SeatIndex as 0 | 1 | 2 | 3 | 4 | 5,
+        Status: 0 as const,
+        BetStatus: BetStatusType.HAND_ENDED as const,
+        Chip: 19_950,
+        BetChip: 0,
+        IsSafeLeave: false
+      }))
+  }
+}
+
+const sessionResults = (
+  timestamp: number,
+  isRebuy: boolean,
+  ranking: number
+): ApiEvent<ApiType.EVT_SESSION_RESULTS> => ({
+  ApiTypeId: ApiType.EVT_SESSION_RESULTS,
+  timestamp,
+  Charas: [],
+  Costumes: [],
+  Decos: [],
+  Emblems: [],
+  EventRewards: [],
+  IsLeave: false,
+  IsRebuy: isRebuy,
+  Items: [],
+  Money: { FreeMoney: -1, PaidMoney: -1 },
+  Ranking: ranking,
+  Rewards: [],
+  TotalMatch: 1
+})
+
+const FIRST_DEAL = deal(BASE_TIMESTAMP + 2, FIRST_LINEUP, 0)
+const FIRST_RESULT = results(BASE_TIMESTAMP + 3, 284_723_970, FIRST_LINEUP, 0)
+const FIRST_REBUY = sessionResults(BASE_TIMESTAMP + 4, true, -1)
+
+const SECOND_DEAL = deal(BASE_TIMESTAMP + 8, SECOND_LINEUP, 5)
+const SECOND_RESULT = results(BASE_TIMESTAMP + 9, 284_724_598, SECOND_LINEUP, 5)
+const SECOND_PRE_MOVE_DEAL = deal(BASE_TIMESTAMP + 10, SECOND_PRE_MOVE_LINEUP, 1)
+const SECOND_PRE_MOVE_RESULT = results(BASE_TIMESTAMP + 11, 284_728_288, SECOND_PRE_MOVE_LINEUP, 1)
+const SECOND_REBUY = sessionResults(BASE_TIMESTAMP + 12, true, -1)
+
+const FINAL_DEAL = deal(BASE_TIMESTAMP + 16, FINAL_LINEUP, 2)
+const FINAL_MOVE_RESULT = results(BASE_TIMESTAMP + 17, 284_728_560, FINAL_LINEUP, 2)
+const FINAL_PLACEMENT_DEAL = deal(BASE_TIMESTAMP + 18, FINAL_LINEUP, 2)
+const FINAL_PLACEMENT_RESULT = results(BASE_TIMESTAMP + 19, 284_772_026, FINAL_LINEUP, 2, true)
+const FINAL_SESSION_RESULT = sessionResults(BASE_TIMESTAMP + 20, false, 3)
+
+export const PRIVATE_MTT_LIFECYCLE_FIXTURE = {
+  heroId: HERO_ID,
+  tournamentId: TOURNAMENT_ID,
+  tournamentName: TOURNAMENT_NAME,
+  lineups: {
+    first: [...FIRST_LINEUP],
+    second: [...SECOND_LINEUP],
+    secondPreMove: [...SECOND_PRE_MOVE_LINEUP],
+    final: [...FINAL_LINEUP]
+  },
+  heroSeats: [0, 5, 1, 2, 2],
+  handIds: [284_723_970, 284_724_598, 284_728_288, 284_728_560, 284_772_026],
+  intermediateResults: [FIRST_REBUY, SECOND_REBUY],
+  finalResult: FINAL_SESSION_RESULT,
+  finalDeal: FINAL_PLACEMENT_DEAL,
+  events: [
+    entry(BASE_TIMESTAMP),
+    details(BASE_TIMESTAMP + 1),
+    FIRST_DEAL,
+    FIRST_RESULT,
+    FIRST_REBUY,
+
+    entry(BASE_TIMESTAMP + 5),
+    details(BASE_TIMESTAMP + 6),
+    seatAssigned(BASE_TIMESTAMP + 7, SECOND_LINEUP),
+    SECOND_DEAL,
+    SECOND_RESULT,
+    SECOND_PRE_MOVE_DEAL,
+    SECOND_PRE_MOVE_RESULT,
+    SECOND_REBUY,
+
+    entry(BASE_TIMESTAMP + 13),
+    details(BASE_TIMESTAMP + 14),
+    seatAssigned(BASE_TIMESTAMP + 15, FINAL_LINEUP),
+    FINAL_DEAL,
+    FINAL_MOVE_RESULT,
+    FINAL_PLACEMENT_DEAL,
+    FINAL_PLACEMENT_RESULT,
+    FINAL_SESSION_RESULT
+  ] as ApiEvent[]
+} as const


### PR DESCRIPTION
## Scope

- Add a sanitized, real-derived private MTT lifecycle fixture from `audit_ref=b1feff03635a`.
- Cover three repeated `201/308` announcements for one tournament, two `313` table moves, two intermediate `309 IsRebuy=true` boundaries, and the final `Ranking=3, IsRebuy=false` result.
- Verify live ingestion, persisted hands/phases, HUD seat context, MTT-only stat filtering, recent-hand/Stars export ordering, and batch rebuild parity.
- Keep runtime code unchanged because the existing pipeline already preserves the lifecycle correctly.

## Evidence and redaction

- Retained only structural event counts, the four audited move-boundary HandIds (`284723970 -> 284724598`, `284728288 -> 284728560`), and late HandId `284772026`.
- Replaced timestamps, cards, stacks, tournament identity/name, lineups, user/display IDs, ranks, and private identifiers with synthetic or redacted values.
- Omitted exact room/event names, entry Codes/Ids, observer IDs, and private ticket markers.

## Validation

- `npm test -- --runInBand src/streams/private-mtt-lifecycle.test.ts`
- `npm test -- --runInBand` (128 suites, 1,193 tests)
- `npm run typecheck`
- `npm run build`
- `npm run e2e:smoke` (7/7 checks)

## Head

- `4451a5dcf355ea1fedd5a9336903b0933b12da85`