### PR TITLE
feat(replay): add experimental session-end capture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -208,6 +208,38 @@ await db.actions.where('[playerId+phase]')
 ### ストレージ影響
 インデックス追加で約 10-15% 増加。クエリ性能向上がコストを上回る。
 
+## 6. 試験機能: セッション終了後リプレイ取込
+
+`experimentalReplayImportEnabled` を `chrome.storage.local` で `true` にした
+開発ビルドだけが有効化する、既定OFFの検証機能。ゲーム中の
+`EVT_HAND_RESULTS` (306) から HandId をローカルキューへ保存し、
+`EVT_SESSION_RESULTS` (309) の後に同一ゲームタブから `/replay/detail` を
+1件ずつ取得する。309欠落時は次の `EVT_ENTRY_QUEUED` (201) を境界に使うが、
+同一トーナメントIDのMTTテーブル移動は継続セッションとして扱う。
+
+レスポンスは `experimentalReplayHands` object store に保存する。現段階では
+`hands` / `phases` / `actions` へ変換せず、エクスポート・Firestore同期・統計計算の
+対象にも含めない。これにより、リプレイとWebSocketでアクション意味論が一致するかを
+実データで評価する前に既存統計を汚さない。
+
+ページ自身の通常API通信（fetch / XMLHttpRequest）から得た `session` とバージョン情報はmain world内だけに保持し、
+content scriptへ渡す前にレスポンスから `session` / `requestKey` を再帰的に除去する。
+新しいhost permissionは追加しない。未課金アカウントではサーバーが返した公開情報だけを
+保存し、フォールド済み相手の `HoleCardList` は空のままである。
+
+開発時の有効化手順:
+
+```javascript
+await chrome.storage.local.set({ experimentalReplayImportEnabled: true })
+```
+
+有効化後はゲームタブを再読み込みし、通常API通信から認証エンベロープを取得させる。
+保存結果は拡張機能Service WorkerのDevToolsで
+`await db.experimentalReplayHands.toArray()` として確認できる。無効化は同じキーを
+`false` に戻す。既定OFF、権限追加なし、ユーザー操作中のゲーム通信を起点とする設計は
+Chrome Web Store審査上の説明可能性を高めるが、提出前にはプライバシーポリシーと
+データ利用開示へこの試験機能を明記し、実際の審査結果を別途確認する必要がある。
+
 ## 将来の検討事項
 1. 30-90 日後の古いデータを Cloud Storage にアーカイブ
 2. 頻繁にアクセスされる統計のサマリーテーブル

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -215,7 +215,10 @@ await db.actions.where('[playerId+phase]')
 `EVT_HAND_RESULTS` (306) から HandId をローカルキューへ保存し、
 `EVT_SESSION_RESULTS` (309) の後に同一ゲームタブから `/replay/detail` を
 1件ずつ取得する。309欠落時は次の `EVT_ENTRY_QUEUED` (201) を境界に使うが、
-同一トーナメントIDのMTTテーブル移動は継続セッションとして扱う。
+同一トーナメントIDのMTTテーブル移動は継続セッションとして扱う。201も欠落した
+非MTTでは2回目の `EVT_SESSION_DETAILS` (308) を境界にし、MTTの反復308は吸収する。
+タブIDとframe IDの安定キーでキューを分離するため、content scriptのport再接続後も
+元タブのセッションへ復帰し、別タブの認証エンベロープへリプレイを渡さない。
 
 レスポンスは `experimentalReplayHands` object store に保存する。現段階では
 `hands` / `phases` / `actions` へ変換せず、エクスポート・Firestore同期・統計計算の
@@ -226,6 +229,9 @@ await db.actions.where('[playerId+phase]')
 content scriptへ渡す前にレスポンスから `session` / `requestKey` を再帰的に除去する。
 新しいhost permissionは追加しない。未課金アカウントではサーバーが返した公開情報だけを
 保存し、フォールド済み相手の `HoleCardList` は空のままである。
+取得前にportが切れた行は再接続時に再送し、認証未取得・一時的HTTP失敗は最大60秒の
+指数backoffで再試行する。セッション終了境界の `pending` → `ready` 更新はイベント取込
+キュー内で完了を待ち、更新・Service Worker再起動より先にIndexedDBへ確定させる。
 
 開発時の有効化手順:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -210,8 +210,11 @@ await db.actions.where('[playerId+phase]')
 
 ## 6. 試験機能: セッション終了後リプレイ取込
 
-`experimentalReplayImportEnabled` を `chrome.storage.local` で `true` にした
-開発ビルドだけが有効化する、既定OFFの検証機能。ゲーム中の
+`experimentalReplayImportEnabled` を `chrome.storage.sync` で `true` にした
+開発ビルドだけが有効化する、既定OFFの検証機能。`storage.local` ではないのは、
+`firebase-auth-service` が起動時に `setAccessLevel('TRUSTED_CONTEXTS')` で
+その領域を content script から遮断しているため（#274）。localに置くと
+content script 側の読み取りが必ず失敗し、機能が永久にOFFのまま固定される。ゲーム中の
 `EVT_HAND_RESULTS` (306) から HandId をローカルキューへ保存し、
 `EVT_SESSION_RESULTS` (309) の後に同一ゲームタブから `/replay/detail` を
 1件ずつ取得する。309欠落時は次の `EVT_ENTRY_QUEUED` (201) を境界に使うが、
@@ -230,19 +233,24 @@ content scriptへ渡す前にレスポンスから `session` / `requestKey` を�
 新しいhost permissionは追加しない。未課金アカウントではサーバーが返した公開情報だけを
 保存し、フォールド済み相手の `HoleCardList` は空のままである。
 取得前にportが切れた行は再接続時に再送し、認証未取得・一時的HTTP失敗は最大60秒の
-指数backoffで再試行する。セッション終了境界の `pending` → `ready` 更新はイベント取込
+指数backoffで再試行する。1件あたり15秒でタイムアウトし、1行あたり8回で
+`failed` として終端させる（上限が無いと、拡張側が自力で解消できない条件で
+永久に再試行し続ける）。参加申込のエラー応答（`Code≠0` の201）は
+セッション境界として扱わない。リプレイ結果のIndexedDB保存はimporter自身の
+キューで直列化し、イベント取込キューには載せない（載せると1バッチ最大100件の
+書き込み中はライブイベントが `apiEvents.add()` にすら到達できずHUDが固まる）。セッション終了境界の `pending` → `ready` 更新はイベント取込
 キュー内で完了を待ち、更新・Service Worker再起動より先にIndexedDBへ確定させる。
 
 開発時の有効化手順:
 
 ```javascript
-await chrome.storage.local.set({ experimentalReplayImportEnabled: true })
+await chrome.storage.sync.set({ experimentalReplayImportEnabled: true })
 ```
 
 有効化後はゲームタブを再読み込みし、通常API通信から認証エンベロープを取得させる。
 保存結果は拡張機能Service WorkerのDevToolsで
 `await db.experimentalReplayHands.toArray()` として確認できる。無効化は同じキーを
-`false` に戻す。既定OFF、権限追加なし、ユーザー操作中のゲーム通信を起点とする設計は
+`false` に戻す。無効化は同期設定なので他端末にも伝播する。既定OFF、権限追加なし、ユーザー操作中のゲーム通信を起点とする設計は
 Chrome Web Store審査上の説明可能性を高めるが、提出前にはプライバシーポリシーと
 データ利用開示へこの試験機能を明記し、実際の審査結果を別途確認する必要がある。
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -21,6 +21,7 @@ import { initUpdateManager } from './background/update-manager'
 import { markWhatsNewOnUpdate, reassertWhatsNewBadgeOnStartup } from './background/whats-new-badge'
 import { needsConfigPersist } from './background/hud-config-sync'
 import { initializeAutoSyncOnReady, createSignInTransitionHandler } from './background/auto-sync-boot'
+import { ExperimentalReplayImporter } from './background/experimental-replay-import'
 import { loadOptions, saveOptions, type Options } from './utils/options-storage'
 import { DEFAULT_TABLE_SIZE_FILTER, selectedTableSizeLayers } from './utils/table-size'
 import { checkMinVersionGate } from './services/min-version-gate'
@@ -42,6 +43,7 @@ declare global {
 
 const db = new PokerChaseDB(self.indexedDB, self.IDBKeyRange)
 const service = new PokerChaseService({ db })
+const experimentalReplayImporter = new ExperimentalReplayImporter(db, service)
 self.db = db
 self.service = service
 self.statsRegistry = defaultRegistry
@@ -186,7 +188,7 @@ registerMessageRouter(service, db, gameUrlPattern)
 
 registerStreamSubscriptions(service, gameUrlPattern)
 
-registerEventIngestion(service)
+registerEventIngestion(service, experimentalReplayImporter)
 
 /**
  * Forced update（sola承認）: 安全な瞬間にダウンロード済み更新を自動適用する。

--- a/src/background.ts
+++ b/src/background.ts
@@ -184,7 +184,7 @@ loadOptions().then((options) => {
 /**
  * データエクスポート機能
  */
-registerMessageRouter(service, db, gameUrlPattern)
+registerMessageRouter(service, db, gameUrlPattern, experimentalReplayImporter)
 
 registerStreamSubscriptions(service, gameUrlPattern)
 

--- a/src/background/event-ingestion.test.ts
+++ b/src/background/event-ingestion.test.ts
@@ -377,26 +377,33 @@ describe('registerEventIngestion (Raw Event Lake)', () => {
     expect(settled).toBe(true)
   })
 
-  test('drains accepted replay results and rejects later results during data deletion', async () => {
+  test('replay結果の保存はライブイベントの取り込みを塞がない', async () => {
+    // 1バッチ最大100件のDexie往復とsanitizeをingestionQueueに載せると、その間
+    // ライブイベントがapiEvents.add()にすら到達できずHUDが固まる。importer自身の
+    // キューで直列化させ、ここでは待たない。
     let releaseReplay!: () => void
     const replayWrite = new Promise<void>(resolve => { releaseReplay = resolve })
     replayImporter.handlePortMessage.mockReturnValueOnce(true)
-    replayImporter.whenIdle.mockReturnValueOnce(replayWrite)
+    replayImporter.whenIdle.mockReturnValue(replayWrite)
 
-    let settled = false
-    const accepted = onMessageHandler({ type: 'experimental-replay-result', requestId: 'before-delete', results: [] })
-      .then(() => { settled = true })
-    await Promise.resolve()
-    setOperationState({ type: 'delete' })
-    await Promise.resolve()
-    expect(settled).toBe(false)
+    await onMessageHandler({ type: 'experimental-replay-result', requestId: 'batch', results: [] })
+
+    // replay書き込みが未完了のままでも、後続のライブイベントは生ログへ入る
+    await onMessageHandler({ ApiTypeId: ApiType.EVT_DEAL, timestamp: 777 })
+    expect(await db.apiEvents.get([777, ApiType.EVT_DEAL, 0])).toBeDefined()
 
     releaseReplay()
-    await accepted
-    expect(settled).toBe(true)
+  })
 
+  test('データ削除の確定後に届いたreplay結果は取り込まない', async () => {
+    // 削除クレーム前に受理済みの書き込みは deleteAllData() 側が
+    // prepareForDataDeletion() → awaitIngestionDrain() の順で待つ。
+    // ここが守るのは「クレーム後の到着を入れない」ことだけ。
+    setOperationState({ type: 'delete' })
     replayImporter.handlePortMessage.mockClear()
+
     await onMessageHandler({ type: 'experimental-replay-result', requestId: 'after-delete', results: [] })
+
     expect(replayImporter.handlePortMessage).not.toHaveBeenCalled()
   })
 })

--- a/src/background/event-ingestion.test.ts
+++ b/src/background/event-ingestion.test.ts
@@ -19,6 +19,7 @@ import {
   resetUndecodedEventStats,
   UNDECODED_EVENT_STATS_KEY
 } from './undecoded-event-tracker'
+import { setOperationState } from './operation-state'
 import { captureSchemaValidationFailure } from '../observability/sentry'
 
 jest.mock('../observability/sentry', () => ({
@@ -51,6 +52,7 @@ describe('registerEventIngestion (Raw Event Lake)', () => {
       attachPort: jest.fn(),
       detachPort: jest.fn(),
       handlePortMessage: jest.fn(() => false),
+      whenIdle: jest.fn(() => Promise.resolve()),
       observePortEvent: jest.fn(() => Promise.resolve())
     }
     registerEventIngestion(service, replayImporter)
@@ -68,6 +70,7 @@ describe('registerEventIngestion (Raw Event Lake)', () => {
   })
 
   afterEach(async () => {
+    setOperationState({ type: 'idle' })
     disconnectHandlers.forEach(fn => fn())
     connectedPorts.clear()
     db.close()
@@ -372,5 +375,28 @@ describe('registerEventIngestion (Raw Event Lake)', () => {
     releaseReplay()
     await ingestion
     expect(settled).toBe(true)
+  })
+
+  test('drains accepted replay results and rejects later results during data deletion', async () => {
+    let releaseReplay!: () => void
+    const replayWrite = new Promise<void>(resolve => { releaseReplay = resolve })
+    replayImporter.handlePortMessage.mockReturnValueOnce(true)
+    replayImporter.whenIdle.mockReturnValueOnce(replayWrite)
+
+    let settled = false
+    const accepted = onMessageHandler({ type: 'experimental-replay-result', requestId: 'before-delete', results: [] })
+      .then(() => { settled = true })
+    await Promise.resolve()
+    setOperationState({ type: 'delete' })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    releaseReplay()
+    await accepted
+    expect(settled).toBe(true)
+
+    replayImporter.handlePortMessage.mockClear()
+    await onMessageHandler({ type: 'experimental-replay-result', requestId: 'after-delete', results: [] })
+    expect(replayImporter.handlePortMessage).not.toHaveBeenCalled()
   })
 })

--- a/src/background/event-ingestion.test.ts
+++ b/src/background/event-ingestion.test.ts
@@ -32,6 +32,7 @@ describe('registerEventIngestion (Raw Event Lake)', () => {
   let onMessageHandler: (message: any) => Promise<void>
   let disconnectHandlers: Array<() => void>
   let mockPort: any
+  let replayImporter: any
 
   beforeEach(async () => {
     jest.mocked(captureSchemaValidationFailure).mockClear()
@@ -46,7 +47,13 @@ describe('registerEventIngestion (Raw Event Lake)', () => {
     await service.ready
 
     ;(chrome.runtime as any).onConnect = { addListener: jest.fn() }
-    registerEventIngestion(service)
+    replayImporter = {
+      attachPort: jest.fn(),
+      detachPort: jest.fn(),
+      handlePortMessage: jest.fn(() => false),
+      observePortEvent: jest.fn(() => Promise.resolve())
+    }
+    registerEventIngestion(service, replayImporter)
     const connectListener = (chrome.runtime as any).onConnect.addListener.mock.calls[0][0]
 
     disconnectHandlers = []
@@ -347,5 +354,23 @@ describe('registerEventIngestion (Raw Event Lake)', () => {
   test('keepalive messages are ignored entirely (not stored, not forwarded)', async () => {
     await onMessageHandler({ type: 'keepalive' })
     expect(await db.apiEvents.count()).toBe(0)
+  })
+
+  test('awaits experimental replay boundary persistence before completing 309 ingestion', async () => {
+    let releaseReplay!: () => void
+    const replayBoundary = new Promise<void>(resolve => { releaseReplay = resolve })
+    replayImporter.observePortEvent.mockReturnValueOnce(replayBoundary)
+
+    let settled = false
+    const ingestion = onMessageHandler({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 999 })
+      .then(() => { settled = true })
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(await db.apiEvents.get([999, ApiType.EVT_SESSION_RESULTS, 0])).toBeDefined()
+    expect(settled).toBe(false)
+
+    releaseReplay()
+    await ingestion
+    expect(settled).toBe(true)
   })
 })

--- a/src/background/event-ingestion.ts
+++ b/src/background/event-ingestion.ts
@@ -23,6 +23,7 @@ import {
 } from '../observability/sentry'
 import { buildSchemaDiagnostic } from '../observability/schema-diagnostic'
 import { getEventFields, getEventSchema } from '../types/api'
+import type { ExperimentalReplayImporter } from './experimental-replay-import'
 
 /**
  * 参加取消申込（ApiTypeId 203）。`ApiType` enum（アプリケーションで使用する
@@ -55,7 +56,10 @@ let ingestionQueue: Promise<void> = Promise.resolve()
  * content_scriptからのポート接続を受け取り、APIイベントの検証・DB保存・
  * 各ストリームへの書き込み・自動同期トリガーを行う。
  */
-export const registerEventIngestion = (service: PokerChaseService): void => {
+export const registerEventIngestion = (
+  service: PokerChaseService,
+  experimentalReplayImporter?: ExperimentalReplayImporter
+): void => {
   // Raw Event Lakeの耐久性バリア（release-blocker監査 finding A）:
   // `db.apiEvents.add()`を待たずにストリーム書き込みやセッションフックの副作用
   // （自動同期トリガー、`chrome.runtime.reload()`を呼びうる保留アップデート
@@ -113,12 +117,14 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
   chrome.runtime.onConnect.addListener(port => {
     if (port.name === PokerChaseService.POKER_CHASE_SERVICE_EVENT) {
       connectedPorts.add(port)
+      experimentalReplayImporter?.attachPort(port)
       port.onMessage.addListener((message: ApiMessage | { type: string }) => {
         // キープアライブメッセージの処理（キュー直列化の対象外 -- 何も
         // 保存・処理しないため、耐久性バリアの対象になる副作用が無い）
         if (typeof message === 'object' && 'type' in message && message.type === 'keepalive') {
           return
         }
+        if (experimentalReplayImporter?.handlePortMessage(message)) return
 
         // Local deletion owns the database through runtime.reload(). Events
         // arriving after that synchronous claim must not enter the queue:
@@ -134,7 +140,7 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
         // 後ろに連結する。`processEvent`は内部で全エラーを捕捉して素通し
         // させない設計だが、想定外のバグでqueueが壊れて以降のイベントが
         // 永久に詰まることのないよう、キューの継続用チェーンは別途catchする。
-        const task = ingestionQueue.then(() => processEvent(service, message))
+        const task = ingestionQueue.then(() => processEvent(service, message, experimentalReplayImporter, port))
         ingestionQueue = task.catch(err => {
           console.error('[background] Unhandled ingestion queue error (fail-safe, queue continues):', err)
           captureHandledException(err, {
@@ -150,6 +156,7 @@ export const registerEventIngestion = (service: PokerChaseService): void => {
         // Keep lastKnownStats for page reloads - only clear interval
         stopPing()
         connectedPorts.delete(port)
+        experimentalReplayImporter?.detachPort(port)
       })
     }
   })
@@ -237,7 +244,9 @@ const applySessionActivity = (rawApiTypeId: unknown, message: ApiMessage | { typ
  */
 const processEvent = async (
   service: PokerChaseService,
-  message: ApiMessage | { type: string }
+  message: ApiMessage | { type: string },
+  experimentalReplayImporter?: ExperimentalReplayImporter,
+  sourcePort?: chrome.runtime.Port
 ): Promise<void> => {
   // Ensure service is ready before processing messages
   try {
@@ -297,6 +306,25 @@ const processEvent = async (
 
   // ここから先はraw書き込みが成功したか、保存不可能で待つべきI/Oが
   // 無かった場合のみ到達する。真の重複と書き込み失敗は上でreturn済み。
+
+  // Experimental replay capture follows the same raw-first durability gate.
+  // HandId registration is awaited so a following 309 cannot overtake it;
+  // all other lifecycle work is internally serialized and remains off the
+  // latency-sensitive ingestion path.
+  const replayTask = experimentalReplayImporter?.observeApiEvent(
+    message as Record<string, unknown>,
+    sourcePort ?? experimentalReplayImporter
+  )
+  if (rawApiTypeId === ApiType.EVT_HAND_RESULTS) {
+    try {
+      await replayTask
+    } catch (err) {
+      // Experimental storage must never suppress the canonical WS pipeline.
+      console.error('[background] Experimental replay HandId queue failed; continuing core ingestion:', err)
+    }
+  } else {
+    replayTask?.catch(err => console.error('[background] Experimental replay lifecycle failed:', err))
+  }
 
   // Forced-update安全性述語（update-manager.ts）のセッション状態追跡。
   // 意図的にパース成功後のdata.ApiTypeIdではなく、生メッセージの数値

--- a/src/background/event-ingestion.ts
+++ b/src/background/event-ingestion.ts
@@ -124,8 +124,6 @@ export const registerEventIngestion = (
         if (typeof message === 'object' && 'type' in message && message.type === 'keepalive') {
           return
         }
-        if (experimentalReplayImporter?.handlePortMessage(message, port)) return
-
         // Local deletion owns the database through runtime.reload(). Events
         // arriving after that synchronous claim must not enter the queue:
         // Dexie would otherwise auto-open and recreate the just-deleted DB in
@@ -134,6 +132,18 @@ export const registerEventIngestion = (
         if (getOperationState().type === 'delete') {
           console.warn('[background] Dropping event while local data deletion is committing:', message)
           return Promise.resolve()
+        }
+
+        if (experimentalReplayImporter?.handlePortMessage(message, port)) {
+          // Replay results serialize on the importer's own queue. Mirror its
+          // drain into ingestionQueue so Delete All Data's stabilization
+          // barrier also waits for replay Dexie writes accepted before the
+          // synchronous delete claim.
+          const task = ingestionQueue.then(() => experimentalReplayImporter.whenIdle())
+          ingestionQueue = task.catch(err => {
+            console.error('[background] Experimental replay drain failed (fail-safe, queue continues):', err)
+          })
+          return task
         }
 
         // このイベントの処理を、直前のイベントの処理（add()の決着含む）の

--- a/src/background/event-ingestion.ts
+++ b/src/background/event-ingestion.ts
@@ -124,7 +124,7 @@ export const registerEventIngestion = (
         if (typeof message === 'object' && 'type' in message && message.type === 'keepalive') {
           return
         }
-        if (experimentalReplayImporter?.handlePortMessage(message)) return
+        if (experimentalReplayImporter?.handlePortMessage(message, port)) return
 
         // Local deletion owns the database through runtime.reload(). Events
         // arriving after that synchronous claim must not enter the queue:
@@ -308,19 +308,24 @@ const processEvent = async (
   // 無かった場合のみ到達する。真の重複と書き込み失敗は上でreturn済み。
 
   // Experimental replay capture follows the same raw-first durability gate.
-  // HandId registration is awaited so a following 309 cannot overtake it;
-  // all other lifecycle work is internally serialized and remains off the
-  // latency-sensitive ingestion path.
-  const replayTask = experimentalReplayImporter?.observeApiEvent(
-    message as Record<string, unknown>,
-    sourcePort ?? experimentalReplayImporter
-  )
-  if (rawApiTypeId === ApiType.EVT_HAND_RESULTS) {
+  // HandId registration and the 201/308/309 boundaries are awaited so reload
+  // safety drains cannot complete while replay rows are still only in the
+  // importer's memory. Other event types remain off the latency-sensitive
+  // ingestion path.
+  const replayTask = sourcePort
+    ? experimentalReplayImporter?.observePortEvent(message as Record<string, unknown>, sourcePort)
+    : experimentalReplayImporter?.observeApiEvent(message as Record<string, unknown>)
+  if (
+    rawApiTypeId === ApiType.EVT_ENTRY_QUEUED ||
+    rawApiTypeId === ApiType.EVT_SESSION_DETAILS ||
+    rawApiTypeId === ApiType.EVT_HAND_RESULTS ||
+    rawApiTypeId === ApiType.EVT_SESSION_RESULTS
+  ) {
     try {
       await replayTask
     } catch (err) {
       // Experimental storage must never suppress the canonical WS pipeline.
-      console.error('[background] Experimental replay HandId queue failed; continuing core ingestion:', err)
+      console.error('[background] Experimental replay lifecycle persistence failed; continuing core ingestion:', err)
     }
   } else {
     replayTask?.catch(err => console.error('[background] Experimental replay lifecycle failed:', err))

--- a/src/background/event-ingestion.ts
+++ b/src/background/event-ingestion.ts
@@ -134,16 +134,18 @@ export const registerEventIngestion = (
           return Promise.resolve()
         }
 
+        // Replay結果の保存はimporter自身のキューで直列化する。ingestionQueue
+        // へは載せない: 1バッチ最大100件のDexie往復とsanitizeを挟むと、その間
+        // ライブイベントが`apiEvents.add()`にすら到達できず（実測で約200ms）
+        // HUDが固まる。このファイル冒頭が禁じている「同期処理でキューを塞ぐ」
+        // そのものになる。
+        //
+        // 削除との競合は既にdeleteAllData()側で閉じている: `type:'delete'`の
+        // 同期クレーム直後・`awaitIngestionDrain()`より前に
+        // `prepareForDataDeletion()`（deletingフラグ+whenIdle）をawaitしており、
+        // クレーム後に届くメッセージは上のガードでここへ到達しない。
         if (experimentalReplayImporter?.handlePortMessage(message, port)) {
-          // Replay results serialize on the importer's own queue. Mirror its
-          // drain into ingestionQueue so Delete All Data's stabilization
-          // barrier also waits for replay Dexie writes accepted before the
-          // synchronous delete claim.
-          const task = ingestionQueue.then(() => experimentalReplayImporter.whenIdle())
-          ingestionQueue = task.catch(err => {
-            console.error('[background] Experimental replay drain failed (fail-safe, queue continues):', err)
-          })
-          return task
+          return Promise.resolve()
         }
 
         // このイベントの処理を、直前のイベントの処理（add()の決着含む）の

--- a/src/background/experimental-replay-import.test.ts
+++ b/src/background/experimental-replay-import.test.ts
@@ -228,6 +228,80 @@ describe('ExperimentalReplayImporter', () => {
     importer.detachPort(replacementPort)
   })
 
+  test('restores active session metadata after a service-worker restart', async () => {
+    await observe({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Id: 'ring-restart',
+      BattleType: BattleType.RING_GAME,
+      timestamp: 100
+    })
+    await observe({ ApiTypeId: ApiType.EVT_SESSION_DETAILS, Name: 'Ring', timestamp: 110 })
+    await observe({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 331, timestamp: 120 })
+    importer.detachPort(port)
+
+    importer = new ExperimentalReplayImporter(db, service)
+    await importer.ready
+    port = {
+      postMessage: jest.fn(),
+      sender: { tab: { id: 10 }, frameId: 0 }
+    } as unknown as chrome.runtime.Port
+    importer.attachPort(port)
+    observe = message => importer.observePortEvent(message, port)
+
+    // The restored detailsSeen flag makes this the repeated-308 fallback
+    // boundary instead of fusing both ring sessions.
+    await observe({ ApiTypeId: ApiType.EVT_SESSION_DETAILS, Name: 'Ring', timestamp: 200 })
+    expect((await db.experimentalReplayHands.get(331))?.status).toBe('ready')
+    expect(port.postMessage).toHaveBeenCalledWith(expect.objectContaining({ handIds: [331] }))
+  })
+
+  test('uses a replacement same-source port when the boundary port is stale', async () => {
+    await observe({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Id: 'stale-port',
+      BattleType: BattleType.SIT_AND_GO,
+      timestamp: 100
+    })
+    await observe({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 341, timestamp: 200 })
+
+    const boundary = observe({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 300 })
+    importer.detachPort(port)
+    const replacementPort = {
+      postMessage: jest.fn(),
+      sender: { tab: { id: 10 }, frameId: 0 }
+    } as unknown as chrome.runtime.Port
+    importer.attachPort(replacementPort)
+    await boundary
+    await importer.whenIdle()
+
+    expect(replacementPort.postMessage).toHaveBeenCalledWith(expect.objectContaining({ handIds: [341] }))
+    importer.detachPort(replacementPort)
+  })
+
+  test('retries a success item that omits replay detail', async () => {
+    await observe({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Id: 'missing-detail',
+      BattleType: BattleType.SIT_AND_GO,
+      timestamp: 100
+    })
+    await observe({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 351, timestamp: 200 })
+    await observe({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 300 })
+    const request = (port.postMessage as jest.Mock).mock.calls[0][0]
+
+    expect(importer.handlePortMessage({
+      type: REPLAY_PORT_RESULT,
+      requestId: request.requestId,
+      results: [{ handId: 351, ok: true }]
+    }, port)).toBe(true)
+    await importer.whenIdle()
+
+    expect(await db.experimentalReplayHands.get(351)).toEqual(expect.objectContaining({
+      status: 'ready',
+      lastError: 'missing-result'
+    }))
+  })
+
   test('retries an all-retryable batch with backoff while the tab stays open', async () => {
     await observe({
       ApiTypeId: ApiType.EVT_ENTRY_QUEUED,

--- a/src/background/experimental-replay-import.test.ts
+++ b/src/background/experimental-replay-import.test.ts
@@ -302,6 +302,69 @@ describe('ExperimentalReplayImporter', () => {
     }))
   })
 
+  test('continues past a full batch of terminal failures', async () => {
+    await observe({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Id: 'large-terminal-failure',
+      BattleType: BattleType.SIT_AND_GO,
+      timestamp: 100
+    })
+    const handIds = Array.from({ length: 101 }, (_, index) => 1_000 + index)
+    for (const handId of handIds) {
+      await observe({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: handId, timestamp: handId })
+    }
+    await observe({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 2_000 })
+    const firstRequest = (port.postMessage as jest.Mock).mock.calls[0][0]
+    expect(firstRequest.handIds).toHaveLength(100)
+
+    expect(importer.handlePortMessage({
+      type: REPLAY_PORT_RESULT,
+      requestId: firstRequest.requestId,
+      results: firstRequest.handIds.map((handId: number) => ({
+        handId,
+        ok: false,
+        error: 'API Code 1',
+        retryable: false
+      }))
+    }, port)).toBe(true)
+    await importer.whenIdle()
+
+    expect(port.postMessage).toHaveBeenNthCalledWith(2, expect.objectContaining({ handIds: [1_100] }))
+  })
+
+  test('cancels retry work and rejects later writes when data deletion starts', async () => {
+    await observe({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Id: 'delete-race',
+      BattleType: BattleType.SIT_AND_GO,
+      timestamp: 100
+    })
+    await observe({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 1_201, timestamp: 200 })
+    await observe({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 300 })
+    const request = (port.postMessage as jest.Mock).mock.calls[0][0]
+
+    jest.useFakeTimers()
+    try {
+      expect(importer.handlePortMessage({
+        type: REPLAY_PORT_RESULT,
+        requestId: request.requestId,
+        results: [{ handId: 1_201, ok: false, error: 'HTTP 503', retryable: true }]
+      }, port)).toBe(true)
+      await importer.whenIdle()
+      await importer.prepareForDataDeletion()
+      ;(port.postMessage as jest.Mock).mockClear()
+
+      await jest.advanceTimersByTimeAsync(60_000)
+      await importer.observePortEvent({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 1_202, timestamp: 400 }, port)
+      await importer.whenIdle()
+
+      expect(port.postMessage).not.toHaveBeenCalled()
+      expect(await db.experimentalReplayHands.get(1_202)).toBeUndefined()
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
   test('retries an all-retryable batch with backoff while the tab stays open', async () => {
     await observe({
       ApiTypeId: ApiType.EVT_ENTRY_QUEUED,

--- a/src/background/experimental-replay-import.test.ts
+++ b/src/background/experimental-replay-import.test.ts
@@ -1,0 +1,171 @@
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { ApiType, BattleType } from '../types'
+import {
+  EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY,
+  REPLAY_PORT_FETCH,
+  REPLAY_PORT_RESULT
+} from '../replay/protocol'
+import { ExperimentalReplayImporter } from './experimental-replay-import'
+
+describe('ExperimentalReplayImporter', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+  let importer: ExperimentalReplayImporter
+  let port: chrome.runtime.Port
+
+  beforeEach(async () => {
+    ;(chrome.storage.local.get as jest.Mock).mockResolvedValue({
+      [EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY]: true
+    })
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    service = new PokerChaseService({ db })
+    await service.ready
+    importer = new ExperimentalReplayImporter(db, service)
+    await importer.ready
+    port = { postMessage: jest.fn() } as unknown as chrome.runtime.Port
+    importer.attachPort(port)
+  })
+
+  afterEach(async () => {
+    importer.detachPort(port)
+    db.close()
+    await db.delete()
+  })
+
+  test('queues HandIds during play and dispatches only after 309', async () => {
+    await importer.observeApiEvent({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Id: 'sng-1',
+      BattleType: BattleType.SIT_AND_GO,
+      timestamp: 100
+    })
+    await importer.observeApiEvent({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 123, timestamp: 200 })
+
+    expect((await db.experimentalReplayHands.get(123))?.status).toBe('pending')
+    expect(port.postMessage).not.toHaveBeenCalled()
+
+    await importer.observeApiEvent({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 300 })
+    expect(port.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      type: REPLAY_PORT_FETCH,
+      handIds: [123]
+    }))
+    expect((await db.experimentalReplayHands.get(123))?.status).toBe('ready')
+  })
+
+  test('stores sanitized detail and never persists response credentials', async () => {
+    await importer.observeApiEvent({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Id: 'ring-1',
+      BattleType: BattleType.RING_GAME,
+      timestamp: 100
+    })
+    await importer.observeApiEvent({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 456, timestamp: 200 })
+    await importer.observeApiEvent({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 300 })
+    const request = (port.postMessage as jest.Mock).mock.calls[0][0]
+
+    expect(importer.handlePortMessage({
+      type: REPLAY_PORT_RESULT,
+      requestId: request.requestId,
+      results: [{
+        handId: 456,
+        ok: true,
+        detail: { Code: 0, session: 'secret', Replay: { HandId: 456, requestKey: 'secret-2' } }
+      }]
+    })).toBe(true)
+    await importer.whenIdle()
+
+    expect(await db.experimentalReplayHands.get(456)).toEqual(expect.objectContaining({
+      status: 'complete',
+      detail: { Code: 0, Replay: { HandId: 456 } }
+    }))
+    expect(JSON.stringify(await db.experimentalReplayHands.get(456))).not.toContain('secret')
+  })
+
+  test('keeps the same MTT session across table-move 201 events', async () => {
+    await importer.observeApiEvent({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Id: 'mtt-1',
+      BattleType: BattleType.TOURNAMENT,
+      timestamp: 100
+    })
+    await importer.observeApiEvent({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 1, timestamp: 200 })
+    await importer.observeApiEvent({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Id: 'mtt-1',
+      BattleType: BattleType.TOURNAMENT,
+      timestamp: 300
+    })
+
+    expect((await db.experimentalReplayHands.get(1))?.status).toBe('pending')
+    expect(port.postMessage).not.toHaveBeenCalled()
+  })
+
+  test('keeps interleaved game tabs in separate session buckets', async () => {
+    const tabA = {}
+    const tabB = {}
+    await importer.observeApiEvent({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Id: 'a', BattleType: BattleType.SIT_AND_GO, timestamp: 100
+    }, tabA)
+    await importer.observeApiEvent({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 11, timestamp: 110 }, tabA)
+    await importer.observeApiEvent({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Id: 'b', BattleType: BattleType.RING_GAME, timestamp: 120
+    }, tabB)
+    await importer.observeApiEvent({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 22, timestamp: 130 }, tabB)
+
+    await importer.observeApiEvent({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 140 }, tabA)
+    expect((await db.experimentalReplayHands.get(11))?.status).toBe('ready')
+    expect((await db.experimentalReplayHands.get(22))?.status).toBe('pending')
+  })
+
+  test('uses the next non-MTT 201 as a missing-309 fallback', async () => {
+    await importer.observeApiEvent({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Id: 'ring-stage',
+      BattleType: BattleType.RING_GAME,
+      timestamp: 100
+    })
+    await importer.observeApiEvent({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 99, timestamp: 200 })
+    await importer.observeApiEvent({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Id: 'ring-stage',
+      BattleType: BattleType.RING_GAME,
+      timestamp: 400
+    })
+
+    expect((await db.experimentalReplayHands.get(99))?.status).toBe('ready')
+    expect(port.postMessage).toHaveBeenCalledWith(expect.objectContaining({ handIds: [99] }))
+  })
+
+  test('re-dispatches a durable ready row when a game port reconnects', async () => {
+    importer.detachPort(port)
+    await importer.observeApiEvent({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Id: 'sng-reconnect',
+      BattleType: BattleType.SIT_AND_GO,
+      timestamp: 100
+    })
+    await importer.observeApiEvent({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 321, timestamp: 200 })
+    await importer.observeApiEvent({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 300 })
+    expect((await db.experimentalReplayHands.get(321))?.status).toBe('ready')
+
+    const replacementPort = { postMessage: jest.fn() } as unknown as chrome.runtime.Port
+    importer.attachPort(replacementPort)
+    await importer.whenIdle()
+    expect(replacementPort.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      type: REPLAY_PORT_FETCH,
+      handIds: [321]
+    }))
+    importer.detachPort(replacementPort)
+  })
+
+  test('does nothing while the opt-in flag is disabled', async () => {
+    ;(chrome.storage.local.get as jest.Mock).mockResolvedValue({})
+    const disabled = new ExperimentalReplayImporter(db, service)
+    await disabled.ready
+
+    await disabled.observeApiEvent({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 777, timestamp: 1 })
+    expect(await db.experimentalReplayHands.count()).toBe(0)
+  })
+})

--- a/src/background/experimental-replay-import.test.ts
+++ b/src/background/experimental-replay-import.test.ts
@@ -13,6 +13,7 @@ describe('ExperimentalReplayImporter', () => {
   let service: PokerChaseService
   let importer: ExperimentalReplayImporter
   let port: chrome.runtime.Port
+  let observe: (message: Record<string, unknown>) => Promise<void>
 
   beforeEach(async () => {
     ;(chrome.storage.local.get as jest.Mock).mockResolvedValue({
@@ -24,8 +25,12 @@ describe('ExperimentalReplayImporter', () => {
     await service.ready
     importer = new ExperimentalReplayImporter(db, service)
     await importer.ready
-    port = { postMessage: jest.fn() } as unknown as chrome.runtime.Port
+    port = {
+      postMessage: jest.fn(),
+      sender: { tab: { id: 10 }, frameId: 0 }
+    } as unknown as chrome.runtime.Port
     importer.attachPort(port)
+    observe = message => importer.observePortEvent(message, port)
   })
 
   afterEach(async () => {
@@ -35,18 +40,18 @@ describe('ExperimentalReplayImporter', () => {
   })
 
   test('queues HandIds during play and dispatches only after 309', async () => {
-    await importer.observeApiEvent({
+    await observe({
       ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
       Id: 'sng-1',
       BattleType: BattleType.SIT_AND_GO,
       timestamp: 100
     })
-    await importer.observeApiEvent({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 123, timestamp: 200 })
+    await observe({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 123, timestamp: 200 })
 
     expect((await db.experimentalReplayHands.get(123))?.status).toBe('pending')
     expect(port.postMessage).not.toHaveBeenCalled()
 
-    await importer.observeApiEvent({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 300 })
+    await observe({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 300 })
     expect(port.postMessage).toHaveBeenCalledWith(expect.objectContaining({
       type: REPLAY_PORT_FETCH,
       handIds: [123]
@@ -55,14 +60,14 @@ describe('ExperimentalReplayImporter', () => {
   })
 
   test('stores sanitized detail and never persists response credentials', async () => {
-    await importer.observeApiEvent({
+    await observe({
       ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
       Id: 'ring-1',
       BattleType: BattleType.RING_GAME,
       timestamp: 100
     })
-    await importer.observeApiEvent({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 456, timestamp: 200 })
-    await importer.observeApiEvent({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 300 })
+    await observe({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 456, timestamp: 200 })
+    await observe({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 300 })
     const request = (port.postMessage as jest.Mock).mock.calls[0][0]
 
     expect(importer.handlePortMessage({
@@ -73,7 +78,7 @@ describe('ExperimentalReplayImporter', () => {
         ok: true,
         detail: { Code: 0, session: 'secret', Replay: { HandId: 456, requestKey: 'secret-2' } }
       }]
-    })).toBe(true)
+    }, port)).toBe(true)
     await importer.whenIdle()
 
     expect(await db.experimentalReplayHands.get(456)).toEqual(expect.objectContaining({
@@ -84,14 +89,14 @@ describe('ExperimentalReplayImporter', () => {
   })
 
   test('keeps the same MTT session across table-move 201 events', async () => {
-    await importer.observeApiEvent({
+    await observe({
       ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
       Id: 'mtt-1',
       BattleType: BattleType.TOURNAMENT,
       timestamp: 100
     })
-    await importer.observeApiEvent({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 1, timestamp: 200 })
-    await importer.observeApiEvent({
+    await observe({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 1, timestamp: 200 })
+    await observe({
       ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
       Id: 'mtt-1',
       BattleType: BattleType.TOURNAMENT,
@@ -103,8 +108,8 @@ describe('ExperimentalReplayImporter', () => {
   })
 
   test('keeps interleaved game tabs in separate session buckets', async () => {
-    const tabA = {}
-    const tabB = {}
+    const tabA = 'tab-a'
+    const tabB = 'tab-b'
     await importer.observeApiEvent({
       ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Id: 'a', BattleType: BattleType.SIT_AND_GO, timestamp: 100
     }, tabA)
@@ -119,6 +124,65 @@ describe('ExperimentalReplayImporter', () => {
     expect((await db.experimentalReplayHands.get(22))?.status).toBe('pending')
   })
 
+  test('dispatches replay rows only through their originating tab', async () => {
+    const tabA = {
+      postMessage: jest.fn(), sender: { tab: { id: 20 }, frameId: 0 }
+    } as unknown as chrome.runtime.Port
+    const tabB = {
+      postMessage: jest.fn(), sender: { tab: { id: 21 }, frameId: 0 }
+    } as unknown as chrome.runtime.Port
+    importer.attachPort(tabA)
+    importer.attachPort(tabB)
+
+    await importer.observePortEvent({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Id: 'a', BattleType: BattleType.SIT_AND_GO, timestamp: 100
+    }, tabA)
+    await importer.observePortEvent({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 31, timestamp: 110 }, tabA)
+    await importer.observePortEvent({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Id: 'b', BattleType: BattleType.RING_GAME, timestamp: 120
+    }, tabB)
+    await importer.observePortEvent({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 32, timestamp: 130 }, tabB)
+    await importer.observePortEvent({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 140 }, tabA)
+
+    expect(tabA.postMessage).toHaveBeenCalledWith(expect.objectContaining({ handIds: [31] }))
+    expect(tabB.postMessage).not.toHaveBeenCalled()
+    importer.detachPort(tabA)
+    importer.detachPort(tabB)
+  })
+
+  test('uses a repeated non-MTT 308 as a missing-309 boundary', async () => {
+    await observe({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Id: 'ring-308',
+      BattleType: BattleType.RING_GAME,
+      timestamp: 100
+    })
+    await observe({ ApiTypeId: ApiType.EVT_SESSION_DETAILS, Name: 'Ring', timestamp: 110 })
+    await observe({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 41, timestamp: 120 })
+    await observe({ ApiTypeId: ApiType.EVT_SESSION_DETAILS, Name: 'Ring', timestamp: 200 })
+
+    expect((await db.experimentalReplayHands.get(41))?.status).toBe('ready')
+    expect(port.postMessage).toHaveBeenCalledWith(expect.objectContaining({ handIds: [41] }))
+
+    await observe({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 42, timestamp: 220 })
+    expect((await db.experimentalReplayHands.get(42))?.status).toBe('pending')
+  })
+
+  test('absorbs repeated 308 events inside the same MTT', async () => {
+    await observe({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Id: 'mtt-308',
+      BattleType: BattleType.TOURNAMENT,
+      timestamp: 100
+    })
+    await observe({ ApiTypeId: ApiType.EVT_SESSION_DETAILS, Name: 'MTT', timestamp: 110 })
+    await observe({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 51, timestamp: 120 })
+    await observe({ ApiTypeId: ApiType.EVT_SESSION_DETAILS, Name: 'MTT table 2', timestamp: 200 })
+
+    expect((await db.experimentalReplayHands.get(51))?.status).toBe('pending')
+    expect(port.postMessage).not.toHaveBeenCalled()
+  })
+
   test('uses the next non-MTT 201 as a missing-309 fallback', async () => {
     await importer.observeApiEvent({
       ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
@@ -126,8 +190,8 @@ describe('ExperimentalReplayImporter', () => {
       BattleType: BattleType.RING_GAME,
       timestamp: 100
     })
-    await importer.observeApiEvent({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 99, timestamp: 200 })
-    await importer.observeApiEvent({
+    await observe({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 99, timestamp: 200 })
+    await observe({
       ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
       Id: 'ring-stage',
       BattleType: BattleType.RING_GAME,
@@ -139,18 +203,22 @@ describe('ExperimentalReplayImporter', () => {
   })
 
   test('re-dispatches a durable ready row when a game port reconnects', async () => {
-    importer.detachPort(port)
-    await importer.observeApiEvent({
+    await observe({
       ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
       Id: 'sng-reconnect',
       BattleType: BattleType.SIT_AND_GO,
       timestamp: 100
     })
-    await importer.observeApiEvent({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 321, timestamp: 200 })
-    await importer.observeApiEvent({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 300 })
+    await observe({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 321, timestamp: 200 })
+    await observe({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 300 })
     expect((await db.experimentalReplayHands.get(321))?.status).toBe('ready')
+    expect(port.postMessage).toHaveBeenCalled()
+    importer.detachPort(port)
 
-    const replacementPort = { postMessage: jest.fn() } as unknown as chrome.runtime.Port
+    const replacementPort = {
+      postMessage: jest.fn(),
+      sender: { tab: { id: 10 }, frameId: 0 }
+    } as unknown as chrome.runtime.Port
     importer.attachPort(replacementPort)
     await importer.whenIdle()
     expect(replacementPort.postMessage).toHaveBeenCalledWith(expect.objectContaining({
@@ -158,6 +226,35 @@ describe('ExperimentalReplayImporter', () => {
       handIds: [321]
     }))
     importer.detachPort(replacementPort)
+  })
+
+  test('retries an all-retryable batch with backoff while the tab stays open', async () => {
+    await observe({
+      ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+      Id: 'retry-session',
+      BattleType: BattleType.SIT_AND_GO,
+      timestamp: 100
+    })
+    await observe({ ApiTypeId: ApiType.EVT_HAND_RESULTS, HandId: 61, timestamp: 200 })
+    await observe({ ApiTypeId: ApiType.EVT_SESSION_RESULTS, timestamp: 300 })
+    const request = (port.postMessage as jest.Mock).mock.calls[0][0]
+
+    jest.useFakeTimers()
+    try {
+      expect(importer.handlePortMessage({
+        type: REPLAY_PORT_RESULT,
+        requestId: request.requestId,
+        results: [{ handId: 61, ok: false, error: 'auth-envelope-unavailable', retryable: true }]
+      }, port)).toBe(true)
+      await importer.whenIdle()
+      ;(port.postMessage as jest.Mock).mockClear()
+
+      await jest.advanceTimersByTimeAsync(2_000)
+      await importer.whenIdle()
+      expect(port.postMessage).toHaveBeenCalledWith(expect.objectContaining({ handIds: [61] }))
+    } finally {
+      jest.useRealTimers()
+    }
   })
 
   test('does nothing while the opt-in flag is disabled', async () => {

--- a/src/background/experimental-replay-import.test.ts
+++ b/src/background/experimental-replay-import.test.ts
@@ -16,7 +16,7 @@ describe('ExperimentalReplayImporter', () => {
   let observe: (message: Record<string, unknown>) => Promise<void>
 
   beforeEach(async () => {
-    ;(chrome.storage.local.get as jest.Mock).mockResolvedValue({
+    ;(chrome.storage.sync.get as jest.Mock).mockResolvedValue({
       [EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY]: true
     })
     db = new PokerChaseDB(indexedDB, IDBKeyRange)
@@ -395,7 +395,7 @@ describe('ExperimentalReplayImporter', () => {
   })
 
   test('does nothing while the opt-in flag is disabled', async () => {
-    ;(chrome.storage.local.get as jest.Mock).mockResolvedValue({})
+    ;(chrome.storage.sync.get as jest.Mock).mockResolvedValue({})
     const disabled = new ExperimentalReplayImporter(db, service)
     await disabled.ready
 

--- a/src/background/experimental-replay-import.ts
+++ b/src/background/experimental-replay-import.ts
@@ -40,6 +40,7 @@ interface InFlightReplayRequest {
  */
 export class ExperimentalReplayImporter {
   private enabled = false
+  private deleting = false
   private readonly activeSessions = new Map<string, ActiveReplaySession>()
   private readonly defaultSource = 'default'
   private readonly ports = new Set<chrome.runtime.Port>()
@@ -94,6 +95,22 @@ export class ExperimentalReplayImporter {
     await this.flushQueue
   }
 
+  /** Stop every replay writer before Delete All Data removes IndexedDB. */
+  async prepareForDataDeletion(): Promise<void> {
+    this.deleting = true
+    this.inFlight.clear()
+    for (const timer of this.retryTimers.values()) clearTimeout(timer)
+    this.retryTimers.clear()
+    await this.whenIdle()
+  }
+
+  /** Re-enable capture if IndexedDB deletion fails and the worker survives. */
+  resumeAfterDataDeletionFailure(): void {
+    if (!this.deleting) return
+    this.deleting = false
+    if (this.enabled) this.flushReady().catch(this.logError('flush after failed deletion'))
+  }
+
   /** Enqueue lifecycle work immediately so event arrival order is preserved. */
   observePortEvent(message: ApiLikeMessage, port: chrome.runtime.Port): Promise<void> {
     return this.observeApiEvent(message, this.sourceKeyForPort(port), port)
@@ -106,7 +123,7 @@ export class ExperimentalReplayImporter {
   ): Promise<void> {
     const task = this.operationQueue.then(async () => {
       await this.ready
-      if (!this.enabled) return
+      if (!this.enabled || this.deleting) return
 
       switch (message.ApiTypeId) {
         case ApiType.EVT_ENTRY_QUEUED:
@@ -132,7 +149,7 @@ export class ExperimentalReplayImporter {
     if (!this.isReplayResult(message)) return false
     const task = this.operationQueue.then(async () => {
       await this.ready
-      if (!this.enabled) return
+      if (!this.enabled || this.deleting) return
       await this.storeResults(message, port)
     })
     this.operationQueue = task.catch(this.logError('replay result'))
@@ -308,7 +325,7 @@ export class ExperimentalReplayImporter {
 
   private async performFlush(preferredPort?: chrome.runtime.Port, excludedHandIds = new Set<number>()): Promise<void> {
     await this.ready
-    if (!this.enabled || !preferredPort || !this.ports.has(preferredPort)) return
+    if (!this.enabled || this.deleting || !preferredPort || !this.ports.has(preferredPort)) return
     const port = preferredPort
     const sourceKey = this.sourceKeyForPort(port)
 
@@ -344,6 +361,7 @@ export class ExperimentalReplayImporter {
     const now = Date.now()
     let successes = 0
     const failedHandIds = new Set<number>()
+    const terminalFailureHandIds = new Set<number>()
     const retryableHandIds = new Set<number>()
     const seenHandIds = new Set<number>()
 
@@ -368,6 +386,7 @@ export class ExperimentalReplayImporter {
       } else {
         failedHandIds.add(result.handId)
         if (result.retryable) retryableHandIds.add(result.handId)
+        else terminalFailureHandIds.add(result.handId)
         await this.db.experimentalReplayHands.put({
           ...row,
           status: result.retryable ? 'ready' : 'failed',
@@ -391,7 +410,9 @@ export class ExperimentalReplayImporter {
     }
     // Continue draining sessions larger than one batch, but do not create a
     // tight loop when the page lacks an auth envelope or the server is down.
-    if (successes > 0) await this.flushReady(expected.port, failedHandIds)
+    if (successes > 0 || terminalFailureHandIds.size > 0) {
+      await this.flushReady(expected.port, failedHandIds)
+    }
     if (retryableHandIds.size > 0) await this.scheduleRetry(expected.sourceKey, expected.port, retryableHandIds)
   }
 
@@ -400,7 +421,7 @@ export class ExperimentalReplayImporter {
     port: chrome.runtime.Port,
     handIds: Set<number>
   ): Promise<void> {
-    if (this.retryTimers.has(sourceKey) || !this.ports.has(port)) return
+    if (this.deleting || this.retryTimers.has(sourceKey) || !this.ports.has(port)) return
     const rows = await this.db.experimentalReplayHands.bulkGet(Array.from(handIds))
     const maxAttempts = Math.max(1, ...rows.map(row => row?.attempts ?? 1))
     const delayMs = Math.min(60_000, 1000 * (2 ** Math.min(maxAttempts, 6)))

--- a/src/background/experimental-replay-import.ts
+++ b/src/background/experimental-replay-import.ts
@@ -1,0 +1,280 @@
+import type PokerChaseService from '../services/poker-chase-service'
+import type { PokerChaseDB } from '../db/poker-chase-db'
+import { ApiType, BattleType } from '../types'
+import {
+  EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY,
+  REPLAY_FETCH_BATCH_LIMIT,
+  REPLAY_PORT_FETCH,
+  REPLAY_PORT_RESULT,
+  errorMessage,
+  isPositiveHandId,
+  sanitizeReplayDetail,
+  type ExperimentalReplayRecord,
+  type ReplayFetchResult
+} from '../replay/protocol'
+
+type ApiLikeMessage = Record<string, unknown> & { ApiTypeId?: unknown, timestamp?: unknown }
+
+interface ActiveReplaySession {
+  key: string
+  id?: string
+  battleType?: BattleType
+  name?: string
+}
+
+/**
+ * Experimental, opt-in replay acquisition coordinator.
+ *
+ * EVT_HAND_RESULTS contributes only HandId while a game is active. The
+ * matching replay/detail requests are released after the session boundary so
+ * normal gameplay traffic is never delayed by HTTP acquisition.
+ */
+export class ExperimentalReplayImporter {
+  private enabled = false
+  private readonly activeSessions = new Map<object, ActiveReplaySession>()
+  private readonly defaultSource = {}
+  private readonly ports = new Set<chrome.runtime.Port>()
+  private readonly inFlight = new Map<string, Set<number>>()
+  private operationQueue: Promise<void> = Promise.resolve()
+  private flushQueue: Promise<void> = Promise.resolve()
+  readonly ready: Promise<void>
+
+  constructor(private readonly db: PokerChaseDB, private readonly service: PokerChaseService) {
+    this.ready = this.restoreEnabled()
+    chrome.storage?.onChanged?.addListener((changes, areaName) => {
+      const change = changes[EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY]
+      if (areaName !== 'local' || !change) return
+      this.enabled = change.newValue === true
+      if (this.enabled) this.flushReady().catch(this.logError('flush after enable'))
+    })
+  }
+
+  attachPort(port: chrome.runtime.Port): void {
+    this.ports.add(port)
+    this.ready
+      .then(() => this.flushReady(port))
+      .catch(this.logError('flush after port connect'))
+  }
+
+  detachPort(port: chrome.runtime.Port): void {
+    this.ports.delete(port)
+  }
+
+  /** Test/diagnostic drain point for the importer's own serialized queue. */
+  async whenIdle(): Promise<void> {
+    await this.operationQueue
+    await this.flushQueue
+  }
+
+  /** Enqueue lifecycle work immediately so event arrival order is preserved. */
+  observeApiEvent(message: ApiLikeMessage, source: object = this.defaultSource): Promise<void> {
+    const task = this.operationQueue.then(async () => {
+      await this.ready
+      if (!this.enabled) return
+
+      switch (message.ApiTypeId) {
+        case ApiType.EVT_ENTRY_QUEUED:
+          await this.startSession(message, source)
+          break
+        case ApiType.EVT_HAND_RESULTS:
+          await this.queueHand(message, source)
+          break
+        case ApiType.EVT_SESSION_DETAILS:
+          this.updateSessionName(message, source)
+          break
+        case ApiType.EVT_SESSION_RESULTS:
+          await this.finishActiveSession(source, source as chrome.runtime.Port)
+          break
+      }
+    })
+    this.operationQueue = task.catch(this.logError('lifecycle event'))
+    return task
+  }
+
+  /** Returns true when the message belongs to this experimental protocol. */
+  handlePortMessage(message: unknown): boolean {
+    if (!this.isReplayResult(message)) return false
+    const task = this.operationQueue.then(async () => {
+      await this.ready
+      if (!this.enabled) return
+      await this.storeResults(message)
+    })
+    this.operationQueue = task.catch(this.logError('replay result'))
+    return true
+  }
+
+  private async restoreEnabled(): Promise<void> {
+    try {
+      const stored = await chrome.storage.local.get(EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY)
+      this.enabled = stored[EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY] === true
+    } catch (error) {
+      console.warn('[experimental-replay] Failed to read feature flag; keeping disabled:', error)
+      this.enabled = false
+    }
+  }
+
+  private async startSession(message: ApiLikeMessage, source: object): Promise<void> {
+    const id = typeof message.Id === 'string' ? message.Id : undefined
+    const battleType = typeof message.BattleType === 'number' ? message.BattleType as BattleType : undefined
+
+    // MTT table moves issue another 201 with the same tournament id. They do
+    // not end the tournament session and must not release a partial batch.
+    const activeSession = this.activeSessions.get(source)
+    const sameMtt = activeSession?.battleType === BattleType.TOURNAMENT &&
+      battleType === BattleType.TOURNAMENT && activeSession.id === id
+    if (sameMtt) return
+
+    if (activeSession) await this.finishActiveSession(source, source as chrome.runtime.Port)
+    const timestamp = typeof message.timestamp === 'number' ? message.timestamp : Date.now()
+    this.activeSessions.set(source, {
+      key: `${timestamp}:${id ?? 'unknown'}`,
+      id,
+      battleType
+    })
+  }
+
+  private updateSessionName(message: ApiLikeMessage, source: object): void {
+    const session = this.activeSessions.get(source)
+    if (session && typeof message.Name === 'string') session.name = message.Name
+  }
+
+  private ensureActiveSession(message: ApiLikeMessage, source: object): ActiveReplaySession {
+    const activeSession = this.activeSessions.get(source)
+    if (activeSession) return activeSession
+    const timestamp = typeof message.timestamp === 'number' ? message.timestamp : Date.now()
+    const recovered = {
+      key: `${timestamp}:${this.service.session.id ?? 'recovered'}`,
+      id: this.service.session.id,
+      battleType: this.service.session.battleType,
+      name: this.service.session.name
+    }
+    this.activeSessions.set(source, recovered)
+    return recovered
+  }
+
+  private async queueHand(message: ApiLikeMessage, source: object): Promise<void> {
+    if (!isPositiveHandId(message.HandId)) return
+    const session = this.ensureActiveSession(message, source)
+    const now = Date.now()
+    const existing = await this.db.experimentalReplayHands.get(message.HandId)
+    if (existing?.status === 'complete') return
+
+    const record: ExperimentalReplayRecord = {
+      handId: message.HandId,
+      sessionKey: session.key,
+      sessionId: session.id,
+      battleType: session.battleType,
+      sessionName: session.name ?? this.service.session.name,
+      status: 'pending',
+      queuedAt: existing?.queuedAt ?? now,
+      updatedAt: now,
+      attempts: existing?.attempts ?? 0,
+      lastAttemptAt: existing?.lastAttemptAt,
+      lastError: existing?.lastError
+    }
+    await this.db.experimentalReplayHands.put(record)
+  }
+
+  private async finishActiveSession(source: object, preferredPort?: chrome.runtime.Port): Promise<void> {
+    const session = this.activeSessions.get(source)
+    if (!session) return
+    const rows = await this.db.experimentalReplayHands.where('sessionKey').equals(session.key).toArray()
+    const now = Date.now()
+    await this.db.experimentalReplayHands.bulkPut(rows
+      .filter(row => row.status === 'pending')
+      .map(row => ({ ...row, status: 'ready' as const, updatedAt: now })))
+    this.activeSessions.delete(source)
+    await this.flushReady(this.ports.has(preferredPort!) ? preferredPort : undefined)
+  }
+
+  private flushReady(preferredPort?: chrome.runtime.Port, excludedHandIds = new Set<number>()): Promise<void> {
+    const task = this.flushQueue.then(() => this.performFlush(preferredPort, excludedHandIds))
+    this.flushQueue = task.catch(this.logError('ready queue flush'))
+    return task
+  }
+
+  private async performFlush(preferredPort?: chrome.runtime.Port, excludedHandIds = new Set<number>()): Promise<void> {
+    await this.ready
+    if (!this.enabled || this.ports.size === 0) return
+    const port = preferredPort && this.ports.has(preferredPort)
+      ? preferredPort
+      : this.ports.values().next().value as chrome.runtime.Port | undefined
+    if (!port) return
+
+    const alreadyInFlight = new Set(Array.from(this.inFlight.values()).flatMap(ids => Array.from(ids)))
+    const readyRows = await this.db.experimentalReplayHands.where('status').equals('ready').toArray()
+    const handIds = readyRows
+      .map(row => row.handId)
+      .filter(id => !alreadyInFlight.has(id) && !excludedHandIds.has(id))
+      .slice(0, REPLAY_FETCH_BATCH_LIMIT)
+    if (handIds.length === 0) return
+
+    const requestId = crypto.randomUUID()
+    this.inFlight.set(requestId, new Set(handIds))
+    const now = Date.now()
+    await this.db.experimentalReplayHands.bulkPut(readyRows
+      .filter(row => handIds.includes(row.handId))
+      .map(row => ({ ...row, attempts: row.attempts + 1, lastAttemptAt: now, updatedAt: now })))
+    try {
+      port.postMessage({ type: REPLAY_PORT_FETCH, requestId, handIds })
+    } catch (error) {
+      this.inFlight.delete(requestId)
+      console.warn('[experimental-replay] Failed to dispatch replay request:', error)
+    }
+  }
+
+  private async storeResults(message: ReplayFetchResult): Promise<void> {
+    const expected = this.inFlight.get(message.requestId)
+    if (!expected) return
+    this.inFlight.delete(message.requestId)
+    const now = Date.now()
+    let successes = 0
+    const failedHandIds = new Set<number>()
+
+    for (const result of message.results) {
+      if (!expected.has(result.handId)) continue
+      const row = await this.db.experimentalReplayHands.get(result.handId)
+      if (!row || row.status === 'complete') continue
+      if (result.ok) {
+        successes += 1
+        await this.db.experimentalReplayHands.put({
+          ...row,
+          status: 'complete',
+          detail: sanitizeReplayDetail(result.detail),
+          capturedAt: now,
+          updatedAt: now,
+          lastError: undefined
+        })
+      } else {
+        failedHandIds.add(result.handId)
+        await this.db.experimentalReplayHands.put({
+          ...row,
+          status: result.retryable ? 'ready' : 'failed',
+          updatedAt: now,
+          lastError: result.error
+        })
+      }
+    }
+    // Continue draining sessions larger than one batch, but do not create a
+    // tight loop when the page lacks an auth envelope or the server is down.
+    if (successes > 0) await this.flushReady(undefined, failedHandIds)
+  }
+
+  private isReplayResult(message: unknown): message is ReplayFetchResult {
+    if (typeof message !== 'object' || message === null) return false
+    const candidate = message as Partial<ReplayFetchResult>
+    return candidate.type === REPLAY_PORT_RESULT &&
+      typeof candidate.requestId === 'string' &&
+      Array.isArray(candidate.results) &&
+      candidate.results.length <= REPLAY_FETCH_BATCH_LIMIT &&
+      candidate.results.every(result => {
+        if (typeof result !== 'object' || result === null || !isPositiveHandId(result.handId) ||
+          typeof result.ok !== 'boolean') return false
+        return result.ok || (typeof result.error === 'string' && typeof result.retryable === 'boolean')
+      })
+  }
+
+  private logError(context: string): (error: unknown) => void {
+    return error => console.error(`[experimental-replay] ${context} failed: ${errorMessage(error)}`)
+  }
+}

--- a/src/background/experimental-replay-import.ts
+++ b/src/background/experimental-replay-import.ts
@@ -20,6 +20,13 @@ interface ActiveReplaySession {
   id?: string
   battleType?: BattleType
   name?: string
+  detailsSeen: boolean
+}
+
+interface InFlightReplayRequest {
+  handIds: Set<number>
+  port: chrome.runtime.Port
+  sourceKey: string
 }
 
 /**
@@ -31,10 +38,14 @@ interface ActiveReplaySession {
  */
 export class ExperimentalReplayImporter {
   private enabled = false
-  private readonly activeSessions = new Map<object, ActiveReplaySession>()
-  private readonly defaultSource = {}
+  private readonly activeSessions = new Map<string, ActiveReplaySession>()
+  private readonly defaultSource = 'default'
   private readonly ports = new Set<chrome.runtime.Port>()
-  private readonly inFlight = new Map<string, Set<number>>()
+  private readonly portSources = new WeakMap<chrome.runtime.Port, string>()
+  private readonly ephemeralPortSources = new WeakMap<chrome.runtime.Port, string>()
+  private ephemeralPortSequence = 0
+  private readonly inFlight = new Map<string, InFlightReplayRequest>()
+  private readonly retryTimers = new Map<string, ReturnType<typeof setTimeout>>()
   private operationQueue: Promise<void> = Promise.resolve()
   private flushQueue: Promise<void> = Promise.resolve()
   readonly ready: Promise<void>
@@ -46,11 +57,17 @@ export class ExperimentalReplayImporter {
       if (areaName !== 'local' || !change) return
       this.enabled = change.newValue === true
       if (this.enabled) this.flushReady().catch(this.logError('flush after enable'))
+      else {
+        this.inFlight.clear()
+        for (const timer of this.retryTimers.values()) clearTimeout(timer)
+        this.retryTimers.clear()
+      }
     })
   }
 
   attachPort(port: chrome.runtime.Port): void {
     this.ports.add(port)
+    this.portSources.set(port, this.sourceKeyForPort(port))
     this.ready
       .then(() => this.flushReady(port))
       .catch(this.logError('flush after port connect'))
@@ -58,6 +75,15 @@ export class ExperimentalReplayImporter {
 
   detachPort(port: chrome.runtime.Port): void {
     this.ports.delete(port)
+    const sourceKey = this.portSources.get(port)
+    for (const [requestId, request] of this.inFlight) {
+      if (request.port === port) this.inFlight.delete(requestId)
+    }
+    if (sourceKey) {
+      const timer = this.retryTimers.get(sourceKey)
+      if (timer) clearTimeout(timer)
+      this.retryTimers.delete(sourceKey)
+    }
   }
 
   /** Test/diagnostic drain point for the importer's own serialized queue. */
@@ -67,23 +93,31 @@ export class ExperimentalReplayImporter {
   }
 
   /** Enqueue lifecycle work immediately so event arrival order is preserved. */
-  observeApiEvent(message: ApiLikeMessage, source: object = this.defaultSource): Promise<void> {
+  observePortEvent(message: ApiLikeMessage, port: chrome.runtime.Port): Promise<void> {
+    return this.observeApiEvent(message, this.sourceKeyForPort(port), port)
+  }
+
+  observeApiEvent(
+    message: ApiLikeMessage,
+    sourceKey: string = this.defaultSource,
+    preferredPort?: chrome.runtime.Port
+  ): Promise<void> {
     const task = this.operationQueue.then(async () => {
       await this.ready
       if (!this.enabled) return
 
       switch (message.ApiTypeId) {
         case ApiType.EVT_ENTRY_QUEUED:
-          await this.startSession(message, source)
+          await this.startSession(message, sourceKey, preferredPort)
           break
         case ApiType.EVT_HAND_RESULTS:
-          await this.queueHand(message, source)
+          await this.queueHand(message, sourceKey)
           break
         case ApiType.EVT_SESSION_DETAILS:
-          this.updateSessionName(message, source)
+          await this.updateSessionDetails(message, sourceKey, preferredPort)
           break
         case ApiType.EVT_SESSION_RESULTS:
-          await this.finishActiveSession(source, source as chrome.runtime.Port)
+          await this.finishActiveSession(sourceKey, preferredPort)
           break
       }
     })
@@ -92,12 +126,12 @@ export class ExperimentalReplayImporter {
   }
 
   /** Returns true when the message belongs to this experimental protocol. */
-  handlePortMessage(message: unknown): boolean {
+  handlePortMessage(message: unknown, port: chrome.runtime.Port): boolean {
     if (!this.isReplayResult(message)) return false
     const task = this.operationQueue.then(async () => {
       await this.ready
       if (!this.enabled) return
-      await this.storeResults(message)
+      await this.storeResults(message, port)
     })
     this.operationQueue = task.catch(this.logError('replay result'))
     return true
@@ -113,54 +147,82 @@ export class ExperimentalReplayImporter {
     }
   }
 
-  private async startSession(message: ApiLikeMessage, source: object): Promise<void> {
+  private async startSession(
+    message: ApiLikeMessage,
+    sourceKey: string,
+    preferredPort?: chrome.runtime.Port
+  ): Promise<void> {
     const id = typeof message.Id === 'string' ? message.Id : undefined
     const battleType = typeof message.BattleType === 'number' ? message.BattleType as BattleType : undefined
 
     // MTT table moves issue another 201 with the same tournament id. They do
     // not end the tournament session and must not release a partial batch.
-    const activeSession = this.activeSessions.get(source)
+    const activeSession = this.activeSessions.get(sourceKey)
     const sameMtt = activeSession?.battleType === BattleType.TOURNAMENT &&
       battleType === BattleType.TOURNAMENT && activeSession.id === id
     if (sameMtt) return
 
-    if (activeSession) await this.finishActiveSession(source, source as chrome.runtime.Port)
+    if (activeSession) await this.finishActiveSession(sourceKey, preferredPort)
     const timestamp = typeof message.timestamp === 'number' ? message.timestamp : Date.now()
-    this.activeSessions.set(source, {
-      key: `${timestamp}:${id ?? 'unknown'}`,
+    this.activeSessions.set(sourceKey, {
+      key: `${sourceKey}:${timestamp}:${id ?? 'unknown'}`,
       id,
-      battleType
+      battleType,
+      detailsSeen: false
     })
   }
 
-  private updateSessionName(message: ApiLikeMessage, source: object): void {
-    const session = this.activeSessions.get(source)
-    if (session && typeof message.Name === 'string') session.name = message.Name
+  private async updateSessionDetails(
+    message: ApiLikeMessage,
+    sourceKey: string,
+    preferredPort?: chrome.runtime.Port
+  ): Promise<void> {
+    let session = this.activeSessions.get(sourceKey)
+    const name = typeof message.Name === 'string' ? message.Name : undefined
+    if (session?.detailsSeen && session.battleType !== BattleType.TOURNAMENT) {
+      await this.finishActiveSession(sourceKey, preferredPort)
+      session = undefined
+    }
+    if (!session) {
+      const timestamp = typeof message.timestamp === 'number' ? message.timestamp : Date.now()
+      session = {
+        key: `${sourceKey}:${timestamp}:${this.service.session.id ?? 'recovered'}`,
+        id: this.service.session.id,
+        battleType: this.service.session.battleType,
+        detailsSeen: true
+      }
+      this.activeSessions.set(sourceKey, session)
+    } else {
+      session.detailsSeen = true
+    }
+    if (name) session.name = name
   }
 
-  private ensureActiveSession(message: ApiLikeMessage, source: object): ActiveReplaySession {
-    const activeSession = this.activeSessions.get(source)
+  private ensureActiveSession(message: ApiLikeMessage, sourceKey: string): ActiveReplaySession {
+    const activeSession = this.activeSessions.get(sourceKey)
     if (activeSession) return activeSession
     const timestamp = typeof message.timestamp === 'number' ? message.timestamp : Date.now()
     const recovered = {
-      key: `${timestamp}:${this.service.session.id ?? 'recovered'}`,
+      key: `${sourceKey}:${timestamp}:${this.service.session.id ?? 'recovered'}`,
       id: this.service.session.id,
       battleType: this.service.session.battleType,
-      name: this.service.session.name
+      name: this.service.session.name,
+      detailsSeen: false
     }
-    this.activeSessions.set(source, recovered)
+    this.activeSessions.set(sourceKey, recovered)
     return recovered
   }
 
-  private async queueHand(message: ApiLikeMessage, source: object): Promise<void> {
+  private async queueHand(message: ApiLikeMessage, sourceKey: string): Promise<void> {
     if (!isPositiveHandId(message.HandId)) return
-    const session = this.ensureActiveSession(message, source)
+    const session = this.ensureActiveSession(message, sourceKey)
     const now = Date.now()
     const existing = await this.db.experimentalReplayHands.get(message.HandId)
     if (existing?.status === 'complete') return
 
     const record: ExperimentalReplayRecord = {
       handId: message.HandId,
+      sourceKey,
       sessionKey: session.key,
       sessionId: session.id,
       battleType: session.battleType,
@@ -175,34 +237,41 @@ export class ExperimentalReplayImporter {
     await this.db.experimentalReplayHands.put(record)
   }
 
-  private async finishActiveSession(source: object, preferredPort?: chrome.runtime.Port): Promise<void> {
-    const session = this.activeSessions.get(source)
+  private async finishActiveSession(sourceKey: string, preferredPort?: chrome.runtime.Port): Promise<void> {
+    const session = this.activeSessions.get(sourceKey)
     if (!session) return
     const rows = await this.db.experimentalReplayHands.where('sessionKey').equals(session.key).toArray()
     const now = Date.now()
     await this.db.experimentalReplayHands.bulkPut(rows
       .filter(row => row.status === 'pending')
       .map(row => ({ ...row, status: 'ready' as const, updatedAt: now })))
-    this.activeSessions.delete(source)
-    await this.flushReady(this.ports.has(preferredPort!) ? preferredPort : undefined)
+    this.activeSessions.delete(sourceKey)
+    await this.flushReady(preferredPort ?? this.connectedPortForSource(sourceKey))
   }
 
   private flushReady(preferredPort?: chrome.runtime.Port, excludedHandIds = new Set<number>()): Promise<void> {
-    const task = this.flushQueue.then(() => this.performFlush(preferredPort, excludedHandIds))
+    const task = this.flushQueue.then(async () => {
+      if (preferredPort) {
+        await this.performFlush(preferredPort, excludedHandIds)
+        return
+      }
+      for (const port of this.ports) await this.performFlush(port, excludedHandIds)
+    })
     this.flushQueue = task.catch(this.logError('ready queue flush'))
     return task
   }
 
   private async performFlush(preferredPort?: chrome.runtime.Port, excludedHandIds = new Set<number>()): Promise<void> {
     await this.ready
-    if (!this.enabled || this.ports.size === 0) return
-    const port = preferredPort && this.ports.has(preferredPort)
-      ? preferredPort
-      : this.ports.values().next().value as chrome.runtime.Port | undefined
-    if (!port) return
+    if (!this.enabled || !preferredPort || !this.ports.has(preferredPort)) return
+    const port = preferredPort
+    const sourceKey = this.sourceKeyForPort(port)
 
-    const alreadyInFlight = new Set(Array.from(this.inFlight.values()).flatMap(ids => Array.from(ids)))
-    const readyRows = await this.db.experimentalReplayHands.where('status').equals('ready').toArray()
+    const alreadyInFlight = new Set(Array.from(this.inFlight.values()).flatMap(request => Array.from(request.handIds)))
+    const readyRows = await this.db.experimentalReplayHands
+      .where('[status+sourceKey]')
+      .equals(['ready', sourceKey])
+      .toArray()
     const handIds = readyRows
       .map(row => row.handId)
       .filter(id => !alreadyInFlight.has(id) && !excludedHandIds.has(id))
@@ -210,7 +279,7 @@ export class ExperimentalReplayImporter {
     if (handIds.length === 0) return
 
     const requestId = crypto.randomUUID()
-    this.inFlight.set(requestId, new Set(handIds))
+    this.inFlight.set(requestId, { handIds: new Set(handIds), port, sourceKey })
     const now = Date.now()
     await this.db.experimentalReplayHands.bulkPut(readyRows
       .filter(row => handIds.includes(row.handId))
@@ -223,16 +292,19 @@ export class ExperimentalReplayImporter {
     }
   }
 
-  private async storeResults(message: ReplayFetchResult): Promise<void> {
+  private async storeResults(message: ReplayFetchResult, port: chrome.runtime.Port): Promise<void> {
     const expected = this.inFlight.get(message.requestId)
-    if (!expected) return
+    if (!expected || expected.port !== port) return
     this.inFlight.delete(message.requestId)
     const now = Date.now()
     let successes = 0
     const failedHandIds = new Set<number>()
+    const retryableHandIds = new Set<number>()
+    const seenHandIds = new Set<number>()
 
     for (const result of message.results) {
-      if (!expected.has(result.handId)) continue
+      if (!expected.handIds.has(result.handId)) continue
+      seenHandIds.add(result.handId)
       const row = await this.db.experimentalReplayHands.get(result.handId)
       if (!row || row.status === 'complete') continue
       if (result.ok) {
@@ -247,6 +319,7 @@ export class ExperimentalReplayImporter {
         })
       } else {
         failedHandIds.add(result.handId)
+        if (result.retryable) retryableHandIds.add(result.handId)
         await this.db.experimentalReplayHands.put({
           ...row,
           status: result.retryable ? 'ready' : 'failed',
@@ -255,9 +328,64 @@ export class ExperimentalReplayImporter {
         })
       }
     }
+    for (const handId of expected.handIds) {
+      if (seenHandIds.has(handId)) continue
+      const row = await this.db.experimentalReplayHands.get(handId)
+      if (!row || row.status === 'complete') continue
+      failedHandIds.add(handId)
+      retryableHandIds.add(handId)
+      await this.db.experimentalReplayHands.put({
+        ...row,
+        status: 'ready',
+        updatedAt: now,
+        lastError: 'missing-result'
+      })
+    }
     // Continue draining sessions larger than one batch, but do not create a
     // tight loop when the page lacks an auth envelope or the server is down.
-    if (successes > 0) await this.flushReady(undefined, failedHandIds)
+    if (successes > 0) await this.flushReady(expected.port, failedHandIds)
+    if (retryableHandIds.size > 0) await this.scheduleRetry(expected.sourceKey, expected.port, retryableHandIds)
+  }
+
+  private async scheduleRetry(
+    sourceKey: string,
+    port: chrome.runtime.Port,
+    handIds: Set<number>
+  ): Promise<void> {
+    if (this.retryTimers.has(sourceKey) || !this.ports.has(port)) return
+    const rows = await this.db.experimentalReplayHands.bulkGet(Array.from(handIds))
+    const maxAttempts = Math.max(1, ...rows.map(row => row?.attempts ?? 1))
+    const delayMs = Math.min(60_000, 1000 * (2 ** Math.min(maxAttempts, 6)))
+    const timer = setTimeout(() => {
+      this.retryTimers.delete(sourceKey)
+      this.flushReady(port).catch(this.logError('retry flush'))
+    }, delayMs)
+    this.retryTimers.set(sourceKey, timer)
+  }
+
+  private connectedPortForSource(sourceKey: string): chrome.runtime.Port | undefined {
+    for (const port of this.ports) {
+      if (this.sourceKeyForPort(port) === sourceKey) return port
+    }
+    return undefined
+  }
+
+  private sourceKeyForPort(port: chrome.runtime.Port): string {
+    const cached = this.portSources.get(port)
+    if (cached) return cached
+    const tabId = port.sender?.tab?.id
+    if (typeof tabId === 'number') {
+      const sourceKey = `tab:${tabId}:frame:${port.sender?.frameId ?? 0}`
+      this.portSources.set(port, sourceKey)
+      return sourceKey
+    }
+    let sourceKey = this.ephemeralPortSources.get(port)
+    if (!sourceKey) {
+      sourceKey = `ephemeral:${++this.ephemeralPortSequence}`
+      this.ephemeralPortSources.set(port, sourceKey)
+    }
+    this.portSources.set(port, sourceKey)
+    return sourceKey
   }
 
   private isReplayResult(message: unknown): message is ReplayFetchResult {

--- a/src/background/experimental-replay-import.ts
+++ b/src/background/experimental-replay-import.ts
@@ -15,6 +15,8 @@ import {
 
 type ApiLikeMessage = Record<string, unknown> & { ApiTypeId?: unknown, timestamp?: unknown }
 
+const ACTIVE_REPLAY_SESSION_META_PREFIX = 'experimentalReplayActiveSession:'
+
 interface ActiveReplaySession {
   key: string
   id?: string
@@ -157,14 +159,16 @@ export class ExperimentalReplayImporter {
 
     // MTT table moves issue another 201 with the same tournament id. They do
     // not end the tournament session and must not release a partial batch.
-    const activeSession = this.activeSessions.get(sourceKey)
+    const activeSession = await this.activeSessionFor(sourceKey)
     const sameMtt = activeSession?.battleType === BattleType.TOURNAMENT &&
       battleType === BattleType.TOURNAMENT && activeSession.id === id
     if (sameMtt) return
 
-    if (activeSession) await this.finishActiveSession(sourceKey, preferredPort)
+    // A new non-MTT 201 is also the fallback boundary for durable pending rows
+    // left behind by a service-worker restart.
+    await this.finishActiveSession(sourceKey, preferredPort)
     const timestamp = typeof message.timestamp === 'number' ? message.timestamp : Date.now()
-    this.activeSessions.set(sourceKey, {
+    await this.persistActiveSession(sourceKey, {
       key: `${sourceKey}:${timestamp}:${id ?? 'unknown'}`,
       id,
       battleType,
@@ -177,7 +181,7 @@ export class ExperimentalReplayImporter {
     sourceKey: string,
     preferredPort?: chrome.runtime.Port
   ): Promise<void> {
-    let session = this.activeSessions.get(sourceKey)
+    let session = await this.activeSessionFor(sourceKey)
     const name = typeof message.Name === 'string' ? message.Name : undefined
     if (session?.detailsSeen && session.battleType !== BattleType.TOURNAMENT) {
       await this.finishActiveSession(sourceKey, preferredPort)
@@ -189,17 +193,19 @@ export class ExperimentalReplayImporter {
         key: `${sourceKey}:${timestamp}:${this.service.session.id ?? 'recovered'}`,
         id: this.service.session.id,
         battleType: this.service.session.battleType,
+        name,
         detailsSeen: true
       }
-      this.activeSessions.set(sourceKey, session)
+      await this.persistActiveSession(sourceKey, session)
     } else {
-      session.detailsSeen = true
+      session = { ...session, detailsSeen: true }
+      if (name) session.name = name
+      await this.persistActiveSession(sourceKey, session)
     }
-    if (name) session.name = name
   }
 
-  private ensureActiveSession(message: ApiLikeMessage, sourceKey: string): ActiveReplaySession {
-    const activeSession = this.activeSessions.get(sourceKey)
+  private async ensureActiveSession(message: ApiLikeMessage, sourceKey: string): Promise<ActiveReplaySession> {
+    const activeSession = await this.activeSessionFor(sourceKey)
     if (activeSession) return activeSession
     const timestamp = typeof message.timestamp === 'number' ? message.timestamp : Date.now()
     const recovered = {
@@ -209,13 +215,13 @@ export class ExperimentalReplayImporter {
       name: this.service.session.name,
       detailsSeen: false
     }
-    this.activeSessions.set(sourceKey, recovered)
+    await this.persistActiveSession(sourceKey, recovered)
     return recovered
   }
 
   private async queueHand(message: ApiLikeMessage, sourceKey: string): Promise<void> {
     if (!isPositiveHandId(message.HandId)) return
-    const session = this.ensureActiveSession(message, sourceKey)
+    const session = await this.ensureActiveSession(message, sourceKey)
     const now = Date.now()
     const existing = await this.db.experimentalReplayHands.get(message.HandId)
     if (existing?.status === 'complete') return
@@ -238,15 +244,54 @@ export class ExperimentalReplayImporter {
   }
 
   private async finishActiveSession(sourceKey: string, preferredPort?: chrome.runtime.Port): Promise<void> {
-    const session = this.activeSessions.get(sourceKey)
-    if (!session) return
-    const rows = await this.db.experimentalReplayHands.where('sessionKey').equals(session.key).toArray()
+    // Pending rows are the durable source of truth. Querying by source also
+    // recovers a session whose in-memory coordinator was lost in an MV3
+    // service-worker restart before its boundary arrived.
+    const rows = await this.db.experimentalReplayHands
+      .where('[status+sourceKey]')
+      .equals(['pending', sourceKey])
+      .toArray()
     const now = Date.now()
     await this.db.experimentalReplayHands.bulkPut(rows
-      .filter(row => row.status === 'pending')
       .map(row => ({ ...row, status: 'ready' as const, updatedAt: now })))
     this.activeSessions.delete(sourceKey)
-    await this.flushReady(preferredPort ?? this.connectedPortForSource(sourceKey))
+    await this.db.meta.delete(this.activeSessionMetaKey(sourceKey))
+    const connectedPort = preferredPort && this.ports.has(preferredPort) &&
+      this.sourceKeyForPort(preferredPort) === sourceKey
+      ? preferredPort
+      : this.connectedPortForSource(sourceKey)
+    await this.flushReady(connectedPort)
+  }
+
+  private activeSessionMetaKey(sourceKey: string): string {
+    return `${ACTIVE_REPLAY_SESSION_META_PREFIX}${sourceKey}`
+  }
+
+  private async activeSessionFor(sourceKey: string): Promise<ActiveReplaySession | undefined> {
+    const cached = this.activeSessions.get(sourceKey)
+    if (cached) return cached
+    const value = (await this.db.meta.get(this.activeSessionMetaKey(sourceKey)))?.value
+    if (typeof value !== 'object' || value === null) return undefined
+    const candidate = value as Partial<ActiveReplaySession>
+    if (typeof candidate.key !== 'string' || typeof candidate.detailsSeen !== 'boolean') return undefined
+    const session: ActiveReplaySession = {
+      key: candidate.key,
+      detailsSeen: candidate.detailsSeen,
+      ...(typeof candidate.id === 'string' ? { id: candidate.id } : {}),
+      ...(typeof candidate.battleType === 'number' ? { battleType: candidate.battleType } : {}),
+      ...(typeof candidate.name === 'string' ? { name: candidate.name } : {})
+    }
+    this.activeSessions.set(sourceKey, session)
+    return session
+  }
+
+  private async persistActiveSession(sourceKey: string, session: ActiveReplaySession): Promise<void> {
+    await this.db.meta.put({
+      id: this.activeSessionMetaKey(sourceKey),
+      value: session,
+      updatedAt: Date.now()
+    })
+    this.activeSessions.set(sourceKey, session)
   }
 
   private flushReady(preferredPort?: chrome.runtime.Port, excludedHandIds = new Set<number>()): Promise<void> {
@@ -304,6 +349,9 @@ export class ExperimentalReplayImporter {
 
     for (const result of message.results) {
       if (!expected.handIds.has(result.handId)) continue
+      // A successful item without a payload is not a success. Leave it unseen
+      // so the missing-result recovery below returns the durable row to ready.
+      if (result.ok && (!('detail' in result) || result.detail === undefined)) continue
       seenHandIds.add(result.handId)
       const row = await this.db.experimentalReplayHands.get(result.handId)
       if (!row || row.status === 'complete') continue

--- a/src/background/experimental-replay-import.ts
+++ b/src/background/experimental-replay-import.ts
@@ -17,6 +17,29 @@ type ApiLikeMessage = Record<string, unknown> & { ApiTypeId?: unknown, timestamp
 
 const ACTIVE_REPLAY_SESSION_META_PREFIX = 'experimentalReplayActiveSession:'
 
+/**
+ * 1行あたりの取得試行上限。
+ *
+ * ページ側は HTTP 401/408/429/5xx・例外送出（オフライン/CORS）・
+ * 認証エンベロープ未取得のすべてを `retryable: true` に分類し、結果が返らない
+ * ケースも `missing-result` として再試行対象になる。上限が無いと、拡張側が
+ * 自力で解消できない条件（アカウントが権限を失った、サーバーが恒久的に
+ * そのHandIdを拒否する）でも最大60秒間隔で永久に再試行し続ける。
+ *
+ * backoffは 1,2,4,8,16,32,60,60 秒なので、8回で約3分あきらめずに粘る。
+ * 上限到達後は `failed` として終端させ、`lastError` に理由を残す。
+ */
+const REPLAY_MAX_ATTEMPTS = 8
+
+/**
+ * 成功と同じApiTypeIdで返る参加申込エラー応答の判定。
+ * `event-ingestion.ts` の同名関数と同じ規則（変更時は両方を揃えること）。
+ */
+const isExplicitEntryFailure = (message: ApiLikeMessage): boolean => {
+  const code = (message as { Code?: unknown }).Code
+  return typeof code === 'number' && code !== 0
+}
+
 interface ActiveReplaySession {
   key: string
   id?: string
@@ -57,7 +80,7 @@ export class ExperimentalReplayImporter {
     this.ready = this.restoreEnabled()
     chrome.storage?.onChanged?.addListener((changes, areaName) => {
       const change = changes[EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY]
-      if (areaName !== 'local' || !change) return
+      if (areaName !== 'sync' || !change) return
       this.enabled = change.newValue === true
       if (this.enabled) this.flushReady().catch(this.logError('flush after enable'))
       else {
@@ -127,6 +150,14 @@ export class ExperimentalReplayImporter {
 
       switch (message.ApiTypeId) {
         case ApiType.EVT_ENTRY_QUEUED:
+          // 参加申込のエラー応答は成功と同じApiTypeIdで返る
+          // （docs/api-events.md「成功イベントと同じApiTypeIdを使うエラー応答」）。
+          // これをセッション境界として扱うと、進行中セッションのpending行を
+          // 一括でreadyへ昇格させ、対局中にHTTP取得を解放してしまう。
+          // event-ingestion.ts の isExplicitEntryFailure() と
+          // content_script.ts のキープアライブ判定は同じ201を除外しており、
+          // ここだけが外れていた。
+          if (isExplicitEntryFailure(message)) break
           await this.startSession(message, sourceKey, preferredPort)
           break
         case ApiType.EVT_HAND_RESULTS:
@@ -158,7 +189,9 @@ export class ExperimentalReplayImporter {
 
   private async restoreEnabled(): Promise<void> {
     try {
-      const stored = await chrome.storage.local.get(EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY)
+      // content script と同じ領域を読む必要がある（storage.local は
+      // content script から遮断されている。content_script.ts のコメント参照）。
+      const stored = await chrome.storage.sync.get(EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY)
       this.enabled = stored[EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY] === true
     } catch (error) {
       console.warn('[experimental-replay] Failed to read feature flag; keeping disabled:', error)
@@ -385,13 +418,17 @@ export class ExperimentalReplayImporter {
         })
       } else {
         failedHandIds.add(result.handId)
-        if (result.retryable) retryableHandIds.add(result.handId)
+        const exhausted = row.attempts >= REPLAY_MAX_ATTEMPTS
+        const retry = result.retryable && !exhausted
+        if (retry) retryableHandIds.add(result.handId)
         else terminalFailureHandIds.add(result.handId)
         await this.db.experimentalReplayHands.put({
           ...row,
-          status: result.retryable ? 'ready' : 'failed',
+          status: retry ? 'ready' : 'failed',
           updatedAt: now,
-          lastError: result.error
+          lastError: exhausted && result.retryable
+            ? `${result.error} (gave up after ${row.attempts} attempts)`
+            : result.error
         })
       }
     }
@@ -400,12 +437,16 @@ export class ExperimentalReplayImporter {
       const row = await this.db.experimentalReplayHands.get(handId)
       if (!row || row.status === 'complete') continue
       failedHandIds.add(handId)
-      retryableHandIds.add(handId)
+      const exhausted = row.attempts >= REPLAY_MAX_ATTEMPTS
+      if (exhausted) terminalFailureHandIds.add(handId)
+      else retryableHandIds.add(handId)
       await this.db.experimentalReplayHands.put({
         ...row,
-        status: 'ready',
+        status: exhausted ? 'failed' : 'ready',
         updatedAt: now,
-        lastError: 'missing-result'
+        lastError: exhausted
+          ? `missing-result (gave up after ${row.attempts} attempts)`
+          : 'missing-result'
       })
     }
     // Continue draining sessions larger than one batch, but do not create a

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -102,7 +102,13 @@ export const clearImportSession = (releaseOperation = true): void => {
  * `service`/`db`/`gameUrlPattern`をクロージャで捕捉し、message-router.tsから
  * 呼び出せる関数群を返す。
  */
-export const createImportExportHandlers = (service: PokerChaseService, db: PokerChaseDB, gameUrlPattern: string) => {
+export const createImportExportHandlers = (
+  service: PokerChaseService,
+  db: PokerChaseDB,
+  gameUrlPattern: string,
+  prepareExperimentalReplayDeletion?: () => Promise<void>,
+  resumeExperimentalReplayAfterDeleteFailure?: () => void
+) => {
   const exportData = async (format: string) => {
     if (format === 'json') {
       await exportJsonData(db)
@@ -746,6 +752,10 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
     // Keep the slot claimed until runtime.reload() replaces this worker.
     setOperationState({ type: 'delete' })
     try {
+      // Stop retry timers and drain replay writes that were accepted before
+      // the synchronous operation-state claim above.
+      await prepareExperimentalReplayDeletion?.()
+
       // Events already queued before the synchronous claim above must finish
       // first. event-ingestion rejects later arrivals while type=delete, so
       // once this drain stabilizes nothing can recreate the database between
@@ -773,6 +783,7 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
       chrome.runtime.reload()
     } catch (error) {
       console.error('Error deleting data:', error)
+      resumeExperimentalReplayAfterDeleteFailure?.()
       setOperationState({ type: 'idle' })
       throw error
     }

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -17,6 +17,7 @@ import { resolveAdvisory } from './rebuild-advisory'
 import { getUndecodedEventStats, resetUndecodedEventStats } from './undecoded-event-tracker'
 import { applyUpdateNow } from './update-manager'
 import { acknowledgeWhatsNew } from './whats-new-badge'
+import type { ExperimentalReplayImporter } from './experimental-replay-import'
 import {
   HAND_LOG_LAYOUT_STORAGE_KEY,
   HUD_POSITION_STORAGE_KEYS,
@@ -106,8 +107,19 @@ const publishImportResult = async (
  * データエクスポート機能
  * `chrome.runtime.onMessage`のディスパッチを登録する。
  */
-export const registerMessageRouter = (service: PokerChaseService, db: PokerChaseDB, gameUrlPattern: string): void => {
-  const { exportData, importData, deleteAllData, getLatestSessionStats, rebuildAllData } = createImportExportHandlers(service, db, gameUrlPattern)
+export const registerMessageRouter = (
+  service: PokerChaseService,
+  db: PokerChaseDB,
+  gameUrlPattern: string,
+  experimentalReplayImporter?: ExperimentalReplayImporter
+): void => {
+  const { exportData, importData, deleteAllData, getLatestSessionStats, rebuildAllData } = createImportExportHandlers(
+    service,
+    db,
+    gameUrlPattern,
+    experimentalReplayImporter ? () => experimentalReplayImporter.prepareForDataDeletion() : undefined,
+    experimentalReplayImporter ? () => experimentalReplayImporter.resumeAfterDataDeletionFailure() : undefined
+  )
   let deviceScaleWriteGeneration = 0
   let handLogLayoutWriteGeneration = 0
   let pendingHandLogLayoutWriteCount = 0

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -66,7 +66,12 @@ const flushPendingReplayRequests = () => {
   for (const message of pendingReplayRequests.splice(0)) postReplayRequest(message)
 }
 
-chrome.storage.local.get(EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY).then(stored => {
+// storage.local ではなく storage.sync に置く。localは
+// firebase-auth-service が起動時に setAccessLevel('TRUSTED_CONTEXTS') で
+// content script から遮断しており（#274、e2e/scenarios/auth-storage-access.ts
+// が実ブラウザでassert済み）、ここからの get は必ず reject される。
+// onChanged も同じゲートで untrusted context には配送されない。
+chrome.storage.sync.get(EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY).then(stored => {
   replayImportEnabled = stored[EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY] === true
   postReplayConfig()
   flushPendingReplayRequests()
@@ -74,7 +79,7 @@ chrome.storage.local.get(EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY).then(stored => 
 
 chrome.storage.onChanged.addListener((changes, areaName) => {
   const change = changes[EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY]
-  if (areaName !== 'local' || !change) return
+  if (areaName !== 'sync' || !change) return
   replayImportEnabled = change.newValue === true
   postReplayConfig()
   if (replayImportEnabled) flushPendingReplayRequests()

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -21,6 +21,18 @@ import type { AllPlayersRealTimeStats } from './realtime-stats/realtime-stats-se
 import { setPendingStats } from './utils/pending-stats-cache'
 import { RuntimePortManager } from './utils/runtime-port-manager'
 import { captureHandledException, initSentry } from './observability/sentry'
+import {
+  EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY,
+  REPLAY_BRIDGE_CONFIG,
+  REPLAY_BRIDGE_FETCH,
+  REPLAY_BRIDGE_RESULT,
+  REPLAY_FETCH_BATCH_LIMIT,
+  REPLAY_PORT_FETCH,
+  REPLAY_PORT_RESULT,
+  isPositiveHandId,
+  type ReplayFetchRequest,
+  type ReplayFetchResult
+} from './replay/protocol'
 /** !!! BACKGROUND、WEB_ACCESSIBLE_RESOURCES からインポートしないこと !!! */
 
 initSentry('content_script')
@@ -32,6 +44,42 @@ const KEEPALIVE_INTERVAL_MS = 25000 // 25秒（30秒タイムアウトより少�
 // ゲーム状態の管理
 let isGameActive = false
 let keepaliveTimer: ReturnType<typeof setInterval> | null = null
+let replayBridgeReady = false
+let replayImportEnabled = false
+const pendingReplayRequests: ReplayFetchRequest[] = []
+
+const postReplayConfig = () => {
+  if (!replayBridgeReady) return
+  window.postMessage({ type: REPLAY_BRIDGE_CONFIG, enabled: replayImportEnabled }, POKER_CHASE_ORIGIN)
+}
+
+const postReplayRequest = (message: ReplayFetchRequest) => {
+  if (!replayBridgeReady || !replayImportEnabled) {
+    pendingReplayRequests.push(message)
+    return
+  }
+  window.postMessage({ ...message, type: REPLAY_BRIDGE_FETCH }, POKER_CHASE_ORIGIN)
+}
+
+const flushPendingReplayRequests = () => {
+  if (!replayBridgeReady || !replayImportEnabled) return
+  for (const message of pendingReplayRequests.splice(0)) postReplayRequest(message)
+}
+
+chrome.storage.local.get(EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY).then(stored => {
+  replayImportEnabled = stored[EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY] === true
+  postReplayConfig()
+  flushPendingReplayRequests()
+}).catch(() => undefined)
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+  const change = changes[EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY]
+  if (areaName !== 'local' || !change) return
+  replayImportEnabled = change.newValue === true
+  postReplayConfig()
+  if (replayImportEnabled) flushPendingReplayRequests()
+  else pendingReplayRequests.splice(0)
+})
 
 export interface StatsData {
   stats: PlayerStats[]
@@ -83,6 +131,15 @@ const portManager = new RuntimePortManager({
   },
   onDisconnected: stopKeepalive,
   onMessage: message => {
+    if (typeof message === 'object' && message !== null &&
+      'type' in message && message.type === REPLAY_PORT_FETCH) {
+      const request = message as Partial<ReplayFetchRequest>
+      if (typeof request.requestId === 'string' && Array.isArray(request.handIds) &&
+        request.handIds.length <= REPLAY_FETCH_BATCH_LIMIT && request.handIds.every(isPositiveHandId)) {
+        postReplayRequest(request as ReplayFetchRequest)
+      }
+      return
+    }
     if (typeof message === 'object' && message !== null && 'stats' in message) {
       const statsMessage = message as {
         stats: PlayerStats[]
@@ -135,6 +192,17 @@ window.addEventListener('message', (event: MessageEvent<unknown>) => {
   ) {
     if (!portManager.send(event.data.payload)) {
       stopKeepalive()
+    }
+    return
+  }
+
+  // The main-world bridge removes transport credentials before this message
+  // crosses into the extension's isolated world.
+  if ('type' in event.data && event.data.type === REPLAY_BRIDGE_RESULT) {
+    const result = event.data as Partial<ReplayFetchResult>
+    if (typeof result.requestId === 'string' && Array.isArray(result.results) &&
+      result.results.length <= REPLAY_FETCH_BATCH_LIMIT) {
+      portManager.send({ ...result, type: REPLAY_PORT_RESULT })
     }
     return
   }
@@ -427,6 +495,11 @@ const injectWebSocketHook = () => {
   const script = document.createElement('script')
   script.type = 'text/javascript'
   script.src = chrome.runtime.getURL(firstResource.resources[0])
+  script.addEventListener('load', () => {
+    replayBridgeReady = true
+    postReplayConfig()
+    flushPendingReplayRequests()
+  })
   document.body?.appendChild(script)
 }
 injectWebSocketHook()

--- a/src/db/poker-chase-db.test.ts
+++ b/src/db/poker-chase-db.test.ts
@@ -28,8 +28,8 @@ describe('PokerChaseDB Raw Event Lake', () => {
     await db.delete()
   })
 
-  it('uses database version 6 for the staged primary-key migration', () => {
-    expect(db.verno).toBe(6)
+  it('uses database version 7 after adding the experimental replay store', () => {
+    expect(db.verno).toBe(7)
   })
 
   it('stores and reads back a known non-application event (202) unfiltered', async () => {
@@ -77,7 +77,7 @@ describe('PokerChaseDB Raw Event Lake', () => {
   })
 })
 
-describe('PokerChaseDB v3 -> v6 apiEvents sequence-key migration', () => {
+describe('PokerChaseDB v3 -> v7 apiEvents sequence-key migration', () => {
   afterEach(async () => {
     const cleanup = new PokerChaseDB(indexedDB, IDBKeyRange)
     await cleanup.delete()
@@ -107,7 +107,7 @@ describe('PokerChaseDB v3 -> v6 apiEvents sequence-key migration', () => {
     const migrated = new PokerChaseDB(indexedDB, IDBKeyRange)
     await migrated.open()
 
-    expect(migrated.verno).toBe(6)
+    expect(migrated.verno).toBe(7)
     const stored = await migrated.apiEvents.orderBy(API_EVENT_PRIMARY_KEY).toArray() as any[]
     expect(stored).toEqual(oldRows.map(row => ({ ...row, sequence: 0 })))
 

--- a/src/db/poker-chase-db.ts
+++ b/src/db/poker-chase-db.ts
@@ -148,7 +148,7 @@ export class PokerChaseDB extends Dexie {
       phases: '[handId+phase],handId,*seatUserIds,phase',
       actions: '[handId+index],handId,playerId,phase,actionType,*actionDetails,[playerId+phase],[playerId+actionType]',
       meta: 'id,updatedAt',
-      experimentalReplayHands: 'handId,sessionKey,sessionId,status,[status+sessionKey],queuedAt,updatedAt'
+      experimentalReplayHands: 'handId,sourceKey,sessionKey,sessionId,status,[status+sourceKey],[status+sessionKey],queuedAt,updatedAt'
     })
 
     // Backward-compatible default for existing internal/test callers that

--- a/src/db/poker-chase-db.ts
+++ b/src/db/poker-chase-db.ts
@@ -7,6 +7,7 @@ import type {
   MetaRecord
 } from '../types'
 import { API_EVENT_PRIMARY_KEY } from '../utils/api-event-key'
+import type { ExperimentalReplayRecord } from '../replay/protocol'
 
 const API_EVENT_MIGRATION_TABLE = '_apiEventsSequenceMigration'
 const API_EVENT_MIGRATION_CHUNK_SIZE = 5000
@@ -37,6 +38,7 @@ export class PokerChaseDB extends Dexie {
   phases!: Table<Phase, number>
   actions!: Table<Action, number>
   meta!: Table<MetaRecord, string>
+  experimentalReplayHands!: Table<ExperimentalReplayRecord, number>
   constructor(indexedDB: IDBFactory, iDBKeyRange: typeof IDBKeyRange) {
     super('PokerChaseDB', { indexedDB, IDBKeyRange: iDBKeyRange })
     this.version(1).stores({
@@ -135,6 +137,18 @@ export class PokerChaseDB extends Dexie {
         const last = stagedRows[stagedRows.length - 1]!
         cursor = [last.timestamp, last.ApiTypeId, last.sequence]
       }
+    })
+
+    // Experimental, opt-in session-end replay capture. This store is kept
+    // separate from the derived hands/actions tables until replay semantics
+    // have been validated against enough live sessions.
+    this.version(7).stores({
+      apiEvents: `${API_EVENT_PRIMARY_KEY},timestamp,ApiTypeId,[timestamp+ApiTypeId],[ApiTypeId+timestamp]`,
+      hands: 'id,*seatUserIds,*winningPlayerIds,approxTimestamp',
+      phases: '[handId+phase],handId,*seatUserIds,phase',
+      actions: '[handId+index],handId,playerId,phase,actionType,*actionDetails,[playerId+phase],[playerId+actionType]',
+      meta: 'id,updatedAt',
+      experimentalReplayHands: 'handId,sessionKey,sessionId,status,[status+sessionKey],queuedAt,updatedAt'
     })
 
     // Backward-compatible default for existing internal/test callers that

--- a/src/replay/protocol.test.ts
+++ b/src/replay/protocol.test.ts
@@ -1,0 +1,16 @@
+import { sanitizeReplayDetail } from './protocol'
+
+describe('sanitizeReplayDetail', () => {
+  test('removes transport credentials recursively without changing replay data', () => {
+    expect(sanitizeReplayDetail({
+      Code: 0,
+      session: 'secret',
+      param: { HandId: 123, requestKey: 'uuid' },
+      Replay: { Players: [{ UserId: 1, HoleCardList: [10, 20] }] }
+    })).toEqual({
+      Code: 0,
+      param: { HandId: 123 },
+      Replay: { Players: [{ UserId: 1, HoleCardList: [10, 20] }] }
+    })
+  })
+})

--- a/src/replay/protocol.ts
+++ b/src/replay/protocol.ts
@@ -1,0 +1,77 @@
+import type { BattleType } from '../types/game'
+
+export const EXPERIMENTAL_REPLAY_IMPORT_STORAGE_KEY = 'experimentalReplayImportEnabled'
+export const REPLAY_DETAIL_URL = 'https://production.api-poker-chase.com/replay/detail'
+export const REPLAY_API_ORIGIN = 'https://production.api-poker-chase.com'
+
+export const REPLAY_BRIDGE_CONFIG = 'pokerchase-hud:replay-config'
+export const REPLAY_BRIDGE_FETCH = 'pokerchase-hud:replay-fetch'
+export const REPLAY_BRIDGE_RESULT = 'pokerchase-hud:replay-result'
+export const REPLAY_PORT_FETCH = 'experimental-replay-fetch'
+export const REPLAY_PORT_RESULT = 'experimental-replay-result'
+
+export const REPLAY_FETCH_BATCH_LIMIT = 100
+
+export interface ReplayBridgeConfigMessage {
+  type: typeof REPLAY_BRIDGE_CONFIG
+  enabled: boolean
+}
+
+export interface ReplayFetchRequest {
+  type: typeof REPLAY_BRIDGE_FETCH | typeof REPLAY_PORT_FETCH
+  requestId: string
+  handIds: number[]
+}
+
+export type ReplayFetchItemResult =
+  | { handId: number, ok: true, detail: unknown }
+  | { handId: number, ok: false, error: string, retryable: boolean }
+
+export interface ReplayFetchResult {
+  type: typeof REPLAY_BRIDGE_RESULT | typeof REPLAY_PORT_RESULT
+  requestId: string
+  results: ReplayFetchItemResult[]
+}
+
+export type ExperimentalReplayStatus = 'pending' | 'ready' | 'complete' | 'failed'
+
+export interface ExperimentalReplayRecord {
+  handId: number
+  sessionKey: string
+  sessionId?: string
+  battleType?: BattleType
+  sessionName?: string
+  status: ExperimentalReplayStatus
+  queuedAt: number
+  updatedAt: number
+  attempts: number
+  lastAttemptAt?: number
+  capturedAt?: number
+  lastError?: string
+  detail?: unknown
+}
+
+export const isPositiveHandId = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isSafeInteger(value) && value > 0
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> => {
+  if (typeof value !== 'object' || value === null) return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+/** Remove transport credentials before a replay response crosses into the extension. */
+export const sanitizeReplayDetail = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(sanitizeReplayDetail)
+  if (!isPlainRecord(value)) return value
+
+  const sanitized: Record<string, unknown> = {}
+  for (const [key, child] of Object.entries(value)) {
+    if (key === 'session' || key === 'requestKey') continue
+    sanitized[key] = sanitizeReplayDetail(child)
+  }
+  return sanitized
+}
+
+export const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)

--- a/src/replay/protocol.ts
+++ b/src/replay/protocol.ts
@@ -37,6 +37,7 @@ export type ExperimentalReplayStatus = 'pending' | 'ready' | 'complete' | 'faile
 
 export interface ExperimentalReplayRecord {
   handId: number
+  sourceKey: string
   sessionKey: string
   sessionId?: string
   battleType?: BattleType

--- a/src/web_accessible_resource.replay.test.ts
+++ b/src/web_accessible_resource.replay.test.ts
@@ -43,12 +43,8 @@ describe('main-world experimental replay bridge', () => {
       require('./web_accessible_resource')
     })
 
-    window.dispatchEvent(new MessageEvent('message', {
-      source: window,
-      origin: POKER_CHASE_ORIGIN,
-      data: { type: REPLAY_BRIDGE_CONFIG, enabled: true }
-    }))
-
+    // Unity can issue its first API request before the content script's
+    // asynchronous storage lookup supplies the initial enabled config.
     const xhr = new XMLHttpRequest()
     xhr.open('POST', 'https://production.api-poker-chase.com/user/status')
     xhr.send(encode({
@@ -61,6 +57,12 @@ describe('main-world experimental replay bridge', () => {
       requestKey: 'original-key'
     }))
     await Promise.resolve()
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: window,
+      origin: POKER_CHASE_ORIGIN,
+      data: { type: REPLAY_BRIDGE_CONFIG, enabled: true }
+    }))
 
     window.dispatchEvent(new MessageEvent('message', {
       source: window,

--- a/src/web_accessible_resource.replay.test.ts
+++ b/src/web_accessible_resource.replay.test.ts
@@ -1,0 +1,100 @@
+import { TextDecoder, TextEncoder } from 'util'
+import { POKER_CHASE_ORIGIN } from './constants/runtime'
+import {
+  REPLAY_BRIDGE_CONFIG,
+  REPLAY_BRIDGE_FETCH,
+  REPLAY_BRIDGE_RESULT,
+  REPLAY_DETAIL_URL
+} from './replay/protocol'
+
+Object.assign(global, { TextEncoder, TextDecoder })
+const { decode, encode } = require('@msgpack/msgpack') as typeof import('@msgpack/msgpack')
+
+const arrayBufferOf = (value: unknown): ArrayBuffer => {
+  const bytes = encode(value)
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer
+}
+
+describe('main-world experimental replay bridge', () => {
+  test('captures a Unity XHR envelope, builds sequential detail requests, and strips credentials', async () => {
+    class FakeWebSocket {
+      addEventListener = jest.fn()
+    }
+    ;(window as any).WebSocket = FakeWebSocket
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      arrayBuffer: jest.fn().mockResolvedValue(arrayBufferOf({
+        Code: 0,
+        session: 'rotated-secret',
+        Replay: { HandId: 777, HoleCardList: [1, 2] }
+      }))
+    })
+    ;(window as any).fetch = fetchMock
+
+    const originalOpen = XMLHttpRequest.prototype.open
+    const originalSend = XMLHttpRequest.prototype.send
+    XMLHttpRequest.prototype.open = jest.fn() as any
+    XMLHttpRequest.prototype.send = jest.fn() as any
+    const postMessageSpy = jest.spyOn(window, 'postMessage')
+
+    jest.isolateModules(() => {
+      require('./web_accessible_resource')
+    })
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: window,
+      origin: POKER_CHASE_ORIGIN,
+      data: { type: REPLAY_BRIDGE_CONFIG, enabled: true }
+    }))
+
+    const xhr = new XMLHttpRequest()
+    xhr.open('POST', 'https://production.api-poker-chase.com/user/status')
+    xhr.send(encode({
+      param: {},
+      session: 'page-only-secret',
+      platform: 2,
+      appVer: '2.05',
+      dataVer: '2_05_0_test',
+      masterVer: 'master-test',
+      requestKey: 'original-key'
+    }))
+    await Promise.resolve()
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: window,
+      origin: POKER_CHASE_ORIGIN,
+      data: { type: REPLAY_BRIDGE_FETCH, requestId: 'request-1', handIds: [777] }
+    }))
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toBe(REPLAY_DETAIL_URL)
+    const request = decode(fetchMock.mock.calls[0][1].body) as Record<string, unknown>
+    expect(request).toEqual(expect.objectContaining({
+      param: { HandId: 777 },
+      session: 'page-only-secret',
+      platform: 2,
+      appVer: '2.05',
+      dataVer: '2_05_0_test',
+      masterVer: 'master-test'
+    }))
+    expect(request.requestKey).toEqual(expect.any(String))
+
+    expect(postMessageSpy).toHaveBeenCalledWith({
+      type: REPLAY_BRIDGE_RESULT,
+      requestId: 'request-1',
+      results: [{
+        handId: 777,
+        ok: true,
+        detail: { Code: 0, Replay: { HandId: 777, HoleCardList: [1, 2] } }
+      }]
+    }, POKER_CHASE_ORIGIN)
+    expect(JSON.stringify(postMessageSpy.mock.calls)).not.toContain('page-only-secret')
+    expect(JSON.stringify(postMessageSpy.mock.calls)).not.toContain('rotated-secret')
+
+    XMLHttpRequest.prototype.open = originalOpen
+    XMLHttpRequest.prototype.send = originalSend
+  })
+})

--- a/src/web_accessible_resource.ts
+++ b/src/web_accessible_resource.ts
@@ -468,15 +468,26 @@ XMLHttpRequest.prototype.send = function (body?: Document | XMLHttpRequestBodyIn
   OriginalXhrSend.call(this, body)
 }
 
+/**
+ * 1件あたりの上限。これが無いと、応答が返らない1件で
+ * `replayFetchQueue`（逐次）が止まり、背景側の`inFlight`にも有効期限が無いため
+ * 該当handIdが永久に再ディスパッチされなくなる ―― バッチ全体ではなく
+ * 取り込み機能そのものが恒久停止する。
+ */
+const REPLAY_FETCH_TIMEOUT_MS = 15000
+
 const fetchReplayDetail = async (handId: number): Promise<ReplayFetchItemResult> => {
   if (!OriginalFetch) return { handId, ok: false, error: 'fetch-unavailable', retryable: false }
   const auth = replayAuth
   if (!auth) return { handId, ok: false, error: 'auth-envelope-unavailable', retryable: true }
 
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), REPLAY_FETCH_TIMEOUT_MS)
   try {
     const response = await OriginalFetch(REPLAY_DETAIL_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/msgpack' },
+      signal: controller.signal,
       body: encode({
         param: { HandId: handId },
         ...auth,
@@ -499,7 +510,10 @@ const fetchReplayDetail = async (handId: number): Promise<ReplayFetchItemResult>
     }
     return { handId, ok: true, detail: sanitizeReplayDetail(decoded) }
   } catch (error) {
+    // AbortErrorは上限到達。再試行可能として返し、backoffに委ねる。
     return { handId, ok: false, error: errorMessage(error), retryable: true }
+  } finally {
+    clearTimeout(timer)
   }
 }
 

--- a/src/web_accessible_resource.ts
+++ b/src/web_accessible_resource.ts
@@ -3,11 +3,25 @@
  * @see https://developer.chrome.com/docs/extensions/reference/manifest/web-accessible-resources?hl=ja
  * @see https://developer.mozilla.org/ja/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources
  */
-import { decode } from '@msgpack/msgpack'
+import { decode, encode } from '@msgpack/msgpack'
 import {
   POKER_CHASE_INVALID_API_EVENT,
   POKER_CHASE_ORIGIN
 } from './constants/runtime'
+import {
+  REPLAY_API_ORIGIN,
+  REPLAY_BRIDGE_CONFIG,
+  REPLAY_BRIDGE_FETCH,
+  REPLAY_BRIDGE_RESULT,
+  REPLAY_DETAIL_URL,
+  REPLAY_FETCH_BATCH_LIMIT,
+  errorMessage,
+  isPositiveHandId,
+  sanitizeReplayDetail,
+  type ReplayBridgeConfigMessage,
+  type ReplayFetchItemResult,
+  type ReplayFetchRequest
+} from './replay/protocol'
 /** !!! BACKGROUND、CONTENT_SCRIPTSからインポートしないこと !!! */
 
 const OriginalWebSocket = window.WebSocket
@@ -303,3 +317,205 @@ function createWebSocket(...args: ConstructorParameters<typeof WebSocket>): WebS
 }
 
 window.WebSocket = createWebSocket as unknown as typeof WebSocket
+
+interface ReplayAuthEnvelope {
+  session: string
+  platform: number
+  appVer: string
+  dataVer: string
+  masterVer: string
+}
+
+const OriginalFetch = window.fetch.bind(window)
+let replayImportEnabled = false
+let replayAuth: ReplayAuthEnvelope | undefined
+let replayFetchQueue: Promise<void> = Promise.resolve()
+
+const requestUrl = (input: RequestInfo | URL): URL | undefined => {
+  try {
+    return new URL(input instanceof Request ? input.url : String(input), window.location.href)
+  } catch {
+    return undefined
+  }
+}
+
+const decodeBody = async (body: BodyInit | null | undefined): Promise<unknown> => {
+  if (body instanceof ArrayBuffer) return decode(new Uint8Array(body))
+  if (ArrayBuffer.isView(body)) return decode(new Uint8Array(body.buffer, body.byteOffset, body.byteLength))
+  if (body instanceof Blob) return decode(new Uint8Array(await body.arrayBuffer()))
+  return undefined
+}
+
+const decodeRequestBody = async (input: RequestInfo | URL, init?: RequestInit): Promise<unknown> => {
+  if (init?.body != null) return decodeBody(init.body)
+  if (input instanceof Request) return decode(new Uint8Array(await input.clone().arrayBuffer()))
+  return undefined
+}
+
+const readAuthEnvelope = (value: unknown): ReplayAuthEnvelope | undefined => {
+  if (typeof value !== 'object' || value === null) return undefined
+  const record = value as Record<string, unknown>
+  if (
+    typeof record.session !== 'string' ||
+    typeof record.platform !== 'number' ||
+    typeof record.appVer !== 'string' ||
+    typeof record.dataVer !== 'string' ||
+    typeof record.masterVer !== 'string'
+  ) return undefined
+  return {
+    session: record.session,
+    platform: record.platform,
+    appVer: record.appVer,
+    dataVer: record.dataVer,
+    masterVer: record.masterVer
+  }
+}
+
+const refreshSessionFromResponse = async (response: Response): Promise<void> => {
+  try {
+    const decoded = decode(new Uint8Array(await response.clone().arrayBuffer()))
+    if (typeof decoded === 'object' && decoded !== null &&
+      'session' in decoded && typeof decoded.session === 'string' && replayAuth) {
+      replayAuth = { ...replayAuth, session: decoded.session }
+    }
+  } catch {
+    // Many API responses are not MessagePack. They are irrelevant here.
+  }
+}
+
+// Capture the same version/session envelope PokerChase itself supplies. The
+// envelope remains inside the page's main-world closure and is never posted to
+// the extension context or IndexedDB.
+window.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const url = requestUrl(input)
+  if (!replayImportEnabled || url?.origin !== REPLAY_API_ORIGIN) {
+    return OriginalFetch(input, init)
+  }
+
+  try {
+    replayAuth = readAuthEnvelope(await decodeRequestBody(input, init)) ?? replayAuth
+  } catch {
+    // A request without a MessagePack body is unrelated to replay auth.
+  }
+  const response = await OriginalFetch(input, init)
+  refreshSessionFromResponse(response).catch(() => undefined)
+  return response
+}) as typeof window.fetch
+
+// Unity WebGL may use XMLHttpRequest rather than fetch for the same API
+// calls. Mirror the envelope observation there; requests themselves still go
+// through the original browser implementation unchanged.
+const xhrUrls = new WeakMap<XMLHttpRequest, URL>()
+const OriginalXhrOpen = XMLHttpRequest.prototype.open
+const OriginalXhrSend = XMLHttpRequest.prototype.send
+
+XMLHttpRequest.prototype.open = function (
+  method: string,
+  url: string | URL,
+  async: boolean = true,
+  username?: string | null,
+  password?: string | null
+): void {
+  try {
+    xhrUrls.set(this, new URL(String(url), window.location.href))
+  } catch {
+    xhrUrls.delete(this)
+  }
+  OriginalXhrOpen.call(this, method, String(url), async, username ?? null, password ?? null)
+}
+
+const refreshSessionFromXhr = async (xhr: XMLHttpRequest): Promise<void> => {
+  try {
+    const response = xhr.response
+    let decoded: unknown
+    if (response instanceof ArrayBuffer) decoded = decode(new Uint8Array(response))
+    else if (ArrayBuffer.isView(response)) decoded = decode(new Uint8Array(response.buffer, response.byteOffset, response.byteLength))
+    else if (response instanceof Blob) decoded = decode(new Uint8Array(await response.arrayBuffer()))
+    if (typeof decoded === 'object' && decoded !== null &&
+      'session' in decoded && typeof decoded.session === 'string' && replayAuth) {
+      replayAuth = { ...replayAuth, session: decoded.session }
+    }
+  } catch {
+    // Non-MessagePack XHR responses are unrelated to replay auth.
+  }
+}
+
+XMLHttpRequest.prototype.send = function (body?: Document | XMLHttpRequestBodyInit | null): void {
+  const url = xhrUrls.get(this)
+  if (replayImportEnabled && url?.origin === REPLAY_API_ORIGIN) {
+    if (!(body instanceof Document)) {
+      decodeBody(body)
+        .then(decoded => { replayAuth = readAuthEnvelope(decoded) ?? replayAuth })
+        .catch(() => undefined)
+    }
+    this.addEventListener('loadend', () => {
+      refreshSessionFromXhr(this).catch(() => undefined)
+    }, { once: true })
+  }
+  OriginalXhrSend.call(this, body)
+}
+
+const fetchReplayDetail = async (handId: number): Promise<ReplayFetchItemResult> => {
+  const auth = replayAuth
+  if (!auth) return { handId, ok: false, error: 'auth-envelope-unavailable', retryable: true }
+
+  try {
+    const response = await OriginalFetch(REPLAY_DETAIL_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/msgpack' },
+      body: encode({
+        param: { HandId: handId },
+        ...auth,
+        requestKey: crypto.randomUUID()
+      })
+    })
+    const responseBytes = new Uint8Array(await response.arrayBuffer())
+    if (!response.ok) {
+      const retryable = response.status === 401 || response.status === 408 || response.status === 429 || response.status >= 500
+      return { handId, ok: false, error: `HTTP ${response.status}`, retryable }
+    }
+    const decoded = decode(responseBytes)
+    if (typeof decoded === 'object' && decoded !== null &&
+      'session' in decoded && typeof decoded.session === 'string') {
+      replayAuth = { ...auth, session: decoded.session }
+    }
+    if (typeof decoded === 'object' && decoded !== null &&
+      'Code' in decoded && typeof decoded.Code === 'number' && decoded.Code !== 0) {
+      return { handId, ok: false, error: `API Code ${decoded.Code}`, retryable: false }
+    }
+    return { handId, ok: true, detail: sanitizeReplayDetail(decoded) }
+  } catch (error) {
+    return { handId, ok: false, error: errorMessage(error), retryable: true }
+  }
+}
+
+const handleReplayFetch = async (message: ReplayFetchRequest): Promise<void> => {
+  const handIds = message.handIds
+    .filter(isPositiveHandId)
+    .slice(0, REPLAY_FETCH_BATCH_LIMIT)
+  const results: ReplayFetchItemResult[] = []
+  for (const handId of handIds) results.push(await fetchReplayDetail(handId))
+  window.postMessage({
+    type: REPLAY_BRIDGE_RESULT,
+    requestId: message.requestId,
+    results
+  }, POKER_CHASE_ORIGIN)
+}
+
+window.addEventListener('message', (event: MessageEvent<unknown>) => {
+  if (event.source !== window || event.origin !== POKER_CHASE_ORIGIN ||
+    typeof event.data !== 'object' || event.data === null || !('type' in event.data)) return
+
+  if (event.data.type === REPLAY_BRIDGE_CONFIG) {
+    const message = event.data as ReplayBridgeConfigMessage
+    replayImportEnabled = message.enabled === true
+    if (!replayImportEnabled) replayAuth = undefined
+    return
+  }
+  if (event.data.type !== REPLAY_BRIDGE_FETCH || !replayImportEnabled) return
+  const message = event.data as Partial<ReplayFetchRequest>
+  if (typeof message.requestId !== 'string' || !Array.isArray(message.handIds)) return
+  replayFetchQueue = replayFetchQueue
+    .then(() => handleReplayFetch(message as ReplayFetchRequest))
+    .catch(error => console.warn('[experimental-replay] Replay fetch batch failed:', error))
+})

--- a/src/web_accessible_resource.ts
+++ b/src/web_accessible_resource.ts
@@ -328,6 +328,7 @@ interface ReplayAuthEnvelope {
 
 const OriginalFetch = window.fetch.bind(window)
 let replayImportEnabled = false
+let replayConfigReceived = false
 let replayAuth: ReplayAuthEnvelope | undefined
 let replayFetchQueue: Promise<void> = Promise.resolve()
 
@@ -388,7 +389,7 @@ const refreshSessionFromResponse = async (response: Response): Promise<void> => 
 // the extension context or IndexedDB.
 window.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
   const url = requestUrl(input)
-  if (!replayImportEnabled || url?.origin !== REPLAY_API_ORIGIN) {
+  if (url?.origin !== REPLAY_API_ORIGIN || (replayConfigReceived && !replayImportEnabled)) {
     return OriginalFetch(input, init)
   }
 
@@ -442,7 +443,7 @@ const refreshSessionFromXhr = async (xhr: XMLHttpRequest): Promise<void> => {
 
 XMLHttpRequest.prototype.send = function (body?: Document | XMLHttpRequestBodyInit | null): void {
   const url = xhrUrls.get(this)
-  if (replayImportEnabled && url?.origin === REPLAY_API_ORIGIN) {
+  if (url?.origin === REPLAY_API_ORIGIN && (!replayConfigReceived || replayImportEnabled)) {
     if (!(body instanceof Document)) {
       decodeBody(body)
         .then(decoded => { replayAuth = readAuthEnvelope(decoded) ?? replayAuth })
@@ -508,6 +509,7 @@ window.addEventListener('message', (event: MessageEvent<unknown>) => {
 
   if (event.data.type === REPLAY_BRIDGE_CONFIG) {
     const message = event.data as ReplayBridgeConfigMessage
+    replayConfigReceived = true
     replayImportEnabled = message.enabled === true
     if (!replayImportEnabled) replayAuth = undefined
     return

--- a/src/web_accessible_resource.ts
+++ b/src/web_accessible_resource.ts
@@ -326,7 +326,17 @@ interface ReplayAuthEnvelope {
   masterVer: string
 }
 
-const OriginalFetch = window.fetch.bind(window)
+/**
+ * ページ側がfetchを差し替える前の実体。モジュール読み込み時に掴むのは、
+ * 後からゲーム側が差し替えても素の実装を使い続けるため。
+ *
+ * ただしfetchが存在しない実行環境（jsdomなど）でも読み込み自体は成功させる。
+ * このファイルの本業はWebSocketの傍受であって、replay取り込みはその上に
+ * 乗った実験機能にすぎない。モジュールスコープで例外を投げると本業ごと
+ * 巻き添えで死ぬ。
+ */
+const OriginalFetch: typeof window.fetch | undefined =
+  typeof window.fetch === 'function' ? window.fetch.bind(window) : undefined
 let replayImportEnabled = false
 let replayConfigReceived = false
 let replayAuth: ReplayAuthEnvelope | undefined
@@ -387,21 +397,23 @@ const refreshSessionFromResponse = async (response: Response): Promise<void> => 
 // Capture the same version/session envelope PokerChase itself supplies. The
 // envelope remains inside the page's main-world closure and is never posted to
 // the extension context or IndexedDB.
-window.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-  const url = requestUrl(input)
-  if (url?.origin !== REPLAY_API_ORIGIN || (replayConfigReceived && !replayImportEnabled)) {
-    return OriginalFetch(input, init)
-  }
+if (OriginalFetch) {
+  window.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = requestUrl(input)
+    if (url?.origin !== REPLAY_API_ORIGIN || (replayConfigReceived && !replayImportEnabled)) {
+      return OriginalFetch(input, init)
+    }
 
-  try {
-    replayAuth = readAuthEnvelope(await decodeRequestBody(input, init)) ?? replayAuth
-  } catch {
-    // A request without a MessagePack body is unrelated to replay auth.
-  }
-  const response = await OriginalFetch(input, init)
-  refreshSessionFromResponse(response).catch(() => undefined)
-  return response
-}) as typeof window.fetch
+    try {
+      replayAuth = readAuthEnvelope(await decodeRequestBody(input, init)) ?? replayAuth
+    } catch {
+      // A request without a MessagePack body is unrelated to replay auth.
+    }
+    const response = await OriginalFetch(input, init)
+    refreshSessionFromResponse(response).catch(() => undefined)
+    return response
+  }) as typeof window.fetch
+}
 
 // Unity WebGL may use XMLHttpRequest rather than fetch for the same API
 // calls. Mirror the envelope observation there; requests themselves still go
@@ -457,6 +469,7 @@ XMLHttpRequest.prototype.send = function (body?: Document | XMLHttpRequestBodyIn
 }
 
 const fetchReplayDetail = async (handId: number): Promise<ReplayFetchItemResult> => {
+  if (!OriginalFetch) return { handId, ok: false, error: 'fetch-unavailable', retryable: false }
   const auth = replayAuth
   if (!auth) return { handId, ok: false, error: 'auth-envelope-unavailable', retryable: true }
 


### PR DESCRIPTION
## Summary

- queue EVT_HAND_RESULTS HandIds during play and fetch replay/detail sequentially after the session boundary
- keep the PokerChase session and version envelope inside the page main world, and strip session/requestKey before crossing into extension storage
- persist replay payloads in a dedicated IndexedDB v7 store without feeding derived stats, exports, or Firestore sync
- preserve MTT table moves, isolate interleaved tabs, recover MV3 restarts/port reconnects, and retry transient failures with backoff

## Experimental scope

- disabled by default behind chrome.storage.local experimentalReplayImportEnabled
- no new extension permissions or host permissions
- unpaid accounts retain the server-filtered response, including empty folded-opponent HoleCardList values
- this PR is for validation only and must not be merged without an explicit follow-up decision

## Validation

- npm test -- --runInBand --randomize (137 suites, 1289 tests)
- npm run typecheck
- npm run build
- git diff --check

Head: 2abdb3f