### PR TITLE
fix: handle latest stats receiver loss

### DIFF
--- a/src/background/message-router.pregame-live-clobber-guard.test.ts
+++ b/src/background/message-router.pregame-live-clobber-guard.test.ts
@@ -55,7 +55,7 @@ describe('message-router requestLatestStats -- pre-game vs. live lineup race gua
     await service.ready
     service.playerId = HERO_ID
 
-    sendMessageMock = jest.fn()
+    sendMessageMock = jest.fn().mockResolvedValue(undefined)
     ;(global as any).chrome.tabs = {
       sendMessage: sendMessageMock,
       query: jest.fn((_query, callback) => callback([])),
@@ -133,5 +133,27 @@ describe('message-router requestLatestStats -- pre-game vs. live lineup race gua
     expect(tabId).toBe(TAB_ID)
     expect(message.action).toBe('latestStats')
     expect(message.stats[0].playerId).toBe(HERO_ID)
+  })
+
+  test('consumes a missing-receiver rejection when the requesting tab navigates away', async () => {
+    const missingReceiver = Promise.reject(
+      new Error('Could not establish connection. Receiving end does not exist.')
+    )
+    await missingReceiver.catch(() => {})
+    const catchSpy = jest.spyOn(missingReceiver, 'catch')
+    sendMessageMock.mockReturnValue(missingReceiver)
+
+    const sendResponse = jest.fn()
+    const handled = listener(
+      { action: 'requestLatestStats', preGame: true } as unknown as ChromeMessage,
+      { tab: { id: TAB_ID } } as chrome.runtime.MessageSender,
+      sendResponse
+    )
+    expect(handled).toBe(true)
+
+    await waitUntil(() => sendResponse.mock.calls.length > 0)
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1)
+    expect(catchSpy).toHaveBeenCalledWith(expect.any(Function))
   })
 })

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -255,6 +255,13 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
             chrome.tabs.sendMessage<LatestStatsMessage>(sender.tab.id, {
               action: 'latestStats',
               stats: stats
+            }).catch(error => {
+              // The requesting content script can disappear while the DB-backed
+              // fallback is being calculated (navigation, reload, or extension
+              // update). Delivery is best-effort once that receiver is gone.
+              if (!(error instanceof Error) || !error.message.includes('Receiving end does not exist')) {
+                console.warn(`[background] Failed to deliver latest stats to tab ${sender.tab?.id}:`, error)
+              }
             })
           }
           sendResponse({ success: true })


### PR DESCRIPTION
## Summary
- consume the expected missing-receiver rejection when a game tab navigates during latest-stats calculation
- keep unexpected tab delivery failures visible as Service Worker warnings
- add a deterministic navigation-race regression test

## Root cause
`requestLatestStats` performs asynchronous DB-backed calculation, then sends `latestStats` back to the originating tab. If that tab reloads or navigates during the calculation, the content-script receiver disappears and the Promise returned by `chrome.tabs.sendMessage` rejected without a handler, producing `Uncaught (in promise): Receiving end does not exist` in the Service Worker console.

## Validation
- `npm test -- --runInBand src/background/message-router.pregame-live-clobber-guard.test.ts` (3 passed)
- `npm test -- --runInBand` (128 suites, 1199 tests passed after rebase onto current main)
- `npm run typecheck`
- `npm run build`

Head SHA: `a3ff2e466dfb7f32e0ff7d1435cd6207372eb509`