### PR TITLE
fix(sync): preserve Firestore watermark prefix

### DIFF
--- a/docs/firebase-setup.md
+++ b/docs/firebase-setup.md
@@ -102,8 +102,10 @@ extension IDが別になる場合、そのID用のOAuth clientを用意する。
 3. 9種のschema-valid application eventだけをupload候補にする。非application / unknown eventは
    localには残るがcloudへ送らない。application typeなのに現schemaでparseできない行は
    `unparseable floor`を永続化して保留し、後のschema修正後に再提示できるようscanを巻き戻す。
-4. 300 writes/batch、最大3 batch並列でFirestore `:commit`へupsertする。document IDが決定的なので、
-   watermark巻き戻しによる再送は同じdocumentを更新する。
+4. 300 writes/batchをtimestamp coverage順に直列でFirestore `:commit`へupsertする。後続batchは
+   直前batchのacknowledge後だけ開始し、古いbatch失敗時に新しいtimestampだけが先にwatermarkを
+   進めない。同一millisecondがbatch境界を跨ぐ場合は、次回その最大timestamp群をまとめて再提示する。
+   document IDが決定的なので、acknowledge済み行の再送は同じdocumentを更新する。
 5. Firestoreが全writeをacknowledgeした後だけfloorと同期完了時刻を進める。
 
 ログの母集団を混同しないこと。`raw events` / `scan snapshot`はlocal Lakeで走査する全行、
@@ -196,7 +198,7 @@ write課金になり得る。ConsoleのUsage / Billingで実測する。
 
 全REST requestは30秒timeout、network/timeout/429/5xxに最大2回（500ms、1,000ms）のbackoff retry、
 401にtoken force-refresh 1回を持つ。既定retry後も`Firestore REST request failed`が続く場合に限り、
-quota、rules、network、batch/parallel設定を調査する。permission denied等の非retryable 4xxは即時errorになる。
+quota、rules、network、batch size / retry設定を調査する。permission denied等の非retryable 4xxは即時errorになる。
 
 ### Popupと同期状態が一致しない
 

--- a/src/constants/database.ts
+++ b/src/constants/database.ts
@@ -16,7 +16,6 @@ export const DATABASE_CONSTANTS = {
   // Firestore sync
   FIRESTORE_BATCH_SIZE: 300,     // Firestore write batch size
   FIRESTORE_DELETE_BATCH: 500,   // Firestore delete batch size
-  FIRESTORE_PARALLEL_BATCHES: 3, // Number of parallel Firestore batches
   FIRESTORE_BATCH_DELAY_MS: 500, // Delay between batch groups
   FIRESTORE_DOWNLOAD_PAGE_SIZE: 1000, // Maximum documents per Firestore download response
   FIRESTORE_REQUEST_TIMEOUT_MS: 30000,   // Per-request AbortController timeout (a stalled fetch must not hold isSyncing forever)

--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -568,11 +568,9 @@ describe('AutoSyncService cloud downloads', () => {
     // Still can't upload the broken row (schema hasn't been fixed), but the
     // scan floor was rewound to just below the pending marker (200 - 1 = 199)
     // instead of trusting the real cloud max (300) -- proving the row is
-    // still being re-scanned, not skipped. 198, not 199: the P1 fix
-    // (auto-sync-service.ts) shifts the threshold syncToCloudBatch actually
-    // receives one further millisecond earlier -- see the threshold-shift
-    // comment in the backfill test below.
-    expect(secondFloor).toBe(198)
+    // still being re-scanned, not skipped. syncToCloudBatch's inclusive
+    // watermark filter receives the scan floor itself.
+    expect(secondFloor).toBe(199)
     // firstEntry (timestamp 100) sits below the rewound floor (199), so it's
     // not re-scanned -- only rows from the broken row's timestamp onward are.
     expect(secondChunk).toEqual([nextSessionEntry])
@@ -688,14 +686,9 @@ describe('AutoSyncService cloud downloads', () => {
     // specific orphan.
     expect(syncBatchSpy).toHaveBeenCalledTimes(1)
     const [uploadedChunk, floor] = syncBatchSpy.mock.calls[0]!
-    // 98, not 99: syncToCloudBatch's own dedup filter is bare-timestamp-only
-    // (`event.timestamp > threshold`), so the P1 compound-key-pagination fix
-    // (auto-sync-service.ts) shifts the threshold it receives one
-    // millisecond earlier than the scan floor itself -- makes that filter
-    // INCLUSIVE of the scan floor's own millisecond, closing the gap where a
-    // not-yet-uploaded row could share that exact millisecond with a
-    // different ApiTypeId than whatever pushed the cloud watermark there.
-    expect(floor).toBe(98)
+    // The downstream watermark filter is inclusive, so it receives the scan
+    // floor itself and re-offers ties at that exact millisecond.
+    expect(floor).toBe(99)
     expect(uploadedChunk).toEqual([oldValidEntry, newEntryAboveCloudMax])
 
     // --- Second sync: the backfill must not run again (one-time, idempotent) ---
@@ -707,7 +700,7 @@ describe('AutoSyncService cloud downloads', () => {
     // re-uploading the already-reconciled history.
     expect(syncBatchSpy).toHaveBeenCalledTimes(2)
     const [secondChunk, secondFloor] = syncBatchSpy.mock.calls[1]!
-    expect(secondFloor).toBe(198) // 199 - 1, same P1 threshold shift as above
+    expect(secondFloor).toBe(199)
     expect(secondChunk).toEqual([newEntryAboveCloudMax])
   })
 
@@ -764,9 +757,7 @@ describe('AutoSyncService cloud downloads', () => {
     // one (there is none) -- and the pass rewound to re-offer it.
     expect(syncBatchSpy).toHaveBeenCalledTimes(1)
     const [uploadedChunk, floor] = syncBatchSpy.mock.calls[0]!
-    // 148, not 149: see the P1 threshold-shift comment in the backfill test
-    // above.
-    expect(floor).toBe(148)
+    expect(floor).toBe(149)
     // recoveredRow is actually included in the upload -- this is the
     // concrete "rows below watermark, parseable, absent from cloud -> floored
     // -> uploaded on next sync" regression the finding calls for.
@@ -891,11 +882,9 @@ describe('AutoSyncService cloud downloads', () => {
     // matching the scenario precondition, and the later row still uploaded.
     const syncBatchSpy = firestoreBackupService.syncToCloudBatch as jest.Mock
     const [uploadedChunk, floor] = syncBatchSpy.mock.calls[0]!
-    // 299, not 300: see the P1 threshold-shift comment in the backfill test
-    // above -- this pass's scanFloor happens to land exactly on
-    // cloudMaxTimestamp (300) here, which is precisely the case the shift
-    // protects.
-    expect(floor).toBe(299)
+    // This pass's scanFloor lands exactly on cloudMaxTimestamp; the inclusive
+    // downstream filter protects every row tied at that millisecond.
+    expect(floor).toBe(300)
     expect(uploadedChunk).toEqual([laterValidRow])
   })
 
@@ -1021,11 +1010,9 @@ describe('AutoSyncService cloud downloads', () => {
     expect(syncBatchSpy).toHaveBeenCalledTimes(1)
     const [firstAttemptChunk, firstAttemptFloor] = syncBatchSpy.mock.calls[0]!
     // Scan floor rewound to just below the OLD pending marker (100 - 1 =
-    // 99), re-offering row@100 despite the newer cloud max (500). 98, not
-    // 99: the P1 fix (auto-sync-service.ts) shifts the threshold
-    // syncToCloudBatch actually receives one further millisecond earlier --
-    // see the threshold-shift comment in the backfill test below.
-    expect(firstAttemptFloor).toBe(98)
+    // 99), re-offering row@100 despite the newer cloud max (500). The
+    // downstream watermark filter is inclusive, so it receives 99 directly.
+    expect(firstAttemptFloor).toBe(99)
     expect(firstAttemptChunk).toEqual([recoveredRow, laterValidRow])
 
     // The critical assertion (P1 #2): even though this chunk's raw scan
@@ -1044,9 +1031,8 @@ describe('AutoSyncService cloud downloads', () => {
     expect(syncBatchSpy).toHaveBeenCalledTimes(2)
     const [secondAttemptChunk, secondAttemptFloor] = syncBatchSpy.mock.calls[1]!
     // Still rewound the same way -- row@100 is re-offered again (proving it
-    // was never dropped after the failed attempt). 98, not 99: same P1
-    // threshold shift as the first attempt above.
-    expect(secondAttemptFloor).toBe(98)
+    // was never dropped after the failed attempt).
+    expect(secondAttemptFloor).toBe(99)
     expect(secondAttemptChunk).toEqual([recoveredRow, laterValidRow])
 
     // Only now -- after this upload was awaited and confirmed -- is it safe

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -930,20 +930,15 @@ export class AutoSyncService {
     // anything newer.
     //
     // `firestoreBackupService.syncToCloudBatch()`'s OWN internal dedup filter
-    // (`event.timestamp > <threshold>`, see its doc comment) is bare-
-    // timestamp-only -- it has no ApiTypeId to compare against, so it can't
-    // be made compound-aware the way the cursor above just was. Shifting the
-    // threshold VALUE passed to it one millisecond earlier than `scanFloor`
-    // makes its `>` check inclusive of `scanFloor`'s own millisecond too,
-    // consistent with the cursor above -- reusing the exact same "pass a
-    // deliberately lowered threshold, rely on idempotent upserts" pattern
-    // this file already established for the unparseable-floor rewind (see
-    // the big comment block above this one). Pre-existing floor-rewind
-    // tests' asserted `floor` values shift down by 1 accordingly (see
-    // auto-sync-service.test.ts).
+    // is intentionally inclusive (`event.timestamp >= threshold`): it must
+    // re-offer the entire maximum-timestamp tie group when a Firestore batch
+    // boundary splits that millisecond and the later commit fails. Passing
+    // `scanFloor` unchanged therefore keeps this compound cursor and the
+    // downstream bare-timestamp filter aligned; deterministic document IDs
+    // make the tied re-upserts idempotent.
     const ApiTypeIdFloorSentinel = 0
     const SequenceFloorSentinel = -1
-    const uploadDedupThreshold = scanFloor !== null ? scanFloor - 1 : null
+    const uploadDedupThreshold = scanFloor
 
     // Count events at-or-newer than the (possibly rewound) scan floor,
     // inclusive of ties at `scanFloor`'s own millisecond (see fix (b) above).
@@ -1085,14 +1080,10 @@ export class AutoSyncService {
           // just extra write cost, bounded to however much happened since the
           // break, and it stops once the row resolves.
           //
-          // `uploadDedupThreshold` (== `scanFloor - 1` when a floor exists;
-          // see P1 fix doc comment above) rather than `scanFloor` itself:
-          // syncToCloudBatch's own filter is `event.timestamp > threshold`,
-          // bare-timestamp-only. Passing `scanFloor` unchanged would make
-          // that filter re-exclude the exact same-millisecond row the
-          // compound-key cursor above was just fixed to include (its
-          // timestamp equals `scanFloor`, not greater than it) -- silently
-          // undoing the fix one layer downstream.
+          // The inclusive downstream filter re-offers rows exactly at this
+          // threshold, matching the compound-key cursor above and closing
+          // both same-millisecond pass-start and Firestore batch-boundary
+          // gaps without inventing an arrival-order field.
           uploadDedupThreshold,
           (progress) => {
             this.updateSyncState({

--- a/src/services/firestore-backup-service.test.ts
+++ b/src/services/firestore-backup-service.test.ts
@@ -159,6 +159,53 @@ describe('FirestoreBackupService', () => {
     expect(commitCalls).toBe(2)
   })
 
+  test('retry re-offers the cloud-max tie group when a batch boundary splits one millisecond', async () => {
+    const service = new FirestoreBackupService({ maxTransientRetries: 0, retryBaseDelayMs: 1 })
+    const events = [
+      ...Array.from({ length: 299 }, (_, index) => ({
+        timestamp: index + 1,
+        ApiTypeId: 304,
+        sequence: 0
+      })),
+      { timestamp: 300, ApiTypeId: 304, sequence: 0 },
+      { timestamp: 300, ApiTypeId: 304, sequence: 1 }
+    ] as ApiEvent[]
+
+    let commitCalls = 0
+    global.fetch = jest.fn().mockImplementation(async (url: string) => {
+      if (!String(url).endsWith(':commit')) return { ok: true, text: async () => '{}' } as Response
+      commitCalls++
+      if (commitCalls === 2) {
+        return { ok: false, status: 500, text: async () => 'failed second batch' } as Response
+      }
+      return {
+        ok: true,
+        text: async () => JSON.stringify({ writeResults: [{}], commitTime: '2026-07-22T00:00:00Z' })
+      } as Response
+    })
+
+    await expect(service.syncToCloudBatch(events, null)).rejects.toThrow('failed second batch')
+    expect(commitCalls).toBe(2)
+
+    const retryCommitBodies: any[] = []
+    global.fetch = jest.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      if (String(url).endsWith(':commit')) retryCommitBodies.push(JSON.parse(String(init?.body)))
+      return {
+        ok: true,
+        text: async () => String(url).endsWith(':commit')
+          ? JSON.stringify({ writeResults: [{}], commitTime: '2026-07-22T00:00:01Z' })
+          : '{}'
+      } as Response
+    })
+
+    await expect(service.syncToCloudBatch(events, 300)).resolves.toMatchObject({ syncedEvents: 2 })
+    expect(retryCommitBodies).toHaveLength(1)
+    expect(retryCommitBodies[0].writes.map((write: any) => write.update.name.split('/').pop())).toEqual([
+      '300_304',
+      '300_304_1'
+    ])
+  })
+
   test('syncFromCloud downloads matching events in bounded, cursor-based pages', async () => {
     const uid = 'XK00mmVIZdg8J52OlfyKvN467SK2'
     const documentName = (timestamp: number) =>

--- a/src/services/firestore-backup-service.test.ts
+++ b/src/services/firestore-backup-service.test.ts
@@ -126,6 +126,39 @@ describe('FirestoreBackupService', () => {
     expect(commitCalls).toBe(2)
   })
 
+  test('does not start a newer timestamp batch before the prior batch is acknowledged', async () => {
+    let resolveFirstCommit!: (response: Response) => void
+    const firstCommit = new Promise<Response>(resolve => { resolveFirstCommit = resolve })
+    let commitCalls = 0
+    global.fetch = jest.fn().mockImplementation(async (url: string) => {
+      if (!String(url).endsWith(':commit')) {
+        return { ok: true, text: async () => '{}' } as Response
+      }
+      commitCalls++
+      if (commitCalls === 1) return firstCommit
+      return {
+        ok: true,
+        text: async () => JSON.stringify({ writeResults: [{}], commitTime: '2026-07-22T00:00:00Z' })
+      } as Response
+    })
+
+    const events = Array.from({ length: 301 }, (_, index) => ({
+      timestamp: index + 1,
+      ApiTypeId: 304
+    })) as ApiEvent[]
+    const sync = new FirestoreBackupService().syncToCloudBatch(events, null)
+
+    for (let attempt = 0; attempt < 10 && commitCalls === 0; attempt++) await Promise.resolve()
+    expect(commitCalls).toBe(1)
+
+    resolveFirstCommit({
+      ok: true,
+      text: async () => JSON.stringify({ writeResults: [{}], commitTime: '2026-07-22T00:00:00Z' })
+    } as Response)
+    await expect(sync).resolves.toMatchObject({ syncedEvents: 301 })
+    expect(commitCalls).toBe(2)
+  })
+
   test('syncFromCloud downloads matching events in bounded, cursor-based pages', async () => {
     const uid = 'XK00mmVIZdg8J52OlfyKvN467SK2'
     const documentName = (timestamp: number) =>

--- a/src/services/firestore-backup-service.ts
+++ b/src/services/firestore-backup-service.ts
@@ -193,27 +193,30 @@ export class FirestoreBackupService {
 
       console.log(`[Firestore] Processing batch of ${apiEvents.length} upload candidates...`)
 
-      const newEvents = cloudMaxTimestamp
+      const newEvents = (cloudMaxTimestamp
         ? apiEvents.filter(event => (event.timestamp || 0) > cloudMaxTimestamp)
-        : apiEvents
+        : [...apiEvents])
+        // This is upload-coverage order, not wire/causal replay order. A
+        // monotonic timestamp prefix is required because the next pass uses
+        // Firestore's maximum timestamp as its scan watermark.
+        .sort((a, b) =>
+          (a.timestamp || 0) - (b.timestamp || 0) ||
+          a.ApiTypeId - b.ApiTypeId ||
+          getApiEventSequence(a) - getApiEventSequence(b)
+        )
 
       console.log(`[Firestore] ${newEvents.length} events remain after the upload watermark filter`)
 
-      const PARALLEL_BATCHES = DATABASE_CONSTANTS.FIRESTORE_PARALLEL_BATCHES
-      for (let i = 0; i < newEvents.length; i += this.BATCH_SIZE * PARALLEL_BATCHES) {
-        const batchPromises = []
-
-        for (let j = 0; j < PARALLEL_BATCHES && i + j * this.BATCH_SIZE < newEvents.length; j++) {
-          const startIndex = i + j * this.BATCH_SIZE
-          const chunk = newEvents.slice(startIndex, startIndex + this.BATCH_SIZE)
-          if (chunk.length === 0) break
-
-          batchPromises.push(this.writeBatch(user.uid, chunk))
-          synced += chunk.length
-        }
-
-        await Promise.all(batchPromises)
-        processed = Math.min(i + this.BATCH_SIZE * PARALLEL_BATCHES, newEvents.length)
+      // Commit strictly in coverage order. Parallel commits can acknowledge a
+      // newer batch while an older one fails; that advances the real cloud max
+      // past the missing batch and makes every later watermark-based retry skip
+      // it permanently. Sequential acknowledgement keeps Firestore a proven
+      // timestamp prefix: after a failure, no later timestamp has been offered.
+      for (let i = 0; i < newEvents.length; i += this.BATCH_SIZE) {
+        const chunk = newEvents.slice(i, i + this.BATCH_SIZE)
+        await this.writeBatch(user.uid, chunk)
+        synced += chunk.length
+        processed += chunk.length
 
         if (onProgress) {
           onProgress({ current: processed, total: newEvents.length })

--- a/src/services/firestore-backup-service.ts
+++ b/src/services/firestore-backup-service.ts
@@ -193,8 +193,14 @@ export class FirestoreBackupService {
 
       console.log(`[Firestore] Processing batch of ${apiEvents.length} upload candidates...`)
 
-      const newEvents = (cloudMaxTimestamp
-        ? apiEvents.filter(event => (event.timestamp || 0) > cloudMaxTimestamp)
+      const newEvents = (cloudMaxTimestamp !== null
+        // Re-offer the whole maximum-timestamp tie group. A 300-write batch
+        // boundary can split two events from the same millisecond; if the
+        // first commit succeeds and the second fails, a strict `>` retry
+        // would skip the uncommitted tied event forever. Firestore document
+        // IDs are deterministic, so re-upserting the already-acknowledged
+        // members of the tie group is idempotent.
+        ? apiEvents.filter(event => (event.timestamp || 0) >= cloudMaxTimestamp)
         : [...apiEvents])
         // This is upload-coverage order, not wire/causal replay order. A
         // monotonic timestamp prefix is required because the next pass uses
@@ -212,6 +218,8 @@ export class FirestoreBackupService {
       // past the missing batch and makes every later watermark-based retry skip
       // it permanently. Sequential acknowledgement keeps Firestore a proven
       // timestamp prefix: after a failure, no later timestamp has been offered.
+      // If the boundary split the failing timestamp itself, the inclusive
+      // watermark filter above re-offers that whole tie group on retry.
       for (let i = 0; i < newEvents.length; i += this.BATCH_SIZE) {
         const chunk = newEvents.slice(i, i + this.BATCH_SIZE)
         await this.writeBatch(user.uid, chunk)


### PR DESCRIPTION
## Summary
- order upload candidates by storage coverage key
- acknowledge Firestore batches sequentially so cloud max cannot jump past an older failed batch
- re-offer the cloud maximum timestamp tie group, covering a batch boundary that splits one millisecond
- keep the auto-sync compound cursor and inclusive downstream watermark filter aligned
- distinguish upload coverage order from causal replay order in code comments

## Validation
- `npm test -- --runInBand` — 132 suites / 1,242 tests passed
- `npm run typecheck` — passed
- `npm run build` — passed
- regression proves a failed second commit at a same-millisecond boundary is fully re-offered

Head: `183cde2`
