### PR TITLE
fix: reactivate realtime stats without session details

### DIFF
--- a/src/streams/realtime-stats-stream.test.ts
+++ b/src/streams/realtime-stats-stream.test.ts
@@ -18,6 +18,67 @@ describe('RealTimeStatsStream', () => {
     stream.reset()
   })
 
+  describe('セッション再開', () => {
+    const heroDeal = {
+      ApiTypeId: ApiType.EVT_DEAL,
+      timestamp: 300,
+      SeatUserIds: [101, 102, -1, -1, -1, -1],
+      Player: {
+        SeatIndex: 0,
+        BetStatus: 1,
+        HoleCards: [48, 49],
+        Chip: 1000,
+        BetChip: 10
+      },
+      OtherPlayers: [
+        { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 1000, BetChip: 20 }
+      ],
+      Game: {
+        CurrentBlindLv: 1,
+        NextBlindUnixSeconds: 0,
+        Ante: 0,
+        SmallBlind: 10,
+        BigBlind: 20,
+        ButtonSeat: 0,
+        SmallBlindSeat: 0,
+        BigBlindSeat: 1
+      },
+      Progress: {
+        Phase: PhaseType.PREFLOP,
+        NextActionSeat: 0,
+        NextActionTypes: [2, 3, 4, 5],
+        NextExtraLimitSeconds: 30,
+        MinRaise: 40,
+        Pot: 30,
+        SidePot: []
+      }
+    } as ApiHandEvent
+
+    test('308が欠落しても201でinactive状態を解除する', async () => {
+      stream.write({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 100 } as any)
+      stream.write({ ApiTypeId: ApiType.EVT_ENTRY_QUEUED, timestamp: 200 } as any)
+      stream.end()
+
+      await new Promise<void>(resolve => stream.once('end', resolve))
+
+      expect((stream as unknown as { isSessionActive: boolean }).isSessionActive).toBe(true)
+    })
+
+    test('201/308がともに欠落してもHero在席の303で統計を再開する', async () => {
+      const outputs: any[] = []
+      stream.on('data', data => outputs.push(data))
+
+      stream.write({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 100 } as any)
+      stream.write(heroDeal)
+      stream.end()
+
+      await new Promise<void>(resolve => stream.once('end', resolve))
+
+      expect(outputs).toHaveLength(2)
+      expect(Object.keys(outputs[1].stats.heroStats)).not.toHaveLength(0)
+    })
+  })
+
   describe('プリフロップ表示', () => {
     test('ホールカードを受け取った時点で統計を計算する', (done) => {
       /**

--- a/src/streams/realtime-stats-stream.ts
+++ b/src/streams/realtime-stats-stream.ts
@@ -44,7 +44,10 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
       // Handle session events separately due to TypeScript limitations
       const eventType = (event as any).ApiTypeId
 
-      if (eventType === ApiType.EVT_SESSION_DETAILS) {
+      // EVT_SESSION_DETAILS (308) is not guaranteed to arrive. Mirror the
+      // ingestion/session-activity fallbacks so a completed session cannot
+      // leave realtime stats disabled throughout the next one.
+      if (eventType === ApiType.EVT_ENTRY_QUEUED || eventType === ApiType.EVT_SESSION_DETAILS) {
         this.isSessionActive = true
       }
 
@@ -55,6 +58,12 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
       switch (event.ApiTypeId) {
 
         case ApiType.EVT_DEAL:
+          // Player is absent for spectator deals. Only a hero-present deal is
+          // strong enough to reactivate calculations when 201/308 were missed.
+          if (event.Player != null) {
+            this.isSessionActive = true
+          }
+
           // Reset for new hand
           this.currentHandId = undefined
           this.communityCards = []


### PR DESCRIPTION
## Summary

- reactivate RealTimeStatsStream on EVT_ENTRY_QUEUED (201), matching the established session-start fallback
- also reactivate on Hero-present EVT_DEAL (303) when both 201 and EVT_SESSION_DETAILS (308) were missed
- keep Player-less spectator deals from reactivating the stream
- add focused coverage for both fallback paths after EVT_SESSION_RESULTS (309)

## Reproduction

On main before the fix, a baseline Hero DEAL emitted a clear event plus populated realtime stats. The sequence 309 -> 201 -> Hero 303 with no 308 emitted only the clear event:

`{ baselineOutputs: 2, baselineHasStats: true, afterEndNo308Outputs: 1, afterEndNo308HasStats: false }`

308 omission is a documented normal event variant, so a previous session end could silently disable preflop/hand-improvement/pot-odds output for the entire next session.

This branch is based on main after #234, which independently clears stale Hero state at every new DEAL.

Head SHA: ce333bdfb19bfd36c3ed5db340f17f7de9656fa7

## Validation

- `npm run typecheck`
- `npm test -- --runInBand src/streams/realtime-stats-stream.test.ts src/background/event-ingestion.test.ts src/background/event-ingestion.arrival-ordering.test.ts src/background/event-ingestion.auto-sync-trigger.test.ts src/background/event-ingestion.session-end-clears-last-known-stats.test.ts src/content_script.session-activity.test.ts src/streams/friend-sng-interleaved-lifecycle.test.ts src/streams/mtt-table-move-lifecycle.test.ts src/streams/private-mtt-lifecycle.test.ts src/streams/ring-rebuy-spectator-lifecycle.test.ts` (53 tests)
- `npm run build`
- `git diff --check`

Codex session: 019f8719-f926-7e81-ae3a-3924c8efbfe9