### PR TITLE
fix(auth): publish persisted sign-ins atomically

### DIFF
--- a/src/services/firebase-auth-service.test.ts
+++ b/src/services/firebase-auth-service.test.ts
@@ -450,6 +450,7 @@ describe('FirebaseAuthService.signOut -- durable state removal', () => {
       const signIn = service.signInWithGoogle()
       while (!signInSetStarted) await Promise.resolve()
 
+      const capturedOldUser = service.getCurrentUser()!
       const signOut = service.signOut()
       await new Promise(resolve => setTimeout(resolve, 0))
 
@@ -457,6 +458,7 @@ describe('FirebaseAuthService.signOut -- durable state removal', () => {
       // allow the delayed sign-in write to resurrect B afterward.
       expect(removeSpy).not.toHaveBeenCalled()
       expect(service.getCurrentUser()?.uid).toBe('user-a')
+      await expect(capturedOldUser.getIdToken()).rejects.toThrow('Sign-out is in progress')
 
       releaseSignInSet?.()
       expect((await signIn).uid).toBe('user-b')

--- a/src/services/firebase-auth-service.test.ts
+++ b/src/services/firebase-auth-service.test.ts
@@ -253,6 +253,107 @@ describe('FirebaseAuthService.getIdToken -- stale refresh handling', () => {
   })
 })
 
+describe('FirebaseAuthService.signInWithGoogle -- durable publication and restore recovery', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  const mockSuccessfulGoogleSignIn = (): (() => void) => {
+    jest.spyOn(chrome.identity, 'getAuthToken').mockImplementation(((_options: unknown, callback: (result: { token: string }) => void) => {
+      callback({ token: 'chrome-token-b' })
+    }) as typeof chrome.identity.getAuthToken)
+
+    const originalFetch = global.fetch
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        idToken: 'b-token',
+        refreshToken: 'b-refresh-token',
+        expiresIn: '3600',
+        localId: 'user-b',
+        email: 'b@example.com'
+      })
+    }) as any
+    return () => { global.fetch = originalFetch }
+  }
+
+  test('keeps the old in-memory account, generation, listeners, and persisted state when the new account cannot be stored', async () => {
+    const stateA = {
+      uid: 'user-a',
+      email: 'a@example.com',
+      displayName: null,
+      photoURL: null,
+      idToken: 'a-token',
+      refreshToken: 'a-refresh-token',
+      expiresAt: Date.now() + 60 * 60 * 1000
+    }
+    await chrome.storage.local.set({ firebaseRestAuthState: stateA })
+
+    const service = new FirebaseAuthService()
+    await service.ready()
+    const generationBeforeSignIn = service.getAuthGeneration()
+    const listener = jest.fn()
+    service.onAuthStateChange(listener)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    listener.mockClear()
+
+    const restoreFetch = mockSuccessfulGoogleSignIn()
+    ;(jest.spyOn(chrome.storage.local, 'set') as jest.SpyInstance)
+      .mockRejectedValueOnce(new Error('chrome.storage.local.set failed'))
+
+    try {
+      await expect(service.signInWithGoogle()).rejects.toThrow('chrome.storage.local.set failed')
+
+      expect(service.getCurrentUser()?.uid).toBe('user-a')
+      expect(service.getAuthGeneration()).toBe(generationBeforeSignIn)
+      expect(listener).not.toHaveBeenCalled()
+
+      const stored = await chrome.storage.local.get('firebaseRestAuthState')
+      expect(stored.firebaseRestAuthState).toEqual(stateA)
+
+      const restartedService = new FirebaseAuthService()
+      await restartedService.ready()
+      expect(restartedService.getCurrentUser()?.uid).toBe('user-a')
+    } finally {
+      restoreFetch()
+    }
+  })
+
+  test('a durable interactive sign-in recovers ready and token access after the startup restore failed', async () => {
+    ;(jest.spyOn(chrome.storage.local, 'get') as jest.SpyInstance)
+      .mockRejectedValueOnce(new Error('chrome.storage.local.get failed'))
+
+    const service = new FirebaseAuthService()
+    await expect(service.ready()).rejects.toThrow('chrome.storage.local.get failed')
+
+    const listener = jest.fn()
+    service.onAuthStateChange(listener)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(listener).toHaveBeenCalledWith(null, 'restore')
+    listener.mockClear()
+
+    const restoreFetch = mockSuccessfulGoogleSignIn()
+    try {
+      const user = await service.signInWithGoogle()
+
+      expect(user.uid).toBe('user-b')
+      await expect(service.ready()).resolves.toBeUndefined()
+      await expect(user.getIdToken()).resolves.toBe('b-token')
+      expect(service.getCurrentUser()?.uid).toBe('user-b')
+      expect(listener).toHaveBeenCalledWith(expect.objectContaining({ uid: 'user-b' }), 'sign-in')
+
+      const stored = await chrome.storage.local.get('firebaseRestAuthState')
+      expect(stored.firebaseRestAuthState).toEqual(expect.objectContaining({
+        uid: 'user-b',
+        idToken: 'b-token',
+        refreshToken: 'b-refresh-token'
+      }))
+    } finally {
+      restoreFetch()
+    }
+  })
+})
+
 describe('FirebaseAuthService.signOut -- durable state removal', () => {
   afterEach(() => {
     jest.restoreAllMocks()

--- a/src/services/firebase-auth-service.test.ts
+++ b/src/services/firebase-auth-service.test.ts
@@ -399,6 +399,85 @@ describe('FirebaseAuthService.signOut -- durable state removal', () => {
     expect(restartedService.getCurrentUser()?.uid).toBe('user-a')
   })
 
+  test('a sign-out started during a slow sign-in storage commit waits and remains authoritative', async () => {
+    const stateA = {
+      uid: 'user-a',
+      email: 'a@example.com',
+      displayName: null,
+      photoURL: null,
+      idToken: 'a-token',
+      refreshToken: 'a-refresh-token',
+      expiresAt: Date.now() + 60 * 60 * 1000
+    }
+    await chrome.storage.local.set({ firebaseRestAuthState: stateA })
+
+    const service = new FirebaseAuthService()
+    await service.ready()
+    const listener = jest.fn()
+    service.onAuthStateChange(listener)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    listener.mockClear()
+
+    jest.spyOn(chrome.identity, 'getAuthToken').mockImplementation(((options: { interactive?: boolean }, callback: (result?: { token: string }) => void) => {
+      callback(options.interactive ? { token: 'new-chrome-token' } : undefined)
+    }) as typeof chrome.identity.getAuthToken)
+
+    const originalSet = (chrome.storage.local.set as jest.Mock).getMockImplementation()!
+    let signInSetStarted = false
+    let releaseSignInSet: (() => void) | undefined
+    jest.spyOn(chrome.storage.local, 'set').mockImplementation(async (items: Record<string, any>) => {
+      if (items.firebaseRestAuthState?.uid === 'user-b') {
+        signInSetStarted = true
+        await new Promise<void>(resolve => { releaseSignInSet = resolve })
+      }
+      return originalSet(items)
+    })
+    const removeSpy = jest.spyOn(chrome.storage.local, 'remove')
+
+    const originalFetch = global.fetch
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        idToken: 'b-token',
+        refreshToken: 'b-refresh-token',
+        expiresIn: '3600',
+        localId: 'user-b',
+        email: 'b@example.com'
+      })
+    }) as any
+
+    try {
+      const signIn = service.signInWithGoogle()
+      while (!signInSetStarted) await Promise.resolve()
+
+      const signOut = service.signOut()
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      // The later sign-out owns the final state, but cannot remove first and
+      // allow the delayed sign-in write to resurrect B afterward.
+      expect(removeSpy).not.toHaveBeenCalled()
+      expect(service.getCurrentUser()?.uid).toBe('user-a')
+
+      releaseSignInSet?.()
+      expect((await signIn).uid).toBe('user-b')
+      await signOut
+
+      expect(service.getCurrentUser()).toBeNull()
+      expect(listener.mock.calls.map(([user, source]) => [user?.uid ?? null, source])).toEqual([
+        ['user-b', 'sign-in'],
+        [null, 'sign-out']
+      ])
+      const stored = await chrome.storage.local.get('firebaseRestAuthState')
+      expect(stored.firebaseRestAuthState).toBeUndefined()
+
+      const restartedService = new FirebaseAuthService()
+      await restartedService.ready()
+      expect(restartedService.getCurrentUser()).toBeNull()
+    } finally {
+      global.fetch = originalFetch
+    }
+  })
+
   test('invalidates in-flight work before durable removal, but publishes sign-out only after removal commits', async () => {
     const storedState = {
       uid: 'user-a',

--- a/src/services/firebase-auth-service.ts
+++ b/src/services/firebase-auth-service.ts
@@ -209,19 +209,24 @@ export class FirebaseAuthService {
       // slow storage write.
       const precedingSignInCommit = this.pendingSignInCommit?.completion
       const operation = this.commitSignIn(nextState, precedingSignInCommit)
-      const pendingSignInCommit = {
-        operation,
+      let pendingSignInCommit!: { operation: Promise<void>, completion: Promise<void> }
+      const completion = operation
         // Sign-out must continue even when the candidate write failed: in
         // that case it removes whichever older account remains authoritative.
-        completion: operation.then(() => {}, () => {})
+        .then(() => {}, () => {})
+        .then(() => {
+          // Clear as part of the completion barrier itself. A sign-out that
+          // drains this promise must not spin on a resolved-but-still-marked
+          // tail while the original sign-in caller resumes separately.
+          if (this.pendingSignInCommit === pendingSignInCommit) this.pendingSignInCommit = null
+        })
+      pendingSignInCommit = {
+        operation,
+        completion
       }
       this.pendingSignInCommit = pendingSignInCommit
 
-      try {
-        await operation
-      } finally {
-        if (this.pendingSignInCommit === pendingSignInCommit) this.pendingSignInCommit = null
-      }
+      await operation
       console.log('[FirebaseAuth] Firebase sign in successful:', nextState.email)
       return this.getCurrentUser()!
     } catch (error) {
@@ -243,23 +248,10 @@ export class FirebaseAuthService {
       return
     }
 
-    // Once a sign-in's storage write has started, let it publish (or fail)
-    // before this later user action removes state. Otherwise the delayed set
-    // can finish after removal and resurrect the account. Re-check the
-    // sign-out owner after waiting because duplicate sign-outs can queue on
-    // the same commit concurrently.
-    if (this.pendingSignInCommit) {
-      await this.pendingSignInCommit.completion
-      const signOutStartedWhileWaiting = this.pendingSignOut
-      if (signOutStartedWhileWaiting) {
-        await signOutStartedWhileWaiting.operation
-        return
-      }
-    }
-
     // performSignOut() runs synchronously through its generation reservation
-    // and first token lookup before returning this promise. The marker is
-    // therefore installed before signOut() yields to any later sign-in.
+    // before returning this promise. The marker is therefore installed before
+    // signOut() yields to token work or any later sign-in, even when the
+    // operation must first drain a slow durable sign-in commit.
     const operation = this.performSignOut()
     const pendingSignOut = {
       operation,
@@ -283,6 +275,13 @@ export class FirebaseAuthService {
     // This is also before the first await (the Chrome token lookup), so a
     // sign-in started while that lookup is slow must wait for this operation.
     this.authGeneration++
+
+    // Once a sign-in's storage write has started, let every already-queued
+    // commit publish (or fail) before this later user action removes state.
+    // `pendingSignOut` is installed by signOut() immediately after this method
+    // returns its promise, so no later sign-in can extend the tail while this
+    // drain is in progress, and getIdToken() rejects throughout the wait.
+    if (this.pendingSignInCommit) await this.waitForPendingSignInCommits()
 
     const previousToken = await this.getChromeAuthToken(false).catch(() => null)
     await chrome.storage.local.remove(FirebaseAuthService.STORAGE_KEY)
@@ -521,6 +520,12 @@ export class FirebaseAuthService {
     // access, and firebaseAuthStatus reflect the recovered account.
     this.restorePromise = Promise.resolve()
     this.notifyAuthStateListeners(this.getCurrentUser(), 'sign-in')
+  }
+
+  private async waitForPendingSignInCommits(): Promise<void> {
+    while (this.pendingSignInCommit) {
+      await this.pendingSignInCommit.completion
+    }
   }
 
   /** Wait until the current sign-out and all of its side effects settle. */

--- a/src/services/firebase-auth-service.ts
+++ b/src/services/firebase-auth-service.ts
@@ -82,6 +82,13 @@ export class FirebaseAuthService {
   private authStateListeners: ((user: AuthUser | null, source: AuthChangeSource) => void)[] = []
   private restorePromise: Promise<void>
   /**
+   * Tail of durable sign-in commits currently in flight or queued. A later
+   * sign-out waits for this tail (success or failure) before removing auth
+   * state, so no delayed storage.set can publish or persist a user again
+   * after sign-out won.
+   */
+  private pendingSignInCommit: { operation: Promise<void>, completion: Promise<void> } | null = null
+  /**
    * Sign-out operation currently owning every local and external side effect.
    * New token work must not start while this exists, a concurrent sign-in
    * waits for `completion` (which always resolves), and duplicate sign-outs
@@ -196,20 +203,26 @@ export class FirebaseAuthService {
       // authGeneration, listeners, and persisted storage alike. Publishing B
       // first used to leave a split brain (live B, persisted A) that silently
       // reverted after the next Service Worker restart.
-      await this.persistAuthState(nextState)
+      // Chain behind an earlier interactive sign-in, if any. The shared
+      // marker always points at the tail, so a later sign-out waits for every
+      // candidate already queued before it and cannot be bypassed by an older
+      // slow storage write.
+      const precedingSignInCommit = this.pendingSignInCommit?.completion
+      const operation = this.commitSignIn(nextState, precedingSignInCommit)
+      const pendingSignInCommit = {
+        operation,
+        // Sign-out must continue even when the candidate write failed: in
+        // that case it removes whichever older account remains authoritative.
+        completion: operation.then(() => {}, () => {})
+      }
+      this.pendingSignInCommit = pendingSignInCommit
 
-      // These publications are deliberately synchronous and adjacent. This
-      // preserves the dependent-state invariant from r3615952256: once any
-      // caller can observe the new account/generation, listeners such as
-      // AutoSyncService are notified before the event loop can advance.
-      this.currentState = nextState
-      this.authGeneration++ // sign-in transition -- see authGeneration's doc comment
-      // A successful durable sign-in is also recovery from a failed startup
-      // storage read. Replace the rejected restore barrier so ready(), token
-      // access, and firebaseAuthStatus reflect the recovered account.
-      this.restorePromise = Promise.resolve()
-      this.notifyAuthStateListeners(this.getCurrentUser(), 'sign-in')
-      console.log('[FirebaseAuth] Firebase sign in successful:', this.currentState.email)
+      try {
+        await operation
+      } finally {
+        if (this.pendingSignInCommit === pendingSignInCommit) this.pendingSignInCommit = null
+      }
+      console.log('[FirebaseAuth] Firebase sign in successful:', nextState.email)
       return this.getCurrentUser()!
     } catch (error) {
       console.error('[FirebaseAuth] Firebase sign in error:', error)
@@ -228,6 +241,20 @@ export class FirebaseAuthService {
     if (existingSignOut) {
       await existingSignOut.operation
       return
+    }
+
+    // Once a sign-in's storage write has started, let it publish (or fail)
+    // before this later user action removes state. Otherwise the delayed set
+    // can finish after removal and resurrect the account. Re-check the
+    // sign-out owner after waiting because duplicate sign-outs can queue on
+    // the same commit concurrently.
+    if (this.pendingSignInCommit) {
+      await this.pendingSignInCommit.completion
+      const signOutStartedWhileWaiting = this.pendingSignOut
+      if (signOutStartedWhileWaiting) {
+        await signOutStartedWhileWaiting.operation
+        return
+      }
     }
 
     // performSignOut() runs synchronously through its generation reservation
@@ -477,6 +504,23 @@ export class FirebaseAuthService {
     if (state) {
       await chrome.storage.local.set({ [FirebaseAuthService.STORAGE_KEY]: state })
     }
+  }
+
+  private async commitSignIn(nextState: StoredAuthState, precedingCommit?: Promise<void>): Promise<void> {
+    if (precedingCommit) await precedingCommit
+    await this.persistAuthState(nextState)
+
+    // These publications are deliberately synchronous and adjacent. This
+    // preserves the dependent-state invariant from r3615952256: once any
+    // caller can observe the new account/generation, listeners such as
+    // AutoSyncService are notified before the event loop can advance.
+    this.currentState = nextState
+    this.authGeneration++ // sign-in transition -- see authGeneration's doc comment
+    // A successful durable sign-in is also recovery from a failed startup
+    // storage read. Replace the rejected restore barrier so ready(), token
+    // access, and firebaseAuthStatus reflect the recovered account.
+    this.restorePromise = Promise.resolve()
+    this.notifyAuthStateListeners(this.getCurrentUser(), 'sign-in')
   }
 
   /** Wait until the current sign-out and all of its side effects settle. */

--- a/src/services/firebase-auth-service.ts
+++ b/src/services/firebase-auth-service.ts
@@ -146,6 +146,12 @@ export class FirebaseAuthService {
     // request. The conditional also makes the ordering explicit: only an
     // operation that already owns the token forces this sign-in to queue.
     if (this.pendingSignOut) await this.waitForPendingSignOut()
+    // A failed startup restore must not permanently poison interactive auth:
+    // sign-in is the explicit recovery path. Also let an in-flight restore
+    // settle before starting so it cannot publish an older stored account
+    // after this newer sign-in succeeds.
+    await this.restorePromise.catch(() => {})
+    if (this.pendingSignOut) await this.waitForPendingSignOut()
     const token = await this.getChromeAuthToken(true)
     console.log('[FirebaseAuth] Got Chrome auth token')
 
@@ -176,7 +182,7 @@ export class FirebaseAuthService {
       // the sign-out cannot delete or overwrite the newly authenticated
       // account when it resumes.
       await this.waitForPendingSignOut()
-      this.currentState = {
+      const nextState: StoredAuthState = {
         uid: result.localId,
         email: result.email ?? null,
         displayName: result.displayName ?? null,
@@ -185,20 +191,24 @@ export class FirebaseAuthService {
         refreshToken: result.refreshToken,
         expiresAt: Date.now() + Number(result.expiresIn) * 1000
       }
+      // Commit the durable state BEFORE exposing it in memory. If storage.set
+      // fails, the old account remains authoritative in currentState,
+      // authGeneration, listeners, and persisted storage alike. Publishing B
+      // first used to leave a split brain (live B, persisted A) that silently
+      // reverted after the next Service Worker restart.
+      await this.persistAuthState(nextState)
+
+      // These publications are deliberately synchronous and adjacent. This
+      // preserves the dependent-state invariant from r3615952256: once any
+      // caller can observe the new account/generation, listeners such as
+      // AutoSyncService are notified before the event loop can advance.
+      this.currentState = nextState
       this.authGeneration++ // sign-in transition -- see authGeneration's doc comment
-      // Notify listeners SYNCHRONOUSLY, in the same step as the currentState/
-      // authGeneration mutation above -- BEFORE the persistAuthState() await
-      // (codex review r3615952256, P2, "Clear stale sync state when
-      // exposing the new user"). Moving this earlier closes the window
-      // where getCurrentUser()/getAuthGeneration() already report the NEW
-      // account but registered listeners (e.g. AutoSyncService clearing its
-      // own stale in-memory state, see its constructor) hadn't been told
-      // yet -- during a direct A->B sign-in, anything reading auth state in
-      // that gap used to see B live while dependent state still reflected
-      // A. persistAuthState() below is a fire-and-forget durability step
-      // from listeners' perspective; it doesn't need to precede them.
+      // A successful durable sign-in is also recovery from a failed startup
+      // storage read. Replace the rejected restore barrier so ready(), token
+      // access, and firebaseAuthStatus reflect the recovered account.
+      this.restorePromise = Promise.resolve()
       this.notifyAuthStateListeners(this.getCurrentUser(), 'sign-in')
-      await this.persistAuthState()
       console.log('[FirebaseAuth] Firebase sign in successful:', this.currentState.email)
       return this.getCurrentUser()!
     } catch (error) {
@@ -463,9 +473,9 @@ export class FirebaseAuthService {
     this.notifyAuthStateListeners(this.getCurrentUser(), 'restore')
   }
 
-  private async persistAuthState(): Promise<void> {
-    if (this.currentState) {
-      await chrome.storage.local.set({ [FirebaseAuthService.STORAGE_KEY]: this.currentState })
+  private async persistAuthState(state: StoredAuthState | null = this.currentState): Promise<void> {
+    if (state) {
+      await chrome.storage.local.set({ [FirebaseAuthService.STORAGE_KEY]: state })
     }
   }
 


### PR DESCRIPTION
## Summary
- persist a successful Firebase sign-in candidate before publishing it to in-memory auth state, generation observers, and listeners
- keep the prior account authoritative when `chrome.storage.local.set` rejects instead of reverting silently after a Service Worker restart
- let a later durable interactive sign-in replace a rejected startup restore barrier so `ready()`, token access, and popup auth status recover
- serialize queued durable sign-in commits; a later sign-out reserves its generation/owner first, drains the tail, then removes state

## Risk gate
- failure-injection coverage verifies a rejected auth-state write preserves the old account in memory, generation, listeners, storage, and a restarted service
- failure-injection coverage verifies a rejected startup storage read can be recovered by a durable sign-in and then serves the new ID token
- delayed-storage failure injection verifies sign-out blocks token use immediately, does not remove early, and remains authoritative in listener order, storage, and after restart

## Validation
- `npm test -- --runInBand` (133 suites, 1270 tests)
- `npm run typecheck`
- `npm run build`

Head: `fd2c00fd1924c5f7506422e42033e695eb3f8806`
