### PR TITLE
fix(background): consume UI API rejections

### DIFF
--- a/src/background/best-effort-chrome-api.ts
+++ b/src/background/best-effort-chrome-api.ts
@@ -1,0 +1,20 @@
+/**
+ * Invoke a Chrome UI API without allowing either a synchronous exception or
+ * its callback-free Promise rejection to escape the Service Worker.
+ *
+ * Only use this for advisory UI (badges/notifications). Storage, messaging,
+ * downloads, and other commit-bearing operations must keep propagating their
+ * failures to their callers.
+ */
+export const runBestEffortChromeUi = (
+  context: string,
+  invoke: () => unknown,
+): void => {
+  try {
+    void Promise.resolve(invoke()).catch(error => {
+      console.warn(`[${context}] Best-effort Chrome UI call failed:`, error)
+    })
+  } catch (error) {
+    console.warn(`[${context}] Best-effort Chrome UI call failed:`, error)
+  }
+}

--- a/src/background/import-export.export-handoff.test.ts
+++ b/src/background/import-export.export-handoff.test.ts
@@ -225,6 +225,40 @@ describe('export download-handoff completion', () => {
     expect(getOperationState()).toEqual({ type: 'idle' })
   })
 
+  test('a rejected no-hands notification stays best-effort and does not reject the export', async () => {
+    jest.spyOn(service, 'exportHandHistory').mockResolvedValue('')
+    ;(chrome.notifications.create as jest.Mock).mockRejectedValue(new Error('notifications unavailable'))
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+
+    await expect(handlers.exportData('pokerstars')).resolves.toBeUndefined()
+    await Promise.resolve()
+
+    expect(getOperationState()).toEqual({ type: 'idle' })
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[export-pokerstars/no-hands-notification] Best-effort Chrome UI call failed:',
+      expect.any(Error),
+    )
+    warnSpy.mockRestore()
+  })
+
+  test('a rejected error notification does not replace the original export failure', async () => {
+    jest.spyOn(service, 'exportHandHistory').mockRejectedValue(new Error('conversion failed'))
+    ;(chrome.notifications.create as jest.Mock).mockRejectedValue(new Error('notifications unavailable'))
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const handlers = createImportExportHandlers(service, db, 'https://example.com/*')
+
+    await expect(handlers.exportData('pokerstars')).rejects.toThrow('conversion failed')
+    await Promise.resolve()
+
+    expect(getOperationState()).toEqual({ type: 'idle' })
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[export-pokerstars/error-notification] Best-effort Chrome UI call failed:',
+      expect.any(Error),
+    )
+    warnSpy.mockRestore()
+  })
+
   test('falls back to a data-URL download (and still awaits it) when no game tab is open', async () => {
     ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => {
       setTimeout(() => callback([]), 0) // no matching tabs

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -31,6 +31,7 @@ import {
 } from '../utils/api-event-key'
 import { HandLogExporter } from '../utils/hand-log-exporter'
 import { awaitIngestionDrain } from './update-manager'
+import { runBestEffortChromeUi } from './best-effort-chrome-api'
 
 const IMPORT_CHUNK_SIZE = DATABASE_CONSTANTS.IMPORT_CHUNK_SIZE
 
@@ -531,12 +532,15 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
           message: 'エクスポートするハンドが見つかりませんでした'
         }).catch(() => {})
         // Show notification to user
-        chrome.notifications.create({
-          type: 'basic',
-          iconUrl: chrome.runtime.getURL('icons/icon_48px.png'),
-          title: 'エクスポートエラー',
-          message: 'エクスポートするハンドが見つかりませんでした。ゲームをプレイしてから再度お試しください。'
-        })
+        if (chrome.notifications?.create) {
+          runBestEffortChromeUi('export-pokerstars/no-hands-notification', () =>
+            chrome.notifications.create({
+              type: 'basic',
+              iconUrl: chrome.runtime.getURL('icons/icon_48px.png'),
+              title: 'エクスポートエラー',
+              message: 'エクスポートするハンドが見つかりませんでした。ゲームをプレイしてから再度お試しください。'
+            }))
+        }
         return
       }
 
@@ -567,12 +571,15 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
         message: `PokerStarsエクスポート失敗: ${error}`
       }).catch(() => {})
       // Show error notification
-      chrome.notifications.create({
-        type: 'basic',
-        iconUrl: chrome.runtime.getURL('icons/icon_48px.png'),
-        title: 'エクスポートエラー',
-        message: 'ハンドヒストリーのエクスポート中にエラーが発生しました。'
-      })
+      if (chrome.notifications?.create) {
+        runBestEffortChromeUi('export-pokerstars/error-notification', () =>
+          chrome.notifications.create({
+            type: 'basic',
+            iconUrl: chrome.runtime.getURL('icons/icon_48px.png'),
+            title: 'エクスポートエラー',
+            message: 'ハンドヒストリーのエクスポート中にエラーが発生しました。'
+          }))
+      }
       throw error
     }
   }

--- a/src/background/rebuild-advisory.test.ts
+++ b/src/background/rebuild-advisory.test.ts
@@ -102,6 +102,22 @@ describe('rebuild-advisory', () => {
       const state = await getRebuildAdvisoryState()
       expect(state.pendingVersion).toBe(REBUILD_ADVISORY_VERSION)
     })
+
+    it('keeps the advisory durable when callback-free badge and notification APIs reject', async () => {
+      const uiError = new Error('extension UI unavailable')
+      ;(chrome.action.setBadgeText as jest.Mock).mockRejectedValue(uiError)
+      ;(chrome.action.setBadgeBackgroundColor as jest.Mock).mockRejectedValue(uiError)
+      ;(chrome.notifications.create as jest.Mock).mockRejectedValue(uiError)
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      ;(mockDb.apiEvents.count as jest.Mock).mockResolvedValue(42)
+
+      await expect(checkOnUpdate(mockDb)).resolves.toBeUndefined()
+      await Promise.resolve()
+
+      expect((await getRebuildAdvisoryState()).pendingVersion).toBe(REBUILD_ADVISORY_VERSION)
+      expect(warnSpy).toHaveBeenCalledTimes(3)
+      warnSpy.mockRestore()
+    })
   })
 
   describe('PR #207 backfill (audit finding #7, codex review pass-3 P2 "Prompt rebuilds for already-stored overlap repairs")', () => {

--- a/src/background/rebuild-advisory.ts
+++ b/src/background/rebuild-advisory.ts
@@ -17,6 +17,7 @@
  */
 import type { PokerChaseDB } from '../db/poker-chase-db'
 import { REBUILD_ADVISORY_VERSION } from '../constants/database'
+import { runBestEffortChromeUi } from './best-effort-chrome-api'
 
 export const REBUILD_ADVISORY_STORAGE_KEY = 'rebuildAdvisory'
 
@@ -43,37 +44,31 @@ const setRebuildAdvisoryState = async (state: RebuildAdvisoryState): Promise<voi
 /** バッジ表示（API未対応環境ではno-op） */
 const setBadge = (): void => {
   if (!chrome.action?.setBadgeText) return
-  try {
-    chrome.action.setBadgeText({ text: BADGE_TEXT })
-    chrome.action.setBadgeBackgroundColor?.({ color: BADGE_BACKGROUND_COLOR })
-  } catch (error) {
-    console.warn('[rebuild-advisory] Failed to set badge:', error)
+  runBestEffortChromeUi('rebuild-advisory/setBadgeText', () =>
+    chrome.action.setBadgeText({ text: BADGE_TEXT }))
+  if (chrome.action.setBadgeBackgroundColor) {
+    runBestEffortChromeUi('rebuild-advisory/setBadgeBackgroundColor', () =>
+      chrome.action.setBadgeBackgroundColor({ color: BADGE_BACKGROUND_COLOR }))
   }
 }
 
 /** バッジ解除（API未対応環境ではno-op） */
 const clearBadge = (): void => {
   if (!chrome.action?.setBadgeText) return
-  try {
-    chrome.action.setBadgeText({ text: '' })
-  } catch (error) {
-    console.warn('[rebuild-advisory] Failed to clear badge:', error)
-  }
+  runBestEffortChromeUi('rebuild-advisory/clearBadgeText', () =>
+    chrome.action.setBadgeText({ text: '' }))
 }
 
 /** ユーザーへの通知（API未対応環境ではno-op） */
 const notifyUser = (): void => {
   if (!chrome.notifications?.create) return
-  try {
+  runBestEffortChromeUi('rebuild-advisory/notification', () =>
     chrome.notifications.create({
       type: 'basic',
       iconUrl: chrome.runtime.getURL('icons/icon_128px.png'),
       title: '統計ロジックが更新されました',
       message: '拡張機能の更新により統計ロジックが改善されました。ポップアップから「データ再構築」を実行して、既存データに正しい統計を反映してください。'
-    })
-  } catch (error) {
-    console.warn('[rebuild-advisory] Failed to create notification:', error)
-  }
+    }))
 }
 
 /**

--- a/src/background/update-manager.test.ts
+++ b/src/background/update-manager.test.ts
@@ -158,6 +158,21 @@ describe('update-manager', () => {
       expect(chrome.action.setBadgeText).toHaveBeenCalledWith({ text: 'UPD' })
     })
 
+    it('keeps the pending update durable when callback-free badge APIs reject', async () => {
+      const uiError = new Error('extension action unavailable')
+      ;(chrome.action.setBadgeText as jest.Mock).mockRejectedValue(uiError)
+      ;(chrome.action.setBadgeBackgroundColor as jest.Mock).mockRejectedValue(uiError)
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      markSessionActive()
+
+      await expect(handleUpdateAvailable({ version: '5.2.0' })).resolves.toBeUndefined()
+      await Promise.resolve()
+
+      expect(await getPendingUpdateState()).toMatchObject({ pending: true, version: '5.2.0' })
+      expect(warnSpy).toHaveBeenCalledTimes(2)
+      warnSpy.mockRestore()
+    })
+
     it('does not set its badge when a rebuild-advisory badge is already pending (precedence)', async () => {
       await chrome.storage.local.set({
         [REBUILD_ADVISORY_STORAGE_KEY]: { pendingVersion: REBUILD_ADVISORY_VERSION },

--- a/src/background/update-manager.ts
+++ b/src/background/update-manager.ts
@@ -61,6 +61,7 @@
  * 詳細はwhats-new-badge.ts冒頭のコメント・CLAUDE.md参照。
  */
 import { getRebuildAdvisoryState } from './rebuild-advisory'
+import { runBestEffortChromeUi } from './best-effort-chrome-api'
 import { isOperationIdle, onOperationBecameIdle } from './operation-state'
 import { autoSyncService } from '../services/auto-sync-service'
 import { PENDING_UPDATE_STORAGE_KEY, type PendingUpdateState } from '../constants/update'
@@ -234,11 +235,11 @@ const setBadge = async (): Promise<void> => {
   if (!chrome.action?.setBadgeText) return
   const advisory = await getRebuildAdvisoryState()
   if (advisory.pendingVersion) return
-  try {
-    chrome.action.setBadgeText({ text: BADGE_TEXT })
-    chrome.action.setBadgeBackgroundColor?.({ color: BADGE_BACKGROUND_COLOR })
-  } catch (error) {
-    console.warn('[update-manager] Failed to set badge:', error)
+  runBestEffortChromeUi('update-manager/setBadgeText', () =>
+    chrome.action.setBadgeText({ text: BADGE_TEXT }))
+  if (chrome.action.setBadgeBackgroundColor) {
+    runBestEffortChromeUi('update-manager/setBadgeBackgroundColor', () =>
+      chrome.action.setBadgeBackgroundColor({ color: BADGE_BACKGROUND_COLOR }))
   }
 }
 
@@ -247,11 +248,8 @@ const clearBadge = async (): Promise<void> => {
   if (!chrome.action?.setBadgeText) return
   const advisory = await getRebuildAdvisoryState()
   if (advisory.pendingVersion) return
-  try {
-    chrome.action.setBadgeText({ text: '' })
-  } catch (error) {
-    console.warn('[update-manager] Failed to clear badge:', error)
-  }
+  runBestEffortChromeUi('update-manager/clearBadgeText', () =>
+    chrome.action.setBadgeText({ text: '' }))
 }
 
 /**

--- a/src/background/whats-new-badge.test.ts
+++ b/src/background/whats-new-badge.test.ts
@@ -68,6 +68,20 @@ describe('whats-new-badge', () => {
       expect(chrome.action.setBadgeBackgroundColor).toHaveBeenCalled()
     })
 
+    it('keeps the unseen version durable when callback-free badge APIs reject', async () => {
+      const uiError = new Error('extension action unavailable')
+      ;(chrome.action.setBadgeText as jest.Mock).mockRejectedValue(uiError)
+      ;(chrome.action.setBadgeBackgroundColor as jest.Mock).mockRejectedValue(uiError)
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+      await expect(markWhatsNewOnUpdate(CURRENT_ENTRY_VERSION)).resolves.toBeUndefined()
+      await Promise.resolve()
+
+      expect(await getUnseenWhatsNewVersion()).toBe(CURRENT_ENTRY_VERSION)
+      expect(warnSpy).toHaveBeenCalledTimes(2)
+      warnSpy.mockRestore()
+    })
+
     it('does not record anything when the version has no curated WHATS_NEW_ENTRIES entry (e.g. an unreleased/unrecognized version)', async () => {
       await markWhatsNewOnUpdate('0.0.1-not-a-real-release')
 

--- a/src/background/whats-new-badge.ts
+++ b/src/background/whats-new-badge.ts
@@ -37,6 +37,7 @@
  */
 import { getRebuildAdvisoryState } from './rebuild-advisory'
 import { getPendingUpdateState } from './update-manager'
+import { runBestEffortChromeUi } from './best-effort-chrome-api'
 import { WHATS_NEW_STORAGE_KEY, WHATS_NEW_ENTRIES } from '../constants/whats-new'
 
 const BADGE_TEXT = 'N'
@@ -99,17 +100,18 @@ const syncBadge = async (): Promise<void> => {
     whatsNewUnseen: !!unseen,
   })
 
-  try {
-    if (active === 'whats-new') {
-      chrome.action.setBadgeText({ text: BADGE_TEXT })
-      chrome.action.setBadgeBackgroundColor?.({ color: BADGE_BACKGROUND_COLOR })
-    } else if (active === null) {
-      chrome.action.setBadgeText({ text: '' })
+  if (active === 'whats-new') {
+    runBestEffortChromeUi('whats-new-badge/setBadgeText', () =>
+      chrome.action.setBadgeText({ text: BADGE_TEXT }))
+    if (chrome.action.setBadgeBackgroundColor) {
+      runBestEffortChromeUi('whats-new-badge/setBadgeBackgroundColor', () =>
+        chrome.action.setBadgeBackgroundColor({ color: BADGE_BACKGROUND_COLOR }))
     }
-    // active === 'rebuild' | 'update': 他モジュールの管轄なので何もしない
-  } catch (error) {
-    console.warn('[whats-new-badge] Failed to sync badge:', error)
+  } else if (active === null) {
+    runBestEffortChromeUi('whats-new-badge/clearBadgeText', () =>
+      chrome.action.setBadgeText({ text: '' }))
   }
+  // active === 'rebuild' | 'update': 他モジュールの管轄なので何もしない
 }
 
 /**


### PR DESCRIPTION
## Summary

- consume synchronous throws and callback-free Promise rejections from best-effort Chrome badge/notification APIs
- cover rebuild, pending-update, what's-new, and PokerStars export UI notifications
- preserve storage, messaging, download, and original export error semantics

## Verification

- `npm test -- --runInBand src/background/rebuild-advisory.test.ts src/background/update-manager.test.ts src/background/whats-new-badge.test.ts src/background/import-export.export-handoff.test.ts` (77 passed)
- `npm test -- --runInBand` (134 suites, 1276 tests passed)
- `npm run typecheck`
- `npm run build`

Head: `8e48209cf0b2bc2234842d3d9162fda24009782f`

Codex-Session: `019f8968-f41d-7951-ad11-f7c9492b5866`