### PR TITLE
fix(hud): separate metric hover tooltips

### DIFF
--- a/src/components/Hud.test.tsx
+++ b/src/components/Hud.test.tsx
@@ -156,8 +156,8 @@ describe('Hud', () => {
       />
     )
 
-    const potOdds = screen.getByText('17%')
-    const spr = screen.getByText('10.5')
+    const potOdds = screen.getByText('Odds 17%')
+    const spr = screen.getByText('SPR 10.5')
 
     expect(potOdds.compareDocumentPosition(spr) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
@@ -173,8 +173,8 @@ describe('Hud', () => {
       />
     )
 
-    expect(screen.getByText('17%')).toBeInTheDocument()
-    expect(screen.getByText('10.5')).toBeInTheDocument()
+    expect(screen.getByText('Odds 17%')).toBeInTheDocument()
+    expect(screen.getByText('SPR 10.5')).toBeInTheDocument()
 
     rerender(
       <Hud
@@ -195,8 +195,8 @@ describe('Hud', () => {
       />
     )
 
-    expect(screen.getByText('22%')).toBeInTheDocument()
-    expect(screen.getByText('6.25')).toBeInTheDocument()
+    expect(screen.getByText('Odds 22%')).toBeInTheDocument()
+    expect(screen.getByText('SPR 6.25')).toBeInTheDocument()
   })
 
   it('ヒーロー（席0）の場合はリアルタイム統計を表示', () => {
@@ -239,6 +239,49 @@ describe('Hud', () => {
         expect.stringContaining('PFR: 20.0% (20/100)')
       )
     })
+  })
+
+  it('metric hoverは親copy tooltipより各解説を優先し、metric clickはcopyを維持する', async () => {
+    render(
+      <Hud
+        actualSeatIndex={0}
+        stat={mockPlayerStats}
+        scale={1}
+        statDisplayConfigs={mockStatDisplayConfigs}
+        playerPotOdds={mockPlayerPotOdds}
+      />
+    )
+
+    const hudPanel = screen.getByTestId('hud-panel')
+    const potOdds = screen.getByText('Odds 17%')
+    const spr = screen.getByText('SPR 10.5')
+
+    // 親HUDのcopy tooltipもcustom portalとして維持する。
+    expect(hudPanel).not.toHaveAttribute('title')
+    await userEvent.hover(hudPanel)
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Click to copy stats to clipboard')
+
+    // metric領域へ移動すると親tooltipを抑止し、metric固有の説明だけを表示する。
+    await userEvent.hover(potOdds)
+    const potOddsTooltip = await screen.findByRole('tooltip')
+    expect(potOddsTooltip).toHaveTextContent('コールに必要な最低勝率')
+    expect(potOddsTooltip).not.toHaveTextContent('Click to copy stats to clipboard')
+    expect(hudPanel.contains(potOddsTooltip)).toBe(false)
+
+    // metric clickはstopPropagationせず、従来通り親HUDのcopyを実行する。
+    await userEvent.click(potOdds)
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        expect.stringContaining('Player: TestPlayer')
+      )
+    })
+
+    await userEvent.unhover(potOdds)
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+    await userEvent.hover(spr)
+    const sprTooltip = await screen.findByRole('tooltip')
+    expect(sprTooltip).toHaveTextContent('残りスタックと現在のポット総額の比')
+    expect(sprTooltip).not.toHaveTextContent('Click to copy stats to clipboard')
   })
 
   it('ドラッグ可能', async () => {
@@ -344,7 +387,7 @@ describe('Hud', () => {
       />
     )
 
-    const potOddsElement = screen.getByText('17%')
+    const potOddsElement = screen.getByText('Odds 17%')
     expect(potOddsElement).toHaveStyle({ color: '#00ff00' })
   })
 

--- a/src/components/Hud.tsx
+++ b/src/components/Hud.tsx
@@ -1,4 +1,5 @@
 import { CSSProperties, useState, useCallback, useMemo, memo } from 'react'
+import type { MouseEvent as ReactMouseEvent } from 'react'
 import type { PlayerStats } from '../types'
 import type { StatDisplayConfig } from '../types'
 import type { StatResult } from '../types/stats'
@@ -15,6 +16,7 @@ import { PositionalPanelTrigger } from './hud/PositionalPanelTrigger'
 import { RecentHandsPanel } from './hud/RecentHandsPanel'
 import { RecentHandsPanelTrigger } from './hud/RecentHandsPanelTrigger'
 import { HUD_MUTED_TEXT_COLOR } from './hud/hudColors'
+import { HudTooltipPortal } from './hud/HudTooltip'
 
 // Types
 interface PlayerPotOdds {
@@ -76,6 +78,7 @@ const EMPTY_SEAT_ID = -1
 const HUD_WIDTH = 240
 const HOVER_BG_COLOR = 'rgba(0, 0, 0, 0.7)'
 const NORMAL_BG_COLOR = 'rgba(0, 0, 0, 0.5)'
+const COPY_TOOLTIP = 'Click to copy stats to clipboard'
 // bustしたプレイヤーのミュート表示（sola仕様）: 統計は読めるが明確に副次的と
 // わかる程度に減光する。opacityはパネル全体（枠・テキスト・compactラインの
 // カラーコーディングを含む）に一様にかかるため、個々のstat色を別途ミュートする
@@ -224,6 +227,7 @@ const getPlayerName = (stat: PlayerStats): string | null => {
 // Main component
 const Hud = memo((props: HudProps) => {
   const [isHovering, setIsHovering] = useState(false)
+  const [copyTooltipPosition, setCopyTooltipPosition] = useState<{ left: number; top: number }>()
   // クリックで展開する16統計グリッド（compactモードのみ）。パネルごとのローカル
   // state -- 各Hudインスタンスが自分のstateを持つため、複数プレイヤーを同時に
   // 展開できる。
@@ -284,6 +288,24 @@ const Hud = memo((props: HudProps) => {
       console.error('Failed to copy stats to clipboard:', error)
     }
   }, [gridDisplayStats, playerName])
+
+  const handleHudMouseMove = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
+    const target = event.target
+    if (
+      target instanceof Element
+      && target.closest('[data-hud-metric="true"], [title]')
+    ) {
+      setCopyTooltipPosition(undefined)
+      return
+    }
+
+    setCopyTooltipPosition({ left: event.clientX + 12, top: event.clientY + 16 })
+  }, [])
+
+  const handleHudMouseLeave = useCallback(() => {
+    setIsHovering(false)
+    setCopyTooltipPosition(undefined)
+  }, [])
 
   // Container styles
   const containerStyle: CSSProperties = {
@@ -401,8 +423,8 @@ const Hud = memo((props: HudProps) => {
           }}
           onClick={copyStatsToClipboard}
           onMouseEnter={() => setIsHovering(true)}
-          onMouseLeave={() => setIsHovering(false)}
-          title="Click to copy stats to clipboard"
+          onMouseMove={handleHudMouseMove}
+          onMouseLeave={handleHudMouseLeave}
         >
           <DragHandle isHovering={isHovering} onMouseDown={handleMouseDown} />
           <HudHeader
@@ -435,6 +457,7 @@ const Hud = memo((props: HudProps) => {
           {props.isRecentHandsPanelOpen && (
             <RecentHandsPanel playerId={props.stat.playerId} handEpoch={props.handEpoch} />
           )}
+          <HudTooltipPortal position={copyTooltipPosition}>{COPY_TOOLTIP}</HudTooltipPortal>
         </div>
       </div>
     </>

--- a/src/components/hud/HudHeader.test.tsx
+++ b/src/components/hud/HudHeader.test.tsx
@@ -33,8 +33,8 @@ describe('HudHeader', () => {
       />
     )
 
-    const potOdds = screen.getByText('17%')
-    const spr = screen.getByText('10.5')
+    const potOdds = screen.getByText('Odds 17%')
+    const spr = screen.getByText('SPR 10.5')
 
     expect(potOdds).toBeInTheDocument()
     expect(spr).toBeInTheDocument()
@@ -43,7 +43,7 @@ describe('HudHeader', () => {
     expect(potOdds.compareDocumentPosition(spr) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 
-  it('ポットオッズとSPRの意味・式をhoverとscreen readerで説明できる', () => {
+  it('ポットオッズとSPRの意味・式をvisual tooltipとscreen readerで説明できる', async () => {
     render(
       <HudHeader
         playerName="TestPlayer"
@@ -63,11 +63,25 @@ describe('HudHeader', () => {
 
     const potOddsTooltip = 'ポットオッズ: コールに必要な最低勝率。式: コール額 ÷（メインポット＋全サイドポット＋コール額）'
     const sprTooltip = 'SPR: このプレイヤーの残りスタックと現在のポット総額の比。式: 残りスタック ÷（メインポット＋全サイドポット）'
-    const potOdds = screen.getByTitle(potOddsTooltip)
-    const spr = screen.getByTitle(sprTooltip)
+    const potOdds = screen.getByText('Odds 17%')
+    const spr = screen.getByText('SPR 10.5')
 
-    expect(potOdds).toHaveAttribute('aria-label', `ポットオッズ 17%。${potOddsTooltip}`)
+    expect(potOdds).not.toHaveAttribute('title')
+    expect(spr).not.toHaveAttribute('title')
+    expect(potOdds).toHaveAttribute('aria-label', `Odds 17%。${potOddsTooltip}`)
     expect(spr).toHaveAttribute('aria-label', `SPR 10.5。${sprTooltip}`)
+
+    await userEvent.hover(potOdds)
+    const visualTooltip = await screen.findByRole('tooltip')
+    expect(visualTooltip).toHaveTextContent(potOddsTooltip)
+    expect(visualTooltip).toHaveStyle({ boxSizing: 'border-box' })
+    expect(visualTooltip.style.maxWidth).toBe('min(280px, calc(100vw - 16px))')
+
+    await userEvent.unhover(potOdds)
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+
+    await userEvent.hover(spr)
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(sprTooltip)
   })
 
   it('プレイヤーのターンの場合はポットオッズがハイライトされる', () => {
@@ -90,7 +104,7 @@ describe('HudHeader', () => {
       />
     )
 
-    const potOddsElement = screen.getByText('17%')
+    const potOddsElement = screen.getByText('Odds 17%')
     expect(potOddsElement).toHaveStyle({ color: '#00ff00' })
   })
 
@@ -114,7 +128,7 @@ describe('HudHeader', () => {
       />
     )
 
-    const potOddsElement = screen.getByText('17%')
+    const potOddsElement = screen.getByText('Odds 17%')
     expect(potOddsElement).toHaveStyle({ color: '#b8b8b8' })
   })
 
@@ -122,6 +136,7 @@ describe('HudHeader', () => {
     render(<HudHeader playerName="TestPlayer" playerId={123} />)
 
     expect(screen.queryByText(/SPR:/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/^SPR /)).not.toBeInTheDocument()
     expect(screen.queryByText(/%/)).not.toBeInTheDocument()
   })
 

--- a/src/components/hud/HudHeader.tsx
+++ b/src/components/hud/HudHeader.tsx
@@ -5,6 +5,7 @@ import { PlayerTypeIcons } from './PlayerTypeIcons'
 import { PositionalPanelTrigger } from './PositionalPanelTrigger'
 import { RecentHandsPanelTrigger } from './RecentHandsPanelTrigger'
 import { HUD_MUTED_TEXT_COLOR } from './hudColors'
+import { HudMetric } from './HudTooltip'
 
 interface PlayerPotOdds {
   spr?: number
@@ -91,26 +92,26 @@ export const HudHeader = memo(({ playerName, playerId, playerPotOdds, isPosition
             </span>
           )}
           {hasPotOdds && (
-            <span
-              title={potOddsTooltip}
-              aria-label={`ポットオッズ ${playerPotOdds.potOdds!.percentage.toFixed(0)}%。${potOddsTooltip}`}
+            <HudMetric
+              tooltip={potOddsTooltip}
+              ariaLabel={`Odds ${playerPotOdds.potOdds!.percentage.toFixed(0)}%。${potOddsTooltip}`}
               style={{
                 color: playerPotOdds.potOdds!.isPlayerTurn ? '#00ff00' : HUD_MUTED_TEXT_COLOR,
                 fontWeight: playerPotOdds.potOdds!.isPlayerTurn ? 'bold' : 'normal',
                 whiteSpace: 'nowrap'
               }}
             >
-              {playerPotOdds.potOdds!.percentage.toFixed(0)}%
-            </span>
+              Odds {playerPotOdds.potOdds!.percentage.toFixed(0)}%
+            </HudMetric>
           )}
           {hasSpr && (
-            <span
-              title={sprTooltip}
-              aria-label={`SPR ${playerPotOdds.spr}。${sprTooltip}`}
+            <HudMetric
+              tooltip={sprTooltip}
+              ariaLabel={`SPR ${playerPotOdds.spr}。${sprTooltip}`}
               style={{ color: '#ffcc00', fontWeight: 'bold', whiteSpace: 'nowrap' }}
             >
-              {playerPotOdds.spr}
-            </span>
+              SPR {playerPotOdds.spr}
+            </HudMetric>
           )}
           {onTogglePositionalPanel && (
             <PositionalPanelTrigger

--- a/src/components/hud/HudTooltip.tsx
+++ b/src/components/hud/HudTooltip.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+
+export interface HudTooltipPosition {
+  left: number
+  top: number
+}
+
+interface HudTooltipPortalProps {
+  children: ReactNode
+  position?: HudTooltipPosition
+}
+
+const TOOLTIP_MARGIN = 8
+const TOOLTIP_MAX_WIDTH = 280
+
+const tooltipStyle = (position: HudTooltipPosition): CSSProperties => ({
+  position: 'fixed',
+  left: `${Math.min(
+    Math.max(position.left, TOOLTIP_MARGIN),
+    Math.max(TOOLTIP_MARGIN, window.innerWidth - TOOLTIP_MAX_WIDTH - TOOLTIP_MARGIN)
+  )}px`,
+  top: `${Math.min(position.top, Math.max(TOOLTIP_MARGIN, window.innerHeight - 64))}px`,
+  zIndex: 2147483647,
+  boxSizing: 'border-box',
+  maxWidth: `min(${TOOLTIP_MAX_WIDTH}px, calc(100vw - ${TOOLTIP_MARGIN * 2}px))`,
+  padding: '5px 7px',
+  border: '1px solid rgba(255, 255, 255, 0.3)',
+  borderRadius: '4px',
+  backgroundColor: 'rgba(16, 16, 16, 0.96)',
+  boxShadow: '0 2px 8px rgba(0, 0, 0, 0.5)',
+  color: '#ffffff',
+  fontFamily: 'sans-serif',
+  fontSize: '11px',
+  lineHeight: 1.4,
+  whiteSpace: 'normal',
+  pointerEvents: 'none',
+  userSelect: 'none',
+})
+
+export const HudTooltipPortal = ({ children, position }: HudTooltipPortalProps) => {
+  if (!position) return null
+
+  return createPortal(
+    <div role="tooltip" style={tooltipStyle(position)}>
+      {children}
+    </div>,
+    document.body
+  )
+}
+
+interface HudMetricProps {
+  ariaLabel: string
+  children: ReactNode
+  style: CSSProperties
+  tooltip: string
+}
+
+export const HudMetric = ({ ariaLabel, children, style, tooltip }: HudMetricProps) => {
+  const [tooltipPosition, setTooltipPosition] = useState<HudTooltipPosition>()
+
+  return (
+    <>
+      <span
+        data-hud-metric="true"
+        aria-label={ariaLabel}
+        style={style}
+        onMouseEnter={(event) => {
+          const rect = event.currentTarget.getBoundingClientRect()
+          setTooltipPosition({ left: rect.left, top: rect.bottom + 6 })
+        }}
+        onMouseLeave={() => setTooltipPosition(undefined)}
+      >
+        {children}
+      </span>
+      <HudTooltipPortal position={tooltipPosition}>{tooltip}</HudTooltipPortal>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary

- show the compact HUD metrics as `Odds 17%` and `SPR 10.5`
- replace nested native `title` tooltips with viewport-safe body portals so each metric shows its own Japanese explanation
- preserve the parent HUD copy tooltip outside metric/title regions and keep metric clicks bubbling to the existing clipboard action
- expose the displayed values and full explanations through accurate `aria-label` text

## Root cause

The normal HUD panel and its metric children both used native `title` attributes. In Chrome, the ancestor panel tooltip (`Click to copy stats to clipboard`) could win over the nested metric titles, hiding the Pot Odds and SPR explanations.

## Validation

- `npm test -- --runInBand src/components/hud/HudHeader.test.tsx src/components/Hud.test.tsx` (55 tests)
- `npm test -- --runInBand` (135 suites, 1,298 tests)
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- independent interaction/design audit: ACCEPT after fixing the right-edge portal clamp

Head SHA: `5d7036c32bdce2bea293c9543cb40470c806ae8c`
