### PR TITLE
fix(background): claim data operation slots atomically

### DIFF
--- a/src/background/event-ingestion.durability-barrier.test.ts
+++ b/src/background/event-ingestion.durability-barrier.test.ts
@@ -39,6 +39,7 @@ import * as updateManager from './update-manager'
 import { autoSyncService } from '../services/auto-sync-service'
 import { getUndecodedEventStats, resetUndecodedEventStats, UNDECODED_EVENT_STATS_KEY } from './undecoded-event-tracker'
 import * as apiEventKey from '../utils/api-event-key'
+import { setOperationState } from './operation-state'
 
 describe('registerEventIngestion (raw-write durability barrier)', () => {
   let db: PokerChaseDB
@@ -71,6 +72,7 @@ describe('registerEventIngestion (raw-write durability barrier)', () => {
   })
 
   afterEach(async () => {
+    setOperationState({ type: 'idle' })
     jest.restoreAllMocks()
     disconnectHandlers.forEach(fn => fn())
     connectedPorts.clear()
@@ -104,6 +106,16 @@ describe('registerEventIngestion (raw-write durability barrier)', () => {
     Items: [],
     Money: { FreeMoney: -1, PaidMoney: -1 },
     Emblems: []
+  })
+
+  test('drops new events while local database deletion owns the commit slot', async () => {
+    const mergeSpy = jest.spyOn(apiEventKey, 'mergeApiEvents')
+    setOperationState({ type: 'delete' })
+
+    await onMessageHandler(entryQueued(1_000))
+
+    expect(mergeSpy).not.toHaveBeenCalled()
+    expect(await db.apiEvents.count()).toBe(0)
   })
 
   test('streams / auto-sync trigger / session-activity tracking all wait behind the raw merge, and all run after it resolves', async () => {

--- a/src/background/event-ingestion.ts
+++ b/src/background/event-ingestion.ts
@@ -13,6 +13,7 @@ import { connectedPorts, startPortPing, setLastKnownStats } from './ports'
 import { recordUndecodedEvent } from './undecoded-event-tracker'
 import { markSessionActive, markSessionInactive, recheckPendingUpdate, setIngestionDrainProvider } from './update-manager'
 import { mergeApiEvents, type RawApiEvent } from '../utils/api-event-key'
+import { getOperationState } from './operation-state'
 
 /**
  * 参加取消申込（ApiTypeId 203）。`ApiType` enum（アプリケーションで使用する
@@ -108,6 +109,16 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
         // 保存・処理しないため、耐久性バリアの対象になる副作用が無い）
         if (typeof message === 'object' && 'type' in message && message.type === 'keepalive') {
           return
+        }
+
+        // Local deletion owns the database through runtime.reload(). Events
+        // arriving after that synchronous claim must not enter the queue:
+        // Dexie would otherwise auto-open and recreate the just-deleted DB in
+        // the narrow window before reload. Tasks queued before the claim are
+        // drained by deleteAllData() and then removed with the database.
+        if (getOperationState().type === 'delete') {
+          console.warn('[background] Dropping event while local data deletion is committing:', message)
+          return Promise.resolve()
         }
 
         // このイベントの処理を、直前のイベントの処理（add()の決着含む）の

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -31,6 +31,7 @@ import {
   type RawApiEvent
 } from '../utils/api-event-key'
 import { HandLogExporter } from '../utils/hand-log-exporter'
+import { awaitIngestionDrain } from './update-manager'
 
 const IMPORT_CHUNK_SIZE = DATABASE_CONSTANTS.IMPORT_CHUNK_SIZE
 
@@ -777,11 +778,23 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
     // Keep the slot claimed until runtime.reload() replaces this worker.
     setOperationState({ type: 'delete' })
     try {
+      // Events already queued before the synchronous claim above must finish
+      // first. event-ingestion rejects later arrivals while type=delete, so
+      // once this drain stabilizes nothing can recreate the database between
+      // delete() and runtime.reload().
+      await awaitIngestionDrain()
+
       // データベースを完全に削除
       await db.delete()
 
-      // データが無くなったので再構築アドバイザリも解消する（reloadより前に行う）
-      await resolveAdvisory()
+      // The database deletion is the commit point. Advisory cleanup is
+      // best-effort after it: a chrome.storage failure must not strand this
+      // worker with a closed database and advertise idle to later callers.
+      try {
+        await resolveAdvisory()
+      } catch (advisoryError) {
+        console.warn('[deleteAllData] Database deleted, but rebuild advisory cleanup failed; reloading anyway:', advisoryError)
+      }
 
       // データベースの新しいインスタンスを確保するために拡張機能をリロード
       chrome.runtime.reload()

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -22,7 +22,7 @@ import type {
   ImportProgressMessage,
   RebuildProgressMessage
 } from '../types/messages'
-import { setOperationState } from './operation-state'
+import { getOperationState, setOperationState } from './operation-state'
 import { resolveAdvisory, markAdvisoryPending } from './rebuild-advisory'
 import {
   API_EVENT_PRIMARY_KEY,
@@ -36,28 +36,60 @@ const IMPORT_CHUNK_SIZE = DATABASE_CONSTANTS.IMPORT_CHUNK_SIZE
 
 interface ImportSession {
   chunks: string[]
+  receivedChunks: number
   totalChunks: number
   fileName: string
 }
 let currentImportSession: ImportSession | null = null
+let importSessionTimeout: ReturnType<typeof setTimeout> | undefined
+const IMPORT_SESSION_TIMEOUT_MS = 5 * 60 * 1000
+
+const armImportSessionTimeout = (): void => {
+  clearTimeout(importSessionTimeout)
+  importSessionTimeout = setTimeout(() => {
+    console.warn('[importData] Abandoned chunk transfer timed out; releasing operation slot')
+    clearImportSession()
+  }, IMPORT_SESSION_TIMEOUT_MS)
+}
 
 export const getCurrentImportSession = (): ImportSession | null => currentImportSession
 
 export const startImportSession = (totalChunks: number, fileName: string): void => {
   currentImportSession = {
     chunks: [],
+    receivedChunks: 0,
     totalChunks,
     fileName
   }
+  // Own the shared operation slot for the whole file transfer, not only the
+  // later parse/rebuild phase. A pending extension update or another data
+  // operation must not reload/delete the worker while chunks live in memory.
+  setOperationState({ type: 'import', progress: 0, processed: 0, total: totalChunks, message: 'インポートファイル転送中...' })
+  armImportSessionTimeout()
 }
 
-export const addImportChunk = (chunkIndex: number, chunkData: string): void => {
-  if (!currentImportSession) return
+export const addImportChunk = (chunkIndex: number, chunkData: string): boolean => {
+  if (!currentImportSession || !Number.isInteger(chunkIndex) || chunkIndex < 0 || chunkIndex >= currentImportSession.totalChunks) return false
+  if (currentImportSession.chunks[chunkIndex] === undefined) currentImportSession.receivedChunks++
   currentImportSession.chunks[chunkIndex] = chunkData
+  setOperationState({
+    type: 'import',
+    progress: Math.round((currentImportSession.receivedChunks / currentImportSession.totalChunks) * 100),
+    processed: currentImportSession.receivedChunks,
+    total: currentImportSession.totalChunks,
+    message: 'インポートファイル転送中...'
+  })
+  armImportSessionTimeout()
+  return true
 }
 
-export const clearImportSession = (): void => {
+export const clearImportSession = (releaseOperation = true): void => {
+  clearTimeout(importSessionTimeout)
+  importSessionTimeout = undefined
   currentImportSession = null
+  if (releaseOperation && getOperationState().type === 'import') {
+    setOperationState({ type: 'idle' })
+  }
 }
 
 /**

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -422,9 +422,12 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
   }
 
   const exportJsonData = async (db: PokerChaseDB) => {
-    const stopKeepAlive = await startKeepAlive()
+    // Claim the shared slot before the first await. Otherwise two messages in
+    // the same task can both observe idle while startKeepAlive() yields.
+    setOperationState({ type: 'export', format: 'json', progress: 0 })
+    let stopKeepAlive = () => {}
     try {
-      setOperationState({ type: 'export', format: 'json', progress: 0 })
+      stopKeepAlive = await startKeepAlive()
       chrome.runtime.sendMessage<ExportProgressMessage>({
         action: 'exportProgress',
         state: 'started',
@@ -517,9 +520,11 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
   }
 
   const exportPokerStarsData = async () => {
-    const stopKeepAlive = await startKeepAlive()
+    // Claim the shared slot before the first await; see exportJsonData().
+    setOperationState({ type: 'export', format: 'pokerstars', progress: 0 })
+    let stopKeepAlive = () => {}
     try {
-      setOperationState({ type: 'export', format: 'pokerstars', progress: 0 })
+      stopKeepAlive = await startKeepAlive()
       chrome.runtime.sendMessage<ExportProgressMessage>({
         action: 'exportProgress',
         state: 'started',
@@ -736,6 +741,9 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
    * Delete all data (logs only, not configuration)
    */
   const deleteAllData = async (): Promise<void> => {
+    // Deleting the database is mutually exclusive with every reader/writer.
+    // Keep the slot claimed until runtime.reload() replaces this worker.
+    setOperationState({ type: 'delete' })
     try {
       // データベースを完全に削除
       await db.delete()
@@ -747,6 +755,7 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
       chrome.runtime.reload()
     } catch (error) {
       console.error('Error deleting data:', error)
+      setOperationState({ type: 'idle' })
       throw error
     }
   }

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -784,6 +784,11 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
       // delete() and runtime.reload().
       await awaitIngestionDrain()
 
+      // processEvent() only enqueues work into the live transform pipeline.
+      // Its promise can settle before WriteEntityStream's async Dexie writes
+      // have completed, so drain the full piped chain before deleting the DB.
+      await service.handAggregateStream.whenIdle()
+
       // データベースを完全に削除
       await db.delete()
 

--- a/src/background/message-router.operation-exclusivity.test.ts
+++ b/src/background/message-router.operation-exclusivity.test.ts
@@ -161,6 +161,24 @@ describe('message-router operation exclusivity', () => {
     expect(getOperationState()).toEqual({ type: 'delete' })
   })
 
+  test('waits for the live transform pipeline before deleting the database', async () => {
+    let releasePipeline!: () => void
+    const pipelineIdle = new Promise<void>(resolve => { releasePipeline = resolve })
+    jest.spyOn(service.handAggregateStream, 'whenIdle').mockReturnValue(pipelineIdle)
+    const deleteSpy = jest.spyOn(db, 'delete')
+    const response = new Promise<MessageResponse>(resolve => {
+      listener({ action: 'deleteAllData' }, {}, resolve)
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(deleteSpy).not.toHaveBeenCalled()
+
+    releasePipeline()
+    await expect(response).resolves.toEqual({ success: true })
+    expect(deleteSpy).toHaveBeenCalledTimes(1)
+  })
+
   test('reloads after database deletion even when advisory cleanup fails', async () => {
     ;(chrome.storage.local.set as jest.Mock).mockRejectedValueOnce(new Error('simulated advisory storage failure'))
     const reload = chrome.runtime.reload as jest.Mock

--- a/src/background/message-router.operation-exclusivity.test.ts
+++ b/src/background/message-router.operation-exclusivity.test.ts
@@ -3,9 +3,9 @@ import PokerChaseService, { PokerChaseDB } from '../app'
 import type { ChromeMessage, MessageResponse } from '../types/messages'
 import { clearImportSession, getCurrentImportSession } from './import-export'
 import { registerMessageRouter } from './message-router'
-import { setOperationState } from './operation-state'
+import { getOperationState, setOperationState } from './operation-state'
 
-describe('message-router import operation exclusivity', () => {
+describe('message-router operation exclusivity', () => {
   let db: PokerChaseDB
   let service: PokerChaseService
   let listener: (
@@ -87,5 +87,38 @@ describe('message-router import operation exclusivity', () => {
 
     expect(sendResponse).toHaveBeenCalledWith({ success: false, error: '別の処理が実行中です' })
     expect(getCurrentImportSession()?.chunks).toEqual(['{}'])
+  })
+
+  test('claims the operation slot synchronously when export starts', async () => {
+    ;(chrome.runtime.sendMessage as jest.Mock).mockResolvedValue(undefined)
+    ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => callback([{ id: 1 }]))
+    ;(chrome.tabs.sendMessage as jest.Mock).mockImplementation((_tabId, _message, callback) => {
+      callback({ success: true })
+    })
+    const completion = new Promise<MessageResponse>(resolve => {
+      listener({ action: 'exportData', format: 'json' }, {}, resolve)
+    })
+
+    expect(getOperationState()).toMatchObject({ type: 'export', format: 'json' })
+    await expect(completion).resolves.toEqual({ success: true })
+  })
+
+  test('rejects local deletion while another operation is active', () => {
+    const deleteSpy = jest.spyOn(db, 'delete')
+    const sendResponse = jest.fn()
+    setOperationState({ type: 'sync' })
+
+    listener({ action: 'deleteAllData' }, {}, sendResponse)
+
+    expect(sendResponse).toHaveBeenCalledWith({ success: false, error: '別の処理が実行中です' })
+    expect(deleteSpy).not.toHaveBeenCalled()
+  })
+
+  test('claims the operation slot synchronously when local deletion starts', () => {
+    jest.spyOn(db, 'delete').mockImplementation(() => new Promise<void>(() => {}) as any)
+
+    listener({ action: 'deleteAllData' }, {}, jest.fn())
+
+    expect(getOperationState()).toEqual({ type: 'delete' })
   })
 })

--- a/src/background/message-router.operation-exclusivity.test.ts
+++ b/src/background/message-router.operation-exclusivity.test.ts
@@ -69,6 +69,45 @@ describe('message-router operation exclusivity', () => {
     expect(getCurrentImportSession()).toBeNull()
   })
 
+  test('chunk-session initialization claims the slot until processing starts', () => {
+    const initResponse = jest.fn()
+    listener({ action: 'importDataInit', totalChunks: 2, fileName: 'data.ndjson' }, {}, initResponse)
+
+    expect(initResponse).toHaveBeenCalledWith({ success: true })
+    expect(getOperationState()).toMatchObject({ type: 'import', processed: 0, total: 2 })
+
+    const exportResponse = jest.fn()
+    listener({ action: 'exportData', format: 'json' }, {}, exportResponse)
+    expect(exportResponse).toHaveBeenCalledWith({ success: false, error: '別の処理が実行中です' })
+  })
+
+  test('does not mistake a sparse final-index chunk for a complete import', () => {
+    listener({ action: 'importDataInit', totalChunks: 2, fileName: 'data.ndjson' }, {}, jest.fn())
+    listener({ action: 'importDataChunk', chunkIndex: 1, chunkData: 'second' }, {}, jest.fn())
+    const processResponse = jest.fn()
+
+    listener({ action: 'importDataProcess' }, {}, processResponse)
+
+    expect(processResponse).toHaveBeenCalledWith({ success: false, error: 'Import session incomplete' })
+    expect(getCurrentImportSession()).toMatchObject({ receivedChunks: 1, chunks: [undefined, 'second'] })
+    expect(getOperationState().type).toBe('import')
+  })
+
+  test('releases an abandoned chunk-session slot after inactivity', () => {
+    jest.useFakeTimers()
+    try {
+      listener({ action: 'importDataInit', totalChunks: 2, fileName: 'data.ndjson' }, {}, jest.fn())
+      expect(getOperationState().type).toBe('import')
+
+      jest.advanceTimersByTime(5 * 60 * 1000)
+
+      expect(getCurrentImportSession()).toBeNull()
+      expect(getOperationState().type).toBe('idle')
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
   test('preserves a completed chunk session when processing is blocked', () => {
     listener(
       { action: 'importDataInit', totalChunks: 1, fileName: 'data.ndjson' },

--- a/src/background/message-router.operation-exclusivity.test.ts
+++ b/src/background/message-router.operation-exclusivity.test.ts
@@ -160,4 +160,16 @@ describe('message-router operation exclusivity', () => {
 
     expect(getOperationState()).toEqual({ type: 'delete' })
   })
+
+  test('reloads after database deletion even when advisory cleanup fails', async () => {
+    ;(chrome.storage.local.set as jest.Mock).mockRejectedValueOnce(new Error('simulated advisory storage failure'))
+    const reload = chrome.runtime.reload as jest.Mock
+    const response = new Promise<MessageResponse>(resolve => {
+      listener({ action: 'deleteAllData' }, {}, resolve)
+    })
+
+    await expect(response).resolves.toEqual({ success: true })
+    expect(reload).toHaveBeenCalled()
+    expect(getOperationState()).toEqual({ type: 'delete' })
+  })
 })

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -289,6 +289,7 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
       return true
     } else if (request.action === 'deleteAllData') {
       // ログと設定を含むすべてのデータを削除
+      if (rejectIfOperationBusy('deleteAllData', sendResponse)) return true
       deleteAllData()
         .then(() => {
           sendResponse({ success: true })

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -113,23 +113,38 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
         sendResponse({ success: false, error: 'No import session active' })
         return true
       }
+      if (getOperationState().type !== 'import') {
+        console.warn(`[importDataChunk] Blocked: operation already in progress (${getOperationState().type})`)
+        sendResponse({ success: false, error: '別の処理が実行中です' })
+        return true
+      }
 
-      addImportChunk(request.chunkIndex, request.chunkData)
+      if (!addImportChunk(request.chunkIndex, request.chunkData)) {
+        sendResponse({ success: false, error: 'Invalid import chunk index' })
+        return true
+      }
 
       sendResponse({ success: true })
       return true
     } else if (request.action === 'importDataProcess') {
       const currentImportSession = getCurrentImportSession()
-      if (!currentImportSession || currentImportSession.chunks.length !== currentImportSession.totalChunks) {
+      if (!currentImportSession || currentImportSession.receivedChunks !== currentImportSession.totalChunks) {
         sendResponse({ success: false, error: 'Import session incomplete' })
         return true
       }
 
-      if (rejectIfOperationBusy('importDataProcess', sendResponse)) return true
+      // importDataInit already owns this slot. Any other type here means
+      // state was externally replaced; preserve the complete session so it
+      // can be retried after that operation finishes.
+      if (getOperationState().type !== 'import') {
+        console.warn(`[importDataProcess] Blocked: operation already in progress (${getOperationState().type})`)
+        sendResponse({ success: false, error: '別の処理が実行中です' })
+        return true
+      }
 
       // すべてのチャンクを結合
       const completeData = currentImportSession.chunks.join('')
-      clearImportSession() // セッションをクリア
+      clearImportSession(false) // importData()が同じslotを引き継ぐ
 
       // データを処理
       importData(completeData)

--- a/src/background/operation-state.ts
+++ b/src/background/operation-state.ts
@@ -9,7 +9,7 @@
  */
 
 export interface OperationState {
-  type: 'idle' | 'export' | 'import' | 'rebuild' | 'sync'
+  type: 'idle' | 'export' | 'import' | 'rebuild' | 'sync' | 'delete'
   format?: 'json' | 'pokerstars'
   progress?: number
   processed?: number

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -350,7 +350,7 @@ export interface SyncInfoResponse extends SuccessResponse {
 
 export interface OperationStateResponse extends SuccessResponse {
   operationState: {
-    type: 'idle' | 'export' | 'import' | 'rebuild' | 'sync'
+    type: 'idle' | 'export' | 'import' | 'rebuild' | 'sync' | 'delete'
     format?: 'json' | 'pokerstars'
     progress?: number
     processed?: number


### PR DESCRIPTION
## Summary
- claim both export formats before their first await
- treat local database deletion as a mutually exclusive operation
- claim chunked import from `importDataInit` through transfer and processing, preventing update reloads or other data operations from interrupting in-memory chunks
- reject sparse/out-of-range chunk completion and release abandoned transfers after bounded inactivity
- drain both queued ingestion and the piped live transform/Dexie writer chain before database deletion
- reject later events until reload, and keep reload committed even if advisory cleanup fails
- cover synchronous slot ownership, transfer ownership, sparse chunks, timeout recovery, pending writer drain, and deletion commit boundaries

## Validation
- `npm test -- --runInBand` — 133 suites / 1,266 tests passed
- `npm run typecheck` — passed
- `npm run build` — passed

Head: `3827d85`