### PR TITLE
fix(stats): accumulate rebuild board cards

### DIFF
--- a/src/entity-converter.test.ts
+++ b/src/entity-converter.test.ts
@@ -3053,7 +3053,7 @@ describe('EntityConverter', () => {
      * に至る。リバーでコールしたseat0のプレイヤー(WINNER_CALLER)は
      * RIVER_CALL_WONが付与されるべき。
      */
-    it('tags RIVER_CALL_WON on the import path for a winning river call (scenario c)', async () => {
+    it('keeps cumulative three-street boards and RIVER_CALL_WON in parity across live and rebuild replays (scenario c)', async () => {
       const WINNER_CALLER = 111222333 // seat0, リバーでコールして勝利
       const OPPONENT = 444555666 // seat3, リバーでベットして勝利（スプリット）
       const events: ApiEvent[] = [
@@ -3355,8 +3355,46 @@ describe('EntityConverter', () => {
       expect(liveRiverCallAction).toBeDefined()
       expect(liveRiverCallAction!.actionDetails).toContain(ActionDetail.RIVER_CALL_WON)
 
-      // 両パイプラインが完全一致
+      // アクション詳細が両パイプラインで完全一致
       expect(riverCallAction!.actionDetails.slice().sort()).toEqual(liveRiverCallAction!.actionDetails.slice().sort())
+
+      // EVT_DEAL_ROUND.CommunityCardsは各ストリートのdeltaだが、Phaseには
+      // ライブ経路と同じ累積ボードを保存する。RESULTSのCommunityCards=[]でも
+      // SHOWDOWNはRIVERまでの5枚を維持しなければならない。
+      const pickComparablePhase = (phase: typeof importResult.phases[0]) => ({
+        phase: phase.phase,
+        seatUserIds: [...phase.seatUserIds].sort((a, b) => a - b),
+        communityCards: phase.communityCards
+      })
+      const importPhases = importResult.phases
+        .slice()
+        .sort((a, b) => a.phase - b.phase)
+        .map(pickComparablePhase)
+      const livePhases = (await dbMock.phases.where('handId').equals(271929009).toArray())
+        .sort((a, b) => a.phase - b.phase)
+        .map(pickComparablePhase)
+
+      expect(importPhases.map(({ phase, communityCards }) => ({ phase, communityCards }))).toEqual([
+        { phase: PhaseType.PREFLOP, communityCards: [] },
+        { phase: PhaseType.FLOP, communityCards: [15, 30, 25] },
+        { phase: PhaseType.TURN, communityCards: [15, 30, 25, 23] },
+        { phase: PhaseType.RIVER, communityCards: [15, 30, 25, 23, 39] },
+        { phase: PhaseType.SHOWDOWN, communityCards: [15, 30, 25, 23, 39] }
+      ])
+      expect(importPhases).toEqual(livePhases)
+
+      // 同じraw event列を再構築して同じ複合キーへ複数回upsertしても、
+      // Phase行やボードが増殖しない（rebuild/duplicate idempotency）。
+      const replay = new EntityConverter(mockSession).convertEventsToEntities(events)
+      expect(
+        replay.phases.slice().sort((a, b) => a.phase - b.phase).map(pickComparablePhase)
+      ).toEqual(importPhases)
+      await dbMock.phases.bulkPut(replay.phases)
+      await dbMock.phases.bulkPut(replay.phases)
+      const replayedPhases = (await dbMock.phases.where('handId').equals(271929009).toArray())
+        .sort((a, b) => a.phase - b.phase)
+        .map(pickComparablePhase)
+      expect(replayedPhases).toEqual(importPhases)
     })
 
     /**

--- a/src/entity-converter.ts
+++ b/src/entity-converter.ts
@@ -335,7 +335,13 @@ export class EntityConverter {
               handId: 0, // EVT_HAND_RESULTSで更新される
               phase: newPhase,
               seatUserIds,
-              communityCards: event.CommunityCards || []
+              // EVT_DEAL_ROUND.CommunityCards is a street delta. Persist the
+              // cumulative board, matching WriteEntityStream and allowing
+              // EVT_HAND_RESULTS to append only its still-undelivered tail.
+              communityCards: [
+                ...(handState.phases.at(-1)?.communityCards || []),
+                ...(event.CommunityCards || [])
+              ]
             })
           }
 


### PR DESCRIPTION
## Summary
- accumulate EVT_DEAL_ROUND board deltas in EntityConverter phases, matching the live WriteEntityStream
- preserve the complete board through TURN, RIVER, and SHOWDOWN during import, manual rebuild, and cloud restore
- strengthen the real three-street fixture with live-vs-rebuild parity and replay/upsert idempotency invariants

## Scope
This is a minimal rebuild-path correction. Live processing, duplicate-street rejection, and result-only all-in synthesis are unchanged.

## Validation
- `npx jest src/entity-converter.test.ts src/background/import-export.rebuild.test.ts src/background/import-export.full-rebuild.test.ts src/services/auto-sync-service.rebuild-canonical.test.ts --runInBand` (4 suites, 45 tests)
- `npm test -- --runInBand` (135 suites, 1298 tests)
- `npm run typecheck`

## Head
- `77cfa93a2451a04a06454421390a1d2c4d0dcb5f`

## Latest main integration validation\n- `npm test -- --runInBand` (136 suites, 1341 tests)\n- `npm run typecheck`\n- `npm run build`