### PR TITLE
fix(sync): replace stale cloud rebuild entities

### DIFF
--- a/src/services/auto-sync-service.rebuild-canonical.test.ts
+++ b/src/services/auto-sync-service.rebuild-canonical.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Canonical cloud-rebuild cleanup regressions.
+ *
+ * A download merges cloud rows into the local Raw Event Lake, then replays the
+ * whole Lake. The replay output is authoritative: cloud-only events can fill a
+ * local gap and invalidate an entity that an earlier incomplete replay emitted.
+ * These tests use a real Dexie database so stale primary keys cannot be hidden
+ * by mocked bulkPut behavior.
+ */
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { PhaseType, type ApiEvent } from '../types'
+import { AutoSyncService } from './auto-sync-service'
+
+const FIRST_HAND_ID = 384370064
+const FIRST_HAND_EVENTS = [
+  {
+    ApiTypeId: 303,
+    SeatUserIds: [2, 4, 3, 1],
+    Game: { CurrentBlindLv: 1, NextBlindUnixSeconds: -1, Ante: 50, SmallBlind: 100, BigBlind: 200, ButtonSeat: 3, SmallBlindSeat: 0, BigBlindSeat: 1 },
+    Player: { SeatIndex: 1, BetStatus: 1, HoleCards: [5, 21], Chip: 5750, BetChip: 200 },
+    OtherPlayers: [
+      { SeatIndex: 0, Status: 0, BetStatus: 1, Chip: 5850, BetChip: 100, IsSafeLeave: false },
+      { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 5950, BetChip: 0, IsSafeLeave: false },
+      { SeatIndex: 3, Status: 0, BetStatus: 1, Chip: 5950, BetChip: 0, IsSafeLeave: false }
+    ],
+    Progress: { Phase: 0, NextActionSeat: 2, NextActionTypes: [2, 3, 4, 5], NextExtraLimitSeconds: 1, MinRaise: 400, Pot: 500, SidePot: [] },
+    timestamp: 1000
+  },
+  {
+    ApiTypeId: 306,
+    CommunityCards: [], Pot: 500, SidePot: [], ResultType: 0, DefeatStatus: 0,
+    HandId: FIRST_HAND_ID, HandLog: '',
+    Results: [{ UserId: 4, HoleCards: [], RankType: 10, Hands: [], HandRanking: 1, Ranking: -2, RewardChip: 500 }],
+    Player: { SeatIndex: 1, BetStatus: -1, Chip: 6250, BetChip: 0 },
+    OtherPlayers: [
+      { SeatIndex: 0, Status: 0, BetStatus: -1, Chip: 5850, BetChip: 0, IsSafeLeave: false },
+      { SeatIndex: 2, Status: 0, BetStatus: -1, Chip: 5950, BetChip: 0, IsSafeLeave: false },
+      { SeatIndex: 3, Status: 0, BetStatus: -1, Chip: 5950, BetChip: 0, IsSafeLeave: false }
+    ],
+    timestamp: 2000
+  }
+] as unknown as ApiEvent[]
+
+describe('AutoSyncService.rebuildLocalEntities() canonical replacement', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+  let autoSyncService: AutoSyncService
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    service = new PokerChaseService({ db })
+    await service.ready
+    ;(globalThis as any).service = service
+    autoSyncService = new AutoSyncService(db)
+  })
+
+  afterEach(async () => {
+    delete (globalThis as any).service
+    db.close()
+    await db.delete()
+  })
+
+  test('removes a formerly-derived hand when a cloud-only event makes canonical replay reject it', async () => {
+    await db.apiEvents.bulkAdd(structuredClone(FIRST_HAND_EVENTS))
+    await (autoSyncService as any).rebuildLocalEntities()
+    expect(await db.hands.get(FIRST_HAND_ID)).toBeDefined()
+
+    const originalDeal = FIRST_HAND_EVENTS[0] as any
+    const result = FIRST_HAND_EVENTS.at(-1)!
+    const interveningTableMoveDeal = {
+      ...structuredClone(originalDeal),
+      timestamp: result.timestamp! - 1,
+      SeatUserIds: [10, 20, 30, 40]
+    }
+    await db.apiEvents.add(interveningTableMoveDeal)
+
+    // The newly complete Lake is DEAL(old) -> DEAL(new table) -> RESULTS(old
+    // table). EntityConverter rejects both sides of this table-move chimera,
+    // so the hand emitted by the earlier incomplete replay must disappear.
+    await (autoSyncService as any).rebuildLocalEntities()
+
+    expect(await db.hands.get(FIRST_HAND_ID)).toBeUndefined()
+    expect(await db.phases.where('handId').equals(FIRST_HAND_ID).count()).toBe(0)
+    expect(await db.actions.where('handId').equals(FIRST_HAND_ID).count()).toBe(0)
+  })
+
+  test('replaces child rows for a regenerated hand instead of leaving obsolete keys', async () => {
+    await db.apiEvents.bulkAdd(structuredClone(FIRST_HAND_EVENTS))
+    await (autoSyncService as any).rebuildLocalEntities()
+
+    const preflop = await db.phases.get([FIRST_HAND_ID, PhaseType.PREFLOP])
+    expect(preflop).toBeDefined()
+    await db.phases.put({ ...preflop!, phase: PhaseType.FLOP })
+    expect(await db.phases.get([FIRST_HAND_ID, PhaseType.FLOP])).toBeDefined()
+
+    await (autoSyncService as any).rebuildLocalEntities()
+
+    expect(await db.phases.get([FIRST_HAND_ID, PhaseType.FLOP])).toBeUndefined()
+  })
+})

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -14,7 +14,7 @@ import { PokerChaseDB } from '../db/poker-chase-db'
 import { EntityConverter } from '../entity-converter'
 import { ApiType, ApiTypeValues, isApiEventType, isApplicationApiEvent, isUnparseableApplicationEvent } from '../types'
 import type { ApiEvent } from '../types'
-import { processInReplayChunks, saveEntities, filterValidApplicationEvents } from '../utils/database-utils'
+import { processInReplayChunks, filterValidApplicationEvents } from '../utils/database-utils'
 import { DATABASE_CONSTANTS } from '../constants/database'
 import { isCloudSyncBlockedByMinVersionGate } from './min-version-gate'
 import {
@@ -1474,6 +1474,13 @@ export class AutoSyncService {
       const converter = new EntityConverter(defaultSession)
       const service = (self as any).service
       const totalEventCount = await this.db.apiEvents.count()
+      // Keep the pre-rebuild key set so a successful canonical replay can
+      // remove hands that were derived from an incomplete local Lake but are
+      // invalid once cloud-only events fill the gap. Restricting cleanup to
+      // this snapshot preserves hands completed by the live pipeline while
+      // the chunked rebuild is running.
+      const previousHandIds = await this.db.hands.toCollection().primaryKeys() as number[]
+      const rebuiltHandIds = new Set<number>()
       let lastProcessedTimestamp = 0
       let latestDealEvent: ApiEvent | undefined
 
@@ -1491,6 +1498,7 @@ export class AutoSyncService {
         // already re-validate internally so they're safe on the raw chunk as-is.
         const validEvents = await filterValidApplicationEvents(events)
         const entities = converter.convertEventChunk(validEvents)
+        entities.hands.forEach(hand => rebuiltHandIds.add(hand.id))
         await this.saveRebuiltEntities(entities)
 
         for (const event of events) {
@@ -1516,7 +1524,28 @@ export class AutoSyncService {
         }
       }
 
-      await this.saveRebuiltEntities(converter.flush())
+      const remainingEntities = converter.flush()
+      remainingEntities.hands.forEach(hand => rebuiltHandIds.add(hand.id))
+      await this.saveRebuiltEntities(remainingEntities)
+
+      // bulkPut alone cannot remove a formerly-derived hand which canonical
+      // replay now rejects (for example, a missing table-move EVT_DEAL arrives
+      // from another device and reveals that the old DEAL -> RESULTS pairing
+      // was a chimera). Clean only keys present before this rebuild; a hand
+      // completed concurrently by live ingestion was not in the snapshot and
+      // must remain intact.
+      const staleHandIds = previousHandIds.filter(handId => !rebuiltHandIds.has(handId))
+      if (staleHandIds.length > 0) {
+        await this.db.transaction('rw', [this.db.hands, this.db.phases, this.db.actions], async () => {
+          for (let offset = 0; offset < staleHandIds.length; offset += DATABASE_CONSTANTS.SYNC_CHUNK_SIZE) {
+            const handIds = staleHandIds.slice(offset, offset + DATABASE_CONSTANTS.SYNC_CHUNK_SIZE)
+            await this.db.phases.where('handId').anyOf(handIds).delete()
+            await this.db.actions.where('handId').anyOf(handIds).delete()
+            await this.db.hands.bulkDelete(handIds)
+          }
+        })
+      }
+
       await this.db.meta.put({
         id: 'importStatus',
         value: {
@@ -1541,13 +1570,22 @@ export class AutoSyncService {
   }
 
   private async saveRebuiltEntities(entities: ReturnType<EntityConverter['flush']>): Promise<void> {
-    await saveEntities(this.db, entities, {
-      onProgress: (counts) => {
-        if (counts.hands + counts.phases + counts.actions > 0) {
-          console.log(`[AutoSync] Generated entities - Hands: ${counts.hands}, Phases: ${counts.phases}, Actions: ${counts.actions}`)
-        }
-      }
+    const handIds = [...new Set(entities.hands.map(hand => hand.id))]
+    if (handIds.length === 0) return
+
+    // Replaying a hand can legitimately produce fewer child records after a
+    // cloud gap is filled. Replace each emitted hand's children instead of
+    // merely bulkPutting the new rows, which would leave obsolete higher
+    // action indexes or phases behind.
+    await this.db.transaction('rw', [this.db.hands, this.db.phases, this.db.actions], async () => {
+      await this.db.phases.where('handId').anyOf(handIds).delete()
+      await this.db.actions.where('handId').anyOf(handIds).delete()
+      await this.db.hands.bulkPut(entities.hands)
+      if (entities.phases.length > 0) await this.db.phases.bulkPut(entities.phases)
+      if (entities.actions.length > 0) await this.db.actions.bulkPut(entities.actions)
     })
+
+    console.log(`[AutoSync] Generated entities - Hands: ${entities.hands.length}, Phases: ${entities.phases.length}, Actions: ${entities.actions.length}`)
   }
 
   private restoreSessionEvent(service: any, event: ApiEvent): void {


### PR DESCRIPTION
## Summary
- treat the full Raw Event Lake replay as the authoritative cloud-rebuild result
- replace phases/actions for each regenerated hand instead of leaving obsolete child keys behind
- remove only pre-rebuild hand IDs absent from the successful replay, preserving hands completed concurrently by live ingestion

## Why
A cloud-only event can fill a local capture gap and change the interpretation of existing rows. For example, an intervening table-move `EVT_DEAL` can reveal that a previously accepted `DEAL -> RESULTS` pair was a chimera. The old rebuild only `bulkPut` newly emitted entities, so a hand rejected by the complete replay remained in IndexedDB indefinitely.

## Validation
- `npm test -- --runInBand` — 133 suites / 1,242 tests passed
- `npm run typecheck` — passed
- `npm run build` — passed
- real fake-indexeddb regression covers a cloud-filled table-move gap and stale child-key replacement

Head: `755f0b5`
