### PR TITLE
fix: clear stale session name during rebuild

### DIFF
--- a/src/entity-converter.test.ts
+++ b/src/entity-converter.test.ts
@@ -1409,6 +1409,53 @@ describe('EntityConverter', () => {
    * `hand.session.id`/`battleType`の欠落として表面化する。
    */
   describe('SessionState seeding (regression, #104)', () => {
+    it('clears a seeded session name on a new 201 when 308 is absent', () => {
+      const previousSession = new SessionState(() => { })
+      previousSession.setId('previous-session')
+      previousSession.setBattleType(BattleType.TOURNAMENT)
+      previousSession.setName('Previous Tournament')
+
+      const events: ApiEvent[] = [
+        createEvent(ApiType.EVT_ENTRY_QUEUED, {
+          timestamp: 1000,
+          Id: 'next-session',
+          BattleType: BattleType.SIT_AND_GO,
+          Code: 0,
+          IsRetire: false
+        }),
+        createEvent(ApiType.EVT_DEAL, {
+          timestamp: 1001,
+          SeatUserIds: [100, 101],
+          Game: {
+            SmallBlind: 10,
+            BigBlind: 20,
+            ButtonSeat: 0,
+            SmallBlindSeat: 0,
+            BigBlindSeat: 1
+          },
+          Progress: { Phase: PhaseType.PREFLOP }
+        } as any, { skipValidation: true }),
+        createEvent(ApiType.EVT_HAND_RESULTS, {
+          timestamp: 1002,
+          HandId: 12346,
+          CommunityCards: [],
+          Results: []
+        } as any, { skipValidation: true })
+      ]
+
+      const result = new EntityConverter(previousSession).convertEventsToEntities(events)
+
+      expect(result.hands).toEqual([
+        expect.objectContaining({
+          session: {
+            id: 'next-session',
+            battleType: BattleType.SIT_AND_GO,
+            name: undefined
+          }
+        })
+      ])
+    })
+
     it('carries over session id/battleType/name from a real SessionState instance even without a leading EVT_ENTRY_QUEUED', () => {
       // 実際のSessionStateインスタンスを構築し、setter経由でフィールドを設定する
       // （#104で導入されたクラス。id/battleType/nameはprototypeのgetterで公開される）

--- a/src/entity-converter.test.ts
+++ b/src/entity-converter.test.ts
@@ -1456,6 +1456,49 @@ describe('EntityConverter', () => {
       ])
     })
 
+    it('preserves the tournament name for a same-id MTT table move without 308', () => {
+      const tournamentSession = new SessionState(() => { })
+      tournamentSession.setId('tournament-123')
+      tournamentSession.setBattleType(BattleType.TOURNAMENT)
+      tournamentSession.setName('Current Tournament')
+
+      const events: ApiEvent[] = [
+        createEvent(ApiType.EVT_ENTRY_QUEUED, {
+          timestamp: 2000,
+          Id: 'tournament-123',
+          BattleType: BattleType.TOURNAMENT,
+          Code: 0,
+          IsRetire: false
+        }),
+        createEvent(ApiType.EVT_DEAL, {
+          timestamp: 2001,
+          SeatUserIds: [100, 101],
+          Game: {
+            SmallBlind: 10,
+            BigBlind: 20,
+            ButtonSeat: 0,
+            SmallBlindSeat: 0,
+            BigBlindSeat: 1
+          },
+          Progress: { Phase: PhaseType.PREFLOP }
+        } as any, { skipValidation: true }),
+        createEvent(ApiType.EVT_HAND_RESULTS, {
+          timestamp: 2002,
+          HandId: 12347,
+          CommunityCards: [],
+          Results: []
+        } as any, { skipValidation: true })
+      ]
+
+      const result = new EntityConverter(tournamentSession).convertEventsToEntities(events)
+
+      expect(result.hands[0]?.session).toEqual({
+        id: 'tournament-123',
+        battleType: BattleType.TOURNAMENT,
+        name: 'Current Tournament'
+      })
+    })
+
     it('carries over session id/battleType/name from a real SessionState instance even without a leading EVT_ENTRY_QUEUED', () => {
       // 実際のSessionStateインスタンスを構築し、setter経由でフィールドを設定する
       // （#104で導入されたクラス。id/battleType/nameはprototypeのgetterで公開される）

--- a/src/entity-converter.ts
+++ b/src/entity-converter.ts
@@ -91,6 +91,9 @@ export class EntityConverter {
       if (isApiEventType(event, ApiType.EVT_ENTRY_QUEUED)) {
         this.currentSession.id = event.Id
         this.currentSession.battleType = event.BattleType
+        // 308 (EVT_SESSION_DETAILS) may be absent. Do not let the previous
+        // session's display name leak into hands from the new 201 segment.
+        this.currentSession.name = undefined
         // 新しいセッション開始時はプレイヤー情報をクリア
         this.currentSession.players = new Map()
       } else if (isApiEventType(event, ApiType.EVT_SESSION_DETAILS)) {

--- a/src/entity-converter.ts
+++ b/src/entity-converter.ts
@@ -9,6 +9,7 @@ import {
   ActionDetail,
   ActionType,
   ApiType,
+  BattleType,
   BetStatusType,
   PhaseType,
   Position,
@@ -89,11 +90,15 @@ export class EntityConverter {
     for (const event of events) {
       // セッション開始イベントの処理
       if (isApiEventType(event, ApiType.EVT_ENTRY_QUEUED)) {
+        const isSameMtt = this.currentSession.battleType === BattleType.TOURNAMENT &&
+          event.BattleType === BattleType.TOURNAMENT &&
+          this.currentSession.id === event.Id
         this.currentSession.id = event.Id
         this.currentSession.battleType = event.BattleType
-        // 308 (EVT_SESSION_DETAILS) may be absent. Do not let the previous
-        // session's display name leak into hands from the new 201 segment.
-        this.currentSession.name = undefined
+        // 308 (EVT_SESSION_DETAILS) may be absent. Clear a previous session's
+        // display name at a true boundary, but preserve it for an MTT table
+        // move: MTT reissues 201 with the same tournament Id at each move.
+        if (!isSameMtt) this.currentSession.name = undefined
         // 新しいセッション開始時はプレイヤー情報をクリア
         this.currentSession.players = new Map()
       } else if (isApiEventType(event, ApiType.EVT_SESSION_DETAILS)) {


### PR DESCRIPTION
## Summary

- clear the batch converter's session name at true EVT_ENTRY_QUEUED boundaries
- preserve a known name for same-Id MTT table moves when EVT_SESSION_DETAILS is absent
- preserve the new session ID and battle type for ordinary 308-omission cases
- add regressions for both a true new session and a same-tournament table move

## Why

EVT_SESSION_DETAILS (308) can be missing. The batch converter previously leaked a prior session name across a true new 201 segment. MTTs are the exception: they reissue 201 with the same tournament Id at table moves, so a known tournament name must survive a missing paired 308.

## Validation

- npm test -- --runInBand src/entity-converter.test.ts src/streams/private-mtt-lifecycle.test.ts src/streams/mtt-table-move-lifecycle.test.ts src/streams/friend-sng-interleaved-lifecycle.test.ts (35 tests)
- npm run typecheck
- npm test -- --runInBand (128 suites, 1200 tests)
- npm run build

Head SHA: 829d4689ac39256bfe06dca8f409c1c793eb8518

Codex session: 019f8719-f926-7e81-ae3a-3924c8efbfe9