### PR TITLE
fix: invalidate live stats cache on hand completion

### DIFF
--- a/src/streams/read-entity-stream.test.ts
+++ b/src/streams/read-entity-stream.test.ts
@@ -14,8 +14,8 @@
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
 import { PokerChaseDB } from '../db/poker-chase-db'
 import PokerChaseService from '../services/poker-chase-service'
-import { BattleType } from '../types/game'
-import type { Hand } from '../types/entities'
+import { ApiType, BattleType, PhaseType } from '../types'
+import type { ApiHandEvent, Hand } from '../types'
 import type { PlayerStats, StatResult } from '../types'
 
 const PLAYER_ID = 1
@@ -129,6 +129,72 @@ describe('ReadEntityStream.calcStats -- table-size filter (C案)', () => {
     const stats = await runCalcStats(service, SEAT_USER_IDS)
     // full+4p = hands {1,2,3}; battleType=TOURNAMENT excludes hand 1 -> hands {2,3} remain.
     expect(handsStatOf(stats, PLAYER_ID)?.value).toBe(2)
+  })
+
+  test('a completed hand invalidates a same-lineup production cache warmed at deal time', async () => {
+    const previousNodeEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+
+    try {
+      const warmed = await runCalcStats(service, SEAT_USER_IDS)
+      expect(handsStatOf(warmed, PLAYER_ID)?.value).toBe(6)
+
+      const completedStats = new Promise<PlayerStats[]>((resolve, reject) => {
+        const onData = (stats: PlayerStats[]) => {
+          service.statsOutputStream.off('data', onData)
+          resolve(stats)
+        }
+        service.statsOutputStream.on('data', onData)
+        service.statsOutputStream.on('error', reject)
+      })
+
+      const completedHand: ApiHandEvent[] = [
+        {
+          ApiTypeId: ApiType.EVT_DEAL,
+          timestamp: 7_000,
+          SeatUserIds: SEAT_USER_IDS,
+          Game: {
+            CurrentBlindLv: 1,
+            NextBlindUnixSeconds: 0,
+            Ante: 0,
+            SmallBlind: 100,
+            BigBlind: 200,
+            ButtonSeat: 5,
+            SmallBlindSeat: 0,
+            BigBlindSeat: 1
+          },
+          Progress: {
+            Phase: PhaseType.PREFLOP,
+            NextActionSeat: 2,
+            NextActionTypes: [],
+            NextExtraLimitSeconds: 0,
+            MinRaise: 0,
+            Pot: 300,
+            SidePot: []
+          },
+          OtherPlayers: []
+        },
+        {
+          ApiTypeId: ApiType.EVT_HAND_RESULTS,
+          timestamp: 7_001,
+          HandId: 7,
+          CommunityCards: [],
+          Pot: 300,
+          SidePot: [],
+          ResultType: 0,
+          DefeatStatus: 0,
+          Results: [],
+          OtherPlayers: []
+        }
+      ]
+
+      service.writeEntityStream.write(completedHand)
+      await service.writeEntityStream.whenIdle()
+
+      expect(handsStatOf(await completedStats, PLAYER_ID)?.value).toBe(7)
+    } finally {
+      process.env.NODE_ENV = previousNodeEnv
+    }
   })
 })
 

--- a/src/streams/read-entity-stream.ts
+++ b/src/streams/read-entity-stream.ts
@@ -54,9 +54,14 @@ export class ReadEntityStream extends SimpleTransform<number[], PlayerStats[]> {
     this.service = service
   }
 
+  /** Drop results derived from an older hands/phases/actions snapshot. */
+  public invalidateCache(): void {
+    this.statsCache.clear()
+  }
+
   public async recalculateStats(): Promise<void> {
     // 新しい計算を保証するためキャッシュをクリア
-    this.statsCache.clear()
+    this.invalidateCache()
 
     // 必要なデータの存在チェック
     if (!this.service.playerId || !this.service.latestEvtDeal) {

--- a/src/streams/write-entity-stream.ts
+++ b/src/streams/write-entity-stream.ts
@@ -60,6 +60,10 @@ export class WriteEntityStream extends SimpleTransform<ApiHandEvent[], number[]>
           this.service.db.phases.bulkPut(phases)
         ])
       })
+      // EVT_DEAL may have warmed this exact lineup into the 5-second HUD
+      // cache. The completed hand changes every aggregate, so invalidate only
+      // after its entity transaction commits and before downstream recalculates.
+      this.service.statsOutputStream.invalidateCache()
       this.push(hand.seatUserIds)
     } catch (error: unknown) {
       const context: ErrorContext = {


### PR DESCRIPTION
## Summary

- expose an explicit ReadEntityStream cache invalidation method
- invalidate the five-second HUD stats cache after a completed hand transaction commits
- keep deal-time warmup caching for repeated non-mutating broadcasts
- add a production-cache regression that moves HAND from 6 to 7 on the same lineup

## Why

A new EVT_DEAL can warm stats for a lineup before the hand ends. If a fast hand completed within the five-second cache window, WriteEntityStream sent the same lineup downstream and ReadEntityStream returned the pre-hand cache entry, temporarily hiding the completed hand and every stat change derived from it.

## Validation

- npm test -- --runInBand src/streams/read-entity-stream.test.ts src/entity-converter.test.ts (41 tests)
- npm run typecheck
- npm test -- --runInBand (128 suites, 1201 tests)
- npm run build

Head SHA: ce63c77a8175f2ae349e407930708e68b9e35dee

Codex session: 019f8719-f926-7e81-ae3a-3924c8efbfe9