### PR TITLE
fix(auth): make sign-out storage commit atomic

### DIFF
--- a/src/background/message-router.auth-signout-race.test.ts
+++ b/src/background/message-router.auth-signout-race.test.ts
@@ -1,0 +1,67 @@
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import type { AuthUser } from '../services/firebase-auth-service'
+import { firebaseAuthService } from '../services/firebase-auth-service'
+import { autoSyncService } from '../services/auto-sync-service'
+import type { ChromeMessage, MessageResponse } from '../types/messages'
+import { registerMessageRouter } from './message-router'
+
+describe('message-router firebaseSignOut auth-transition ordering', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+  let listener: (
+    request: ChromeMessage,
+    sender: chrome.runtime.MessageSender,
+    sendResponse: (response: MessageResponse) => void
+  ) => boolean | void
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    service = new PokerChaseService({ db })
+    await service.ready
+
+    ;(chrome.runtime.onMessage.addListener as jest.Mock).mockClear()
+    registerMessageRouter(service, db, 'https://example.com/*')
+    listener = (chrome.runtime.onMessage.addListener as jest.Mock).mock.calls[0][0]
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    db.close()
+    await db.delete()
+  })
+
+  test('does not apply a stale signed-out sync reset after a newer account becomes current', async () => {
+    const newerUser: AuthUser = {
+      uid: 'user-b',
+      email: 'b@example.com',
+      displayName: null,
+      photoURL: null,
+      getIdToken: async () => 'b-token'
+    }
+    jest.spyOn(firebaseAuthService, 'signOut').mockResolvedValue()
+    jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue(newerUser)
+    const authStateChanged = jest.spyOn(autoSyncService, 'onAuthStateChanged').mockResolvedValue()
+    const sendResponse = jest.fn()
+
+    expect(listener({ action: 'firebaseSignOut' }, {}, sendResponse)).toBe(true)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(authStateChanged).not.toHaveBeenCalledWith(null)
+    expect(sendResponse).toHaveBeenCalledWith({ success: true })
+  })
+
+  test('still resets sync state when sign-out leaves no current user', async () => {
+    jest.spyOn(firebaseAuthService, 'signOut').mockResolvedValue()
+    jest.spyOn(firebaseAuthService, 'getCurrentUser').mockReturnValue(null)
+    const authStateChanged = jest.spyOn(autoSyncService, 'onAuthStateChanged').mockResolvedValue()
+    const sendResponse = jest.fn()
+
+    expect(listener({ action: 'firebaseSignOut' }, {}, sendResponse)).toBe(true)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(authStateChanged).toHaveBeenCalledWith(null)
+    expect(sendResponse).toHaveBeenCalledWith({ success: true })
+  })
+})

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -45,8 +45,13 @@ const handleFirebaseSignOut = async (): Promise<void> => {
     await firebaseAuthService.signOut()
     console.log('[Firebase] User signed out')
 
-    // Update sync state
-    await autoSyncService.onAuthStateChanged(null)
+    // A newer sign-in may have waited for this sign-out and published its
+    // account as soon as the auth operation settled. Do not let this older
+    // message continuation overwrite that account's freshly initialized sync
+    // state with a stale signed-out reset.
+    if (!firebaseAuthService.getCurrentUser()) {
+      await autoSyncService.onAuthStateChanged(null)
+    }
   } catch (error) {
     console.error('[Firebase] Sign out error:', error)
     throw error

--- a/src/services/firebase-auth-service.test.ts
+++ b/src/services/firebase-auth-service.test.ts
@@ -362,6 +362,65 @@ describe('FirebaseAuthService.signOut -- durable state removal', () => {
     expect(restartedService.getCurrentUser()).toBeNull()
   })
 
+  test('reserves sign-out before a slow Chrome token lookup so an in-flight newer sign-in cannot publish early', async () => {
+    const storedState = {
+      uid: 'user-a',
+      email: 'a@example.com',
+      displayName: null,
+      photoURL: null,
+      idToken: 'a-token',
+      refreshToken: 'a-refresh-token',
+      expiresAt: Date.now() + 60 * 60 * 1000
+    }
+    await chrome.storage.local.set({ firebaseRestAuthState: storedState })
+
+    const service = new FirebaseAuthService()
+    await service.ready()
+    const generationBeforeSignOut = service.getAuthGeneration()
+
+    let finishNonInteractiveLookup: (() => void) | undefined
+    jest.spyOn(chrome.identity, 'getAuthToken').mockImplementation(((options: { interactive?: boolean }, callback: (result?: { token: string }) => void) => {
+      if (options.interactive) {
+        callback({ token: 'new-chrome-token' })
+      } else {
+        finishNonInteractiveLookup = () => callback(undefined)
+      }
+    }) as typeof chrome.identity.getAuthToken)
+
+    const originalFetch = global.fetch
+    const signInFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        idToken: 'b-token',
+        refreshToken: 'b-refresh-token',
+        expiresIn: '3600',
+        localId: 'user-b',
+        email: 'b@example.com'
+      })
+    })
+    global.fetch = signInFetch as any
+
+    try {
+      const signOut = service.signOut()
+
+      // Reservation and pending marker are established synchronously before
+      // the non-interactive Chrome lookup returns.
+      expect(service.getAuthGeneration()).toBe(generationBeforeSignOut + 1)
+      expect(finishNonInteractiveLookup).toBeDefined()
+
+      const signIn = service.signInWithGoogle()
+      while (signInFetch.mock.calls.length === 0) await Promise.resolve()
+      expect(service.getCurrentUser()?.uid).toBe('user-a')
+
+      finishNonInteractiveLookup?.()
+      await signOut
+      expect((await signIn).uid).toBe('user-b')
+      expect(service.getCurrentUser()?.uid).toBe('user-b')
+    } finally {
+      global.fetch = originalFetch
+    }
+  })
+
   test('lets a newer sign-in publish after an older pending sign-out finishes instead of clobbering it', async () => {
     const storedState = {
       uid: 'user-a',
@@ -384,7 +443,7 @@ describe('FirebaseAuthService.signOut -- durable state removal', () => {
     const originalRemove = (chrome.storage.local.remove as jest.Mock).getMockImplementation()!
     let removeStarted = false
     let releaseRemove: (() => void) | undefined
-    jest.spyOn(chrome.storage.local, 'remove').mockImplementation(async (keys: string | string[]) => {
+    const removeSpy = jest.spyOn(chrome.storage.local, 'remove').mockImplementation(async (keys: string | string[]) => {
       removeStarted = true
       await new Promise<void>(resolve => { releaseRemove = resolve })
       return originalRemove(keys)
@@ -406,6 +465,10 @@ describe('FirebaseAuthService.signOut -- durable state removal', () => {
       const signOut = service.signOut()
       while (!removeStarted) await Promise.resolve()
 
+      // A duplicate popup/message request must join the existing destructive
+      // operation rather than queue a second auth-state removal behind it.
+      const duplicateSignOut = service.signOut()
+
       // The newer sign-in may complete its network exchange, but must wait
       // behind the older durable removal before publishing or persisting B.
       const signIn = service.signInWithGoogle()
@@ -414,8 +477,10 @@ describe('FirebaseAuthService.signOut -- durable state removal', () => {
 
       releaseRemove?.()
       await signOut
+      await duplicateSignOut
       const userB = await signIn
 
+      expect(removeSpy).toHaveBeenCalledTimes(1)
       expect(userB.uid).toBe('user-b')
       expect(service.getCurrentUser()?.uid).toBe('user-b')
 
@@ -424,6 +489,76 @@ describe('FirebaseAuthService.signOut -- durable state removal', () => {
       expect(restartedService.getCurrentUser()?.uid).toBe('user-b')
     } finally {
       global.fetch = originalFetch
+    }
+  })
+
+  test('keeps a newer sign-in blocked through external token revocation side effects', async () => {
+    const storedState = {
+      uid: 'user-a',
+      email: 'a@example.com',
+      displayName: null,
+      photoURL: null,
+      idToken: 'a-token',
+      refreshToken: 'a-refresh-token',
+      expiresAt: Date.now() + 60 * 60 * 1000
+    }
+    await chrome.storage.local.set({ firebaseRestAuthState: storedState })
+
+    const service = new FirebaseAuthService()
+    await service.ready()
+
+    jest.spyOn(chrome.identity, 'getAuthToken').mockImplementation(((options: { interactive?: boolean }, callback: (result?: { token: string }) => void) => {
+      callback({ token: options.interactive ? 'new-chrome-token' : 'old-chrome-token' })
+    }) as typeof chrome.identity.getAuthToken)
+    const originalRemoveCachedAuthToken = chrome.identity.removeCachedAuthToken
+    ;(chrome.identity as any).removeCachedAuthToken = jest.fn(((_details: unknown, callback?: () => void) => {
+      callback?.()
+    }) as any)
+
+    let revokeStarted = false
+    let releaseRevoke: (() => void) | undefined
+    const originalFetch = global.fetch
+    global.fetch = jest.fn().mockImplementation((input: string) => {
+      if (input.includes('accounts.google.com/o/oauth2/revoke')) {
+        revokeStarted = true
+        return new Promise(resolve => {
+          releaseRevoke = () => resolve({ ok: true })
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          idToken: 'b-token',
+          refreshToken: 'b-refresh-token',
+          expiresIn: '3600',
+          localId: 'user-b',
+          email: 'b@example.com'
+        })
+      })
+    }) as any
+
+    try {
+      const signOut = service.signOut()
+      while (!revokeStarted) await Promise.resolve()
+      expect(service.getCurrentUser()).toBeNull()
+
+      const signIn = service.signInWithGoogle()
+      await new Promise(resolve => setTimeout(resolve, 0))
+      // The Firebase exchange may finish, but B is not published until the
+      // older sign-out's revoke request has also settled.
+      expect(service.getCurrentUser()).toBeNull()
+
+      releaseRevoke?.()
+      await signOut
+      expect((await signIn).uid).toBe('user-b')
+      expect(service.getCurrentUser()?.uid).toBe('user-b')
+    } finally {
+      global.fetch = originalFetch
+      if (originalRemoveCachedAuthToken) {
+        ;(chrome.identity as any).removeCachedAuthToken = originalRemoveCachedAuthToken
+      } else {
+        delete (chrome.identity as Partial<typeof chrome.identity>).removeCachedAuthToken
+      }
     }
   })
 })

--- a/src/services/firebase-auth-service.test.ts
+++ b/src/services/firebase-auth-service.test.ts
@@ -313,6 +313,7 @@ describe('FirebaseAuthService.signOut -- durable state removal', () => {
     const service = new FirebaseAuthService()
     await service.ready()
     const generationBeforeSignOut = service.getAuthGeneration()
+    const capturedUser = service.getCurrentUser()!
     const listener = jest.fn()
     service.onAuthStateChange(listener)
     await new Promise(resolve => setTimeout(resolve, 0)) // consume the listener's initial restore callback
@@ -344,6 +345,7 @@ describe('FirebaseAuthService.signOut -- durable state removal', () => {
     const generationSnapshottedWhileRemovePending = service.getAuthGeneration()
     expect(service.getCurrentUser()?.uid).toBe('user-a')
     expect(listener).not.toHaveBeenCalled()
+    await expect(capturedUser.getIdToken(true)).rejects.toThrow('Sign-out is in progress')
 
     releaseRemove?.()
     await signOut
@@ -358,5 +360,70 @@ describe('FirebaseAuthService.signOut -- durable state removal', () => {
     const restartedService = new FirebaseAuthService()
     await restartedService.ready()
     expect(restartedService.getCurrentUser()).toBeNull()
+  })
+
+  test('lets a newer sign-in publish after an older pending sign-out finishes instead of clobbering it', async () => {
+    const storedState = {
+      uid: 'user-a',
+      email: 'a@example.com',
+      displayName: null,
+      photoURL: null,
+      idToken: 'a-token',
+      refreshToken: 'a-refresh-token',
+      expiresAt: Date.now() + 60 * 60 * 1000
+    }
+    await chrome.storage.local.set({ firebaseRestAuthState: storedState })
+
+    const service = new FirebaseAuthService()
+    await service.ready()
+
+    jest.spyOn(chrome.identity, 'getAuthToken').mockImplementation(((options: { interactive?: boolean }, callback: (result?: { token: string }) => void) => {
+      callback(options.interactive ? { token: 'new-chrome-token' } : undefined)
+    }) as typeof chrome.identity.getAuthToken)
+
+    const originalRemove = (chrome.storage.local.remove as jest.Mock).getMockImplementation()!
+    let removeStarted = false
+    let releaseRemove: (() => void) | undefined
+    jest.spyOn(chrome.storage.local, 'remove').mockImplementation(async (keys: string | string[]) => {
+      removeStarted = true
+      await new Promise<void>(resolve => { releaseRemove = resolve })
+      return originalRemove(keys)
+    })
+
+    const originalFetch = global.fetch
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        idToken: 'b-token',
+        refreshToken: 'b-refresh-token',
+        expiresIn: '3600',
+        localId: 'user-b',
+        email: 'b@example.com'
+      })
+    }) as any
+
+    try {
+      const signOut = service.signOut()
+      while (!removeStarted) await Promise.resolve()
+
+      // The newer sign-in may complete its network exchange, but must wait
+      // behind the older durable removal before publishing or persisting B.
+      const signIn = service.signInWithGoogle()
+      await new Promise(resolve => setTimeout(resolve, 0))
+      expect(service.getCurrentUser()?.uid).toBe('user-a')
+
+      releaseRemove?.()
+      await signOut
+      const userB = await signIn
+
+      expect(userB.uid).toBe('user-b')
+      expect(service.getCurrentUser()?.uid).toBe('user-b')
+
+      const restartedService = new FirebaseAuthService()
+      await restartedService.ready()
+      expect(restartedService.getCurrentUser()?.uid).toBe('user-b')
+    } finally {
+      global.fetch = originalFetch
+    }
   })
 })

--- a/src/services/firebase-auth-service.test.ts
+++ b/src/services/firebase-auth-service.test.ts
@@ -567,4 +567,75 @@ describe('FirebaseAuthService.signOut -- durable state removal', () => {
       }
     }
   })
+
+  test('releases sign-in after a stalled Google revoke request times out', async () => {
+    jest.useFakeTimers()
+    const storedState = {
+      uid: 'user-a',
+      email: 'a@example.com',
+      displayName: null,
+      photoURL: null,
+      idToken: 'a-token',
+      refreshToken: 'a-refresh-token',
+      expiresAt: Date.now() + 60 * 60 * 1000
+    }
+    await chrome.storage.local.set({ firebaseRestAuthState: storedState })
+
+    const service = new FirebaseAuthService()
+    await service.ready()
+
+    let interactiveLookupCount = 0
+    jest.spyOn(chrome.identity, 'getAuthToken').mockImplementation(((options: { interactive?: boolean }, callback: (result?: { token: string }) => void) => {
+      if (options.interactive) interactiveLookupCount++
+      callback({ token: options.interactive ? 'new-chrome-token' : 'old-chrome-token' })
+    }) as typeof chrome.identity.getAuthToken)
+    const originalRemoveCachedAuthToken = chrome.identity.removeCachedAuthToken
+    ;(chrome.identity as any).removeCachedAuthToken = jest.fn(((_details: unknown, callback?: () => void) => {
+      callback?.()
+    }) as any)
+
+    let revokeStarted = false
+    const originalFetch = global.fetch
+    global.fetch = jest.fn().mockImplementation((input: string, init?: RequestInit) => {
+      if (input.includes('accounts.google.com/o/oauth2/revoke')) {
+        revokeStarted = true
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(new Error('aborted')))
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          idToken: 'b-token',
+          refreshToken: 'b-refresh-token',
+          expiresIn: '3600',
+          localId: 'user-b',
+          email: 'b@example.com'
+        })
+      })
+    }) as any
+
+    try {
+      const signOut = service.signOut()
+      while (!revokeStarted) await Promise.resolve()
+
+      const signIn = service.signInWithGoogle()
+      await Promise.resolve()
+      expect(interactiveLookupCount).toBe(0)
+
+      await jest.advanceTimersByTimeAsync(30_000)
+      await signOut
+      expect((await signIn).uid).toBe('user-b')
+      expect(interactiveLookupCount).toBe(1)
+      expect(service.getCurrentUser()?.uid).toBe('user-b')
+    } finally {
+      jest.useRealTimers()
+      global.fetch = originalFetch
+      if (originalRemoveCachedAuthToken) {
+        ;(chrome.identity as any).removeCachedAuthToken = originalRemoveCachedAuthToken
+      } else {
+        delete (chrome.identity as Partial<typeof chrome.identity>).removeCachedAuthToken
+      }
+    }
+  })
 })

--- a/src/services/firebase-auth-service.test.ts
+++ b/src/services/firebase-auth-service.test.ts
@@ -273,6 +273,7 @@ describe('FirebaseAuthService.signOut -- durable state removal', () => {
     const service = new FirebaseAuthService()
     await service.ready()
     expect(service.getCurrentUser()?.uid).toBe('user-a')
+    const generationBeforeSignOut = service.getAuthGeneration()
 
     jest.spyOn(chrome.identity, 'getAuthToken').mockImplementation(((_options: unknown, callback: (result: { token: string }) => void) => {
       callback({ token: 'chrome-token' })
@@ -287,6 +288,10 @@ describe('FirebaseAuthService.signOut -- durable state removal', () => {
     // is still present, so the current instance must remain consistently
     // signed in and let the popup report the sign-out failure.
     expect(service.getCurrentUser()?.uid).toBe('user-a')
+    // The reservation is deliberately retained: work that started before
+    // the failed attempt must still see that an auth-sensitive operation
+    // intervened, even though no signed-out state was published.
+    expect(service.getAuthGeneration()).toBe(generationBeforeSignOut + 1)
 
     const restartedService = new FirebaseAuthService()
     await restartedService.ready()
@@ -333,8 +338,10 @@ describe('FirebaseAuthService.signOut -- durable state removal', () => {
 
     // The generation reservation is visible immediately, invalidating work
     // that snapshotted the old session, while user-facing auth state and
-    // listeners remain unchanged until the durable delete succeeds.
+    // listeners remain unchanged until the durable delete succeeds. Capture
+    // it as if a sync started inside this pending-removal window.
     expect(service.getAuthGeneration()).toBe(generationBeforeSignOut + 1)
+    const generationSnapshottedWhileRemovePending = service.getAuthGeneration()
     expect(service.getCurrentUser()?.uid).toBe('user-a')
     expect(listener).not.toHaveBeenCalled()
 
@@ -342,6 +349,10 @@ describe('FirebaseAuthService.signOut -- durable state removal', () => {
     await signOut
 
     expect(service.getCurrentUser()).toBeNull()
+    // A second increment at publication invalidates work that began during
+    // the remove() window with user A plus the reservation generation.
+    expect(service.getAuthGeneration()).toBe(generationBeforeSignOut + 2)
+    expect(service.getAuthGeneration()).toBeGreaterThan(generationSnapshottedWhileRemovePending)
     expect(listener).toHaveBeenCalledWith(null, 'sign-out')
 
     const restartedService = new FirebaseAuthService()

--- a/src/services/firebase-auth-service.test.ts
+++ b/src/services/firebase-auth-service.test.ts
@@ -362,7 +362,7 @@ describe('FirebaseAuthService.signOut -- durable state removal', () => {
     expect(restartedService.getCurrentUser()).toBeNull()
   })
 
-  test('reserves sign-out before a slow Chrome token lookup so an in-flight newer sign-in cannot publish early', async () => {
+  test('waits for a slow sign-out before requesting a new Chrome token', async () => {
     const storedState = {
       uid: 'user-a',
       email: 'a@example.com',
@@ -379,8 +379,10 @@ describe('FirebaseAuthService.signOut -- durable state removal', () => {
     const generationBeforeSignOut = service.getAuthGeneration()
 
     let finishNonInteractiveLookup: (() => void) | undefined
+    let interactiveLookupCount = 0
     jest.spyOn(chrome.identity, 'getAuthToken').mockImplementation(((options: { interactive?: boolean }, callback: (result?: { token: string }) => void) => {
       if (options.interactive) {
+        interactiveLookupCount++
         callback({ token: 'new-chrome-token' })
       } else {
         finishNonInteractiveLookup = () => callback(undefined)
@@ -409,12 +411,16 @@ describe('FirebaseAuthService.signOut -- durable state removal', () => {
       expect(finishNonInteractiveLookup).toBeDefined()
 
       const signIn = service.signInWithGoogle()
-      while (signInFetch.mock.calls.length === 0) await Promise.resolve()
+      await new Promise(resolve => setTimeout(resolve, 0))
+      expect(interactiveLookupCount).toBe(0)
+      expect(signInFetch).not.toHaveBeenCalled()
       expect(service.getCurrentUser()?.uid).toBe('user-a')
 
       finishNonInteractiveLookup?.()
       await signOut
       expect((await signIn).uid).toBe('user-b')
+      expect(interactiveLookupCount).toBe(1)
+      expect(signInFetch).toHaveBeenCalledTimes(1)
       expect(service.getCurrentUser()?.uid).toBe('user-b')
     } finally {
       global.fetch = originalFetch

--- a/src/services/firebase-auth-service.test.ts
+++ b/src/services/firebase-auth-service.test.ts
@@ -252,3 +252,100 @@ describe('FirebaseAuthService.getIdToken -- stale refresh handling', () => {
     expect((service as any).authGeneration).toBe(generationAfterRoundTrip)
   })
 })
+
+describe('FirebaseAuthService.signOut -- durable state removal', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('does not publish an in-memory sign-out when removing the persisted auth state fails', async () => {
+    const storedState = {
+      uid: 'user-a',
+      email: 'a@example.com',
+      displayName: null,
+      photoURL: null,
+      idToken: 'a-token',
+      refreshToken: 'a-refresh-token',
+      expiresAt: Date.now() + 60 * 60 * 1000
+    }
+    await chrome.storage.local.set({ firebaseRestAuthState: storedState })
+
+    const service = new FirebaseAuthService()
+    await service.ready()
+    expect(service.getCurrentUser()?.uid).toBe('user-a')
+
+    jest.spyOn(chrome.identity, 'getAuthToken').mockImplementation(((_options: unknown, callback: (result: { token: string }) => void) => {
+      callback({ token: 'chrome-token' })
+    }) as typeof chrome.identity.getAuthToken)
+    ;(jest.spyOn(chrome.storage.local, 'remove') as jest.SpyInstance)
+      .mockRejectedValueOnce(new Error('chrome.storage.local.remove failed'))
+
+    await expect(service.signOut()).rejects.toThrow('chrome.storage.local.remove failed')
+
+    // A failed durable commit must not expose a transient signed-out state
+    // that reverses on the next Service Worker startup. The persisted token
+    // is still present, so the current instance must remain consistently
+    // signed in and let the popup report the sign-out failure.
+    expect(service.getCurrentUser()?.uid).toBe('user-a')
+
+    const restartedService = new FirebaseAuthService()
+    await restartedService.ready()
+    expect(restartedService.getCurrentUser()?.uid).toBe('user-a')
+  })
+
+  test('invalidates in-flight work before durable removal, but publishes sign-out only after removal commits', async () => {
+    const storedState = {
+      uid: 'user-a',
+      email: 'a@example.com',
+      displayName: null,
+      photoURL: null,
+      idToken: 'a-token',
+      refreshToken: 'a-refresh-token',
+      expiresAt: Date.now() + 60 * 60 * 1000
+    }
+    await chrome.storage.local.set({ firebaseRestAuthState: storedState })
+
+    const service = new FirebaseAuthService()
+    await service.ready()
+    const generationBeforeSignOut = service.getAuthGeneration()
+    const listener = jest.fn()
+    service.onAuthStateChange(listener)
+    await new Promise(resolve => setTimeout(resolve, 0)) // consume the listener's initial restore callback
+    listener.mockClear()
+
+    // No Chrome identity token means there is no external-revocation leg to
+    // exercise here; this test isolates the local durable commit boundary.
+    jest.spyOn(chrome.identity, 'getAuthToken').mockImplementation(((_options: unknown, callback: (result?: { token: string }) => void) => {
+      callback(undefined)
+    }) as typeof chrome.identity.getAuthToken)
+
+    const originalRemove = (chrome.storage.local.remove as jest.Mock).getMockImplementation()!
+    let removeStarted = false
+    let releaseRemove: (() => void) | undefined
+    jest.spyOn(chrome.storage.local, 'remove').mockImplementation(async (keys: string | string[]) => {
+      removeStarted = true
+      await new Promise<void>(resolve => { releaseRemove = resolve })
+      return originalRemove(keys)
+    })
+
+    const signOut = service.signOut()
+    while (!removeStarted) await Promise.resolve()
+
+    // The generation reservation is visible immediately, invalidating work
+    // that snapshotted the old session, while user-facing auth state and
+    // listeners remain unchanged until the durable delete succeeds.
+    expect(service.getAuthGeneration()).toBe(generationBeforeSignOut + 1)
+    expect(service.getCurrentUser()?.uid).toBe('user-a')
+    expect(listener).not.toHaveBeenCalled()
+
+    releaseRemove?.()
+    await signOut
+
+    expect(service.getCurrentUser()).toBeNull()
+    expect(listener).toHaveBeenCalledWith(null, 'sign-out')
+
+    const restartedService = new FirebaseAuthService()
+    await restartedService.ready()
+    expect(restartedService.getCurrentUser()).toBeNull()
+  })
+})

--- a/src/services/firebase-auth-service.ts
+++ b/src/services/firebase-auth-service.ts
@@ -75,6 +75,9 @@ interface FirebaseRefreshResponse {
 
 export class FirebaseAuthService {
   private static readonly STORAGE_KEY = 'firebaseRestAuthState'
+  // Match the existing 30s bounded-network convention used by Firestore
+  // without coupling auth cleanup to a database-specific constant.
+  private static readonly GOOGLE_REVOKE_TIMEOUT_MS = 30_000
   private currentState: StoredAuthState | null = null
   private authStateListeners: ((user: AuthUser | null, source: AuthChangeSource) => void)[] = []
   private restorePromise: Promise<void>
@@ -257,7 +260,25 @@ export class FirebaseAuthService {
       await new Promise<void>((resolve) => {
         chrome.identity.removeCachedAuthToken({ token: previousToken }, () => resolve())
       })
-      await fetch(`https://accounts.google.com/o/oauth2/revoke?token=${previousToken}`).catch(() => {})
+      // Revocation is best-effort after Chrome's local token cache has already
+      // been cleared. Bound the network leg so a stalled/offline endpoint
+      // cannot keep pendingSignOut alive forever and permanently block the
+      // next interactive sign-in in this Service Worker.
+      const revokeController = new AbortController()
+      const revokeTimeout = setTimeout(
+        () => revokeController.abort(),
+        FirebaseAuthService.GOOGLE_REVOKE_TIMEOUT_MS
+      )
+      try {
+        await fetch(
+          `https://accounts.google.com/o/oauth2/revoke?token=${previousToken}`,
+          { signal: revokeController.signal }
+        )
+      } catch {
+        // Local removal is authoritative; network revoke remains best-effort.
+      } finally {
+        clearTimeout(revokeTimeout)
+      }
     }
   }
 

--- a/src/services/firebase-auth-service.ts
+++ b/src/services/firebase-auth-service.ts
@@ -79,6 +79,13 @@ export class FirebaseAuthService {
   private authStateListeners: ((user: AuthUser | null, source: AuthChangeSource) => void)[] = []
   private restorePromise: Promise<void>
   /**
+   * Durable sign-out commit currently removing STORAGE_KEY. New token work
+   * must not start while this exists, and a concurrently completing sign-in
+   * waits for it so the newer sign-in is published after the older removal.
+   * The completion promise always resolves, including when removal fails.
+   */
+  private pendingSignOut: { completion: Promise<void>, complete: () => void } | null = null
+  /**
    * Monotonic counter, incremented on every auth-state TRANSITION (sign-in,
    * sign-out, or the initial restore-from-storage on startup). Sign-out uses
    * two increments: one reservation before its durable storage commit, then
@@ -150,6 +157,12 @@ export class FirebaseAuthService {
       }
 
       const result = await response.json() as FirebaseSignInResponse
+      // A sign-out that started while the Google/Firebase network exchange
+      // above was in flight owns the durable auth-storage commit. Publish and
+      // persist this newer sign-in only AFTER that older removal settles, so
+      // the sign-out cannot delete or overwrite the newly authenticated
+      // account when it resumes.
+      await this.waitForPendingSignOut()
       this.currentState = {
         uid: result.localId,
         email: result.email ?? null,
@@ -187,6 +200,17 @@ export class FirebaseAuthService {
   async signOut(): Promise<void> {
     const previousToken = await this.getChromeAuthToken(false).catch(() => null)
 
+    // Serialize duplicate sign-out requests. More importantly, this keeps a
+    // single pending marker authoritative for getIdToken()/sign-in waiters.
+    await this.waitForPendingSignOut()
+
+    let completePendingSignOut: (() => void) | undefined
+    const pendingSignOut = {
+      completion: new Promise<void>(resolve => { completePendingSignOut = resolve }),
+      complete: () => completePendingSignOut?.()
+    }
+    this.pendingSignOut = pendingSignOut
+
     // Reserve the sign-out generation BEFORE the durable storage commit.
     // This invalidates any token refresh that started under the old
     // generation so it cannot race the remove() below and persist the auth
@@ -195,16 +219,23 @@ export class FirebaseAuthService {
     // create a phantom logout that reverses on the next restart when the
     // still-persisted record is restored.
     this.authGeneration++
-    await chrome.storage.local.remove(FirebaseAuthService.STORAGE_KEY)
+    try {
+      await chrome.storage.local.remove(FirebaseAuthService.STORAGE_KEY)
 
-    // Publish the transition only after its durable half committed. Advance
-    // the generation AGAIN so work that started during the slow remove()
-    // window (and therefore snapshotted the reservation generation together
-    // with the still-live old user) is invalidated too. There is intentionally
-    // no await across this state/generation/listener commit.
-    this.currentState = null
-    this.authGeneration++
-    this.notifyAuthStateListeners(null, 'sign-out')
+      // Publish the transition only after its durable half committed.
+      // Advance the generation AGAIN so work that began before the pending
+      // marker was observed is invalidated too. There is intentionally no
+      // await across this state/generation/listener commit.
+      this.currentState = null
+      this.authGeneration++
+      this.notifyAuthStateListeners(null, 'sign-out')
+    } finally {
+      // Always release sign-in waiters and make a failed sign-out retryable.
+      // Identity comparison prevents an older finally block from clearing a
+      // future attempt should this method ever gain additional concurrency.
+      if (this.pendingSignOut === pendingSignOut) this.pendingSignOut = null
+      pendingSignOut.complete()
+    }
 
     if (previousToken) {
       await new Promise<void>((resolve) => {
@@ -236,6 +267,14 @@ export class FirebaseAuthService {
    */
   async getIdToken(forceRefresh = false): Promise<string> {
     await this.ready()
+    // A captured AuthUser object can outlive the moment sign-out starts, so
+    // checking only getCurrentUser() at the Firestore call site is not
+    // sufficient. Fail before using or refreshing any token while the
+    // durable removal is pending; callers surface/retry this like any other
+    // auth failure.
+    if (this.pendingSignOut) {
+      throw new Error('Sign-out is in progress')
+    }
     if (!this.currentState) {
       throw new Error('User not authenticated')
     }
@@ -390,6 +429,15 @@ export class FirebaseAuthService {
   private async persistAuthState(): Promise<void> {
     if (this.currentState) {
       await chrome.storage.local.set({ [FirebaseAuthService.STORAGE_KEY]: this.currentState })
+    }
+  }
+
+  /** Wait until every currently pending durable sign-out commit settles. */
+  private async waitForPendingSignOut(): Promise<void> {
+    // Loop so a queued duplicate sign-out that claims the marker immediately
+    // after the previous one completes is also observed by a waiting sign-in.
+    while (this.pendingSignOut) {
+      await this.pendingSignOut.completion
     }
   }
 

--- a/src/services/firebase-auth-service.ts
+++ b/src/services/firebase-auth-service.ts
@@ -134,6 +134,15 @@ export class FirebaseAuthService {
    * Sign in with Google using chrome.identity API.
    */
   async signInWithGoogle(): Promise<AuthUser> {
+    // A pending sign-out still owns the Chrome identity token: it may remove
+    // and revoke that token after its durable local-state removal. Waiting
+    // only before publishing the Firebase result is too late because an
+    // interactive lookup can otherwise reuse and exchange the old cached
+    // token while that cleanup is still in flight.
+    // Keep the no-sign-out path synchronous through starting the Chrome token
+    // request. The conditional also makes the ordering explicit: only an
+    // operation that already owns the token forces this sign-in to queue.
+    if (this.pendingSignOut) await this.waitForPendingSignOut()
     const token = await this.getChromeAuthToken(true)
     console.log('[FirebaseAuth] Got Chrome auth token')
 

--- a/src/services/firebase-auth-service.ts
+++ b/src/services/firebase-auth-service.ts
@@ -80,11 +80,13 @@ export class FirebaseAuthService {
   private restorePromise: Promise<void>
   /**
    * Monotonic counter, incremented on every auth-state TRANSITION (sign-in,
-   * sign-out, or the initial restore-from-storage on startup) -- and reserved
-   * before a durable sign-out commit so in-flight refreshes are invalidated
-   * even when storage removal ultimately fails. Never decremented, and never
-   * bumped by a same-account token refresh (`getIdToken(forceRefresh)`'s
-   * `currentState` reassignment preserves the same `uid`).
+   * sign-out, or the initial restore-from-storage on startup). Sign-out uses
+   * two increments: one reservation before its durable storage commit, then
+   * one when `null` is actually published. This invalidates work started
+   * both before and during a slow removal; if removal fails, only the
+   * reservation remains. Never decremented, and never bumped by a
+   * same-account token refresh (`getIdToken(forceRefresh)`'s `currentState`
+   * reassignment preserves the same `uid`).
    *
    * WHY (codex post-merge review on #192, r3615389112, P1, "Detect ABA
    * account switches before committing bookkeeping"): callers used to
@@ -195,10 +197,13 @@ export class FirebaseAuthService {
     this.authGeneration++
     await chrome.storage.local.remove(FirebaseAuthService.STORAGE_KEY)
 
-    // Publish the transition only after its durable half committed. There is
-    // intentionally no await between currentState=null and listener
-    // notification, so all in-memory readers observe the same transition.
+    // Publish the transition only after its durable half committed. Advance
+    // the generation AGAIN so work that started during the slow remove()
+    // window (and therefore snapshotted the reservation generation together
+    // with the still-live old user) is invalidated too. There is intentionally
+    // no await across this state/generation/listener commit.
     this.currentState = null
+    this.authGeneration++
     this.notifyAuthStateListeners(null, 'sign-out')
 
     if (previousToken) {

--- a/src/services/firebase-auth-service.ts
+++ b/src/services/firebase-auth-service.ts
@@ -80,9 +80,11 @@ export class FirebaseAuthService {
   private restorePromise: Promise<void>
   /**
    * Monotonic counter, incremented on every auth-state TRANSITION (sign-in,
-   * sign-out, or the initial restore-from-storage on startup) -- never on a
-   * same-account token refresh (`getIdToken(forceRefresh)`'s `currentState`
-   * reassignment preserves the same `uid`, so it does NOT bump this).
+   * sign-out, or the initial restore-from-storage on startup) -- and reserved
+   * before a durable sign-out commit so in-flight refreshes are invalidated
+   * even when storage removal ultimately fails. Never decremented, and never
+   * bumped by a same-account token refresh (`getIdToken(forceRefresh)`'s
+   * `currentState` reassignment preserves the same `uid`).
    *
    * WHY (codex post-merge review on #192, r3615389112, P1, "Detect ABA
    * account switches before committing bookkeeping"): callers used to
@@ -182,9 +184,21 @@ export class FirebaseAuthService {
    */
   async signOut(): Promise<void> {
     const previousToken = await this.getChromeAuthToken(false).catch(() => null)
-    this.currentState = null
-    this.authGeneration++ // sign-out transition -- see authGeneration's doc comment
+
+    // Reserve the sign-out generation BEFORE the durable storage commit.
+    // This invalidates any token refresh that started under the old
+    // generation so it cannot race the remove() below and persist the auth
+    // record again. Keep currentState intact until remove() succeeds: if the
+    // durable commit fails, exposing `null` only in this Service Worker would
+    // create a phantom logout that reverses on the next restart when the
+    // still-persisted record is restored.
+    this.authGeneration++
     await chrome.storage.local.remove(FirebaseAuthService.STORAGE_KEY)
+
+    // Publish the transition only after its durable half committed. There is
+    // intentionally no await between currentState=null and listener
+    // notification, so all in-memory readers observe the same transition.
+    this.currentState = null
     this.notifyAuthStateListeners(null, 'sign-out')
 
     if (previousToken) {

--- a/src/services/firebase-auth-service.ts
+++ b/src/services/firebase-auth-service.ts
@@ -79,12 +79,13 @@ export class FirebaseAuthService {
   private authStateListeners: ((user: AuthUser | null, source: AuthChangeSource) => void)[] = []
   private restorePromise: Promise<void>
   /**
-   * Durable sign-out commit currently removing STORAGE_KEY. New token work
-   * must not start while this exists, and a concurrently completing sign-in
-   * waits for it so the newer sign-in is published after the older removal.
-   * The completion promise always resolves, including when removal fails.
+   * Sign-out operation currently owning every local and external side effect.
+   * New token work must not start while this exists, a concurrent sign-in
+   * waits for `completion` (which always resolves), and duplicate sign-outs
+   * join `operation` so they observe the original success/failure instead of
+   * starting a second destructive removal.
    */
-  private pendingSignOut: { completion: Promise<void>, complete: () => void } | null = null
+  private pendingSignOut: { operation: Promise<void>, completion: Promise<void> } | null = null
   /**
    * Monotonic counter, incremented on every auth-state TRANSITION (sign-in,
    * sign-out, or the initial restore-from-storage on startup). Sign-out uses
@@ -198,44 +199,50 @@ export class FirebaseAuthService {
    * Sign out from Firebase and revoke Chrome identity token.
    */
   async signOut(): Promise<void> {
-    const previousToken = await this.getChromeAuthToken(false).catch(() => null)
+    // Coalesce duplicate requests with the operation already in progress.
+    // In particular, never let a second sign-out queue behind the first and
+    // then erase a newer sign-in that was waiting on the same completion.
+    const existingSignOut = this.pendingSignOut
+    if (existingSignOut) {
+      await existingSignOut.operation
+      return
+    }
 
-    // Serialize duplicate sign-out requests. More importantly, this keeps a
-    // single pending marker authoritative for getIdToken()/sign-in waiters.
-    await this.waitForPendingSignOut()
-
-    let completePendingSignOut: (() => void) | undefined
+    // performSignOut() runs synchronously through its generation reservation
+    // and first token lookup before returning this promise. The marker is
+    // therefore installed before signOut() yields to any later sign-in.
+    const operation = this.performSignOut()
     const pendingSignOut = {
-      completion: new Promise<void>(resolve => { completePendingSignOut = resolve }),
-      complete: () => completePendingSignOut?.()
+      operation,
+      // Sign-in should be released after a failed sign-out too: the old
+      // account remains intact and the newer successful sign-in may replace
+      // it. Duplicate sign-out callers use `operation` above and still see
+      // the real failure.
+      completion: operation.then(() => {}, () => {})
     }
     this.pendingSignOut = pendingSignOut
 
-    // Reserve the sign-out generation BEFORE the durable storage commit.
-    // This invalidates any token refresh that started under the old
-    // generation so it cannot race the remove() below and persist the auth
-    // record again. Keep currentState intact until remove() succeeds: if the
-    // durable commit fails, exposing `null` only in this Service Worker would
-    // create a phantom logout that reverses on the next restart when the
-    // still-persisted record is restored.
-    this.authGeneration++
     try {
-      await chrome.storage.local.remove(FirebaseAuthService.STORAGE_KEY)
-
-      // Publish the transition only after its durable half committed.
-      // Advance the generation AGAIN so work that began before the pending
-      // marker was observed is invalidated too. There is intentionally no
-      // await across this state/generation/listener commit.
-      this.currentState = null
-      this.authGeneration++
-      this.notifyAuthStateListeners(null, 'sign-out')
+      await operation
     } finally {
-      // Always release sign-in waiters and make a failed sign-out retryable.
-      // Identity comparison prevents an older finally block from clearing a
-      // future attempt should this method ever gain additional concurrency.
       if (this.pendingSignOut === pendingSignOut) this.pendingSignOut = null
-      pendingSignOut.complete()
     }
+  }
+
+  private async performSignOut(): Promise<void> {
+    // Reserve the sign-out generation BEFORE the durable storage commit.
+    // This is also before the first await (the Chrome token lookup), so a
+    // sign-in started while that lookup is slow must wait for this operation.
+    this.authGeneration++
+
+    const previousToken = await this.getChromeAuthToken(false).catch(() => null)
+    await chrome.storage.local.remove(FirebaseAuthService.STORAGE_KEY)
+
+    // Publish only after the durable removal commits. Keep currentState intact
+    // on failure so logout cannot reverse after a Service Worker restart.
+    this.currentState = null
+    this.authGeneration++
+    this.notifyAuthStateListeners(null, 'sign-out')
 
     if (previousToken) {
       await new Promise<void>((resolve) => {
@@ -432,10 +439,8 @@ export class FirebaseAuthService {
     }
   }
 
-  /** Wait until every currently pending durable sign-out commit settles. */
+  /** Wait until the current sign-out and all of its side effects settle. */
   private async waitForPendingSignOut(): Promise<void> {
-    // Loop so a queued duplicate sign-out that claims the marker immediately
-    // after the previous one completes is also observed by a waiting sign-in.
     while (this.pendingSignOut) {
       await this.pendingSignOut.completion
     }


### PR DESCRIPTION
## Summary

- reserve sign-out synchronously before the first Chrome identity await so newer sign-ins cannot publish into an older logout
- coalesce duplicate sign-out requests into one destructive operation and propagate its original success/failure
- keep captured-user token refreshes blocked until durable removal and external Chrome/Google token cleanup settle
- defer every new Chrome/Firebase sign-in token request until an already-active sign-out has completed
- bound the best-effort Google revoke request to 30 seconds after authoritative local token-cache removal
- publish the in-memory signed-out state only after `chrome.storage.local.remove` succeeds
- let a newer sign-in publish after the older complete sign-out operation, and suppress the older router continuation's stale signed-out sync reset
- keep the current user consistently signed in when durable removal fails

## Root cause

`signOut()` originally cleared `currentState` before awaiting removal of `firebaseRestAuthState`. If removal rejected, the live Service Worker appeared signed out while the refresh token remained durable, so a later startup restored the account.

The first fix moved publication after storage removal, but the complete transition still lacked one serialization boundary: the pending marker began after an awaited Chrome token lookup, ended before external token revocation, duplicate sign-outs queued another destructive removal, and newer sign-ins requested/exchanged a cached Chrome token before waiting. Once the transition was correctly serialized, an unbounded best-effort Google revoke fetch could keep that boundary alive forever and block every later sign-in.

The final implementation reserves the auth generation before the first await, exposes one coalesced pending operation through every sign-out side effect, blocks token work during it, waits before acquiring a new interactive Chrome token, bounds the post-cache-removal Google revoke leg, and checks the live account before the message router applies a signed-out sync reset.

## Reproduction

Deterministic regressions cover:

- storage removal rejection followed by a fresh service instance
- a newer sign-in waiting before Chrome token acquisition while the non-interactive lookup is held
- duplicate sign-out requests sharing one held storage removal
- a newer sign-in waiting through a held Google token-revocation request
- a permanently stalled Google revoke timing out before a new sign-in proceeds
- an older sign-out message continuation observing a newer current account before resetting auto-sync

## Validation

- `npm test -- --runInBand src/services/firebase-auth-service.test.ts src/background/message-router.auth-signout-race.test.ts` (11/11)
- `npm test -- --runInBand` (130 suites, 1,223 tests)
- `npm run typecheck`
- `npm run build`
- `npm run build:e2e`
- `npm run e2e:smoke` (7/7)
- `git diff --check`

## Head

`c5ca25fcf9133156d376b3b529cfeb02ca7738b8`