### PR TITLE
fix(export): snapshot raw NDJSON rows

### DIFF
--- a/src/background/import-export.export-handoff.test.ts
+++ b/src/background/import-export.export-handoff.test.ts
@@ -33,6 +33,7 @@
  */
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
 import PokerChaseService, { PokerChaseDB } from '../app'
+import { DATABASE_CONSTANTS } from '../constants/database'
 import { createImportExportHandlers } from './import-export'
 import { getOperationState, setOperationState } from './operation-state'
 
@@ -122,6 +123,82 @@ describe('export download-handoff completion', () => {
       .filter(Boolean)
       .map(line => JSON.parse(line))
     expect(exported.map(event => event.ApiTypeId)).toEqual([305, 304])
+  })
+
+  test('NDJSON export excludes rows inserted after its first snapshot chunk is read', async () => {
+    const writerDb = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await writerDb.open()
+    const originalChunkSize = DATABASE_CONSTANTS.EXPORT_CHUNK_SIZE
+    Object.defineProperty(DATABASE_CONSTANTS, 'EXPORT_CHUNK_SIZE', {
+      value: 1,
+      configurable: true,
+      enumerable: true,
+      writable: true
+    })
+
+    const initialEvents = [
+      { timestamp: 100, ApiTypeId: 301, sequence: 0, marker: 'first' },
+      { timestamp: 100, ApiTypeId: 304, sequence: 0, marker: 'second' }
+    ]
+    // This later row shares both timestamp and type with the first row. Its
+    // sequence keeps the key unique, while its complete compound key still
+    // sorts below the second row that was already present at export start.
+    // This is the case an upper-bound-only snapshot cannot exclude.
+    const lateEvent = { timestamp: 100, ApiTypeId: 301, sequence: 1, marker: 'late' }
+    await db.apiEvents.bulkAdd(initialEvents as any)
+
+    let lateInsert: Promise<unknown> | undefined
+    const originalBulkGet = db.apiEvents.bulkGet.bind(db.apiEvents)
+    jest.spyOn(db.apiEvents, 'bulkGet').mockImplementation(((keys) =>
+      originalBulkGet(keys).then(rows => {
+        if (!lateInsert) {
+          // Open the live write after the first snapshot page has been read but
+          // before the exporter requests its next page. The fixed key list must
+          // exclude it without keeping a read transaction open across the scan.
+          lateInsert = writerDb.apiEvents.add(lateEvent as any)
+        }
+        return rows
+      })
+    ) as typeof db.apiEvents.bulkGet)
+
+    ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => callback([{ id: 42 }]))
+    ;(chrome.tabs.sendMessage as jest.Mock).mockImplementation((_tabId, _message, callback) => callback?.())
+
+    try {
+      const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+      await handlers.exportData('json')
+      expect(lateInsert).toBeDefined()
+      await lateInsert
+
+      const downloadCall = (chrome.tabs.sendMessage as jest.Mock).mock.calls.find(([, message]) =>
+        message.action === 'downloadFile'
+      )
+      const exported = String(downloadCall?.[1].content)
+        .split('\n')
+        .filter(Boolean)
+        .map(line => JSON.parse(line))
+
+      expect(exported.map(event => event.marker)).toEqual(['first', 'second'])
+      expect(await db.apiEvents.count()).toBe(3)
+      const progressMessages = (chrome.runtime.sendMessage as jest.Mock).mock.calls
+        .map(([message]) => message)
+        .filter(message => message.action === 'exportProgress' && message.format === 'json')
+      expect(progressMessages.filter(message => message.state === 'processing')).toEqual([
+        expect.objectContaining({ processed: 2, total: 2, progress: 100 })
+      ])
+      expect(progressMessages.find(message => message.state === 'completed')).toEqual(
+        expect.objectContaining({ processed: 2, total: 2, progress: 100 })
+      )
+      expect(getOperationState()).toEqual({ type: 'idle' })
+    } finally {
+      Object.defineProperty(DATABASE_CONSTANTS, 'EXPORT_CHUNK_SIZE', {
+        value: originalChunkSize,
+        configurable: true,
+        enumerable: true,
+        writable: true
+      })
+      writerDb.close()
+    }
   })
 
   test('PokerStars export dispatches the tabs.sendMessage handoff before returning to idle', async () => {

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -27,6 +27,7 @@ import { resolveAdvisory, markAdvisoryPending } from './rebuild-advisory'
 import {
   API_EVENT_PRIMARY_KEY,
   mergeApiEvents,
+  type ApiEventKey,
   type RawApiEvent
 } from '../utils/api-event-key'
 import { HandLogExporter } from '../utils/hand-log-exporter'
@@ -431,19 +432,28 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
         message: 'NDJSONエクスポート開始...'
       }).catch(() => {})
 
-      const totalCount = await db.apiEvents.count()
-      console.log(`[Export] Exporting ${totalCount} events...`)
-
       // Cursor by stable primary key, but hold/resolve each equal-timestamp group
       // before emitting it so the NDJSON preserves the proven causal order.
       // Dumps the full apiEvents Lake verbatim (raw fidelity, "a line is a line") — no
       // filtering by validity or application-type here; this is what feeds the warehouse
       // and offline schema-diff tooling (see docs/architecture.md "Raw Event Lake").
-      const chunks: string[] = []
+      let totalCount = 0
       let processedCount = 0
       const chunkSize = DATABASE_CONSTANTS.EXPORT_CHUNK_SIZE
+      // Capture only the ordered primary keys in a short read transaction, then
+      // release the store before fetching/stringifying the full rows. Exact keys
+      // exclude every later insert, including an equal-ms row whose ApiTypeId
+      // sorts below the start-time maximum; unlike a transaction held for the
+      // complete export, live ingestion is blocked only for this lightweight
+      // key scan.
+      const snapshotKeys = await db.transaction('r', db.apiEvents, async () =>
+        await db.apiEvents.orderBy(API_EVENT_PRIMARY_KEY).primaryKeys() as ApiEventKey[]
+      )
+      totalCount = snapshotKeys.length
+      console.log(`[Export] Exporting ${totalCount} events...`)
+      const chunks: string[] = []
 
-      for await (const chunk of processInReplayChunks(db.apiEvents, chunkSize)) {
+      for await (const chunk of processInReplayChunks(db.apiEvents, chunkSize, { snapshotKeys })) {
         chunks.push(chunk.map(event => JSON.stringify(event)).join('\n'))
         processedCount += chunk.length
 

--- a/src/utils/database-utils.ts
+++ b/src/utils/database-utils.ts
@@ -152,22 +152,40 @@ export async function* processInReplayChunks<T extends { timestamp?: number; Api
   table: Dexie.Table<T, any>,
   chunkSize: number,
   options?: {
+    /** Exact primary keys captured at the start of a stable export snapshot. */
+    snapshotKeys?: ApiEventKey[]
     onProgress?: (current: number, total: number) => void
   }
 ): AsyncGenerator<T[], void, unknown> {
-  const total = await table.count()
+  const snapshotKeys = options?.snapshotKeys
+  const total = snapshotKeys?.length ?? await table.count()
   if (total === 0) return
 
   let cursor: ApiEventKey | undefined
+  let snapshotOffset = 0
   let carry: T[] = []
   let processed = 0
 
   while (true) {
-    const rawChunk = await (cursor
-      ? table.where(API_EVENT_PRIMARY_KEY).above(cursor)
-      : table.orderBy(API_EVENT_PRIMARY_KEY))
-      .limit(chunkSize)
-      .toArray()
+    let rawChunk: T[]
+    let reachedEnd: boolean
+    if (snapshotKeys) {
+      const pageKeys = snapshotKeys.slice(snapshotOffset, snapshotOffset + chunkSize)
+      const rows = await table.bulkGet(pageKeys)
+      if (rows.some(row => row === undefined)) {
+        throw new Error('Raw export snapshot changed while it was being read')
+      }
+      rawChunk = rows as T[]
+      snapshotOffset += pageKeys.length
+      reachedEnd = snapshotOffset >= snapshotKeys.length
+    } else {
+      rawChunk = await (cursor
+        ? table.where(API_EVENT_PRIMARY_KEY).above(cursor)
+        : table.orderBy(API_EVENT_PRIMARY_KEY))
+        .limit(chunkSize)
+        .toArray()
+      reachedEnd = rawChunk.length < chunkSize
+    }
 
     if (rawChunk.length === 0) {
       if (carry.length > 0) {
@@ -183,7 +201,7 @@ export async function* processInReplayChunks<T extends { timestamp?: number; Api
     cursor = [last.timestamp!, last.ApiTypeId, getApiEventSequence(last)]
     const combined = [...carry, ...rawChunk]
 
-    if (rawChunk.length < chunkSize) {
+    if (reachedEnd) {
       const ordered = orderApiEventsForReplay(combined as unknown as RawApiEvent[]) as unknown as T[]
       yield ordered
       processed += ordered.length


### PR DESCRIPTION
## Summary
- capture the exact ordered raw-event primary keys at export start, then fetch only those rows in replay-safe chunks
- prevent live rows committed between chunks from leaking into the current NDJSON file or producing progress such as `3/2`
- cover a concurrent equal-millisecond, same-type sequence insert whose key sorts below the start-time maximum (so an upper-key-only boundary would not be sufficient)

## Scope
- raw NDJSON export only
- no storage schema, event ordering, import, sync, or PokerStars export changes

## Validation
- `npm test -- --runInBand` (1,232 tests)
- `npm run typecheck`
- `npm run build`

Head: `4d89db1`

Codex-Session: `019f8719-f926-7e81-ae3a-3924c8efbfe9`