### PR TITLE
fix(sync): protect imported history from cloud watermarks

### DIFF
--- a/src/background/import-export.import-accounting.test.ts
+++ b/src/background/import-export.import-accounting.test.ts
@@ -9,6 +9,10 @@ import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
 import PokerChaseService, { PokerChaseDB } from '../app'
 import { createImportExportHandlers } from './import-export'
 import { setOperationState } from './operation-state'
+import {
+  SYNC_RESCAN_BACKFILL_DONE_META_KEY,
+  SYNC_RESCAN_FLOOR_META_KEY
+} from '../constants/sync'
 
 describe('importData() legacy sequence assignment and content dedup', () => {
   let db: PokerChaseDB
@@ -55,5 +59,40 @@ describe('importData() legacy sequence assignment and content dedup', () => {
 
     expect(replay).toMatchObject({ successCount: 0, duplicateCount: 2, totalLines: 2 })
     expect(await db.apiEvents.count()).toBe(2)
+  })
+
+  test('stores an imported application row atomically with every reconciled account watermark floor', async () => {
+    const imported = {
+      timestamp: 100,
+      ApiTypeId: 201,
+      Code: 0,
+      BattleType: 0,
+      Id: 'imported-stage',
+      IsRetire: false
+    }
+    await db.meta.bulkPut([
+      { id: `${SYNC_RESCAN_BACKFILL_DONE_META_KEY}:user-a`, value: true, updatedAt: 1 },
+      { id: `${SYNC_RESCAN_BACKFILL_DONE_META_KEY}:user-b`, value: true, updatedAt: 1 },
+      { id: `${SYNC_RESCAN_FLOOR_META_KEY}:user-b`, value: 50, updatedAt: 1 }
+    ])
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+
+    const realPut = db.meta.put.bind(db.meta)
+    const putSpy = jest.spyOn(db.meta, 'put').mockImplementation((record: any) => {
+      if (record.id === `${SYNC_RESCAN_FLOOR_META_KEY}:user-a`) {
+        return Promise.reject(new Error('synthetic floor persistence failure')) as any
+      }
+      return realPut(record) as any
+    })
+
+    await expect(handlers.importData(JSON.stringify(imported)))
+      .rejects.toThrow('synthetic floor persistence failure')
+    expect(await db.apiEvents.count()).toBe(0)
+
+    putSpy.mockRestore()
+    await expect(handlers.importData(JSON.stringify(imported))).resolves.toMatchObject({ successCount: 1 })
+    expect((await db.meta.get(`${SYNC_RESCAN_FLOOR_META_KEY}:user-a`))?.value).toBe(100)
+    // Never raise an already-earlier protection floor.
+    expect((await db.meta.get(`${SYNC_RESCAN_FLOOR_META_KEY}:user-b`))?.value).toBe(50)
   })
 })

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -153,7 +153,9 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
         // assigns one atomically. New-format rows preserve their sequence
         // when free, and a conflicting slot is safely reallocated.
         if (rawEventsToStore.length > 0) {
-          const merge = await mergeApiEvents(db, rawEventsToStore)
+          const merge = await mergeApiEvents(db, rawEventsToStore, {
+            protectAddedApplicationEventsFromCloudWatermark: true
+          })
           successCount += merge.added.length
           duplicateCount += merge.duplicates
 

--- a/src/background/message-router.operation-exclusivity.test.ts
+++ b/src/background/message-router.operation-exclusivity.test.ts
@@ -47,6 +47,18 @@ describe('message-router import operation exclusivity', () => {
     expect(setBatchMode).not.toHaveBeenCalled()
   })
 
+  test('rejects a direct import while cloud sync owns the shared operation slot', () => {
+    const setBatchMode = jest.spyOn(service, 'setBatchMode')
+    const sendResponse = jest.fn()
+    setOperationState({ type: 'sync' })
+
+    const handled = listener({ action: 'importData', data: '{}' }, {}, sendResponse)
+
+    expect(handled).toBe(true)
+    expect(sendResponse).toHaveBeenCalledWith({ success: false, error: '別の処理が実行中です' })
+    expect(setBatchMode).not.toHaveBeenCalled()
+  })
+
   test('rejects chunk-session initialization while another operation is active', () => {
     const sendResponse = jest.fn()
     setOperationState({ type: 'rebuild' })

--- a/src/background/operation-state.test.ts
+++ b/src/background/operation-state.test.ts
@@ -1,4 +1,4 @@
-import { getOperationState, setOperationState, isOperationIdle, onOperationBecameIdle } from './operation-state'
+import { getOperationState, setOperationState, isOperationIdle, onOperationBecameIdle, waitForOperationIdle } from './operation-state'
 
 describe('operation-state', () => {
   afterEach(() => {
@@ -89,6 +89,20 @@ describe('operation-state', () => {
 
       unsubscribe1()
       unsubscribe2()
+    })
+
+    it('resolves every concurrent idle waiter even though each removes itself', async () => {
+      setOperationState({ type: 'import' })
+      const first = waitForOperationIdle()
+      const second = waitForOperationIdle()
+      const settled: string[] = []
+      void first.then(() => settled.push('first'))
+      void second.then(() => settled.push('second'))
+
+      setOperationState({ type: 'idle' })
+      await Promise.all([first, second])
+
+      expect(settled).toEqual(['first', 'second'])
     })
   })
 })

--- a/src/background/operation-state.ts
+++ b/src/background/operation-state.ts
@@ -2,14 +2,14 @@
 /**
  * Popup ↔ Background の排他制御用の状態管理。
  *
- * `export`/`import`/`rebuild` のような長時間実行される操作は同時に1つしか
+ * `export`/`import`/`rebuild`/`sync` のような長時間実行される操作は同時に1つしか
  * 実行できない（CLAUDE.md「Operation Exclusivity」参照）。Popup側は楽観的に
  * ボタンを無効化するが、Background側でも`currentOperationState`を見て
  * 二重実行を拒否することでサーバーサイドの保証とする。
  */
 
 export interface OperationState {
-  type: 'idle' | 'export' | 'import' | 'rebuild'
+  type: 'idle' | 'export' | 'import' | 'rebuild' | 'sync'
   format?: 'json' | 'pokerstars'
   progress?: number
   processed?: number
@@ -58,3 +58,22 @@ export const setOperationState = (state: OperationState): void => {
 
 /** アイドル状態かどうか（同時実行不可な操作の開始可否判定用） */
 export const isOperationIdle = (): boolean => currentOperationState.type === 'idle'
+
+/** 現在の長時間処理が終わるまで待つ。既にidleなら即座に解決する。 */
+export const waitForOperationIdle = async (): Promise<void> => {
+  if (isOperationIdle()) return
+
+  await new Promise<void>(resolve => {
+    const unsubscribe = onOperationBecameIdle(() => {
+      unsubscribe()
+      resolve()
+    })
+
+    // Check again after subscription so an idle transition between the
+    // initial check and listener registration cannot leave this hung.
+    if (isOperationIdle()) {
+      unsubscribe()
+      resolve()
+    }
+  })
+}

--- a/src/background/operation-state.ts
+++ b/src/background/operation-state.ts
@@ -46,13 +46,16 @@ export const setOperationState = (state: OperationState): void => {
   const wasIdle = currentOperationState.type === 'idle'
   currentOperationState = state
   if (!wasIdle && state.type === 'idle') {
-    idleListeners.forEach(listener => {
+    // Listeners such as waitForOperationIdle() unsubscribe themselves while
+    // handling this transition. Iterate over a snapshot so splicing the live
+    // registry cannot skip the next waiter.
+    for (const listener of [...idleListeners]) {
       try {
         listener()
       } catch (error) {
         console.error('[operation-state] onOperationBecameIdle listener failed:', error)
       }
-    })
+    }
   }
 }
 

--- a/src/constants/sync.ts
+++ b/src/constants/sync.ts
@@ -1,0 +1,8 @@
+/** Account-scoped upload rewind floor stored in PokerChaseDB.meta. */
+export const SYNC_RESCAN_FLOOR_META_KEY = 'syncUnparseableFloor'
+
+/** Account-scoped marker for the one-time below-watermark reconciliation. */
+export const SYNC_RESCAN_BACKFILL_DONE_META_KEY = 'syncUnparseableFloorBackfillDoneV2'
+
+export const isScopedSyncMetaKey = (id: string, baseKey: string): boolean =>
+  id === baseKey || id.startsWith(`${baseKey}:`)

--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -8,6 +8,8 @@ import { AutoSyncService, REBUILD_AFTER_DOWNLOAD_FAILED_MESSAGE } from './auto-s
 import { firestoreBackupService } from './firestore-backup-service'
 import { firebaseAuthService } from './firebase-auth-service'
 import * as minVersionGate from './min-version-gate'
+import { mergeApiEvents } from '../utils/api-event-key'
+import { getOperationState, setOperationState } from '../background/operation-state'
 
 describe('AutoSyncService cloud downloads', () => {
   let db: PokerChaseDB
@@ -17,9 +19,11 @@ describe('AutoSyncService cloud downloads', () => {
     sendMessageMock.mockResolvedValue(undefined)
     db = new PokerChaseDB(indexedDB, IDBKeyRange)
     await db.open()
+    setOperationState({ type: 'idle' })
   })
 
   afterEach(async () => {
+    setOperationState({ type: 'idle' })
     jest.restoreAllMocks()
     db.close()
     await db.delete()
@@ -1054,6 +1058,82 @@ describe('AutoSyncService cloud downloads', () => {
     })
   })
 
+  test('re-offers an older application row imported after the cloud watermark has advanced', async () => {
+    const originalChunkSize = DATABASE_CONSTANTS.SYNC_CHUNK_SIZE
+    ;(DATABASE_CONSTANTS as any).SYNC_CHUNK_SIZE = 2
+
+    try {
+      const initialEvents = [100, 300, 400].map(timestamp => ({
+        ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+        Code: 0,
+        BattleType: BattleType.SIT_AND_GO,
+        Id: `initial-${timestamp}`,
+        IsRetire: false,
+        timestamp
+      } as ApiEvent))
+      const importedOlderEvent = {
+        ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+        Code: 0,
+        BattleType: BattleType.SIT_AND_GO,
+        Id: 'imported-200',
+        IsRetire: false,
+        timestamp: 200
+      } as ApiEvent
+      await db.apiEvents.bulkAdd(initialEvents)
+
+      jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue({ uid: 'test-user' } as any)
+      jest.spyOn(minVersionGate, 'isCloudSyncBlockedByMinVersionGate').mockResolvedValue(false)
+      jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp')
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue(400)
+
+      const uploadedIds: string[] = []
+      jest.spyOn(firestoreBackupService, 'syncToCloudBatch').mockImplementation(async events => {
+        uploadedIds.push(...events.map(event => event.Id as string))
+        return { totalEvents: events.length, syncedEvents: events.length, lastSyncTime: new Date() }
+      })
+
+      const service = new AutoSyncService(db)
+      await service.performSync('upload')
+
+      // The first proven-empty pass records the one-time reconciliation as
+      // done. A later import must lower that account's durable scan floor in
+      // the same transaction as this new row, or the 400 watermark hides it.
+      await mergeApiEvents(db, [importedOlderEvent as any], {
+        protectAddedApplicationEventsFromCloudWatermark: true
+      })
+
+      // A later cloud watermark now sits at 400. A correct concurrency
+      // contract must still offer the imported row on this retry rather than
+      // trusting a watermark that the overlapping pass advanced past it.
+      await service.performSync('upload')
+
+      expect(uploadedIds).toContain(importedOlderEvent.Id)
+    } finally {
+      ;(DATABASE_CONSTANTS as any).SYNC_CHUNK_SIZE = originalChunkSize
+    }
+  })
+
+  test('claims the shared operation slot for the entire sync and refuses to start while import owns it', async () => {
+    const service = new AutoSyncService(db)
+    let resolveGate: ((blocked: boolean) => void) | undefined
+    jest.spyOn(minVersionGate, 'isCloudSyncBlockedByMinVersionGate')
+      .mockImplementation(() => new Promise<boolean>(resolve => { resolveGate = resolve }))
+    jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockResolvedValue(null)
+
+    const sync = service.performSync('upload')
+    expect(getOperationState().type).toBe('sync')
+    while (!resolveGate) await Promise.resolve()
+    resolveGate(false)
+    await sync
+    expect(getOperationState().type).toBe('idle')
+
+    setOperationState({ type: 'import' })
+    const blocked = await service.performSync('upload')
+    expect(blocked).toEqual({ success: false, error: expect.stringContaining('実行中') })
+    expect(getOperationState().type).toBe('import')
+  })
+
   test('releases the _isSyncing latch (via finally) even when the min-version gate blocks the sync', async () => {
     const service = new AutoSyncService(db)
     jest.spyOn(minVersionGate, 'isCloudSyncBlockedByMinVersionGate').mockResolvedValue(true)
@@ -1566,6 +1646,27 @@ describe('AutoSyncService cloud downloads', () => {
     // B's own first sync succeeded once the latch was actually free -- not
     // abandoned after 3 immediate, doomed retries that all short-circuited
     // on the same still-held latch.
+    expect((await chrome.storage.local.get('autoSyncLastTime:user-b'))['autoSyncLastTime:user-b']).toBeDefined()
+  })
+
+  test('waits for an active import operation before retrying a first-account sync', async () => {
+    await chrome.storage.local.remove(['autoSyncLastTime:user-b'])
+    jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue({ uid: 'user-b' } as any)
+    jest.spyOn(firebaseAuthService, 'getAuthGeneration').mockReturnValue(1)
+    jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockResolvedValue(null)
+    jest.spyOn(firestoreBackupService, 'syncFromCloud').mockResolvedValue(0)
+    jest.spyOn(minVersionGate, 'isCloudSyncBlockedByMinVersionGate').mockResolvedValue(false)
+
+    const service = new AutoSyncService(db)
+    setOperationState({ type: 'import' })
+    const initialize = service.initialize()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect((await chrome.storage.local.get('autoSyncLastTime:user-b'))['autoSyncLastTime:user-b']).toBeUndefined()
+
+    setOperationState({ type: 'idle' })
+    await initialize
+
     expect((await chrome.storage.local.get('autoSyncLastTime:user-b'))['autoSyncLastTime:user-b']).toBeDefined()
   })
 

--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -332,6 +332,46 @@ describe('AutoSyncService cloud downloads', () => {
     )
   })
 
+  test('queues a session-boundary automatic upload while import owns the operation slot, then runs it after import finishes', async () => {
+    const event = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Code: 0,
+      BattleType: BattleType.SIT_AND_GO,
+      Id: 'queued-after-import',
+      IsRetire: false,
+      timestamp: 100
+    } as ApiEvent
+    await db.apiEvents.add(event)
+
+    jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue({ uid: 'test-user' } as any)
+    jest.spyOn(firebaseAuthService, 'getAuthGeneration').mockReturnValue(1)
+    jest.spyOn(minVersionGate, 'isCloudSyncBlockedByMinVersionGate').mockResolvedValue(false)
+    jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockResolvedValue(null)
+    const syncBatchSpy = jest.spyOn(firestoreBackupService, 'syncToCloudBatch')
+      .mockResolvedValue({ totalEvents: 1, syncedEvents: 1, lastSyncTime: new Date() })
+
+    const service = new AutoSyncService(db)
+    ;(service as any).EVENTS_THRESHOLD = 1
+    setOperationState({ type: 'import' })
+
+    const automaticUpload = service.onGameSessionEnd()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // The trigger is pending rather than falsely completing or overlapping
+    // the import. Releasing the shared slot must run that same upload without
+    // requiring another session event or a manual sync.
+    expect(syncBatchSpy).not.toHaveBeenCalled()
+    expect(getOperationState().type).toBe('import')
+
+    setOperationState({ type: 'idle' })
+    await automaticUpload
+
+    expect(syncBatchSpy).toHaveBeenCalledTimes(1)
+    expect(syncBatchSpy.mock.calls[0]?.[0]).toEqual([event])
+    expect(service.getSyncState().status).toBe('success')
+    expect(getOperationState().type).toBe('idle')
+  })
+
   test('upload: a normal chunk of only valid application events uploads and advances the cloud watermark past every event (unaffected by the unparseable-row guard)', async () => {
     const firstEntry = {
       ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
@@ -1130,7 +1170,11 @@ describe('AutoSyncService cloud downloads', () => {
 
     setOperationState({ type: 'import' })
     const blocked = await service.performSync('upload')
-    expect(blocked).toEqual({ success: false, error: expect.stringContaining('実行中') })
+    expect(blocked).toEqual({
+      success: false,
+      error: expect.stringContaining('実行中'),
+      reason: 'operation-busy'
+    })
     expect(getOperationState().type).toBe('import')
   })
 

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -77,11 +77,11 @@ export type SyncDirection = 'upload' | 'download' | 'both'
  *
  * `performSync()` itself must keep its long-standing NEVER-THROW contract on
  * its own internal failure paths (the remote min-version gate blocking sync,
- * or `syncToCloud()`/`syncFromCloud()` throwing) -- `initialize()` and
- * `syncIfBacklogExceedsThreshold()` both call it fire-and-forget-style
- * (`await this.performSync()` / `await this.performSync('upload')`, ignoring
- * the resolved value entirely) and rely on that resolving cleanly so their
- * own retry/backoff logic runs on every path, not just the happy one. Before
+ * or `syncToCloud()`/`syncFromCloud()` throwing) -- `initialize()` ignores
+ * the resolved outcome, while `syncIfBacklogExceedsThreshold()` only
+ * inspects the structured operation-busy reason to queue an automatic
+ * retry. Both rely on internal failures resolving cleanly so their own
+ * control flow runs on every path, not just the happy one. Before
  * this fix, `Promise<void>` gave callers no way to distinguish "sync ran and
  * succeeded" from "sync ran and failed internally" other than re-reading
  * `getSyncState()` afterward -- `message-router.ts`'s manual-sync handlers
@@ -100,7 +100,7 @@ export type SyncDirection = 'upload' | 'download' | 'both'
  */
 export type SyncOutcome =
   | { success: true }
-  | { success: false, error: string }
+  | { success: false, error: string, reason?: 'operation-busy' }
 
 export interface SyncState {
   status: SyncStatus
@@ -580,7 +580,11 @@ export class AutoSyncService {
     // the shared long-operation slot synchronously before the first await so
     // import/export/rebuild and cloud sync cannot overlap in either order.
     if (!isOperationIdle()) {
-      return { success: false, error: '別のデータ処理が実行中です。完了後にもう一度お試しください。' }
+      return {
+        success: false,
+        error: '別のデータ処理が実行中です。完了後にもう一度お試しください。',
+        reason: 'operation-busy'
+      }
     }
 
     // Latch BEFORE the awaited gate check below (codex#3612092798): if we set
@@ -714,9 +718,10 @@ export class AutoSyncService {
         // `message-router.ts`'s manual-sync handlers, which only checked
         // resolve-vs-reject, reported `{ success: true }` to the popup even
         // though the sync (e.g. a Firestore write) actually failed. Keeping
-        // this never-throw for internal callers (`initialize()`,
-        // `syncIfBacklogExceedsThreshold()`, both of which ignore the
-        // resolved value) -- only the resolved SHAPE now tells the truth.
+        // this never-throw for internal callers (`initialize()` and the
+        // automatic threshold path) -- only the resolved SHAPE now tells
+        // the truth, and the automatic path selectively handles the
+        // operation-busy reason above.
         const errorMessage = error instanceof Error ? error.message : 'Unknown error'
         this.updateSyncState({
           status: 'error',
@@ -1675,7 +1680,34 @@ export class AutoSyncService {
 
       if (newEventsCount >= this.EVENTS_THRESHOLD) {
         console.log(`[AutoSync] ${trigger} with ${newEventsCount} raw events since the last completed sync, performing upload sync...`)
-        await this.performSync('upload')
+        // Session-boundary auto sync is a durability trigger, so do not drop
+        // it merely because import/export/rebuild currently owns the shared
+        // operation slot. Manual sync still receives the immediate busy
+        // outcome from performSync(); only this automatic path waits and
+        // retries. A structured reason avoids coupling this decision to the
+        // localized user-facing error text.
+        const triggerGeneration = firebaseAuthService.getAuthGeneration()
+        let outcome = await this.performSync('upload')
+        while (!outcome.success && outcome.reason === 'operation-busy') {
+          console.warn(`[AutoSync] ${trigger} upload is waiting for the active ${getOperationState().type} operation to finish`)
+          await waitForOperationIdle()
+
+          // The queued trigger belongs to the account that was live when the
+          // upload was first attempted. Generation (rather than uid) catches
+          // A -> B -> A transitions as well; the newly-live account's own
+          // initialize/session trigger is responsible for its sync.
+          if (firebaseAuthService.getAuthGeneration() !== triggerGeneration ||
+            !firebaseAuthService.getCurrentUser()) {
+            console.warn(`[AutoSync] ${trigger} upload retry cancelled because the signed-in account changed while waiting`)
+            return
+          }
+
+          // Another non-sync operation may win the slot between the idle
+          // notification and this retry. Loop until an upload starts, while
+          // a concurrent sync-busy outcome can safely stop here because that
+          // owning sync will cover the same shared local backlog.
+          outcome = await this.performSync('upload')
+        }
       } else {
         console.log(`[AutoSync] ${trigger} with only ${newEventsCount} raw events since the last completed sync, skipping sync (threshold: ${this.EVENTS_THRESHOLD})`)
       }

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -5,6 +5,11 @@
 
 import { firestoreBackupService } from './firestore-backup-service'
 import { firebaseAuthService } from './firebase-auth-service'
+import { getOperationState, isOperationIdle, setOperationState, waitForOperationIdle } from '../background/operation-state'
+import {
+  SYNC_RESCAN_BACKFILL_DONE_META_KEY,
+  SYNC_RESCAN_FLOOR_META_KEY
+} from '../constants/sync'
 import { PokerChaseDB } from '../db/poker-chase-db'
 import { EntityConverter } from '../entity-converter'
 import { ApiType, ApiTypeValues, isApiEventType, isApplicationApiEvent, isUnparseableApplicationEvent } from '../types'
@@ -274,7 +279,7 @@ export class AutoSyncService {
    * 直前までスキャン開始点を巻き戻す。実際のキーは`scopedMetaKey()`でサインイン中の
    * uidにスコープされる（上記 ACCOUNT-SCOPING INVARIANTS 参照）。
    */
-  private readonly SYNC_UNPARSEABLE_FLOOR_KEY = 'syncUnparseableFloor'
+  private readonly SYNC_UNPARSEABLE_FLOOR_KEY = SYNC_RESCAN_FLOOR_META_KEY
   /**
    * `meta`テーブルのキー。一度だけ実行するバックフィルスキャン
    * （`backfillUnparseableFloorIfNeeded`、下記の invariant spec 参照）が
@@ -286,7 +291,7 @@ export class AutoSyncService {
    * `backfillUnparseableFloorIfNeeded`参照）とuidスコープを確実に一度だけ
    * 適用させるため。
    */
-  private readonly SYNC_UNPARSEABLE_BACKFILL_DONE_KEY = 'syncUnparseableFloorBackfillDoneV2'
+  private readonly SYNC_UNPARSEABLE_BACKFILL_DONE_KEY = SYNC_RESCAN_BACKFILL_DONE_META_KEY
 
   constructor(db?: PokerChaseDB) {
     this.db = db ?? new PokerChaseDB(self.indexedDB, self.IDBKeyRange)
@@ -523,6 +528,9 @@ export class AutoSyncService {
           if (this.isSyncing && this.inFlightSyncPromise) {
             console.warn('[AutoSync] initialize(): first sync did not run because a different pass is still in flight, waiting for it to settle before retrying')
             await this.inFlightSyncPromise
+          } else if (!isOperationIdle()) {
+            console.warn(`[AutoSync] initialize(): first sync is waiting for the active ${getOperationState().type} operation to finish`)
+            await waitForOperationIdle()
           } else {
             console.warn('[AutoSync] initialize(): first sync did not complete, retrying')
           }
@@ -567,6 +575,14 @@ export class AutoSyncService {
       return { success: false, error: '別のクラウド同期が実行中です。完了後にもう一度お試しください。' }
     }
 
+    // Importing older history while an upload cursor is in flight can insert
+    // a row behind that cursor and below the Firestore max watermark. Claim
+    // the shared long-operation slot synchronously before the first await so
+    // import/export/rebuild and cloud sync cannot overlap in either order.
+    if (!isOperationIdle()) {
+      return { success: false, error: '別のデータ処理が実行中です。完了後にもう一度お試しください。' }
+    }
+
     // Latch BEFORE the awaited gate check below (codex#3612092798): if we set
     // this after awaiting, two performSync() calls arriving close together can
     // both pass the `this._isSyncing` check above, both await the gate, and
@@ -574,6 +590,7 @@ export class AutoSyncService {
     // race this flag exists to prevent. Reset in `finally` so every return
     // path (gate-blocked or sync completed/failed) releases the latch.
     this._isSyncing = true
+    setOperationState({ type: 'sync' })
     let resolveInFlightSyncPromise: (() => void) | undefined
     this.inFlightSyncPromise = new Promise<void>(resolve => { resolveInFlightSyncPromise = resolve })
 
@@ -711,6 +728,7 @@ export class AutoSyncService {
       this._isSyncing = false
       this.inFlightSyncPromise = null
       resolveInFlightSyncPromise?.()
+      if (getOperationState().type === 'sync') setOperationState({ type: 'idle' })
     }
   }
 

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -349,7 +349,7 @@ export interface SyncInfoResponse extends SuccessResponse {
 
 export interface OperationStateResponse extends SuccessResponse {
   operationState: {
-    type: 'idle' | 'export' | 'import' | 'rebuild'
+    type: 'idle' | 'export' | 'import' | 'rebuild' | 'sync'
     format?: 'json' | 'pokerstars'
     progress?: number
     processed?: number

--- a/src/utils/api-event-key.ts
+++ b/src/utils/api-event-key.ts
@@ -1,5 +1,10 @@
 import type { PokerChaseDB } from '../db/poker-chase-db'
-import type { ApiEvent } from '../types/api'
+import { ApiTypeValues, type ApiEvent } from '../types/api'
+import {
+  isScopedSyncMetaKey,
+  SYNC_RESCAN_BACKFILL_DONE_META_KEY,
+  SYNC_RESCAN_FLOOR_META_KEY
+} from '../constants/sync'
 
 export const API_EVENT_PRIMARY_KEY = '[timestamp+ApiTypeId+sequence]'
 export const API_EVENT_TIMESTAMP_TYPE_INDEX = '[timestamp+ApiTypeId]'
@@ -15,6 +20,15 @@ export type RawApiEvent = Record<string, unknown> & {
 export interface MergeApiEventsResult {
   added: RawApiEvent[]
   duplicates: number
+}
+
+export interface MergeApiEventsOptions {
+  /**
+   * Imported history may sort below an account's Firestore max timestamp.
+   * Lower every previously-reconciled account's scan floor in the same
+   * transaction as the new raw rows so the watermark cannot hide them.
+   */
+  protectAddedApplicationEventsFromCloudWatermark?: boolean
 }
 
 export const getApiEventSequence = (event: { sequence?: unknown }): number =>
@@ -72,11 +86,16 @@ export const getApiEventContentIdentity = (event: RawApiEvent): string => {
  */
 export async function mergeApiEvents(
   db: PokerChaseDB,
-  inputEvents: RawApiEvent[]
+  inputEvents: RawApiEvent[],
+  options: MergeApiEventsOptions = {}
 ): Promise<MergeApiEventsResult> {
   if (inputEvents.length === 0) return { added: [], duplicates: 0 }
 
-  return await db.transaction('rw', db.apiEvents, async () => {
+  const transactionTables = options.protectAddedApplicationEventsFromCloudWatermark
+    ? [db.apiEvents, db.meta]
+    : [db.apiEvents]
+
+  return await db.transaction('rw', transactionTables, async () => {
     const groupKeys = [...new Map(
       inputEvents.map(event => [`${event.timestamp}\u0000${event.ApiTypeId}`, [event.timestamp, event.ApiTypeId] as [number, number]])
     ).values()]
@@ -124,6 +143,34 @@ export async function mergeApiEvents(
 
     if (added.length > 0) {
       await db.apiEvents.bulkAdd(added as unknown as ApiEvent[])
+
+      if (options.protectAddedApplicationEventsFromCloudWatermark) {
+        const importedApplicationTimestamps = added
+          .filter(event => ApiTypeValues.includes(event.ApiTypeId as any))
+          .map(event => event.timestamp)
+        const earliestImportedTimestamp = importedApplicationTimestamps.length > 0
+          ? Math.min(...importedApplicationTimestamps)
+          : null
+
+        if (earliestImportedTimestamp !== null) {
+          const reconciledAccounts = await db.meta
+            .filter(record => isScopedSyncMetaKey(record.id, SYNC_RESCAN_BACKFILL_DONE_META_KEY))
+            .toArray()
+
+          for (const marker of reconciledAccounts) {
+            const accountSuffix = marker.id.slice(SYNC_RESCAN_BACKFILL_DONE_META_KEY.length)
+            const floorKey = `${SYNC_RESCAN_FLOOR_META_KEY}${accountSuffix}`
+            const existingFloor = await db.meta.get(floorKey)
+            if (typeof existingFloor?.value !== 'number' || existingFloor.value > earliestImportedTimestamp) {
+              await db.meta.put({
+                id: floorKey,
+                value: earliestImportedTimestamp,
+                updatedAt: Date.now()
+              })
+            }
+          }
+        }
+      }
     }
 
     return { added, duplicates }


### PR DESCRIPTION
## Summary

- lower every reconciled account upload floor atomically with newly imported application rows
- serialize cloud sync with import/export/rebuild through the existing long-operation state
- wait for an active data operation before retrying first-account initialization
- notify every concurrent operation waiter from an immutable listener snapshot
- queue session-boundary automatic uploads until an active data operation finishes

## Root cause

Firestore max timestamp is only a high watermark; it cannot prove there are no gaps below it. Once the one-time reconciliation marker existed, importing a new older row left it below the watermark forever. An overlapping upload made the same gap possible when the row landed behind its current compound cursor. Import did not persist any account-scoped rewind marker, and sync did not participate in operation exclusivity.

The fix uses the existing durable scan-floor contract: when import adds an application-typed raw row, the same IndexedDB transaction lowers each previously-reconciled account floor. Sync and other long operations then cannot overlap and clear that protection. A failed floor write rolls the raw insert back. Idle waiters iterate over a snapshot so concurrent initializers all resume. Automatic session-boundary uploads wait for a busy import/export/rebuild slot and retry under the same auth generation; manual sync still returns busy immediately.

## Validation

- `npm test -- --runInBand` (128 suites, 1,206 tests)
- `npm run typecheck`
- `npm run build`
- `npm run e2e:smoke` (7/7 checks)

## Head

`e18c62f`