### PR TITLE
fix: persist hand start timestamps

### DIFF
--- a/src/background/rebuild-advisory.test.ts
+++ b/src/background/rebuild-advisory.test.ts
@@ -135,6 +135,22 @@ describe('rebuild-advisory', () => {
     })
   })
 
+  describe('hand start timestamp backfill', () => {
+    it('re-surfaces the advisory for users who acknowledged version 3', async () => {
+      await chrome.storage.local.set({
+        [REBUILD_ADVISORY_STORAGE_KEY]: { acknowledgedVersion: 3 }
+      })
+      ;(mockDb.apiEvents.count as jest.Mock).mockResolvedValue(1)
+
+      await checkOnUpdate(mockDb)
+
+      const state = await getRebuildAdvisoryState()
+      expect(REBUILD_ADVISORY_VERSION).toBeGreaterThan(3)
+      expect(state.pendingVersion).toBe(REBUILD_ADVISORY_VERSION)
+      expect(chrome.notifications.create).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('resolveAdvisory', () => {
     it('clears pendingVersion, sets acknowledgedVersion, and clears the badge', async () => {
       await chrome.storage.local.set({

--- a/src/constants/database.ts
+++ b/src/constants/database.ts
@@ -83,9 +83,14 @@ export type DbOperationType = 'import' | 'export' | 'sync' | 'rebuild'
  * 機械的な主キー移行で、hands/phases/actionsのキー・導出ロジック・内容を
  * 変更しないため、このアドバイザリはバンプしない。
  *
+ * version 4: `Hand.approxTimestamp`をEVT_HAND_RESULTSの到着時刻から
+ * EVT_DEALの到着時刻へ修正。既存の派生handには終了時刻が保存されて
+ * おり、PokerStars形式エクスポートの開始時刻にもその値が使われるため、
+ * Raw Event Lakeからの再構築で既存行を修復する。
+ *
  * インクリメントすると、拡張機能の更新後に既存ユーザーへ一度だけ
  * 「データ再構築」の実行を促すアドバイソリーが表示される
  * （`src/background/rebuild-advisory.ts`参照）。単なるUI変更やバグ修正でも
  * 書き込み時の導出結果に影響しないものはバンプ不要。
  */
-export const REBUILD_ADVISORY_VERSION = 3
+export const REBUILD_ADVISORY_VERSION = 4

--- a/src/entity-converter.ts
+++ b/src/entity-converter.ts
@@ -432,8 +432,6 @@ export class EntityConverter {
             ?.filter(result => result.RewardChip > 0)
             .map(result => result.UserId) || []
           handState.hand.results = event.Results || []
-          handState.hand.approxTimestamp = event.timestamp
-
           // RIVER_CALLで勝利したアクションにRIVER_CALL_WONを付与する
           // （WriteEntityStreamと同一ロジック。River Call Accuracy統計が参照する）
           handState.actions.forEach(action => {

--- a/src/streams/hand-start-timestamp.test.ts
+++ b/src/streams/hand-start-timestamp.test.ts
@@ -1,0 +1,59 @@
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { EntityConverter } from '../entity-converter'
+import { MTT_TABLE_MOVE_FIXTURE } from '../test-fixtures/mtt-table-move-lifecycle'
+import type { Session } from '../types'
+import { HandLogExporter } from '../utils/hand-log-exporter'
+
+const EMPTY_SESSION: Session = {
+  id: undefined,
+  battleType: undefined,
+  name: undefined,
+  players: new Map(),
+  reset: () => { }
+}
+
+const formatJst = (timestamp: number): string => {
+  const date = new Date(timestamp + 9 * 60 * 60 * 1000)
+  return `${date.getUTCFullYear()}/${String(date.getUTCMonth() + 1).padStart(2, '0')}/${String(date.getUTCDate()).padStart(2, '0')} ` +
+    `${String(date.getUTCHours()).padStart(2, '0')}:${String(date.getUTCMinutes()).padStart(2, '0')}:${String(date.getUTCSeconds()).padStart(2, '0')} JST`
+}
+
+describe('hand start timestamps', () => {
+  let db: PokerChaseDB
+
+  beforeEach(async () => {
+    HandLogExporter.clearCache()
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+  })
+
+  afterEach(async () => {
+    db.close()
+    await db.delete()
+    HandLogExporter.clearCache()
+  })
+
+  test('live writes, rebuilds, and exported logs use EVT_DEAL rather than EVT_HAND_RESULTS time', async () => {
+    const events = MTT_TABLE_MOVE_FIXTURE.events.slice(0, 6)
+    const handId = MTT_TABLE_MOVE_FIXTURE.handIds.oldAccepted
+    const dealTimestamp = MTT_TABLE_MOVE_FIXTURE.timestamps.oldAcceptedDeal
+
+    await db.apiEvents.bulkPut(events.map(event => ({ ...event, sequence: 0 })))
+
+    const service = new PokerChaseService({ db })
+    await service.ready
+    for (const event of events) service.handAggregateStream.write(event)
+    await service.handAggregateStream.whenIdle()
+
+    expect((await db.hands.get(handId))?.approxTimestamp).toBe(dealTimestamp)
+
+    const rebuilt = new EntityConverter(EMPTY_SESSION).convertEventsToEntities(events)
+    expect(rebuilt.hands).toEqual([
+      expect.objectContaining({ id: handId, approxTimestamp: dealTimestamp })
+    ])
+
+    const exported = await HandLogExporter.exportHand(db, handId)
+    expect(exported).toContain(`- ${formatJst(dealTimestamp)}`)
+  })
+})

--- a/src/streams/hand-start-timestamp.test.ts
+++ b/src/streams/hand-start-timestamp.test.ts
@@ -2,7 +2,7 @@ import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
 import PokerChaseService, { PokerChaseDB } from '../app'
 import { EntityConverter } from '../entity-converter'
 import { MTT_TABLE_MOVE_FIXTURE } from '../test-fixtures/mtt-table-move-lifecycle'
-import type { Session } from '../types'
+import { ApiType, type Session } from '../types'
 import { HandLogExporter } from '../utils/hand-log-exporter'
 
 const EMPTY_SESSION: Session = {
@@ -35,9 +35,14 @@ describe('hand start timestamps', () => {
   })
 
   test('live writes, rebuilds, and exported logs use EVT_DEAL rather than EVT_HAND_RESULTS time', async () => {
-    const events = MTT_TABLE_MOVE_FIXTURE.events.slice(0, 6)
     const handId = MTT_TABLE_MOVE_FIXTURE.handIds.oldAccepted
     const dealTimestamp = MTT_TABLE_MOVE_FIXTURE.timestamps.oldAcceptedDeal
+    const resultTimestamp = dealTimestamp + 60_000
+    const events = MTT_TABLE_MOVE_FIXTURE.events.slice(0, 6).map(event =>
+      event.ApiTypeId === ApiType.EVT_HAND_RESULTS ? { ...event, timestamp: resultTimestamp } : event
+    )
+
+    expect(resultTimestamp - dealTimestamp).toBeGreaterThan(30_000)
 
     await db.apiEvents.bulkPut(events.map(event => ({ ...event, sequence: 0 })))
 
@@ -55,5 +60,8 @@ describe('hand start timestamps', () => {
 
     const exported = await HandLogExporter.exportHand(db, handId)
     expect(exported).toContain(`- ${formatJst(dealTimestamp)}`)
+
+    const batchExported = await HandLogExporter.exportRecentHands(db, undefined, 1)
+    expect(batchExported).toContain(`- ${formatJst(dealTimestamp)}`)
   })
 })

--- a/src/streams/write-entity-stream.ts
+++ b/src/streams/write-entity-stream.ts
@@ -108,6 +108,9 @@ export class WriteEntityStream extends SimpleTransform<ApiHandEvent[], number[]>
       switch (event.ApiTypeId) {
         case ApiType.EVT_DEAL:
           handState.hand.seatUserIds = event.SeatUserIds
+          // Receive chronology and exported hand-log timestamps are anchored
+          // at the start of the hand, not when EVT_HAND_RESULTS arrives.
+          handState.hand.approxTimestamp = event.timestamp
           positionMap = getPositionMap(event.SeatUserIds, event.Game)
           handState.phases.push({
             phase: event.Progress.Phase,
@@ -311,7 +314,6 @@ export class WriteEntityStream extends SimpleTransform<ApiHandEvent[], number[]>
           // WWSF/W$SDはPT4の定義上「ポットの一部でも獲得したか」を問うため、
           // RewardChip基準がこれらの統計と整合する。
           handState.hand.winningPlayerIds = event.Results.filter(({ RewardChip }) => RewardChip > 0).map(({ UserId }) => UserId)
-          handState.hand.approxTimestamp = event.timestamp
           handState.hand.results = event.Results
 
           // Update actions with handId and add RIVER_CALL_WON for winning river calls

--- a/src/utils/hand-log-exporter.ts
+++ b/src/utils/hand-log-exporter.ts
@@ -26,7 +26,6 @@ export class HandLogExporter {
   
   // Time constants for event retrieval
   private static readonly TIME_BUFFER_MS = 300000 // 5 minutes buffer to catch player seat assignments
-  private static readonly POST_HAND_BUFFER_MS = 30000 // 30 seconds after hand completion
 
   /**
    * Build a global player names map from all available events in the database
@@ -216,13 +215,27 @@ export class HandLogExporter {
     }
 
     const minTime = Math.min(...timestamps) - this.TIME_BUFFER_MS
-    const maxTime = Math.max(...timestamps) + this.POST_HAND_BUFFER_MS
+    const targetHandIds = new Set(handIds)
+    const resultEvents = await db.apiEvents
+      .where('[ApiTypeId+timestamp]')
+      .between(
+        [ApiType.EVT_HAND_RESULTS, minTime],
+        [ApiType.EVT_HAND_RESULTS, Number.MAX_SAFE_INTEGER],
+        true,
+        true
+      )
+      .filter(event => isApiEventType(event, ApiType.EVT_HAND_RESULTS) && targetHandIds.has(event.HandId))
+      .toArray()
+    const maxTime = Math.max(
+      ...timestamps,
+      ...resultEvents.map(event => event.timestamp!)
+    )
 
     // 4. Fetch ALL events in the range in ONE query
     console.log(`[HandLogExporter] Prefetching events from ${new Date(minTime).toISOString()} to ${new Date(maxTime).toISOString()}`)
     const rawEvents = await db.apiEvents
       .where('timestamp')
-      .between(minTime, maxTime)
+      .between(minTime, maxTime, true, true)
       .toArray()
 
     // apiEvents is the raw Lake (see docs/architecture.md): the time window may
@@ -299,21 +312,20 @@ export class HandLogExporter {
    * Same logic as getHandApiEvents but operates on in-memory data instead of DB.
    */
   private static extractHandEvents(allEvents: ApiEvent[], hand: Hand): ApiEvent[] {
-    // Filter to the hand's time range first
-    const startTime = hand.approxTimestamp! - this.TIME_BUFFER_MS
-    const endTime = hand.approxTimestamp! + this.POST_HAND_BUFFER_MS
-
-    const rangeEvents = allEvents.filter(e =>
-      e.timestamp! >= startTime && e.timestamp! <= endTime
-    )
-
-    // Find EVT_HAND_RESULTS with matching HandId
-    const resultEvent = rangeEvents.find((e: ApiEvent) =>
-      isApiEventType(e, ApiType.EVT_HAND_RESULTS) && e.HandId === hand.id
+    const resultEvent = allEvents.find((event): event is ApiEvent<ApiType.EVT_HAND_RESULTS> =>
+      isApiEventType(event, ApiType.EVT_HAND_RESULTS) && event.HandId === hand.id
     )
     if (!resultEvent) {
       throw new Error(`Could not find EVT_HAND_RESULTS for hand ${hand.id}`)
     }
+
+    // Filter from before the deal through this hand's independently-located result.
+    const startTime = hand.approxTimestamp! - this.TIME_BUFFER_MS
+    const endTime = resultEvent.timestamp!
+
+    const rangeEvents = allEvents.filter(e =>
+      e.timestamp! >= startTime && e.timestamp! <= endTime
+    )
 
     // Extract EVT_DEAL to EVT_HAND_RESULTS sequence
     const handEvents: ApiEvent[] = []
@@ -390,13 +402,29 @@ export class HandLogExporter {
    * Get API events for a specific hand
    */
   private static async getHandApiEvents(db: PokerChaseDB, hand: Hand): Promise<ApiEvent[]> {
-    // Get events around the hand timestamp (with buffer for related events and player names)
     const startTime = hand.approxTimestamp! - this.TIME_BUFFER_MS
-    const endTime = hand.approxTimestamp! + this.POST_HAND_BUFFER_MS
+    // Find the terminal event independently. `approxTimestamp` is the hand
+    // start time, so a fixed post-start window would drop ordinary long hands.
+    const resultEvent = await db.apiEvents
+      .where('[ApiTypeId+timestamp]')
+      .between(
+        [ApiType.EVT_HAND_RESULTS, startTime],
+        [ApiType.EVT_HAND_RESULTS, Number.MAX_SAFE_INTEGER],
+        true,
+        true
+      )
+      .filter(event => isApiEventType(event, ApiType.EVT_HAND_RESULTS) && event.HandId === hand.id)
+      .first()
+    if (!resultEvent) {
+      throw new Error(`Could not find EVT_HAND_RESULTS for hand ${hand.id}`)
+    }
+
+    // Get events from before the deal through the matching result.
+    const endTime = resultEvent.timestamp!
 
     const rawEvents = await db.apiEvents
       .where('timestamp')
-      .between(startTime, endTime)
+      .between(startTime, endTime, true, true)
       .toArray()
 
     // apiEvents is the raw Lake (see docs/architecture.md): filter to validated
@@ -413,15 +441,6 @@ export class HandLogExporter {
       eventTypeCounts[e.ApiTypeId] = (eventTypeCounts[e.ApiTypeId] || 0) + 1
     })
     // Event type distribution
-
-    // Find the specific hand events by looking for EVT_HAND_RESULTS with matching HandId
-    const resultEvent = allEvents.find((e: ApiEvent) =>
-      isApiEventType(e, ApiType.EVT_HAND_RESULTS) && e.HandId === hand.id
-    )
-
-    if (!resultEvent) {
-      throw new Error(`Could not find EVT_HAND_RESULTS for hand ${hand.id}`)
-    }
 
     // Get all events from EVT_DEAL to EVT_HAND_RESULTS for this hand
     const handEvents: ApiEvent[] = []


### PR DESCRIPTION
## Summary

- anchor Hand.approxTimestamp to EVT_DEAL in both live and rebuild converters
- keep exported PokerStars-format hand timestamps aligned with live hand logs
- locate matching EVT_HAND_RESULTS independently so long hands are not truncated in single or batch export
- bump the rebuild advisory so existing derived hands can be repaired from the Raw Event Lake
- add a 60-second regression spanning live persistence, batch rebuild, single export, and batch export

## Why

Both converters overwrote the hand timestamp when EVT_HAND_RESULTS arrived. HandLogExporter then preferred that persisted value over the original EVT_DEAL timestamp, so exported logs reported hand completion time as the start time. Once anchored correctly, export bounds must follow the matching result event rather than the old fixed 30-second post-start window.

## Validation

- npm test -- --runInBand src/streams/hand-start-timestamp.test.ts src/streams/mtt-table-move-lifecycle.test.ts src/streams/private-mtt-lifecycle.test.ts
- npm run typecheck
- npm test -- --runInBand (129 suites, 1201 tests)
- npm run build
- verify-stats at 100% threshold on all four e2e NDJSON fixtures

Head SHA: bcabceb82f07a34818226108f73b8d747bf5b4c7

Codex session: 019f8719-f926-7e81-ae3a-3924c8efbfe9