### PR TITLE
fix(export): reject failed tab queries

### DIFF
--- a/src/background/import-export.export-handoff.test.ts
+++ b/src/background/import-export.export-handoff.test.ts
@@ -238,6 +238,30 @@ describe('export download-handoff completion', () => {
     expect(getOperationState()).toEqual({ type: 'idle' })
   })
 
+  test('a tabs.query lastError rejects the export instead of leaving it pending', async () => {
+    ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => {
+      ;(chrome.runtime as any).lastError = { message: 'Tabs permission unavailable' }
+      callback(undefined)
+      delete (chrome.runtime as any).lastError
+    })
+
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+
+    await expect(handlers.exportData('json')).rejects.toThrow(/Tabs permission unavailable/)
+    expect(chrome.downloads.download).not.toHaveBeenCalled()
+    expect(getOperationState()).toEqual({ type: 'idle' })
+  })
+
+  test('an undefined tabs.query result rejects the export instead of throwing outside its promise', async () => {
+    ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => callback(undefined))
+
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+
+    await expect(handlers.exportData('json')).rejects.toThrow(/no result returned/)
+    expect(chrome.downloads.download).not.toHaveBeenCalled()
+    expect(getOperationState()).toEqual({ type: 'idle' })
+  })
+
   // --- Independent release-audit finding #10 --------------------------------
 
   test('a deferred tabs.sendMessage keeps the operation state as "export" until it is acknowledged', async () => {

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -662,6 +662,16 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
     // Send to content script for Blob-based download (avoids data URL size limits)
     return new Promise<void>((resolve, reject) => {
       chrome.tabs.query({ url: gameUrlPattern }, async tabs => {
+        const queryError = chrome.runtime.lastError
+        if (queryError) {
+          reject(new Error(queryError.message || 'Failed to query game tabs'))
+          return
+        }
+        if (!Array.isArray(tabs)) {
+          reject(new Error('Failed to query game tabs: no result returned'))
+          return
+        }
+
         const tab = tabs.find(t => t.id)
         if (tab?.id) {
           const tabId = tab.id


### PR DESCRIPTION
## Summary
- reject `chrome.tabs.query` callback failures before inspecting the tab list
- reject a malformed/undefined query result instead of throwing outside the export promise
- return the export operation to idle with an explicit failure, avoiding a permanently stuck export/keepalive

## Validation
- `npm test -- --runInBand` (133 suites, 1269 tests)
- `npm run typecheck`
- `npm run build`

## Head
`a1dabb2`