### PR TITLE
fix: surface popup auth request failures

### DIFF
--- a/src/background/message-router.auth-signout-race.test.ts
+++ b/src/background/message-router.auth-signout-race.test.ts
@@ -6,7 +6,7 @@ import { autoSyncService } from '../services/auto-sync-service'
 import type { ChromeMessage, MessageResponse } from '../types/messages'
 import { registerMessageRouter } from './message-router'
 
-describe('message-router firebaseSignOut auth-transition ordering', () => {
+describe('message-router auth ordering', () => {
   let db: PokerChaseDB
   let service: PokerChaseService
   let listener: (
@@ -63,5 +63,48 @@ describe('message-router firebaseSignOut auth-transition ordering', () => {
 
     expect(authStateChanged).toHaveBeenCalledWith(null)
     expect(sendResponse).toHaveBeenCalledWith({ success: true })
+  })
+
+  test('waits for persisted auth restore before answering firebaseAuthStatus', async () => {
+    let releaseRestore: (() => void) | undefined
+    const ready = jest.spyOn(firebaseAuthService, 'ready').mockImplementation(() => (
+      new Promise<void>(resolve => { releaseRestore = resolve })
+    ))
+    jest.spyOn(firebaseAuthService, 'isSignedIn').mockReturnValue(true)
+    jest.spyOn(firebaseAuthService, 'getUserInfo').mockReturnValue({
+      email: 'restored@example.com',
+      displayName: null,
+      photoURL: null,
+      uid: 'restored-user'
+    })
+    const sendResponse = jest.fn()
+
+    expect(listener({ action: 'firebaseAuthStatus' }, {}, sendResponse)).toBe(true)
+    expect(ready).toHaveBeenCalledTimes(1)
+    expect(sendResponse).not.toHaveBeenCalled()
+
+    releaseRestore?.()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      isSignedIn: true,
+      userInfo: {
+        email: 'restored@example.com',
+        displayName: null,
+        photoURL: null,
+        uid: 'restored-user'
+      }
+    })
+  })
+
+  test('returns an error when persisted auth restore fails', async () => {
+    jest.spyOn(firebaseAuthService, 'ready').mockRejectedValue(new Error('auth restore failed'))
+    const sendResponse = jest.fn()
+
+    expect(listener({ action: 'firebaseAuthStatus' }, {}, sendResponse)).toBe(true)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(sendResponse).toHaveBeenCalledWith({ success: false, error: 'auth restore failed' })
   })
 })

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -301,11 +301,19 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
         })
       return true
     } else if (request.action === 'firebaseAuthStatus') {
-      // Check current auth status
-      const isSignedIn = firebaseAuthService.isSignedIn()
-      const userInfo = firebaseAuthService.getUserInfo()
-
-      sendResponse({ success: true, isSignedIn, userInfo })
+      // Auth restore starts independently when the Service Worker module is
+      // loaded. Do not answer from the initial in-memory `null` before the
+      // persisted state has finished restoring.
+      firebaseAuthService.ready()
+        .then(() => {
+          const isSignedIn = firebaseAuthService.isSignedIn()
+          const userInfo = firebaseAuthService.getUserInfo()
+          sendResponse({ success: true, isSignedIn, userInfo })
+        })
+        .catch(error => {
+          console.error('Firebase auth status error:', error)
+          sendResponse({ success: false, error: error instanceof Error ? error.message : String(error) })
+        })
       return true
     } else if (request.action === 'firebaseSignIn') {
       // Firebase sign in

--- a/src/components/Popup.test.tsx
+++ b/src/components/Popup.test.tsx
@@ -641,6 +641,47 @@ describe('Popup', () => {
       jest.useRealTimers()
     })
 
+    it('認証後の初回同期が長引いて応答がタイムアウトしても、認証済みなら失敗扱いにしない', async () => {
+      jest.useFakeTimers()
+      let signedIn = false
+      mockSignedOutPopupMessages(() => {
+        // Authentication commits, but the original callback remains pending
+        // behind a long first auto-sync in the background.
+      }, () => signedIn
+        ? {
+            isSignedIn: true,
+            userInfo: { email: 'test@example.com', uid: 'test-uid' },
+          }
+        : { isSignedIn: false, userInfo: null }
+      )
+
+      render(<Popup />)
+
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: '自動バックアップを有効にする' }))
+
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      expect(screen.getByRole('button', { name: '有効化しています...' })).toBeDisabled()
+
+      signedIn = true
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(120_000)
+      })
+
+      expect(screen.getByText('test@example.com')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'ログアウト' })).toBeEnabled()
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+      jest.useRealTimers()
+    })
+
     it('素早い二重クリックでも認証要求を1件だけ送る', async () => {
       let respondToSignIn: ((response?: unknown) => void) | undefined
       mockSignedOutPopupMessages((callback) => {

--- a/src/components/Popup.test.tsx
+++ b/src/components/Popup.test.tsx
@@ -77,6 +77,22 @@ describe('Popup', () => {
     await new Promise(resolve => setTimeout(resolve, 0))
   }
 
+  const mockSignedOutPopupMessages = (
+    handleSignIn: (callback: (response?: unknown) => void) => void
+  ) => {
+    mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
+      if (message.action === 'firebaseAuthStatus') {
+        callback({ success: true, isSignedIn: false, userInfo: null })
+      } else if (message.action === 'getSyncState') {
+        callback({ success: true, syncState: null })
+      } else if (message.action === 'acknowledgeWhatsNew') {
+        callback({ success: true })
+      } else if (message.action === 'firebaseSignIn') {
+        handleSignIn(callback)
+      }
+    })
+  }
+
   beforeEach(() => {
     jest.clearAllMocks()
     window.localStorage.removeItem(POPUP_THEME_LOCAL_STORAGE_KEY)
@@ -493,6 +509,148 @@ describe('Popup', () => {
     // Component should render without errors
     const buttons = screen.getAllByRole('button')
     expect(buttons.length).toBeGreaterThan(0)
+  })
+
+  describe('Firebase認証操作のフィードバック', () => {
+    it('成功応答までボタンを無効化し、成功後はlistenerによる認証状態更新を待つ', async () => {
+      let respondToSignIn: ((response?: unknown) => void) | undefined
+      mockSignedOutPopupMessages((callback) => {
+        respondToSignIn = callback
+      })
+
+      render(<Popup />)
+      await waitForAsyncOperations()
+
+      fireEvent.click(screen.getByRole('button', { name: '自動バックアップを有効にする' }))
+
+      await waitFor(() => {
+        expect(respondToSignIn).toBeDefined()
+        expect(screen.getByRole('button', { name: '有効化しています...' })).toBeDisabled()
+      })
+
+      act(() => {
+        respondToSignIn?.({ success: true })
+      })
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: '自動バックアップを有効にする' })).toBeEnabled()
+      })
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+      // A successful response does not optimistically change auth state;
+      // the existing firebaseAuthStatus listener remains authoritative.
+      expect(screen.queryByText('ログアウト')).not.toBeInTheDocument()
+    })
+
+    it('backgroundのエラー応答を表示し、再試行開始時に古いエラーを消す', async () => {
+      let attempt = 0
+      let respondToRetry: ((response?: unknown) => void) | undefined
+      mockSignedOutPopupMessages((callback) => {
+        attempt += 1
+        if (attempt === 1) {
+          callback({ success: false, error: 'Google認証に失敗しました' })
+        } else {
+          respondToRetry = callback
+        }
+      })
+
+      render(<Popup />)
+      await waitForAsyncOperations()
+
+      await userEvent.click(screen.getByRole('button', { name: '自動バックアップを有効にする' }))
+      expect(await screen.findByRole('alert')).toHaveTextContent('Google認証に失敗しました')
+
+      fireEvent.click(screen.getByRole('button', { name: '自動バックアップを有効にする' }))
+
+      await waitFor(() => {
+        expect(respondToRetry).toBeDefined()
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+        expect(screen.getByRole('button', { name: '有効化しています...' })).toBeDisabled()
+      })
+
+      act(() => {
+        respondToRetry?.({ success: true })
+      })
+    })
+
+    it.each(['undefined response', 'synchronous sendMessage rejection'])('%sを通信エラーとして表示する', async (failureMode) => {
+      mockSignedOutPopupMessages((callback) => {
+        if (failureMode === 'undefined response') {
+          callback(undefined)
+          return
+        }
+        throw new Error('Extension context invalidated')
+      })
+
+      render(<Popup />)
+      await waitForAsyncOperations()
+
+      await userEvent.click(screen.getByRole('button', { name: '自動バックアップを有効にする' }))
+
+      expect(await screen.findByRole('alert')).toHaveTextContent(
+        'バックグラウンドとの通信に失敗しました。もう一度お試しください。'
+      )
+      expect(screen.getByRole('button', { name: '自動バックアップを有効にする' })).toBeEnabled()
+    })
+
+    it('backgroundが応答しない場合は8秒でタイムアウトして再試行可能にする', async () => {
+      jest.useFakeTimers()
+      mockSignedOutPopupMessages(() => {
+        // Deliberately leave the callback unresolved.
+      })
+
+      render(<Popup />)
+
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: '自動バックアップを有効にする' }))
+
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      expect(screen.getByRole('button', { name: '有効化しています...' })).toBeDisabled()
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(8000)
+      })
+
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'バックグラウンドとの通信に失敗しました。もう一度お試しください。'
+      )
+      expect(screen.getByRole('button', { name: '自動バックアップを有効にする' })).toBeEnabled()
+
+      jest.useRealTimers()
+    })
+
+    it('素早い二重クリックでも認証要求を1件だけ送る', async () => {
+      let respondToSignIn: ((response?: unknown) => void) | undefined
+      mockSignedOutPopupMessages((callback) => {
+        respondToSignIn = callback
+      })
+
+      render(<Popup />)
+      await waitForAsyncOperations()
+
+      const button = screen.getByRole('button', { name: '自動バックアップを有効にする' })
+      act(() => {
+        fireEvent.click(button)
+        fireEvent.click(button)
+      })
+
+      await waitFor(() => {
+        expect(respondToSignIn).toBeDefined()
+      })
+      expect(
+        mockChromeRuntimeSendMessage.mock.calls.filter(([message]) => message.action === 'firebaseSignIn')
+      ).toHaveLength(1)
+
+      act(() => {
+        respondToSignIn?.({ success: true })
+      })
+    })
   })
 
   it('インポート/エクスポート機能', async () => {

--- a/src/components/Popup.test.tsx
+++ b/src/components/Popup.test.tsx
@@ -131,10 +131,14 @@ describe('Popup', () => {
       if (typeof callback === 'function') callback()
     })
 
+    ;(chrome.storage.local.get as jest.Mock).mockImplementation(
+      (_key: string, callback: (result: Record<string, unknown>) => void) => callback({})
+    )
+
     mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
       // Execute callback immediately - tests will use waitFor
       if (message.action === 'firebaseAuthStatus') {
-        callback({ isSignedIn: false, userInfo: null })
+        callback({ success: true, isSignedIn: false, userInfo: null })
       } else if (message.action === 'getSyncState') {
         callback({ syncState: null })
       } else if (message.action === 'acknowledgeWhatsNew') {
@@ -758,6 +762,7 @@ describe('Popup', () => {
       // Execute callback immediately - tests will use waitFor
       if (message.action === 'firebaseAuthStatus') {
         callback({
+          success: true,
           isSignedIn: true,
           userInfo: { email: 'test@example.com', uid: 'test-uid' },
         })
@@ -900,7 +905,7 @@ describe('Popup', () => {
       // syncStateのレスポンス形式をテスト
       mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
         if (message.action === 'firebaseAuthStatus') {
-          callback({ isSignedIn: false })
+          callback({ success: true, isSignedIn: false })
         } else if (message.action === 'getSyncState') {
           // 修正後の正しい形式
           callback({
@@ -933,7 +938,7 @@ describe('Popup', () => {
       // getSyncStateのモックを設定
       mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
         if (message.action === 'firebaseAuthStatus') {
-          callback({ isSignedIn: false })
+          callback({ success: true, isSignedIn: false })
         } else if (message.action === 'getSyncState') {
           callback({
             success: true,
@@ -974,6 +979,31 @@ describe('Popup', () => {
   })
 
   describe('Service Worker無応答時のフェイルオープン', () => {
+    it('auth restoreエラー応答ではstorage cacheのサインイン表示を維持する', async () => {
+      ;(chrome.storage.local.get as jest.Mock).mockImplementation(
+        (_key: string, callback: (result: Record<string, unknown>) => void) => callback({
+          firebaseAuthCache: {
+            isSignedIn: true,
+            userInfo: { email: 'cached@example.com', uid: 'cached-user' },
+          },
+        })
+      )
+      mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
+        if (message.action === 'firebaseAuthStatus') {
+          callback({ success: false, error: 'auth restore failed' })
+        } else if (message.action === 'getSyncState') {
+          callback({ success: true, syncState: null })
+        } else if (message.action === 'acknowledgeWhatsNew') {
+          callback({ success: true })
+        }
+      })
+
+      render(<Popup />)
+
+      expect(await screen.findByText('cached@example.com')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'ログアウト' })).toBeEnabled()
+    })
+
     it('firebaseAuthStatus/getSyncStateがタイムアウトしてもUIはブロックされず既定状態で使用可能', async () => {
       jest.useFakeTimers()
 

--- a/src/components/Popup.test.tsx
+++ b/src/components/Popup.test.tsx
@@ -78,11 +78,15 @@ describe('Popup', () => {
   }
 
   const mockSignedOutPopupMessages = (
-    handleSignIn: (callback: (response?: unknown) => void) => void
+    handleSignIn: (callback: (response?: unknown) => void) => void,
+    getAuthStatus: () => { isSignedIn: boolean; userInfo: { email: string; uid: string } | null } = () => ({
+      isSignedIn: false,
+      userInfo: null,
+    })
   ) => {
     mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
       if (message.action === 'firebaseAuthStatus') {
-        callback({ success: true, isSignedIn: false, userInfo: null })
+        callback({ success: true, ...getAuthStatus() })
       } else if (message.action === 'getSyncState') {
         callback({ success: true, syncState: null })
       } else if (message.action === 'acknowledgeWhatsNew') {
@@ -512,10 +516,17 @@ describe('Popup', () => {
   })
 
   describe('Firebase認証操作のフィードバック', () => {
-    it('成功応答までボタンを無効化し、成功後はlistenerによる認証状態更新を待つ', async () => {
+    it('成功応答までボタンを無効化し、成功後はbackgroundの認証状態を再取得する', async () => {
       let respondToSignIn: ((response?: unknown) => void) | undefined
+      let signedIn = false
       mockSignedOutPopupMessages((callback) => {
         respondToSignIn = callback
+      }, () => {
+        if (!signedIn) return { isSignedIn: false, userInfo: null }
+        return {
+          isSignedIn: true,
+          userInfo: { email: 'test@example.com', uid: 'test-uid' },
+        }
       })
 
       render(<Popup />)
@@ -529,16 +540,21 @@ describe('Popup', () => {
       })
 
       act(() => {
+        signedIn = true
         respondToSignIn?.({ success: true })
       })
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: '自動バックアップを有効にする' })).toBeEnabled()
+        expect(screen.getByText('test@example.com')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'ログアウト' })).toBeEnabled()
       })
       expect(screen.queryByRole('alert')).not.toBeInTheDocument()
-      // A successful response does not optimistically change auth state;
-      // the existing firebaseAuthStatus listener remains authoritative.
-      expect(screen.queryByText('ログアウト')).not.toBeInTheDocument()
+      // The action response itself carries no user details. Success therefore
+      // refetches the background's authoritative auth state instead of
+      // optimistically inventing one in the popup.
+      expect(
+        mockChromeRuntimeSendMessage.mock.calls.filter(([message]) => message.action === 'firebaseAuthStatus')
+      ).toHaveLength(2)
     })
 
     it('backgroundのエラー応答を表示し、再試行開始時に古いエラーを消す', async () => {
@@ -592,7 +608,7 @@ describe('Popup', () => {
       expect(screen.getByRole('button', { name: '自動バックアップを有効にする' })).toBeEnabled()
     })
 
-    it('backgroundが応答しない場合は8秒でタイムアウトして再試行可能にする', async () => {
+    it('対話型サインインが応答しない場合は2分でタイムアウトして再試行可能にする', async () => {
       jest.useFakeTimers()
       mockSignedOutPopupMessages(() => {
         // Deliberately leave the callback unresolved.
@@ -614,7 +630,7 @@ describe('Popup', () => {
       expect(screen.getByRole('button', { name: '有効化しています...' })).toBeDisabled()
 
       await act(async () => {
-        await jest.advanceTimersByTimeAsync(8000)
+        await jest.advanceTimersByTimeAsync(120_000)
       })
 
       expect(screen.getByRole('alert')).toHaveTextContent(

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -11,6 +11,7 @@ import type { UIConfig } from '../types/hand-log'
 import { DEFAULT_UI_CONFIG } from '../types/hand-log'
 import type {
   ChromeMessage,
+  MessageResponse,
   UpdateBattleTypeFilterMessage,
   FirebaseSignInMessage,
   FirebaseSignOutMessage,
@@ -44,6 +45,8 @@ import {
 } from './popup/popup-theme-storage'
 
 export type { Options }
+
+const FIREBASE_AUTH_COMMUNICATION_ERROR = 'バックグラウンドとの通信に失敗しました。もう一度お試しください。'
 
 export interface PopupProps {
   /**
@@ -105,6 +108,9 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
   const [isFirebaseSignedIn, setIsFirebaseSignedIn] = useState<boolean>(false)
   const [firebaseUserInfo, setFirebaseUserInfo] = useState<{ email: string; uid: string } | null>(null)
   const [syncState, setSyncState] = useState<SyncState | null>(null)
+  const [isFirebaseAuthPending, setIsFirebaseAuthPending] = useState(false)
+  const [firebaseAuthError, setFirebaseAuthError] = useState('')
+  const firebaseAuthRequestInFlightRef = useRef(false)
 
   // Fetch sync state
   useEffect(() => {
@@ -416,14 +422,39 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
   }
 
   // Firebase handlers
-  const handleFirebaseSignIn = async () => {
-    await openGameTab()
-    chrome.runtime.sendMessage<FirebaseSignInMessage>({ action: 'firebaseSignIn' })
+  const performFirebaseAuthAction = async (
+    message: FirebaseSignInMessage | FirebaseSignOutMessage,
+    beforeSend?: () => Promise<void>
+  ) => {
+    if (firebaseAuthRequestInFlightRef.current) return
+
+    firebaseAuthRequestInFlightRef.current = true
+    setIsFirebaseAuthPending(true)
+    setFirebaseAuthError('')
+
+    try {
+      await beforeSend?.()
+      const response = await sendMessageWithTimeout<MessageResponse>(message)
+
+      if (!response) {
+        setFirebaseAuthError(FIREBASE_AUTH_COMMUNICATION_ERROR)
+      } else if (!response.success) {
+        setFirebaseAuthError(response.error)
+      }
+    } catch {
+      setFirebaseAuthError(FIREBASE_AUTH_COMMUNICATION_ERROR)
+    } finally {
+      firebaseAuthRequestInFlightRef.current = false
+      setIsFirebaseAuthPending(false)
+    }
   }
 
-  const handleFirebaseSignOut = () => {
-    chrome.runtime.sendMessage<FirebaseSignOutMessage>({ action: 'firebaseSignOut' })
-  }
+  const handleFirebaseSignIn = () => performFirebaseAuthAction(
+    { action: 'firebaseSignIn' },
+    openGameTab
+  )
+
+  const handleFirebaseSignOut = () => performFirebaseAuthAction({ action: 'firebaseSignOut' })
 
   const handleManualSyncUpload = () => {
     chrome.runtime.sendMessage<ManualSyncUploadMessage>({ action: 'manualSyncUpload' })
@@ -524,6 +555,8 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
           isFirebaseSignedIn={isFirebaseSignedIn}
           firebaseUserInfo={firebaseUserInfo}
           syncState={syncState}
+          isAuthPending={isFirebaseAuthPending}
+          authError={firebaseAuthError}
           setImportStatus={setImportStatus}
           handleFirebaseSignIn={handleFirebaseSignIn}
           handleFirebaseSignOut={handleFirebaseSignOut}

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -116,10 +116,10 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
   const firebaseAuthRequestInFlightRef = useRef(false)
 
   const refreshFirebaseAuthStatus = async (): Promise<AuthStatusResponse | undefined> => {
-    const response = await sendMessageWithTimeout<AuthStatusResponse>({
+    const response = await sendMessageWithTimeout<MessageResponse>({
       action: 'firebaseAuthStatus'
     })
-    if (!response) return undefined
+    if (!response?.success || !('isSignedIn' in response)) return undefined
 
     setIsFirebaseSignedIn(response.isSignedIn)
     setFirebaseUserInfo(
@@ -255,20 +255,15 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
       // Then verify with background (authoritative source).
       // Fails open: on timeout/error, keep whatever was already set from
       // the chrome.storage.local cache above instead of blocking the UI.
-      sendMessageWithTimeout<{ isSignedIn?: boolean; userInfo?: { email: string; uid: string } | null }>({
-        action: 'firebaseAuthStatus'
-      }).then((response) => {
-        if (response) {
-          setIsFirebaseSignedIn(response.isSignedIn || false)
-          setFirebaseUserInfo(response.userInfo || null)
+      refreshFirebaseAuthStatus().then((response) => {
+        if (!response?.isSignedIn) return
 
-          // Also get sync state if signed in
-          sendMessageWithTimeout<{ syncState?: SyncState }>({ action: 'getSyncState' }).then((syncResponse) => {
-            if (syncResponse?.syncState) {
-              setSyncState(syncResponse.syncState)
-            }
-          })
-        }
+        // Also get sync state if signed in
+        sendMessageWithTimeout<{ syncState?: SyncState }>({ action: 'getSyncState' }).then((syncResponse) => {
+          if (syncResponse?.syncState) {
+            setSyncState(syncResponse.syncState)
+          }
+        })
       })
     })
   }, [])
@@ -293,7 +288,7 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
         if (message.imported !== undefined) {
           setImportSuccess(message.imported)
         }
-      } else if (message.action === 'firebaseAuthStatus') {
+      } else if (message.action === 'firebaseAuthStatus' && typeof message.isSignedIn === 'boolean') {
         setIsFirebaseSignedIn(message.isSignedIn)
         if (message.userInfo && message.userInfo.email && message.userInfo.uid) {
           setFirebaseUserInfo({

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -115,11 +115,11 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
   const [firebaseAuthError, setFirebaseAuthError] = useState('')
   const firebaseAuthRequestInFlightRef = useRef(false)
 
-  const refreshFirebaseAuthStatus = async (): Promise<boolean> => {
+  const refreshFirebaseAuthStatus = async (): Promise<AuthStatusResponse | undefined> => {
     const response = await sendMessageWithTimeout<AuthStatusResponse>({
       action: 'firebaseAuthStatus'
     })
-    if (!response) return false
+    if (!response) return undefined
 
     setIsFirebaseSignedIn(response.isSignedIn)
     setFirebaseUserInfo(
@@ -127,7 +127,7 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
         ? { email: response.userInfo.email, uid: response.userInfo.uid }
         : null
     )
-    return true
+    return response
   }
 
   // Fetch sync state
@@ -456,7 +456,15 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
       const response = await sendMessageWithTimeout<MessageResponse>(message, timeoutMs)
 
       if (!response) {
-        setFirebaseAuthError(FIREBASE_AUTH_COMMUNICATION_ERROR)
+        // The auth request can outlive this popup wait because sign-in's
+        // background handler also keeps the first cloud sync alive. Check the
+        // authoritative auth state before calling that a failure: auth may
+        // already have committed while only the sync tail is still running.
+        const authStatus = await refreshFirebaseAuthStatus()
+        const reachedRequestedState = authStatus?.isSignedIn === (message.action === 'firebaseSignIn')
+        if (!reachedRequestedState) {
+          setFirebaseAuthError(FIREBASE_AUTH_COMMUNICATION_ERROR)
+        }
       } else if (!response.success) {
         setFirebaseAuthError(response.error)
       } else if (!await refreshFirebaseAuthStatus()) {

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -11,6 +11,7 @@ import type { UIConfig } from '../types/hand-log'
 import { DEFAULT_UI_CONFIG } from '../types/hand-log'
 import type {
   ChromeMessage,
+  AuthStatusResponse,
   MessageResponse,
   UpdateBattleTypeFilterMessage,
   FirebaseSignInMessage,
@@ -47,6 +48,8 @@ import {
 export type { Options }
 
 const FIREBASE_AUTH_COMMUNICATION_ERROR = 'バックグラウンドとの通信に失敗しました。もう一度お試しください。'
+const FIREBASE_SIGN_IN_TIMEOUT_MS = 120_000
+const FIREBASE_SIGN_OUT_TIMEOUT_MS = 30_000
 
 export interface PopupProps {
   /**
@@ -111,6 +114,21 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
   const [isFirebaseAuthPending, setIsFirebaseAuthPending] = useState(false)
   const [firebaseAuthError, setFirebaseAuthError] = useState('')
   const firebaseAuthRequestInFlightRef = useRef(false)
+
+  const refreshFirebaseAuthStatus = async (): Promise<boolean> => {
+    const response = await sendMessageWithTimeout<AuthStatusResponse>({
+      action: 'firebaseAuthStatus'
+    })
+    if (!response) return false
+
+    setIsFirebaseSignedIn(response.isSignedIn)
+    setFirebaseUserInfo(
+      response.userInfo?.email && response.userInfo.uid
+        ? { email: response.userInfo.email, uid: response.userInfo.uid }
+        : null
+    )
+    return true
+  }
 
   // Fetch sync state
   useEffect(() => {
@@ -424,6 +442,7 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
   // Firebase handlers
   const performFirebaseAuthAction = async (
     message: FirebaseSignInMessage | FirebaseSignOutMessage,
+    timeoutMs: number,
     beforeSend?: () => Promise<void>
   ) => {
     if (firebaseAuthRequestInFlightRef.current) return
@@ -434,12 +453,14 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
 
     try {
       await beforeSend?.()
-      const response = await sendMessageWithTimeout<MessageResponse>(message)
+      const response = await sendMessageWithTimeout<MessageResponse>(message, timeoutMs)
 
       if (!response) {
         setFirebaseAuthError(FIREBASE_AUTH_COMMUNICATION_ERROR)
       } else if (!response.success) {
         setFirebaseAuthError(response.error)
+      } else if (!await refreshFirebaseAuthStatus()) {
+        setFirebaseAuthError(FIREBASE_AUTH_COMMUNICATION_ERROR)
       }
     } catch {
       setFirebaseAuthError(FIREBASE_AUTH_COMMUNICATION_ERROR)
@@ -451,10 +472,14 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
 
   const handleFirebaseSignIn = () => performFirebaseAuthAction(
     { action: 'firebaseSignIn' },
+    FIREBASE_SIGN_IN_TIMEOUT_MS,
     openGameTab
   )
 
-  const handleFirebaseSignOut = () => performFirebaseAuthAction({ action: 'firebaseSignOut' })
+  const handleFirebaseSignOut = () => performFirebaseAuthAction(
+    { action: 'firebaseSignOut' },
+    FIREBASE_SIGN_OUT_TIMEOUT_MS
+  )
 
   const handleManualSyncUpload = () => {
     chrome.runtime.sendMessage<ManualSyncUploadMessage>({ action: 'manualSyncUpload' })

--- a/src/components/popup/FirebaseAuthSection.test.tsx
+++ b/src/components/popup/FirebaseAuthSection.test.tsx
@@ -14,6 +14,8 @@ describe('FirebaseAuthSection', () => {
     isFirebaseSignedIn: false,
     firebaseUserInfo: null,
     syncState: null,
+    isAuthPending: false,
+    authError: '',
     setImportStatus: mockSetImportStatus,
     handleFirebaseSignIn: mockHandleFirebaseSignIn,
     handleFirebaseSignOut: mockHandleFirebaseSignOut,
@@ -43,6 +45,33 @@ describe('FirebaseAuthSection', () => {
 
     expect(screen.getByText('自動バックアップを有効にする')).toBeInTheDocument()
     expect(screen.queryByText('ログアウト')).not.toBeInTheDocument()
+  })
+
+  it('認証処理中は表示中の認証ボタンを無効化する', () => {
+    const { rerender } = render(
+      <FirebaseAuthSection {...defaultProps} isAuthPending={true} />
+    )
+
+    expect(screen.getByRole('button', { name: '有効化しています...' })).toBeDisabled()
+
+    rerender(
+      <FirebaseAuthSection
+        {...defaultProps}
+        isFirebaseSignedIn={true}
+        firebaseUserInfo={{ email: 'test@example.com', uid: 'test-uid' }}
+        isAuthPending={true}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'ログアウトしています...' })).toBeDisabled()
+  })
+
+  it('認証エラーを表示する', () => {
+    render(
+      <FirebaseAuthSection {...defaultProps} authError="認証に失敗しました" />
+    )
+
+    expect(screen.getByRole('alert')).toHaveTextContent('認証に失敗しました')
   })
 
   it('サインイン時はユーザー情報と同期ボタンを表示', async () => {

--- a/src/components/popup/FirebaseAuthSection.tsx
+++ b/src/components/popup/FirebaseAuthSection.tsx
@@ -9,9 +9,11 @@ interface FirebaseAuthSectionProps {
   isFirebaseSignedIn: boolean
   firebaseUserInfo: { email: string; uid: string } | null
   syncState: SyncState | null
+  isAuthPending: boolean
+  authError: string
   setImportStatus: (status: string) => void
-  handleFirebaseSignIn: () => void
-  handleFirebaseSignOut: () => void
+  handleFirebaseSignIn: () => Promise<void>
+  handleFirebaseSignOut: () => Promise<void>
   handleManualSyncUpload: () => void
   handleManualSyncDownload: () => void
 }
@@ -20,6 +22,8 @@ export const FirebaseAuthSection = ({
   isFirebaseSignedIn,
   firebaseUserInfo,
   syncState,
+  isAuthPending,
+  authError,
   setImportStatus,
   handleFirebaseSignIn,
   handleFirebaseSignOut,
@@ -28,16 +32,24 @@ export const FirebaseAuthSection = ({
 }: FirebaseAuthSectionProps) => {
   if (!isFirebaseSignedIn) {
     return (
-      <Button
-        variant="contained"
-        color="primary"
-        fullWidth
-        onClick={handleFirebaseSignIn}
-        size="large"
-        startIcon={<CloudIcon />}
-      >
-        自動バックアップを有効にする
-      </Button>
+      <Box>
+        <Button
+          variant="contained"
+          color="primary"
+          fullWidth
+          onClick={handleFirebaseSignIn}
+          disabled={isAuthPending}
+          size="large"
+          startIcon={<CloudIcon />}
+        >
+          {isAuthPending ? '有効化しています...' : '自動バックアップを有効にする'}
+        </Button>
+        {authError && (
+          <Typography role="alert" variant="caption" color="error" sx={{ display: 'block', mt: 1 }}>
+            {authError}
+          </Typography>
+        )}
+      </Box>
     )
   }
 
@@ -77,11 +89,17 @@ export const FirebaseAuthSection = ({
         size="small"
         fullWidth
         onClick={handleFirebaseSignOut}
+        disabled={isAuthPending}
         startIcon={<CloudOffIcon />}
         sx={{ mt: 1 }}
       >
-        ログアウト
+        {isAuthPending ? 'ログアウトしています...' : 'ログアウト'}
       </Button>
+      {authError && (
+        <Typography role="alert" variant="caption" color="error" sx={{ display: 'block', mt: 1 }}>
+          {authError}
+        </Typography>
+      )}
 
       {/* Sync Status */}
       {syncState && (

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -181,7 +181,8 @@ export interface UpdateUIConfigMessage {
 // Firebase backup messages
 export interface FirebaseAuthStatusMessage {
   action: 'firebaseAuthStatus'
-  isSignedIn: boolean
+  /** Present on background-to-popup status updates; omitted on status requests. */
+  isSignedIn?: boolean
   userInfo?: {
     email: string | null
     displayName: string | null


### PR DESCRIPTION
## Summary\n\n- await popup sign-in/sign-out responses through the bounded runtime-message helper\n- disable auth actions while pending and prevent rapid duplicate requests\n- surface background, missing-response, and timeout failures with retryable feedback\n- refresh the background-authoritative auth state after successful actions\n- allow up to two minutes for interactive Google sign-in, then reconcile authoritative auth state before reporting a timeout\n- wait for persisted auth restoration before answering popup auth-status requests, preserving the popup cache on restore failure\n\n## Validation\n\n- 
> pokerchase-hud@5.2.0 test
> jest --runInBand (132 suites, 1,252 tests)\n- 
> pokerchase-hud@5.2.0 typecheck
> tsc --noEmit\n- 
> pokerchase-hud@5.2.0 build
> tsx esbuild.config.ts

Build succeeded

> pokerchase-hud@5.2.0 postbuild
> zip -r extension.zip dist/ icons/ manifest.json

updating: dist/ (stored 0%)
updating: dist/web_accessible_resource.js (deflated 69%)
updating: dist/popup.js (deflated 70%)
updating: dist/index.html (deflated 53%)
updating: dist/background.js (deflated 71%)
updating: dist/popup-boot.js (deflated 24%)
updating: dist/content_script.js (deflated 71%)
updating: icons/ (stored 0%)
updating: icons/icon_16px.png (stored 0%)
updating: icons/icon_48px.png (stored 0%)
updating: icons/icon_128px.png (stored 0%)
updating: manifest.json (deflated 47%)\n- \n- post-#246 rebase range-diff confirmed the original three commits remained patch-equivalent\n- owner risk gate on final head: 
> pokerchase-hud@5.2.0 test
> jest --runInBand src/components/Popup.test.tsx src/components/popup/FirebaseAuthSection.test.tsx src/background/message-router.auth-signout-race.test.ts (3 suites, 52 tests)\n  - failure injection covers response errors, missing/rejected responses, auth timeout, committed-auth/slow-sync reconciliation, rapid duplicate clicks, persisted-auth restore wait/failure, and cache-preserving fail-open behavior\n\n## Integration\n\n- rebased onto  at  (#246)\n- #246 sign-out atomicity and bounded revoke behavior remain intact\n- head: \n\nCodex session: 