### PR TITLE
chore(deps): refresh audited dev transitives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7604,9 +7604,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9051,9 +9051,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- update transitive `js-yaml` from 3.14.2 to 3.15.0
- update transitive `brace-expansion` from 1.1.12 to 1.1.16
- keep `package.json` and all direct dependency ranges unchanged

## Security impact

This clears the two development-only `npm audit` findings covering GHSA-h67p-54hq-rp68, GHSA-52cp-r559-cp3m, GHSA-f886-m6hf-6m8v, and GHSA-3jxr-9vmj-r5cp. `npm audit --omit=dev` was already clean, and neither package ships in the Chrome extension archive.

## Validation

- `npm ci --ignore-scripts`
- `npm test -- --runInBand` (134 suites, 1279 tests)
- `npm run typecheck`
- `npm run build`
- `npm audit` (0 vulnerabilities)

## Head

`594d38e3590ff4482ff40137f8b51375c3d792f1`