### PR TITLE
fix(export): refresh names after history merge

### DIFF
--- a/src/background/import-export.import-accounting.test.ts
+++ b/src/background/import-export.import-accounting.test.ts
@@ -13,22 +13,76 @@ import {
   SYNC_RESCAN_BACKFILL_DONE_META_KEY,
   SYNC_RESCAN_FLOOR_META_KEY
 } from '../constants/sync'
+import { EntityConverter } from '../entity-converter'
+import { ApiType } from '../types'
+import type { ApiEvent } from '../types'
+import { HandLogExporter } from '../utils/hand-log-exporter'
+
+const rank = {
+  RankId: 'rank-id',
+  RankName: '',
+  RankLvId: 'rank-lv-id',
+  RankLvName: ''
+}
+
+const tableUser = (userId: number, userName: string) => ({
+  UserId: userId,
+  UserName: userName,
+  FavoriteCharaId: '',
+  CostumeId: '',
+  EmblemId: '',
+  IsCpu: false,
+  IsOfficial: false,
+  SettingDecoIds: ['', '', '', '', '', '', ''],
+  Rank: rank
+})
+
+const olderNameEventCases: Array<[string, ApiEvent, number]> = [
+  ['EVT_PLAYER_SEAT_ASSIGNED (313)', {
+    ApiTypeId: ApiType.EVT_PLAYER_SEAT_ASSIGNED,
+    timestamp: 100,
+    IsLeave: false,
+    IsRetire: false,
+    ProcessType: 0,
+    SeatUserIds: [1001, 1002, 1003, 1004],
+    TableUsers: [
+      tableUser(1001, 'backfilled-seat-name'),
+      tableUser(1002, 'seat-2'),
+      tableUser(1003, 'seat-3'),
+      tableUser(1004, 'seat-4')
+    ]
+  } as ApiEvent, 1001],
+  ['EVT_PLAYER_JOIN (301)', {
+    ApiTypeId: ApiType.EVT_PLAYER_JOIN,
+    timestamp: 100,
+    JoinUser: tableUser(2001, 'backfilled-join-name'),
+    JoinPlayer: {
+      BetChip: 0,
+      BetStatus: 0,
+      Chip: 10_000,
+      SeatIndex: 0,
+      Status: 0
+    }
+  } as ApiEvent, 2001]
+]
 
 describe('importData() legacy sequence assignment and content dedup', () => {
   let db: PokerChaseDB
   let service: PokerChaseService
 
   beforeEach(async () => {
+    HandLogExporter.clearCache()
     db = new PokerChaseDB(indexedDB, IDBKeyRange)
     await db.open()
     service = new PokerChaseService({ db })
     await service.ready
     setOperationState({ type: 'idle' })
-    ;(chrome.runtime.sendMessage as jest.Mock).mockReturnValue(undefined)
+    ;(chrome.runtime.sendMessage as jest.Mock).mockResolvedValue(undefined)
   })
 
   afterEach(async () => {
     jest.restoreAllMocks()
+    HandLogExporter.clearCache()
     db.close()
     await db.delete()
   })
@@ -94,5 +148,40 @@ describe('importData() legacy sequence assignment and content dedup', () => {
     expect((await db.meta.get(`${SYNC_RESCAN_FLOOR_META_KEY}:user-a`))?.value).toBe(100)
     // Never raise an already-earlier protection floor.
     expect((await db.meta.get(`${SYNC_RESCAN_FLOOR_META_KEY}:user-b`))?.value).toBe(50)
+  })
+
+  test.each(olderNameEventCases)('rebuilds the hand-log name cache when import backfills an older %s', async (_label, importedEvent, expectedUserId) => {
+    // Warm the incremental cache past the event that will be imported. Before
+    // this regression fix, the next lookup resumed above timestamp 200 and
+    // could never discover the newly inserted timestamp-100 name event.
+    await db.apiEvents.put({ timestamp: 200, ApiTypeId: 9999, sequence: 0 } as unknown as ApiEvent)
+    const buildPlayerNamesMap = (HandLogExporter as any).buildPlayerNamesMap.bind(HandLogExporter) as
+      (targetDb: PokerChaseDB) => Promise<Map<number, { name: string, rank: string }>>
+    expect(await buildPlayerNamesMap(db)).toEqual(new Map())
+
+    const clearCache = jest.spyOn(HandLogExporter, 'clearCache')
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+    await expect(handlers.importData(JSON.stringify(importedEvent))).resolves.toMatchObject({ successCount: 1 })
+
+    expect(clearCache).toHaveBeenCalledTimes(1)
+    const names = await buildPlayerNamesMap(db)
+    expect(names.get(expectedUserId)?.name).toMatch(/^backfilled-/)
+
+    clearCache.mockClear()
+    await expect(handlers.importData(JSON.stringify(importedEvent))).resolves.toMatchObject({ successCount: 0 })
+    expect(clearCache).not.toHaveBeenCalled()
+  })
+
+  test('does not clear the hand-log name cache when a post-import rebuild fails', async () => {
+    await db.apiEvents.put({ timestamp: 200, ApiTypeId: 9999, sequence: 0 } as unknown as ApiEvent)
+    const clearCache = jest.spyOn(HandLogExporter, 'clearCache')
+    jest.spyOn(EntityConverter.prototype, 'convertEventChunk').mockImplementation(() => {
+      throw new Error('synthetic rebuild failure')
+    })
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+
+    await expect(handlers.importData(JSON.stringify(olderNameEventCases[0]![1])))
+      .rejects.toThrow('synthetic rebuild failure')
+    expect(clearCache).not.toHaveBeenCalled()
   })
 })

--- a/src/background/import-export.rebuild.test.ts
+++ b/src/background/import-export.rebuild.test.ts
@@ -22,6 +22,7 @@
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
 import PokerChaseService, { PokerChaseDB } from '../app'
 import { createImportExportHandlers } from './import-export'
+import { HandLogExporter } from '../utils/hand-log-exporter'
 
 // A known-good hand (EVT_DEAL -> 3x EVT_ACTION -> EVT_HAND_RESULTS), copied
 // verbatim from src/app.test.ts's event_timeline fixture (already exercised
@@ -70,7 +71,9 @@ describe('rebuildAllData Raw Event Lake recovery', () => {
     ] as any)
 
     const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+    const clearCache = jest.spyOn(HandLogExporter, 'clearCache')
     await expect(handlers.rebuildAllData()).resolves.toBeUndefined()
+    expect(clearCache).toHaveBeenCalledTimes(1)
 
     const hand = await db.hands.get(384370064)
     expect(hand).toBeDefined()

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -27,6 +27,7 @@ import {
   mergeApiEvents,
   type RawApiEvent
 } from '../utils/api-event-key'
+import { HandLogExporter } from '../utils/hand-log-exporter'
 
 const IMPORT_CHUNK_SIZE = DATABASE_CONSTANTS.IMPORT_CHUNK_SIZE
 
@@ -399,6 +400,14 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
           })
         }
       }
+
+      // HandLogExporter normally advances its name cache with an exact
+      // raw-event key. Imports can backfill older 301/313 events below that
+      // cursor, so a successful history merge must force the next export to
+      // rebuild the map from the full Lake. Do this only after the complete
+      // import path succeeds; duplicate-only and failed imports leave the
+      // existing cache untouched.
+      if (successCount > 0) HandLogExporter.clearCache()
 
       return { successCount, totalLines: lines.length, duplicateCount }
 
@@ -1125,6 +1134,12 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
             message
           }).catch(() => {})
         })
+
+        // Manual full rebuild is the recovery boundary for raw history that
+        // an earlier import stored before entity generation failed. Rebuild
+        // the exporter name map from the same Raw Lake on its next use, even
+        // when the Lake is empty (where this is a harmless cache reset).
+        HandLogExporter.clearCache()
 
         if (result.totalCount === 0) {
           setOperationState({ type: 'idle' })

--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -10,6 +10,7 @@ import { firebaseAuthService } from './firebase-auth-service'
 import * as minVersionGate from './min-version-gate'
 import { mergeApiEvents } from '../utils/api-event-key'
 import { getOperationState, setOperationState } from '../background/operation-state'
+import { HandLogExporter } from '../utils/hand-log-exporter'
 
 describe('AutoSyncService cloud downloads', () => {
   let db: PokerChaseDB
@@ -57,10 +58,12 @@ describe('AutoSyncService cloud downloads', () => {
         return 1
       })
 
+    const clearCache = jest.spyOn(HandLogExporter, 'clearCache')
     const service = new AutoSyncService(db)
     await service.performSync('download')
 
     expect(syncSpy).toHaveBeenCalledTimes(1)
+    expect(clearCache).toHaveBeenCalledTimes(1)
     expect(await db.apiEvents.count()).toBe(2)
     expect(await db.apiEvents.get([100, ApiType.EVT_ENTRY_QUEUED, 0])).toEqual({ ...cloudEvent, sequence: 0 })
     expect(service.getSyncState()).toMatchObject({
@@ -108,6 +111,30 @@ describe('AutoSyncService cloud downloads', () => {
     ])
   })
 
+  test('clears the hand-log name cache after a successful duplicate-only download rebuild', async () => {
+    const existingEvent = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Code: 0,
+      BattleType: BattleType.SIT_AND_GO,
+      Id: 'duplicate-cloud-document',
+      IsRetire: false,
+      timestamp: 100,
+      sequence: 0
+    } as ApiEvent
+    await db.apiEvents.put(existingEvent)
+    jest.spyOn(firestoreBackupService, 'syncFromCloud').mockImplementation(async options => {
+      await options.onBatch([existingEvent])
+      return 1
+    })
+    const clearCache = jest.spyOn(HandLogExporter, 'clearCache')
+
+    const service = new AutoSyncService(db)
+    await service.performSync('download')
+
+    expect(service.getSyncState().status).toBe('success')
+    expect(clearCache).toHaveBeenCalledTimes(1)
+  })
+
   test('a failed derived-table rebuild after download surfaces as a sync ERROR and is not marked as done (release audit 2026-07-21, finding 5)', async () => {
     const cloudEvent = {
       ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
@@ -130,6 +157,7 @@ describe('AutoSyncService cloud downloads', () => {
       throw new Error('QuotaExceededError: derived-table save failed')
     })
 
+    const clearCache = jest.spyOn(HandLogExporter, 'clearCache')
     const service = new AutoSyncService(db)
     await service.performSync('download')
 
@@ -157,6 +185,7 @@ describe('AutoSyncService cloud downloads', () => {
     // own completion bookkeeping) must remain untouched so nothing claims the
     // derived tables are current.
     expect(await db.meta.get('importStatus')).toBeUndefined()
+    expect(clearCache).not.toHaveBeenCalled()
   })
 
   test('partial download (page 1 durable, page 2 fails) with a failing rebuild still surfaces the DOWNLOAD error and leaves no completion bookkeeping (release audit 2026-07-21, coverage gap #5)', async () => {
@@ -180,6 +209,7 @@ describe('AutoSyncService cloud downloads', () => {
       throw new Error('derived-table save failed')
     })
 
+    const clearCache = jest.spyOn(HandLogExporter, 'clearCache')
     const service = new AutoSyncService(db)
     await service.performSync('download')
 
@@ -192,6 +222,72 @@ describe('AutoSyncService cloud downloads', () => {
     // Page 1's raw events remain durable, and nothing marked the rebuild done.
     expect(await db.apiEvents.count()).toBe(1)
     expect(await db.meta.get('importStatus')).toBeUndefined()
+    expect(clearCache).not.toHaveBeenCalled()
+  })
+
+  test('clears the hand-log name cache after successfully rebuilding a durable partial download', async () => {
+    const pageOneEvent = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Code: 0,
+      BattleType: BattleType.SIT_AND_GO,
+      Id: 'stage-page-1-recovered',
+      IsRetire: false,
+      timestamp: 100
+    } as ApiEvent
+    jest.spyOn(firestoreBackupService, 'syncFromCloud').mockImplementation(async options => {
+      await options.onBatch([pageOneEvent])
+      throw new Error('Cloud sync failed: Firestore REST request failed: 503')
+    })
+    const clearCache = jest.spyOn(HandLogExporter, 'clearCache')
+
+    const service = new AutoSyncService(db)
+    await service.performSync('download')
+
+    expect(service.getSyncState().status).toBe('error')
+    expect(await db.apiEvents.count()).toBe(1)
+    expect((await db.meta.get('importStatus'))?.value).toMatchObject({
+      lastProcessedTimestamp: 100,
+      lastProcessedEventCount: 1
+    })
+    expect(clearCache).toHaveBeenCalledTimes(1)
+  })
+
+  test('clears stale names when a failed partial rebuild is recovered by a duplicate-only partial retry', async () => {
+    const durableEvent = {
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Code: 0,
+      BattleType: BattleType.SIT_AND_GO,
+      Id: 'stage-partial-retry',
+      IsRetire: false,
+      timestamp: 100
+    } as ApiEvent
+    const download = jest.spyOn(firestoreBackupService, 'syncFromCloud')
+      .mockImplementationOnce(async options => {
+        await options.onBatch([durableEvent])
+        throw new Error('Cloud sync failed: Firestore REST request failed: 503')
+      })
+      .mockImplementationOnce(async options => {
+        // Same document on retry: mergeApiEvents reports it as a duplicate.
+        await options.onBatch([durableEvent])
+        throw new Error('Cloud sync failed again after the duplicate page: 503')
+      })
+    jest.spyOn(EntityConverter.prototype, 'convertEventChunk')
+      .mockImplementationOnce(() => { throw new Error('first recovery rebuild failed') })
+    const clearCache = jest.spyOn(HandLogExporter, 'clearCache')
+    const service = new AutoSyncService(db)
+
+    await service.performSync('download')
+    expect(service.getSyncState().status).toBe('error')
+    expect(await db.apiEvents.count()).toBe(1)
+    expect(clearCache).not.toHaveBeenCalled()
+
+    await service.performSync('download')
+    expect(download).toHaveBeenCalledTimes(2)
+    // The later page still fails, but the catch-path rebuild succeeds and
+    // makes the already-durable name row usable.
+    expect(service.getSyncState().status).toBe('error')
+    expect(await db.apiEvents.count()).toBe(1)
+    expect(clearCache).toHaveBeenCalledTimes(1)
   })
 
   test('upload: filters non-application noise before syncing, and still advances past a chunk that is 100% noise', async () => {

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -24,6 +24,7 @@ import {
   mergeApiEvents,
   type RawApiEvent
 } from '../utils/api-event-key'
+import { HandLogExporter } from '../utils/hand-log-exporter'
 
 /** Shown in the popup and logged when the min-version gate stops cloud sync (#forced-update). */
 export const MIN_VERSION_SYNC_BLOCKED_MESSAGE = 'このバージョンはサポートが終了しました。Chromeを再起動すると更新が適用されます'
@@ -1413,6 +1414,12 @@ export class AutoSyncService {
       if (downloadedEvents > 0) {
         try {
           await this.rebuildLocalEntities()
+          // Earlier pages are already durable even though a later page
+          // failed. A retry may download only duplicates, but if recovery
+          // rebuilt the durable rows successfully, historical 301/313 events
+          // are usable and the exporter must rescan below its previous
+          // cursor. A failed recovery rebuild leaves the cache as-is.
+          HandLogExporter.clearCache()
         } catch (rebuildError) {
           console.error('[AutoSync] Rebuild after a partial download failed too:', rebuildError)
         }
@@ -1423,6 +1430,11 @@ export class AutoSyncService {
     if (downloadedEvents > 0) {
       console.log(`[AutoSync] Downloaded ${downloadedEvents} cloud events and added ${addedEvents} new raw rows`)
       await this.rebuildLocalEntities()
+      // A successful download rebuild is also the recovery boundary for an
+      // earlier partial pass whose raw rows landed but whose rebuild failed.
+      // Such a retry can receive only duplicates (addedEvents === 0), yet it
+      // still makes historical 301/313 rows below the old cursor usable.
+      HandLogExporter.clearCache()
     }
   }
 


### PR DESCRIPTION
## Summary

- invalidate the hand-log player-name cache after a successful import that adds raw history
- treat every successful rebuild after receiving cloud events as a recovery boundary, on both normal and partial-download catch paths
- cover duplicate-only retries of previously durable rows while leaving the cache untouched when rebuilding those rows fails
- treat a successful manual full rebuild as the Raw Lake recovery boundary for the name cache
- cover older `EVT_PLAYER_JOIN` (301) and `EVT_PLAYER_SEAT_ASSIGNED` (313) backfills below the cache cursor

## Why

`HandLogExporter` advances an exact raw-event cursor while building its player-name map. Import and cloud restore can insert older 301/313 events below that cursor, so future PokerStars exports could keep fallback `Player<id>` names until the extension restarted. Retries can receive already-durable rows as duplicates and may still end in a later-page failure, so successful rebuilding of received/durable cloud rows is the single reliable recovery boundary regardless of the outer download outcome.

## Validation

- `npm test -- --runInBand` (129 suites, 1,221 tests)
- `npm run typecheck`
- `npm run build`

Head: `f0dfcf081b27800dae5bac0dcfebe55990a7af94`