### PR TITLE
fix: target HUD config broadcasts safely

### DIFF
--- a/src/components/popup/HudDisplaySection.test.tsx
+++ b/src/components/popup/HudDisplaySection.test.tsx
@@ -31,6 +31,7 @@ describe('HudDisplaySection', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockTabsSendMessage.mockResolvedValue(undefined)
     mockTabsQuery.mockImplementation((_, callback) => {
       callback([{ id: 1 }, { id: 2 }])
     })

--- a/src/components/popup/HudDisplaySection.tsx
+++ b/src/components/popup/HudDisplaySection.tsx
@@ -4,6 +4,7 @@ import FormControlLabel from '@mui/material/FormControlLabel'
 import RadioGroup from '@mui/material/RadioGroup'
 import Typography from '@mui/material/Typography'
 import type { UIConfig } from '../../types/hand-log'
+import { broadcastUIConfig } from './broadcast-ui-config'
 import { SegmentRadio } from './SegmentRadio'
 
 interface HudDisplaySectionProps {
@@ -23,16 +24,7 @@ export const HudDisplaySection = ({
   const updateUIConfig = (newConfig: UIConfig) => {
     setUIConfig(newConfig)
     chrome.storage.sync.set({ uiConfig: newConfig })
-    chrome.tabs.query({}, (tabs) => {
-      tabs.forEach(tab => {
-        if (tab.id) {
-          chrome.tabs.sendMessage(tab.id, {
-            action: 'updateUIConfig',
-            config: newConfig
-          })
-        }
-      })
-    })
+    broadcastUIConfig(newConfig)
   }
 
   // DEFAULT_UI_CONFIGとのマージ済みuiConfigが渡ってくる前提だが、念のため

--- a/src/components/popup/UIScaleSection.test.tsx
+++ b/src/components/popup/UIScaleSection.test.tsx
@@ -31,6 +31,7 @@ describe('UIScaleSection', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockTabsSendMessage.mockResolvedValue(undefined)
     mockTabsQuery.mockImplementation((_, callback) => {
       callback([{ id: 1 }, { id: 2 }])
     })
@@ -90,6 +91,24 @@ describe('UIScaleSection', () => {
       action: 'updateUIConfig',
       config: expectedConfig,
     })
+  })
+
+  it('ゲームタブだけに通知し、偶発的なreceiver消失を消費する', async () => {
+    const missingReceiver = Promise.reject(
+      new Error('Could not establish connection. Receiving end does not exist.')
+    )
+    await missingReceiver.catch(() => {})
+    const catchSpy = jest.spyOn(missingReceiver, 'catch')
+    mockTabsSendMessage.mockReturnValue(missingReceiver)
+
+    render(<UIScaleSection {...defaultProps} />)
+    await userEvent.click(screen.getByText('+'))
+
+    expect(mockTabsQuery).toHaveBeenCalledWith(
+      { url: 'https://game.poker-chase.com/*' },
+      expect.any(Function)
+    )
+    expect(catchSpy).toHaveBeenCalledWith(expect.any(Function))
   })
 
   it('スケールの最小値と最大値を制限', () => {

--- a/src/components/popup/UIScaleSection.test.tsx
+++ b/src/components/popup/UIScaleSection.test.tsx
@@ -93,22 +93,28 @@ describe('UIScaleSection', () => {
     })
   })
 
-  it('ゲームタブだけに通知し、偶発的なreceiver消失を消費する', async () => {
+  it.each([
+    'Could not establish connection. Receiving end does not exist.',
+    'The message port closed before a response was received.',
+  ])('ゲームタブだけに通知し、想定済みのone-way送信エラーを消費する: %s', async (errorMessage) => {
     const missingReceiver = Promise.reject(
-      new Error('Could not establish connection. Receiving end does not exist.')
+      new Error(errorMessage)
     )
     await missingReceiver.catch(() => {})
     const catchSpy = jest.spyOn(missingReceiver, 'catch')
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
     mockTabsSendMessage.mockReturnValue(missingReceiver)
 
     render(<UIScaleSection {...defaultProps} />)
     await userEvent.click(screen.getByText('+'))
 
     expect(mockTabsQuery).toHaveBeenCalledWith(
-      { url: 'https://game.poker-chase.com/*' },
+      { url: ['https://game.poker-chase.com/*'] },
       expect.any(Function)
     )
     expect(catchSpy).toHaveBeenCalledWith(expect.any(Function))
+    await Promise.resolve()
+    expect(warnSpy).not.toHaveBeenCalled()
   })
 
   it('スケールの最小値と最大値を制限', () => {

--- a/src/components/popup/UIScaleSection.tsx
+++ b/src/components/popup/UIScaleSection.tsx
@@ -4,6 +4,7 @@ import ToggleButton from '@mui/material/ToggleButton'
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import Typography from '@mui/material/Typography'
 import type { UIConfig } from '../../types/hand-log'
+import { broadcastUIConfig } from './broadcast-ui-config'
 
 interface UIScaleSectionProps {
   uiConfig: UIConfig
@@ -17,16 +18,7 @@ export const UIScaleSection = ({
   const updateUIConfig = (newConfig: UIConfig) => {
     setUIConfig(newConfig)
     chrome.storage.sync.set({ uiConfig: newConfig })
-    chrome.tabs.query({}, (tabs) => {
-      tabs.forEach(tab => {
-        if (tab.id) {
-          chrome.tabs.sendMessage(tab.id, {
-            action: 'updateUIConfig',
-            config: newConfig
-          })
-        }
-      })
-    })
+    broadcastUIConfig(newConfig)
   }
 
   return (

--- a/src/components/popup/broadcast-ui-config.ts
+++ b/src/components/popup/broadcast-ui-config.ts
@@ -1,0 +1,23 @@
+import type { UIConfig } from '../../types/hand-log'
+
+const GAME_URL_PATTERN = 'https://game.poker-chase.com/*'
+
+export const broadcastUIConfig = (config: UIConfig): void => {
+  chrome.tabs.query({ url: GAME_URL_PATTERN }, (tabs) => {
+    tabs.forEach(tab => {
+      if (!tab.id) return
+
+      chrome.tabs.sendMessage(tab.id, {
+        action: 'updateUIConfig',
+        config,
+      }).catch(error => {
+        // A matching game tab can still lose its content script while
+        // navigating or reloading. The persisted config will be loaded when
+        // the receiver returns, so this one-shot delivery is best-effort.
+        if (!(error instanceof Error) || !error.message.includes('Receiving end does not exist')) {
+          console.warn(`[popup] Failed to update UI config in tab ${tab.id}:`, error)
+        }
+      })
+    })
+  })
+}

--- a/src/components/popup/broadcast-ui-config.ts
+++ b/src/components/popup/broadcast-ui-config.ts
@@ -1,9 +1,16 @@
 import type { UIConfig } from '../../types/hand-log'
+import { content_scripts } from '../../../manifest.json'
 
-const GAME_URL_PATTERN = 'https://game.poker-chase.com/*'
+const gameUrlPatterns = content_scripts[0]!.matches
+
+const isExpectedOneWayDeliveryError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false
+  return error.message.includes('Receiving end does not exist') ||
+    error.message.includes('message port closed before a response was received')
+}
 
 export const broadcastUIConfig = (config: UIConfig): void => {
-  chrome.tabs.query({ url: GAME_URL_PATTERN }, (tabs) => {
+  chrome.tabs.query({ url: gameUrlPatterns }, (tabs) => {
     tabs.forEach(tab => {
       if (!tab.id) return
 
@@ -14,7 +21,7 @@ export const broadcastUIConfig = (config: UIConfig): void => {
         // A matching game tab can still lose its content script while
         // navigating or reloading. The persisted config will be loaded when
         // the receiver returns, so this one-shot delivery is best-effort.
-        if (!(error instanceof Error) || !error.message.includes('Receiving end does not exist')) {
+        if (!isExpectedOneWayDeliveryError(error)) {
           console.warn(`[popup] Failed to update UI config in tab ${tab.id}:`, error)
         }
       })


### PR DESCRIPTION
## Summary
- send popup HUD configuration updates only to tabs matched by the bundled content-script manifest
- preserve the E2E localhost fixture match injected at build time
- consume expected missing-receiver and no-response closures for one-way updates
- share one delivery helper across scale, visibility, display mode, and color controls
- keep unexpected delivery failures visible as warnings

## Root cause
Both popup UI sections queried every browser tab and fire-and-forgot `chrome.tabs.sendMessage`. Non-game tabs have no content-script receiver, so every setting change could emit unhandled `Receiving end does not exist` rejections; a matching game tab could produce the same rejection while navigating.

## Validation
- `npm test -- --runInBand src/components/popup/UIScaleSection.test.tsx src/components/popup/HudDisplaySection.test.tsx` (13 passed)
- `npm test -- --runInBand` (128 suites, 1202 tests passed)
- `npm run typecheck`
- `npm run build`
- `npm run build:e2e`

Head SHA: `cc41ec5a29043daf410d67cc2c0e7b1209e2ce93`