### PR TITLE
fix(background): consume import notification failures

### DIFF
--- a/src/background/import-export.cleanup.test.ts
+++ b/src/background/import-export.cleanup.test.ts
@@ -33,4 +33,22 @@ describe('importData cleanup', () => {
     expect(setBatchMode.mock.calls).toEqual([[true], [false]])
     expect(getOperationState()).toEqual({ type: 'idle' })
   })
+
+  test('keeps import successful when no popup receives best-effort progress', async () => {
+    ;(chrome.runtime.sendMessage as jest.Mock).mockRejectedValue(
+      new Error('Could not establish connection. Receiving end does not exist.')
+    )
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+
+    await expect(handlers.importData(JSON.stringify({
+      timestamp: 1_000,
+      ApiTypeId: 9_999,
+      marker: 'raw-only'
+    }))).resolves.toMatchObject({ successCount: 1, totalLines: 1 })
+
+    // Flush the rejection handler. Without `.catch()`, Jest observes the
+    // same unhandled Promise rejection printed by the Service Worker.
+    await Promise.resolve()
+    expect(getOperationState()).toEqual({ type: 'idle' })
+  })
 })

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -199,6 +199,9 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
           total: lines.length,
           duplicates: duplicateCount,
           imported: successCount
+        }).catch(() => {
+          // Popup may close while import continues; progress delivery is
+          // best-effort and must not become an unhandled SW rejection.
         })
 
         // Log progress every 10%
@@ -361,6 +364,9 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
               if (tab.id) {
                 chrome.tabs.sendMessage(tab.id, {
                   action: 'refreshStats'
+                }).catch(() => {
+                  // A matching tab can be navigating or awaiting content
+                  // script reinjection. The durable import already succeeded.
                 })
               }
             })

--- a/src/background/message-router.import-notifications.test.ts
+++ b/src/background/message-router.import-notifications.test.ts
@@ -1,0 +1,49 @@
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import type { ChromeMessage, MessageResponse } from '../types/messages'
+import { registerMessageRouter } from './message-router'
+import { setOperationState } from './operation-state'
+
+describe('message-router import notifications', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+  let listener: (
+    request: ChromeMessage,
+    sender: chrome.runtime.MessageSender,
+    sendResponse: (response: MessageResponse) => void
+  ) => boolean | void
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    service = new PokerChaseService({ db })
+    await service.ready
+    setOperationState({ type: 'idle' })
+    ;(chrome.runtime.onMessage.addListener as jest.Mock).mockClear()
+    registerMessageRouter(service, db, 'https://example.com/*')
+    listener = (chrome.runtime.onMessage.addListener as jest.Mock).mock.calls[0][0]
+  })
+
+  afterEach(async () => {
+    setOperationState({ type: 'idle' })
+    jest.restoreAllMocks()
+    db.close()
+    await db.delete()
+  })
+
+  test('missing popup receivers do not reject a successful background import', async () => {
+    ;(chrome.runtime.sendMessage as jest.Mock).mockRejectedValue(
+      new Error('Could not establish connection. Receiving end does not exist.')
+    )
+    const response = new Promise<MessageResponse>(resolve => {
+      listener({
+        action: 'importData',
+        data: JSON.stringify({ timestamp: 1_000, ApiTypeId: 9_999, marker: 'raw-only' })
+      }, {}, resolve)
+    })
+
+    await expect(response).resolves.toEqual({ success: true })
+    await Promise.resolve()
+    expect(await db.apiEvents.count()).toBe(1)
+  })
+})

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -91,7 +91,7 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
           chrome.runtime.sendMessage<ImportStatusMessage>({
             action: 'importStatus',
             status: `インポートが完了しました (${result.successCount.toLocaleString()}件のログ${result.duplicateCount > 0 ? `, ${result.duplicateCount.toLocaleString()}件の重複をスキップ` : ''})`
-          })
+          }).catch(() => {})
           sendResponse({ success: true })
         })
         .catch(error => {
@@ -99,7 +99,7 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
           chrome.runtime.sendMessage<ImportStatusMessage>({
             action: 'importStatus',
             status: 'インポートに失敗しました: ' + error.message
-          })
+          }).catch(() => {})
           sendResponse({ success: false, error: error.message })
         })
       return true // 非同期レスポンスを示す
@@ -152,7 +152,7 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
           chrome.runtime.sendMessage<ImportStatusMessage>({
             action: 'importStatus',
             status: `インポートが完了しました (${result.successCount.toLocaleString()}件のログ${result.duplicateCount > 0 ? `, ${result.duplicateCount.toLocaleString()}件の重複をスキップ` : ''})`
-          })
+          }).catch(() => {})
           sendResponse({ success: true })
         })
         .catch(error => {
@@ -160,7 +160,7 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
           chrome.runtime.sendMessage<ImportStatusMessage>({
             action: 'importStatus',
             status: 'インポートに失敗しました: ' + error.message
-          })
+          }).catch(() => {})
           sendResponse({ success: false, error: error.message })
         })
       return true


### PR DESCRIPTION
## Summary
- consume rejected best-effort import progress/status messages when the popup has closed
- consume rejected post-import tab refresh messages when a matching content script is unavailable
- cover both direct import handlers and routed background imports with the real missing-receiver rejection

This prevents `Uncaught (in promise) Error: Could not establish connection. Receiving end does not exist.` without changing durable import success/failure semantics.

## Validation
- `npm test -- --runInBand` (134 suites, 1269 tests)
- `npm run typecheck`
- `npm run build`

## Head
`fafd614`