### PR TITLE
fix(import): preserve UTF-8 across file chunks

### DIFF
--- a/src/components/popup/ImportExportSection.test.tsx
+++ b/src/components/popup/ImportExportSection.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { TextDecoder as NodeTextDecoder } from 'util'
 import { useRef, useState } from 'react'
 import userEvent from '@testing-library/user-event'
 import { ImportExportSection } from './ImportExportSection'
@@ -44,6 +45,7 @@ describe('ImportExportSection - rebuild advisory banner', () => {
   let mockSendMessage: jest.Mock
 
   beforeEach(() => {
+    ;(globalThis as any).TextDecoder = NodeTextDecoder
     storageChangeListeners = []
     storageLocalData = {}
     // Default: respond synchronously with no operationState (mirrors "nothing in
@@ -178,5 +180,32 @@ describe('ImportExportSection - rebuild advisory banner', () => {
     expect(actions).toContain('importDataInit')
     expect(actions).not.toContain('importDataChunk')
     expect(actions).not.toContain('importDataProcess')
+  })
+
+  it('preserves a UTF-8 character split across file chunk boundaries', async () => {
+    const uploadedChunks: string[] = []
+    mockSendMessage.mockImplementation((message: { action?: string, chunkData?: string }, callback?: (response: unknown) => void) => {
+      if (typeof callback === 'function') {
+        callback({})
+        return undefined
+      }
+      if (message.action === 'importDataChunk') uploadedChunks.push(message.chunkData ?? '')
+      return Promise.resolve({ success: true })
+    })
+
+    const chunkSize = 5 * 1024 * 1024
+    const content = `${'x'.repeat(chunkSize - 1)}あ\n`
+    const { container } = render(<ImportStatusHarness />)
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File([content], 'utf8-boundary.ndjson', { type: 'application/x-ndjson' })
+
+    fireEvent.change(input, { target: { files: [file] } })
+
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalledWith(expect.objectContaining({ action: 'importDataProcess' }))
+    })
+    expect(uploadedChunks).toHaveLength(2)
+    expect(uploadedChunks.join('')).toBe(content)
+    expect(uploadedChunks.join('')).not.toContain('\uFFFD')
   })
 })

--- a/src/components/popup/ImportExportSection.tsx
+++ b/src/components/popup/ImportExportSection.tsx
@@ -273,16 +273,24 @@ export const ImportExportSection = ({
       requireSuccessfulResponse(initResponse, 'インポートを開始できませんでした')
 
       // Read and send file in chunks
+      // Keep one decoder alive across Blob boundaries. `Blob.slice()` uses byte
+      // offsets, so decoding every 5 MiB slice independently can split a UTF-8
+      // code point (for example, a Japanese player name) and silently replace
+      // both halves with U+FFFD before the background joins the chunks.
+      const decoder = new TextDecoder()
       for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
         const start = chunkIndex * FILE_CHUNK_SIZE
         const end = Math.min(start + FILE_CHUNK_SIZE, file.size)
         const chunk = file.slice(start, end)
         
-        const chunkContent = await new Promise<string>((resolve, reject) => {
+        const chunkBytes = await new Promise<ArrayBuffer>((resolve, reject) => {
           const reader = new FileReader()
-          reader.onload = (e) => resolve(e.target?.result as string)
+          reader.onload = (e) => resolve(e.target?.result as ArrayBuffer)
           reader.onerror = reject
-          reader.readAsText(chunk)
+          reader.readAsArrayBuffer(chunk)
+        })
+        const chunkContent = decoder.decode(new Uint8Array(chunkBytes), {
+          stream: chunkIndex < totalChunks - 1
         })
 
         // Send chunk to background


### PR DESCRIPTION
## Summary
- decode 5 MiB file slices with one streaming UTF-8 decoder
- prevent multibyte player names from becoming replacement characters at chunk boundaries
- cover a three-byte character split exactly across the boundary

## Validation
- `npm test -- --runInBand`
- `npm run typecheck`
- `npm run build`

Head: `7a06e2b`