### PR TITLE
fix(hud): refresh live pot odds state

### DIFF
--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -727,7 +727,29 @@ describe('App', () => {
 
     it('セッション終了(EVT_SESSION_RESULTS)でhero以外の全パネル（ミュート中含む）がクリアされ、heroパネルはそのまま残る', async () => {
       render(<App />)
-      await dispatchStats(mockStatsData.stats)
+      await act(async () => {
+        window.dispatchEvent(new CustomEvent('PokerChaseServiceEvent', {
+          detail: {
+            stats: mockStatsData.stats,
+            realTimeStats: {
+              heroStats: {},
+              playerStats: {
+                0: {
+                  spr: 10,
+                  potOdds: {
+                    pot: 300,
+                    call: 100,
+                    percentage: 25,
+                    ratio: '3:1',
+                    isPlayerTurn: true
+                  }
+                }
+              }
+            }
+          }
+        }))
+      })
+      expect(screen.getByTestId('hud-0')).toHaveTextContent('PotOdds: yes')
 
       // 席1をbustさせてミュート状態にする
       const bustedLineup: StatsData['stats'] = mockStatsData.stats.map((s, i) => (i === 1 ? { playerId: -1 } : s))
@@ -741,6 +763,7 @@ describe('App', () => {
 
       // hero(席0)はそのまま残る
       expect(screen.getByTestId('hud-0')).toHaveTextContent('Player: 1')
+      expect(screen.getByTestId('hud-0')).toHaveTextContent('PotOdds: no')
       // hero以外は空席へクリアされ、ミュートも解除される
       for (let i = 1; i < 6; i++) {
         expect(screen.getByTestId(`hud-${i}`)).toHaveTextContent('Player: -1')

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -391,6 +391,10 @@ const App = memo(() => {
   // 通りここでは一切触らない(pregameでのキャリア統計復元は別経路)。
   const handleSessionEnd = useCallback(() => {
     closeAllDrillDownPanels()
+    // The background clears lastKnownStats before the realtime stream handles
+    // EVT_SESSION_RESULTS, so that stream's empty update is not broadcast.
+    // Clear the local realtime state on the session event itself instead.
+    setAllPlayersRealTimeStats(undefined)
     const dimCache = dimCacheRef.current
     // #179 post-merge review P2「Preserve the hero by player id at session
     // end」指摘: 直前の更新が観戦モードdeal（上のisSpectatorDeal分岐）だった

--- a/src/components/Hud.test.tsx
+++ b/src/components/Hud.test.tsx
@@ -156,8 +156,8 @@ describe('Hud', () => {
       />
     )
 
-    const potOdds = screen.getByText('100/20 (17%)')
-    const spr = screen.getByText('SPR:10.5')
+    const potOdds = screen.getByText('17%')
+    const spr = screen.getByText('10.5')
 
     expect(potOdds.compareDocumentPosition(spr) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
@@ -173,8 +173,8 @@ describe('Hud', () => {
       />
     )
 
-    expect(screen.getByText('100/20 (17%)')).toBeInTheDocument()
-    expect(screen.getByText('SPR:10.5')).toBeInTheDocument()
+    expect(screen.getByText('17%')).toBeInTheDocument()
+    expect(screen.getByText('10.5')).toBeInTheDocument()
 
     rerender(
       <Hud
@@ -195,8 +195,8 @@ describe('Hud', () => {
       />
     )
 
-    expect(screen.getByText('140/40 (22%)')).toBeInTheDocument()
-    expect(screen.getByText('SPR:6.25')).toBeInTheDocument()
+    expect(screen.getByText('22%')).toBeInTheDocument()
+    expect(screen.getByText('6.25')).toBeInTheDocument()
   })
 
   it('ヒーロー（席0）の場合はリアルタイム統計を表示', () => {
@@ -344,7 +344,7 @@ describe('Hud', () => {
       />
     )
 
-    const potOddsElement = screen.getByText('100/20 (17%)')
+    const potOddsElement = screen.getByText('17%')
     expect(potOddsElement).toHaveStyle({ color: '#00ff00' })
   })
 

--- a/src/components/hud/HudHeader.test.tsx
+++ b/src/components/hud/HudHeader.test.tsx
@@ -33,12 +33,47 @@ describe('HudHeader', () => {
       />
     )
 
-    const potOdds = screen.getByText('100/20 (17%)')
-    const spr = screen.getByText('SPR:10.5')
+    const potOdds = screen.getByText('17%')
+    const spr = screen.getByText('10.5')
 
     expect(potOdds).toBeInTheDocument()
     expect(spr).toBeInTheDocument()
+    expect(screen.queryByText('100/20', { exact: false })).not.toBeInTheDocument()
+    expect(screen.queryByText(/SPR:/)).not.toBeInTheDocument()
     expect(potOdds.compareDocumentPosition(spr) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('ポットオッズとSPRの意味・式をhoverとkeyboard focusで説明できる', async () => {
+    const user = userEvent.setup()
+    render(
+      <HudHeader
+        playerName="TestPlayer"
+        playerId={123}
+        playerPotOdds={{
+          spr: 10.5,
+          potOdds: {
+            pot: 100,
+            call: 20,
+            percentage: 16.7,
+            ratio: '5:1',
+            isPlayerTurn: true,
+          },
+        }}
+      />
+    )
+
+    const potOddsTooltip = 'ポットオッズ: コールに必要な最低勝率。式: コール額 ÷（メインポット＋全サイドポット＋コール額）'
+    const sprTooltip = 'SPR: このプレイヤーの残りスタックと現在のポット総額の比。式: 残りスタック ÷（メインポット＋全サイドポット）'
+    const potOdds = screen.getByTitle(potOddsTooltip)
+    const spr = screen.getByTitle(sprTooltip)
+
+    expect(potOdds).toHaveAttribute('aria-label', `ポットオッズ 17%。${potOddsTooltip}`)
+    expect(spr).toHaveAttribute('aria-label', `SPR 10.5。${sprTooltip}`)
+
+    await user.tab()
+    expect(potOdds).toHaveFocus()
+    await user.tab()
+    expect(spr).toHaveFocus()
   })
 
   it('プレイヤーのターンの場合はポットオッズがハイライトされる', () => {
@@ -61,7 +96,7 @@ describe('HudHeader', () => {
       />
     )
 
-    const potOddsElement = screen.getByText('100/20 (17%)')
+    const potOddsElement = screen.getByText('17%')
     expect(potOddsElement).toHaveStyle({ color: '#00ff00' })
   })
 
@@ -85,7 +120,7 @@ describe('HudHeader', () => {
       />
     )
 
-    const potOddsElement = screen.getByText('100/20 (17%)')
+    const potOddsElement = screen.getByText('17%')
     expect(potOddsElement).toHaveStyle({ color: '#b8b8b8' })
   })
 

--- a/src/components/hud/HudHeader.test.tsx
+++ b/src/components/hud/HudHeader.test.tsx
@@ -43,8 +43,7 @@ describe('HudHeader', () => {
     expect(potOdds.compareDocumentPosition(spr) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 
-  it('ポットオッズとSPRの意味・式をhoverとkeyboard focusで説明できる', async () => {
-    const user = userEvent.setup()
+  it('ポットオッズとSPRの意味・式をhoverとscreen readerで説明できる', () => {
     render(
       <HudHeader
         playerName="TestPlayer"
@@ -69,11 +68,6 @@ describe('HudHeader', () => {
 
     expect(potOdds).toHaveAttribute('aria-label', `ポットオッズ 17%。${potOddsTooltip}`)
     expect(spr).toHaveAttribute('aria-label', `SPR 10.5。${sprTooltip}`)
-
-    await user.tab()
-    expect(potOdds).toHaveFocus()
-    await user.tab()
-    expect(spr).toHaveFocus()
   })
 
   it('プレイヤーのターンの場合はポットオッズがハイライトされる', () => {

--- a/src/components/hud/HudHeader.tsx
+++ b/src/components/hud/HudHeader.tsx
@@ -94,7 +94,6 @@ export const HudHeader = memo(({ playerName, playerId, playerPotOdds, isPosition
             <span
               title={potOddsTooltip}
               aria-label={`ポットオッズ ${playerPotOdds.potOdds!.percentage.toFixed(0)}%。${potOddsTooltip}`}
-              tabIndex={0}
               style={{
                 color: playerPotOdds.potOdds!.isPlayerTurn ? '#00ff00' : HUD_MUTED_TEXT_COLOR,
                 fontWeight: playerPotOdds.potOdds!.isPlayerTurn ? 'bold' : 'normal',
@@ -108,7 +107,6 @@ export const HudHeader = memo(({ playerName, playerId, playerPotOdds, isPosition
             <span
               title={sprTooltip}
               aria-label={`SPR ${playerPotOdds.spr}。${sprTooltip}`}
-              tabIndex={0}
               style={{ color: '#ffcc00', fontWeight: 'bold', whiteSpace: 'nowrap' }}
             >
               {playerPotOdds.spr}

--- a/src/components/hud/HudHeader.tsx
+++ b/src/components/hud/HudHeader.tsx
@@ -75,6 +75,8 @@ const styles = {
 export const HudHeader = memo(({ playerName, playerId, playerPotOdds, isPositionalPanelOpen, onTogglePositionalPanel, isRecentHandsPanelOpen, onToggleRecentHandsPanel, statResults, isDimmed }: HudHeaderProps) => {
   const hasPotOdds = playerPotOdds?.potOdds && playerPotOdds.potOdds.call > 0
   const hasSpr = playerPotOdds?.spr !== undefined
+  const potOddsTooltip = 'ポットオッズ: コールに必要な最低勝率。式: コール額 ÷（メインポット＋全サイドポット＋コール額）'
+  const sprTooltip = 'SPR: このプレイヤーの残りスタックと現在のポット総額の比。式: 残りスタック ÷（メインポット＋全サイドポット）'
   
   return (
     <div style={styles.header}>
@@ -89,17 +91,27 @@ export const HudHeader = memo(({ playerName, playerId, playerPotOdds, isPosition
             </span>
           )}
           {hasPotOdds && (
-            <span style={{ 
-              color: playerPotOdds.potOdds!.isPlayerTurn ? '#00ff00' : HUD_MUTED_TEXT_COLOR,
-              fontWeight: playerPotOdds.potOdds!.isPlayerTurn ? 'bold' : 'normal',
-              whiteSpace: 'nowrap'
-            }}>
-              {playerPotOdds.potOdds!.pot}/{playerPotOdds.potOdds!.call} ({playerPotOdds.potOdds!.percentage.toFixed(0)}%)
+            <span
+              title={potOddsTooltip}
+              aria-label={`ポットオッズ ${playerPotOdds.potOdds!.percentage.toFixed(0)}%。${potOddsTooltip}`}
+              tabIndex={0}
+              style={{
+                color: playerPotOdds.potOdds!.isPlayerTurn ? '#00ff00' : HUD_MUTED_TEXT_COLOR,
+                fontWeight: playerPotOdds.potOdds!.isPlayerTurn ? 'bold' : 'normal',
+                whiteSpace: 'nowrap'
+              }}
+            >
+              {playerPotOdds.potOdds!.percentage.toFixed(0)}%
             </span>
           )}
           {hasSpr && (
-            <span style={{ color: '#ffcc00', fontWeight: 'bold', whiteSpace: 'nowrap' }}>
-              SPR:{playerPotOdds.spr}
+            <span
+              title={sprTooltip}
+              aria-label={`SPR ${playerPotOdds.spr}。${sprTooltip}`}
+              tabIndex={0}
+              style={{ color: '#ffcc00', fontWeight: 'bold', whiteSpace: 'nowrap' }}
+            >
+              {playerPotOdds.spr}
             </span>
           )}
           {onTogglePositionalPanel && (

--- a/src/streams/realtime-stats-stream.test.ts
+++ b/src/streams/realtime-stats-stream.test.ts
@@ -74,8 +74,11 @@ describe('RealTimeStatsStream', () => {
 
       await new Promise<void>(resolve => stream.once('end', resolve))
 
-      expect(outputs).toHaveLength(2)
-      expect(Object.keys(outputs[1].stats.heroStats)).not.toHaveLength(0)
+      // Session end clears the previous live values, then the seated deal
+      // clears/reinitializes before emitting current stats.
+      expect(outputs).toHaveLength(3)
+      expect(outputs[0].stats).toEqual({ heroStats: {}, playerStats: {} })
+      expect(Object.keys(outputs[2].stats.heroStats)).not.toHaveLength(0)
     })
   })
 
@@ -285,11 +288,11 @@ describe('RealTimeStatsStream', () => {
             SeatIndex: 0,
             BetStatus: 1,
             HoleCards: [16, 19],
-            Chip: 10000,
+            Chip: 9600,
             BetChip: 0
           },
           OtherPlayers: [
-            { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 10000, BetChip: 0 },
+            { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 9200, BetChip: 0 },
             { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 10000, BetChip: 0 },
             { SeatIndex: 3, Status: 0, BetStatus: 1, Chip: 10000, BetChip: 0 },
             { SeatIndex: 4, Status: 0, BetStatus: 1, Chip: 10000, BetChip: 0 },
@@ -317,6 +320,16 @@ describe('RealTimeStatsStream', () => {
         const flopStats = results[results.length - 1]
         expect(flopStats.stats.heroStats.communityCards).toEqual([49, 33, 21])
         expect(flopStats.stats.heroStats.holeCards).toEqual([16, 19])
+        // New-street snapshots reset every BetChip and carry the current
+        // stacks. No player should inherit a preflop call amount or SPR.
+        expect(flopStats.stats.playerStats[0]).toMatchObject({
+          spr: 32,
+          potOdds: { call: 0 }
+        })
+        expect(flopStats.stats.playerStats[1]).toMatchObject({
+          spr: 30.7,
+          potOdds: { call: 0 }
+        })
 
         done()
       })
@@ -649,12 +662,13 @@ describe('RealTimeStatsStream', () => {
         // 結果の確認
         // 1. 最初のハンドのクリア統計
         // 2. 最初のハンドの統計
-        // 3. 新しいハンドのクリア統計
-        // 4. 新しいハンドの統計
-        expect(results.length).toBe(4)
+        // 3. ハンド終了時のクリア統計
+        // 4. 新しいハンドのクリア統計
+        // 5. 新しいハンドの統計
+        expect(results.length).toBe(5)
 
         // 新しいハンド開始時のクリア統計
-        const clearStats = results[2]
+        const clearStats = results[3]
         expect(clearStats.handId).toBeUndefined()
         expect(clearStats.stats).toEqual({
           heroStats: {},
@@ -662,7 +676,7 @@ describe('RealTimeStatsStream', () => {
         })
 
         // 新しいハンドの統計
-        const newHandStats = results[3]
+        const newHandStats = results[4]
         expect(newHandStats.stats.heroStats.holeCards).toEqual([44, 45])
 
         done()
@@ -1149,6 +1163,10 @@ describe('SPR (Stack to Pot Ratio) Tracking', () => {
       // SPR should be 5000 / 900 = 5.6
       expect(potOddsData.spr).toBe(5.6)
 
+      // Player 3's EVT_ACTION reports the post-raise stack (4400), which must
+      // replace the deal-time stack (5000): 4400 / 900 = 4.9.
+      expect(lastStats.stats.playerStats[3].spr).toBe(4.9)
+
       done()
     })
 
@@ -1381,6 +1399,12 @@ describe('SPR (Stack to Pot Ratio) Tracking', () => {
 
     stream.on('end', () => {
       expect(handCount).toBe(2)
+      const clearOutputs = results.filter(result => (
+        Object.keys(result.stats.heroStats).length === 0
+        && Object.keys(result.stats.playerStats).length === 0
+      ))
+      // One clear per deal plus immediate invalidation at hand completion.
+      expect(clearOutputs).toHaveLength(3)
       done()
     })
 

--- a/src/streams/realtime-stats-stream.test.ts
+++ b/src/streams/realtime-stats-stream.test.ts
@@ -281,6 +281,23 @@ describe('RealTimeStatsStream', () => {
           }
         },
         {
+          ApiTypeId: ApiType.EVT_ACTION,
+          timestamp: 150,
+          SeatIndex: 5,
+          ActionType: 2,
+          Chip: 10000,
+          BetChip: 100,
+          Progress: {
+            Phase: PhaseType.PREFLOP,
+            NextActionSeat: 1,
+            NextActionTypes: [2, 3, 4, 5],
+            NextExtraLimitSeconds: 30,
+            MinRaise: 400,
+            Pot: 300,
+            SidePot: []
+          }
+        },
+        {
           ApiTypeId: ApiType.EVT_DEAL_ROUND,
           timestamp: 200,
           CommunityCards: [49, 33, 21], // A♥ 9♥ 6♥
@@ -295,12 +312,11 @@ describe('RealTimeStatsStream', () => {
             { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 9200, BetChip: 0 },
             { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 10000, BetChip: 0 },
             { SeatIndex: 3, Status: 0, BetStatus: 1, Chip: 10000, BetChip: 0 },
-            { SeatIndex: 4, Status: 0, BetStatus: 1, Chip: 10000, BetChip: 0 },
-            { SeatIndex: 5, Status: 0, BetStatus: 1, Chip: 10000, BetChip: 0 }
+            { SeatIndex: 4, Status: 0, BetStatus: 1, Chip: 10000, BetChip: 0 }
           ],
           Progress: {
             Phase: PhaseType.FLOP,
-            NextActionSeat: 5,
+            NextActionSeat: 1,
             NextActionTypes: [0, 1, 5],
             NextExtraLimitSeconds: 30,
             MinRaise: 0,
@@ -330,6 +346,9 @@ describe('RealTimeStatsStream', () => {
           spr: 30.7,
           potOdds: { call: 0 }
         })
+        // Seat 5 folded preflop and is omitted from EVT_DEAL_ROUND. Its old
+        // small blind must still be cleared at the street boundary.
+        expect(flopStats.stats.playerStats[5].potOdds.call).toBe(0)
 
         done()
       })

--- a/src/streams/realtime-stats-stream.ts
+++ b/src/streams/realtime-stats-stream.ts
@@ -135,6 +135,11 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
         case ApiType.EVT_DEAL_ROUND:
           // Update community cards and phase
           if (event.CommunityCards && event.CommunityCards.length > 0) {
+            // A new street resets every seat's cumulative street bet. Folded
+            // players can be omitted from the round snapshot, so reset the
+            // full array before applying the seats that are present.
+            this.seatBetAmounts = this.seatBetAmounts.map(() => 0)
+
             // EVT_DEAL_ROUND may send only new cards, not all community cards
             // Append new cards to existing community cards
             if (this.currentPhase === PhaseType.PREFLOP) {

--- a/src/streams/realtime-stats-stream.ts
+++ b/src/streams/realtime-stats-stream.ts
@@ -53,6 +53,7 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
 
       if (eventType === ApiType.EVT_SESSION_RESULTS) {
         this.isSessionActive = false
+        this.emitClearStats()
       }
 
       switch (event.ApiTypeId) {
@@ -79,15 +80,7 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
           this.seatUserIds = [-1, -1, -1, -1, -1, -1]  // Reset user IDs
 
           // Emit empty stats to clear previous hand's display
-          const clearStats: { handId?: number; stats: AllPlayersRealTimeStats; timestamp: number } = {
-            handId: undefined,
-            stats: {
-              heroStats: {} as RealTimeStats,
-              playerStats: {}
-            },
-            timestamp: Date.now()
-          }
-          this.push(clearStats)
+          this.emitClearStats()
 
           // Extract hero information
           if (event.Player && event.Player.HoleCards?.length === 2 && event.SeatUserIds) {
@@ -173,6 +166,13 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
             if (event.Player && event.OtherPlayers) {
               let activeCount = 0
 
+              // EVT_DEAL_ROUND is the authoritative snapshot for a new street.
+              // BetChip resets to zero and Chip reflects every action from the
+              // previous street, so keeping the EVT_DEAL values here makes pot
+              // odds and SPR look cached until each seat acts again.
+              this.seatBetAmounts[event.Player.SeatIndex] = event.Player.BetChip ?? 0
+              this.seatChips[event.Player.SeatIndex] = event.Player.Chip ?? 0
+
               // Check hero's status
               if (event.Player.BetStatus === 1 || event.Player.BetStatus === 3) {
                 activeCount++
@@ -180,6 +180,8 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
 
               // Check other players' status
               for (const player of event.OtherPlayers) {
+                this.seatBetAmounts[player.SeatIndex] = player.BetChip ?? 0
+                this.seatChips[player.SeatIndex] = player.Chip ?? 0
                 if (player.BetStatus === 1 || player.BetStatus === 3) {
                   activeCount++
                 }
@@ -217,6 +219,7 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
           this.currentHandEvents = []
           this.heroPlayerId = undefined
           this.heroHoleCards = undefined
+          this.emitClearStats()
           break
 
         case ApiType.EVT_ACTION:
@@ -235,6 +238,10 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
           // Update bet amount for this seat
           if (event.BetChip !== undefined) {
             this.seatBetAmounts[event.SeatIndex] = event.BetChip
+          }
+
+          if (event.Chip !== undefined) {
+            this.seatChips[event.SeatIndex] = event.Chip
           }
 
 
@@ -321,6 +328,17 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
       }
       this.push(output)
     }
+  }
+
+  private emitClearStats(): void {
+    this.push({
+      handId: undefined,
+      stats: {
+        heroStats: {} as RealTimeStats,
+        playerStats: {}
+      },
+      timestamp: Date.now()
+    })
   }
 
   private shouldCalculateStats(): boolean {


### PR DESCRIPTION
## Summary
- reset every seat bet at each street before applying the seats present in the round snapshot
- refresh current chip stacks from new-street and action events so SPR follows the live stack
- clear realtime pot odds at hand completion and directly in the App at session completion
- show Pot Odds as a percentage only and SPR as a number only
- add Japanese formula tooltips plus screen-reader labels without adding passive tab stops
- add regressions for omitted folded seats, action stack updates, terminal invalidation, display values, labels, and tooltip accessibility

## Root cause
PR #235 fixed the React memo comparator, but the upstream realtime stream still retained deal-time stacks and previous-street bet amounts. Folded seats can be omitted from `EVT_DEAL_ROUND`, so resetting only seats present in that event still left a prior blind or bet as a phantom call amount. At session end, the background lineup is cleared before the realtime clear reaches its broadcast gate, so the App also needs to invalidate its local realtime state.

## Display behavior
- Pot Odds: percentage only (for example `25%`)
- SPR: numeric value only (for example `3.2`)
- mouse hover explanations use the implemented formulas, including all side pots and the individual player remaining stack used by the calculator
- accessible names expose the same explanations to screen readers

## Validation
- `npm test -- --runInBand src/components/hud/HudHeader.test.tsx src/components/Hud.test.tsx src/components/App.test.tsx src/streams/realtime-stats-stream.test.ts` (108 passed)
- `npm test -- --runInBand` (1280 passed)
- `npm run typecheck`
- `npm run build`

Head SHA: `6d56428ad24c123408782fb69b1ce2f69147aacc`