### PR TITLE
fix: clear stale hero state on new deal

### DIFF
--- a/src/streams/realtime-stats-stream.test.ts
+++ b/src/streams/realtime-stats-stream.test.ts
@@ -404,6 +404,66 @@ describe('RealTimeStatsStream', () => {
   })
 
   describe('新しいハンド開始時のクリア', () => {
+    test('306欠落後の観戦DEALで直前Heroのホールカードを再利用しない', async () => {
+      const baseDeal = {
+        ApiTypeId: ApiType.EVT_DEAL,
+        SeatUserIds: [101, 102, -1, -1, -1, -1],
+        OtherPlayers: [
+          { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 1000, BetChip: 20 }
+        ],
+        Game: {
+          CurrentBlindLv: 1,
+          NextBlindUnixSeconds: 0,
+          Ante: 0,
+          SmallBlind: 10,
+          BigBlind: 20,
+          ButtonSeat: 0,
+          SmallBlindSeat: 0,
+          BigBlindSeat: 1
+        },
+        Progress: {
+          Phase: PhaseType.PREFLOP,
+          NextActionSeat: 0,
+          NextActionTypes: [2, 3, 4, 5],
+          NextExtraLimitSeconds: 30,
+          MinRaise: 40,
+          Pot: 30,
+          SidePot: []
+        }
+      }
+      const outputs: any[] = []
+      stream.on('data', data => outputs.push(data))
+
+      stream.write({
+        ...baseDeal,
+        timestamp: 100,
+        Player: {
+          SeatIndex: 0,
+          BetStatus: 1,
+          HoleCards: [48, 49],
+          Chip: 1000,
+          BetChip: 10
+        }
+      } as ApiHandEvent)
+      // EVT_HAND_RESULTSを受信しないまま、Playerのない観戦DEALへ遷移する。
+      stream.write({
+        ...baseDeal,
+        timestamp: 200,
+        Player: undefined,
+        OtherPlayers: [
+          { SeatIndex: 0, Status: 0, BetStatus: 1, Chip: 1000, BetChip: 10 },
+          { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 1000, BetChip: 20 }
+        ]
+      } as ApiHandEvent)
+      stream.end()
+
+      await new Promise<void>(resolve => stream.once('end', resolve))
+
+      expect(outputs).toHaveLength(3)
+      expect(outputs[1].stats.heroStats.holeCards).toEqual([48, 49])
+      expect(outputs[2].stats.heroStats).toEqual({})
+    })
+
     test('EVT_DEALで前のハンドの表示がクリアされる', (done) => {
       /**
        * シナリオ: ハンドが終了し、新しいハンドが開始される場合

--- a/src/streams/realtime-stats-stream.ts
+++ b/src/streams/realtime-stats-stream.ts
@@ -62,6 +62,8 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
           this.currentHandEvents = []  // Clear previous hand events
           this.activePlayerCount = 0
           this.currentProgress = undefined
+          this.heroPlayerId = undefined
+          this.heroHoleCards = undefined
           this.heroSeatIndex = undefined
           this.seatBetAmounts = [0, 0, 0, 0, 0, 0]  // Reset bet amounts
           this.seatChips = [0, 0, 0, 0, 0, 0]  // Reset chip stacks


### PR DESCRIPTION
## Summary

- reset realtime Hero identity and hole cards at every EVT_DEAL
- prevent a missing EVT_HAND_RESULTS (306) from leaking the previous Hero hand into a following spectator deal
- add focused regression coverage for Hero DEAL -> spectator DEAL without an intervening 306

## Reproduction

On main `b098f04`, a Hero DEAL with `[48,49]` followed by a Player-less spectator DEAL emitted:

`[clear, hero AA stats, clear, stale hero AA stats]`

The final output carried the old hole cards with no current Hero/player context. After this fix, the spectator DEAL emits only the clear event.

Head SHA: 3821ae0e90a9acef26ae3b5bf7dd0926651beedb

## Validation

- `npm run typecheck`
- `npm test -- --runInBand src/streams/realtime-stats-stream.test.ts src/background/event-ingestion.test.ts src/background/event-ingestion.arrival-ordering.test.ts src/background/event-ingestion.session-end-clears-last-known-stats.test.ts src/streams/friend-sng-interleaved-lifecycle.test.ts src/streams/mtt-table-move-lifecycle.test.ts src/streams/private-mtt-lifecycle.test.ts src/streams/ring-rebuy-spectator-lifecycle.test.ts` (39 tests)
- `npm run build`
- `git diff --check`

Codex session: 019f8719-f926-7e81-ae3a-3924c8efbfe9