### PR TITLE
fix(import): preserve recovery after initial rebuild failure

### DIFF
--- a/src/background/import-export.full-rebuild.test.ts
+++ b/src/background/import-export.full-rebuild.test.ts
@@ -575,5 +575,36 @@ describe('importData() full rebuild after overlapping imports (audit finding #7,
         expect((await getRebuildAdvisoryState()).pendingVersion).toBeUndefined()
       })
     })
+
+    test('a failed first import marks the rebuild advisory pending because retrying the same file only sees duplicates', async () => {
+      const fullExport = [ENTRY_QUEUED, ...HAND1_EVENTS]
+
+      await runWithFreshDb(async ({ db, handlers }) => {
+        expect(await db.apiEvents.count()).toBe(0)
+        expect((await getRebuildAdvisoryState()).pendingVersion).toBeUndefined()
+
+        const convertSpy = jest.spyOn(EntityConverter.prototype, 'convertEventsToEntities')
+          .mockImplementation(() => { throw new Error('synthetic initial entity-generation failure') })
+
+        await expect(handlers.importData(toJsonl(fullExport))).rejects.toThrow(/entity generation failed/i)
+        convertSpy.mockRestore()
+
+        // Raw rows landed before entity generation failed, so the next import
+        // is no longer an "empty DB" import even though no derived rows exist.
+        expect(await db.apiEvents.count()).toBe(fullExport.length)
+        expect(await db.hands.count()).toBe(0)
+        expect(await db.actions.count()).toBe(0)
+
+        // Required recovery invariant: the user must keep seeing the manual
+        // rebuild prompt, because retrying this exact file cannot trigger the
+        // non-empty/new-row rebuild branch (all rows are now duplicates).
+        expect((await getRebuildAdvisoryState()).pendingVersion).toBe(REBUILD_ADVISORY_VERSION)
+
+        const retryResult = await handlers.importData(toJsonl(fullExport))
+        expect(retryResult.successCount).toBe(0)
+        expect(retryResult.duplicateCount).toBe(fullExport.length)
+        expect(await db.hands.count()).toBe(0)
+      })
+    })
   })
 })

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -347,8 +347,10 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
 
         } catch (entityError) {
           console.error('[importData] Entity generation error:', entityError)
-          // エラーの詳細をログに記録するが、処理は継続
-          // refreshDatabaseへのフォールバックは削除（トランザクション競合を避けるため）
+          // raw event は既に永続化されている。ここで保留印を残さないと、
+          // 同じファイルの再インポートは全件重複となり、派生データ生成を
+          // 再試行できないまま成功扱いになってしまう。
+          await markAdvisoryPending()
           const errorMessage = entityError instanceof Error ? entityError.message : String(entityError)
           throw new Error(`Entity generation failed: ${errorMessage}`)
         }


### PR DESCRIPTION
## Summary

- keep the rebuild advisory pending when initial import entity generation fails after raw events are already durable
- cover the duplicate-only retry path that otherwise reports success while derived hands/actions remain absent

## Root cause

The empty-database import path stores raw events before generating derived entities. If entity generation failed, it threw without marking the rebuild advisory pending. Re-importing the same file then saw only duplicates and skipped every rebuild path, leaving raw and derived data inconsistent without a persistent recovery prompt.

## Validation

- `npm test -- --runInBand` (128 suites, 1,194 tests)
- `npm run typecheck`
- `npm run build`
- `npm run e2e:smoke` (7/7 checks)

## Head

`768a1d93adbedf5ed78dc529fe573c8ce6a1cc96`