### PR TITLE
fix: refresh non-hero pot odds in HUD

### DIFF
--- a/src/components/Hud.test.tsx
+++ b/src/components/Hud.test.tsx
@@ -162,6 +162,43 @@ describe('Hud', () => {
     expect(potOdds.compareDocumentPosition(spr) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 
+  it('non-heroのポットオッズとSPRをリアルタイムに更新', () => {
+    const { rerender } = render(
+      <Hud
+        actualSeatIndex={1}
+        stat={mockPlayerStats}
+        scale={1}
+        statDisplayConfigs={mockStatDisplayConfigs}
+        playerPotOdds={mockPlayerPotOdds}
+      />
+    )
+
+    expect(screen.getByText('100/20 (17%)')).toBeInTheDocument()
+    expect(screen.getByText('SPR:10.5')).toBeInTheDocument()
+
+    rerender(
+      <Hud
+        actualSeatIndex={1}
+        stat={mockPlayerStats}
+        scale={1}
+        statDisplayConfigs={mockStatDisplayConfigs}
+        playerPotOdds={{
+          spr: 6.25,
+          potOdds: {
+            pot: 140,
+            call: 40,
+            percentage: 22.2,
+            ratio: '3.5:1',
+            isPlayerTurn: false,
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByText('140/40 (22%)')).toBeInTheDocument()
+    expect(screen.getByText('SPR:6.25')).toBeInTheDocument()
+  })
+
   it('ヒーロー（席0）の場合はリアルタイム統計を表示', () => {
     render(
       <Hud

--- a/src/components/Hud.tsx
+++ b/src/components/Hud.tsx
@@ -448,6 +448,12 @@ const Hud = memo((props: HudProps) => {
   if (prevProps.hudDisplayMode !== nextProps.hudDisplayMode) return false
   if (prevProps.hudColorCoding !== nextProps.hudColorCoding) return false
   if (prevProps.isDimmed !== nextProps.isDimmed) return false
+  if (prevProps.playerPotOdds?.spr !== nextProps.playerPotOdds?.spr) return false
+  if (prevProps.playerPotOdds?.potOdds?.pot !== nextProps.playerPotOdds?.potOdds?.pot) return false
+  if (prevProps.playerPotOdds?.potOdds?.call !== nextProps.playerPotOdds?.potOdds?.call) return false
+  if (prevProps.playerPotOdds?.potOdds?.percentage !== nextProps.playerPotOdds?.potOdds?.percentage) return false
+  if (prevProps.playerPotOdds?.potOdds?.ratio !== nextProps.playerPotOdds?.potOdds?.ratio) return false
+  if (prevProps.playerPotOdds?.potOdds?.isPlayerTurn !== nextProps.playerPotOdds?.potOdds?.isPlayerTurn) return false
   // handEpoch (audit finding 11, P2): only forces a re-render while one of this
   // seat's drill-down panels is actually open -- an open panel needs the fresh
   // handEpoch prop to reach its fetch effect's deps so it refetches once per


### PR DESCRIPTION
## Summary
- include non-hero Pot Odds and SPR fields in the HUD memo comparison
- keep the existing render optimization while refreshing values when action state changes
- add a regression test that rerenders one opponent seat with updated realtime values

## Root cause
`Hud` uses a custom `React.memo` comparator. It compared hero realtime stats and persisted player stats, but omitted `playerPotOdds`, so opponent seats reused stale rendered Pot/SPR values.

## Validation
- `npm test -- --runInBand src/components/Hud.test.tsx` (37 passed)
- `npm test -- --runInBand` (128 suites, 1194 tests passed)
- `npm run typecheck`
- `npm run build`

Head SHA: `0213d5251c65c573ca4ad41476ade863bdd5c0ff`