### PR TITLE
fix(sync): report concurrent requests as busy

### DIFF
--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -1027,6 +1027,33 @@ describe('AutoSyncService cloud downloads', () => {
     expect((service as any)._isSyncing).toBe(false)
   })
 
+  test('does not report a concurrent manual download as successful when an upload owns the sync latch and no download runs', async () => {
+    const service = new AutoSyncService(db)
+
+    let resolveGate: ((blocked: boolean) => void) | undefined
+    jest.spyOn(minVersionGate, 'isCloudSyncBlockedByMinVersionGate')
+      .mockImplementation(() => new Promise<boolean>(resolve => { resolveGate = resolve }))
+    jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockResolvedValue(null)
+    const downloadSpy = jest.spyOn(firestoreBackupService, 'syncFromCloud').mockResolvedValue(0)
+
+    const upload = service.performSync('upload')
+    const concurrentDownload = service.performSync('download')
+
+    // The second call currently short-circuits immediately while the upload
+    // owns the latch. Let the real owner finish so this test leaves no
+    // unresolved work behind, then verify the second call's truthful outcome.
+    const downloadOutcome = await concurrentDownload
+    while (!resolveGate) await Promise.resolve()
+    resolveGate(false)
+    await upload
+
+    expect(downloadSpy).not.toHaveBeenCalled()
+    expect(downloadOutcome).toEqual({
+      success: false,
+      error: expect.stringContaining('実行中')
+    })
+  })
+
   test('releases the _isSyncing latch (via finally) even when the min-version gate blocks the sync', async () => {
     const service = new AutoSyncService(db)
     jest.spyOn(minVersionGate, 'isCloudSyncBlockedByMinVersionGate').mockResolvedValue(true)

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -561,9 +561,10 @@ export class AutoSyncService {
     // Check if already syncing
     if (this._isSyncing) {
       console.log('[AutoSync] Sync already in progress')
-      // Not a failure -- a concurrent pass owns this sync; its own outcome
-      // (success or failure) is what will actually land in syncState.
-      return { success: true }
+      // This call did not run its requested direction. Returning success here
+      // made a concurrent manual download/upload claim completion even when
+      // only the other pass ran (and that owner could still fail afterward).
+      return { success: false, error: '別のクラウド同期が実行中です。完了後にもう一度お試しください。' }
     }
 
     // Latch BEFORE the awaited gate check below (codex#3612092798): if we set


### PR DESCRIPTION
## Summary

- return a truthful busy failure when another cloud sync owns the single-flight latch
- cover an upload/download interleaving where the requested download never runs

## Root cause

`performSync()` returned `{ success: true }` to every concurrent caller while `_isSyncing` was held. If an upload was active and the user requested a manual download, the download path was skipped but message-router forwarded success to the popup. The owning upload could also fail later, so its outcome could not justify success for the skipped request.

## Validation

- `npm test -- --runInBand` (128 suites, 1,197 tests)
- `npm run typecheck`
- `npm run build`
- `npm run e2e:smoke` (7/7 checks)

## Head

`7586cef8755c10b49c06694ae27b324fee094023`