### PR TITLE
fix: handle filter broadcast closure

### DIFF
--- a/src/background/message-router.spectator-filter-refresh.test.ts
+++ b/src/background/message-router.spectator-filter-refresh.test.ts
@@ -187,4 +187,28 @@ describe('message-router updateBattleTypeFilter -- spectator lastKnownStats refr
 
     expect(writeSpy).toHaveBeenCalledWith([10, 20])
   })
+
+  test('consumes the expected one-way delivery rejection when forwarding the filter update', async () => {
+    const noResponse = Promise.reject(
+      new Error('The message port closed before a response was received.')
+    )
+    await noResponse.catch(() => {})
+    const catchSpy = jest.spyOn(noResponse, 'catch')
+    const sendMessageMock = jest.fn().mockReturnValue(noResponse)
+    ;(global as any).chrome.tabs = {
+      sendMessage: sendMessageMock,
+      query: jest.fn((_query, callback) => callback([{ id: 42 }])),
+    }
+
+    messageListener(
+      { action: 'updateBattleTypeFilter', filterOptions: FILTER_OPTIONS } as unknown as ChromeMessage,
+      {} as chrome.runtime.MessageSender,
+      jest.fn()
+    )
+
+    expect(sendMessageMock).toHaveBeenCalledWith(42, expect.objectContaining({
+      action: 'updateBattleTypeFilter',
+    }))
+    expect(catchSpy).toHaveBeenCalledWith(expect.any(Function))
+  })
 })

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -166,7 +166,18 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
 
       // コンテンツスクリプトにメッセージを転送
       chrome.tabs.query({ url: gameUrlPattern }, tabs => {
-        tabs.forEach(tab => tab.id && chrome.tabs.sendMessage(tab.id, request))
+        tabs.forEach(tab => {
+          if (!tab.id) return
+          chrome.tabs.sendMessage(tab.id, request).catch(error => {
+            // This is a one-way update: the content script intentionally does
+            // not respond, and it can also disappear during navigation.
+            const message = error instanceof Error ? error.message : ''
+            if (!message.includes('Receiving end does not exist') &&
+                !message.includes('message port closed before a response was received')) {
+              console.warn(`[background] Failed to forward filter update to tab ${tab.id}:`, error)
+            }
+          })
+        })
       })
 
       // 新しいフィルターに基づいてHUD表示を強制更新


### PR DESCRIPTION
## Summary
- consume expected one-way no-response closures when forwarding filter updates
- consume the matching-tab navigation/missing-receiver race
- keep unexpected delivery failures visible as Service Worker warnings
- add a deterministic regression test

## Root cause
`updateBattleTypeFilter` forwards the update from the Service Worker to matching game tabs, but the content-script listener intentionally sends no response. The returned Promise therefore rejects with `The message port closed before a response was received`; navigation can also remove the receiver. Without a handler, the Service Worker reports `Uncaught (in promise)`.

## Validation
- `npm test -- --runInBand src/background/message-router.spectator-filter-refresh.test.ts` (5 passed)
- `npm test -- --runInBand` (128 suites, 1205 tests passed)
- `npm run typecheck`
- `npm run build`

Head SHA: `c6c61e7e0630470c9ede7e8c0b0b1d93ae4d035d`