### PR TITLE
fix(content): retry disconnected port events

### DIFF
--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -18,6 +18,7 @@ import { RuntimePortManager } from './utils/runtime-port-manager'
 /** !!! BACKGROUND、WEB_ACCESSIBLE_RESOURCES からインポートしないこと !!! */
 
 const RECONNECT_DELAY_MS = 500
+const PORT_EVENT_QUEUE_LIMIT = 1000
 const KEEPALIVE_INTERVAL_MS = 25000 // 25秒（30秒タイムアウトより少し短く）
 
 // ゲーム状態の管理
@@ -68,6 +69,7 @@ const stopKeepalive = () => {
 const portManager = new RuntimePortManager({
   connect: () => chrome.runtime.connect({ name: POKER_CHASE_SERVICE_EVENT }),
   reconnectDelayMs: RECONNECT_DELAY_MS,
+  maxQueueSize: PORT_EVENT_QUEUE_LIMIT,
   onConnected: port => {
     if (isGameActive) startKeepalive(port)
   },
@@ -87,10 +89,9 @@ const portManager = new RuntimePortManager({
       }
     }
   },
-  onSendError: error => {
-    if (error instanceof Error && error.message === 'Extension context invalidated.') {
-      window.location.reload()
-    }
+  onFatalError: error => {
+    console.error('[content_script] Runtime Port can no longer preserve event delivery; reloading:', error)
+    window.location.reload()
   }
 })
 
@@ -187,7 +188,12 @@ window.addEventListener('message', (event: MessageEvent<unknown>) => {
       break
   }
 
-  portManager.send(event.data)
+  // false means the bounded queue can no longer preserve at-least-once
+  // delivery. The fatal callback above reloads the page to establish a fresh
+  // extension context rather than silently dropping this and later events.
+  if (!portManager.send(event.data)) {
+    stopKeepalive()
+  }
 })
 
 // Cleanup on window unload

--- a/src/utils/runtime-port-manager.test.ts
+++ b/src/utils/runtime-port-manager.test.ts
@@ -1,4 +1,4 @@
-import { RuntimePortManager } from './runtime-port-manager'
+import { RuntimePortManager, RuntimePortQueueOverflowError } from './runtime-port-manager'
 
 const createPort = () => {
   let disconnectListener: (() => void) | undefined
@@ -19,6 +19,16 @@ const createPort = () => {
   }
 }
 
+const managerOptions = (
+  connect: () => chrome.runtime.Port,
+  overrides: Partial<ConstructorParameters<typeof RuntimePortManager>[0]> = {}
+) => ({
+  connect,
+  reconnectDelayMs: 500,
+  maxQueueSize: 100,
+  ...overrides
+})
+
 describe('RuntimePortManager', () => {
   beforeEach(() => {
     jest.useFakeTimers()
@@ -34,7 +44,7 @@ describe('RuntimePortManager', () => {
     const connect = jest.fn()
       .mockReturnValueOnce(first.port)
       .mockReturnValueOnce(second.port)
-    const manager = new RuntimePortManager({ connect, reconnectDelayMs: 500 })
+    const manager = new RuntimePortManager(managerOptions(connect))
 
     manager.connect()
     first.disconnect()
@@ -48,19 +58,177 @@ describe('RuntimePortManager', () => {
 
   test('connects and forwards the triggering message when no Port is active', () => {
     const replacement = createPort()
-    const manager = new RuntimePortManager({
-      connect: () => replacement.port,
-      reconnectDelayMs: 500
-    })
+    const manager = new RuntimePortManager(managerOptions(() => replacement.port))
 
     expect(manager.send({ ApiTypeId: 2 })).toBe(true)
     expect(replacement.port.postMessage).toHaveBeenCalledWith({ ApiTypeId: 2 })
   })
 
+  test('retries the exact event whose postMessage throws on the replacement Port', () => {
+    const failed = createPort()
+    const replacement = createPort()
+    const event = { ApiTypeId: 303, timestamp: 1000 }
+    ;(failed.port.postMessage as jest.Mock).mockImplementation(() => {
+      throw new Error('Attempting to use a disconnected port object')
+    })
+    const connect = jest.fn()
+      .mockReturnValueOnce(failed.port)
+      .mockReturnValueOnce(replacement.port)
+    const onSendError = jest.fn()
+    const manager = new RuntimePortManager(managerOptions(connect, { onSendError }))
+
+    manager.connect()
+    expect(manager.send(event)).toBe(true)
+    jest.advanceTimersByTime(500)
+
+    expect(failed.port.postMessage).toHaveBeenCalledWith(event)
+    expect(replacement.port.postMessage).toHaveBeenCalledWith(event)
+    expect(onSendError).toHaveBeenCalledTimes(1)
+  })
+
+  test('preserves causal order when more events arrive before reconnect', () => {
+    const failed = createPort()
+    const replacement = createPort()
+    const first = { ApiTypeId: 303, timestamp: 1000 }
+    const second = { ApiTypeId: 313, timestamp: 1001 }
+    const third = { ApiTypeId: 319, timestamp: 1002 }
+    ;(failed.port.postMessage as jest.Mock).mockImplementation(() => {
+      throw new Error('Attempting to use a disconnected port object')
+    })
+    const connect = jest.fn()
+      .mockReturnValueOnce(failed.port)
+      .mockReturnValueOnce(replacement.port)
+    const manager = new RuntimePortManager(managerOptions(connect))
+
+    manager.connect()
+    manager.send(first)
+    manager.send(second)
+    manager.send(third)
+    jest.advanceTimersByTime(500)
+
+    expect(replacement.port.postMessage).toHaveBeenNthCalledWith(1, first)
+    expect(replacement.port.postMessage).toHaveBeenNthCalledWith(2, second)
+    expect(replacement.port.postMessage).toHaveBeenNthCalledWith(3, third)
+  })
+
+  test('retains an ambiguously delivered head event when disconnect races postMessage', () => {
+    const raced = createPort()
+    const replacement = createPort()
+    const first = { ApiTypeId: 303, timestamp: 1000 }
+    const second = { ApiTypeId: 313, timestamp: 1001 }
+    ;(raced.port.postMessage as jest.Mock).mockImplementation(() => raced.disconnect())
+    const connect = jest.fn()
+      .mockReturnValueOnce(raced.port)
+      .mockReturnValueOnce(replacement.port)
+    const manager = new RuntimePortManager(managerOptions(connect))
+
+    manager.connect()
+    manager.send(first)
+    manager.send(second)
+    jest.advanceTimersByTime(500)
+
+    expect(raced.port.postMessage).toHaveBeenCalledWith(first)
+    expect(replacement.port.postMessage).toHaveBeenNthCalledWith(1, first)
+    expect(replacement.port.postMessage).toHaveBeenNthCalledWith(2, second)
+  })
+
+  test('ignores a stale disconnect fired by an earlier Port', () => {
+    const first = createPort()
+    const replacement = createPort()
+    const connect = jest.fn()
+      .mockReturnValueOnce(first.port)
+      .mockReturnValueOnce(replacement.port)
+    const manager = new RuntimePortManager(managerOptions(connect))
+
+    manager.connect()
+    first.disconnect()
+    jest.advanceTimersByTime(500)
+    first.disconnect()
+    manager.send({ ApiTypeId: 319 })
+
+    expect(connect).toHaveBeenCalledTimes(2)
+    expect(replacement.port.postMessage).toHaveBeenCalledWith({ ApiTypeId: 319 })
+  })
+
+  test('queues later events behind a failed connection without a connect storm', () => {
+    const replacement = createPort()
+    const connect = jest.fn()
+      .mockImplementationOnce(() => {
+        throw new Error('Service worker unavailable')
+      })
+      .mockReturnValueOnce(replacement.port)
+    const manager = new RuntimePortManager(managerOptions(connect))
+    const first = { ApiTypeId: 303 }
+    const second = { ApiTypeId: 313 }
+
+    manager.send(first)
+    manager.send(second)
+
+    expect(connect).toHaveBeenCalledTimes(1)
+    jest.advanceTimersByTime(500)
+    expect(replacement.port.postMessage).toHaveBeenNthCalledWith(1, first)
+    expect(replacement.port.postMessage).toHaveBeenNthCalledWith(2, second)
+  })
+
+  test('stops retrying and reports a fatal extension context invalidation', () => {
+    const invalid = createPort()
+    const invalidation = new Error('Extension context invalidated.')
+    ;(invalid.port.postMessage as jest.Mock).mockImplementation(() => {
+      throw invalidation
+    })
+    const connect = jest.fn(() => invalid.port)
+    const onFatalError = jest.fn()
+    const manager = new RuntimePortManager(managerOptions(connect, { onFatalError }))
+
+    manager.connect()
+    expect(manager.send({ ApiTypeId: 303 })).toBe(false)
+    expect(manager.send({ ApiTypeId: 313 })).toBe(false)
+    jest.advanceTimersByTime(500)
+
+    expect(connect).toHaveBeenCalledTimes(1)
+    expect(onFatalError).toHaveBeenCalledWith(invalidation)
+  })
+
+  test('stops retrying when connect reports an invalidated extension context', () => {
+    const invalidation = new Error('Extension context invalidated.')
+    const connect = jest.fn(() => {
+      throw invalidation
+    })
+    const onFatalError = jest.fn()
+    const manager = new RuntimePortManager(managerOptions(connect, { onFatalError }))
+
+    expect(manager.send({ ApiTypeId: 303 })).toBe(false)
+    jest.advanceTimersByTime(500)
+
+    expect(connect).toHaveBeenCalledTimes(1)
+    expect(onFatalError).toHaveBeenCalledWith(invalidation)
+  })
+
+  test('fails closed and reports overflow instead of silently dropping a queued event', () => {
+    const connect = jest.fn(() => {
+      throw new Error('Service worker unavailable')
+    })
+    const onFatalError = jest.fn()
+    const manager = new RuntimePortManager(managerOptions(connect, {
+      maxQueueSize: 2,
+      onFatalError
+    }))
+
+    expect(manager.send({ ApiTypeId: 303 })).toBe(true)
+    expect(manager.send({ ApiTypeId: 313 })).toBe(true)
+    expect(manager.send({ ApiTypeId: 319 })).toBe(false)
+    expect(manager.send({ ApiTypeId: 309 })).toBe(false)
+    jest.advanceTimersByTime(500)
+
+    expect(connect).toHaveBeenCalledTimes(1)
+    expect(onFatalError).toHaveBeenCalledWith(expect.any(RuntimePortQueueOverflowError))
+    expect(onFatalError.mock.calls[0]?.[0]).toMatchObject({ maxQueueSize: 2 })
+  })
+
   test('does not reconnect after an intentional disconnect', () => {
     const current = createPort()
     const connect = jest.fn(() => current.port)
-    const manager = new RuntimePortManager({ connect, reconnectDelayMs: 500 })
+    const manager = new RuntimePortManager(managerOptions(connect))
 
     manager.connect()
     manager.disconnect()
@@ -68,5 +236,14 @@ describe('RuntimePortManager', () => {
     jest.advanceTimersByTime(500)
 
     expect(connect).toHaveBeenCalledTimes(1)
+  })
+
+  test('rejects an invalid queue limit', () => {
+    const current = createPort()
+
+    expect(() => new RuntimePortManager(managerOptions(
+      () => current.port,
+      { maxQueueSize: 0 }
+    ))).toThrow('maxQueueSize must be a positive integer.')
   })
 })

--- a/src/utils/runtime-port-manager.ts
+++ b/src/utils/runtime-port-manager.ts
@@ -1,35 +1,55 @@
 interface RuntimePortManagerOptions {
   connect: () => chrome.runtime.Port
   reconnectDelayMs: number
+  maxQueueSize: number
   onConnected?: (port: chrome.runtime.Port) => void
   onDisconnected?: () => void
   onMessage?: (message: unknown) => void
   onSendError?: (error: unknown) => void
+  onFatalError?: (error: unknown) => void
 }
+
+export class RuntimePortQueueOverflowError extends Error {
+  constructor(readonly maxQueueSize: number) {
+    super(`Runtime Port retry queue reached its limit of ${maxQueueSize} messages.`)
+    this.name = 'RuntimePortQueueOverflowError'
+  }
+}
+
+const isExtensionContextInvalidated = (error: unknown): boolean =>
+  error instanceof Error && error.message === 'Extension context invalidated.'
 
 /**
  * Owns a runtime Port across service-worker restarts.
  *
- * The manager, rather than a caller-local callback, stores every replacement
- * Port so future messages never keep targeting a disconnected instance.
+ * Captured events are queued in arrival order. A synchronous postMessage()
+ * failure leaves the head event in place, reconnects, and retries that same
+ * event before later arrivals. A disconnect observed during postMessage() is
+ * ambiguous, so the head is retained and may be delivered twice; Raw Event
+ * Lake identity deduplication makes that preferable to a permanent gap.
  */
 export class RuntimePortManager {
   private activePort: chrome.runtime.Port | null = null
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private readonly queue: unknown[] = []
+  private isFlushing = false
+  private fatal = false
 
-  constructor(private readonly options: RuntimePortManagerOptions) {}
+  constructor(private readonly options: RuntimePortManagerOptions) {
+    if (!Number.isInteger(options.maxQueueSize) || options.maxQueueSize <= 0) {
+      throw new RangeError('maxQueueSize must be a positive integer.')
+    }
+  }
 
   get port(): chrome.runtime.Port | null {
     return this.activePort
   }
 
   connect(): chrome.runtime.Port | null {
+    if (this.fatal) return null
     if (this.activePort) return this.activePort
 
-    if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer)
-      this.reconnectTimer = null
-    }
+    this.clearReconnectTimer()
 
     try {
       const port = this.options.connect()
@@ -38,36 +58,83 @@ export class RuntimePortManager {
       port.onMessage.addListener(message => this.options.onMessage?.(message))
       port.onDisconnect.addListener(() => this.handleDisconnect(port))
       this.options.onConnected?.(port)
+      this.flushQueue()
       return port
-    } catch {
-      this.scheduleReconnect()
+    } catch (error) {
+      if (isExtensionContextInvalidated(error)) {
+        this.failPermanently(error)
+      } else {
+        this.scheduleReconnect()
+      }
       return null
     }
   }
 
+  /**
+   * Returns true once the message has either been posted or accepted into the
+   * bounded retry queue. False means the manager cannot preserve delivery and
+   * the caller must take its fatal recovery path (normally a page reload).
+   */
   send(message: unknown): boolean {
-    const port = this.activePort ?? this.connect()
-    if (!port) return false
+    if (this.fatal) return false
 
-    try {
-      port.postMessage(message)
-      return true
-    } catch (error) {
-      this.handleDisconnect(port)
-      this.options.onSendError?.(error)
+    if (this.queue.length >= this.options.maxQueueSize) {
+      this.failPermanently(new RuntimePortQueueOverflowError(this.options.maxQueueSize))
       return false
     }
+
+    this.queue.push(message)
+    this.flushQueue()
+    return !this.fatal
   }
 
   disconnect(): void {
-    if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer)
-      this.reconnectTimer = null
-    }
+    this.clearReconnectTimer()
+    this.queue.length = 0
 
     const port = this.activePort
     this.activePort = null
     if (port) port.disconnect()
+  }
+
+  private flushQueue(): void {
+    if (this.isFlushing || this.fatal) return
+
+    this.isFlushing = true
+    try {
+      while (this.queue.length > 0) {
+        if (!this.activePort) {
+          // A failed attempt already owns the next retry. Further arrivals
+          // append to the queue without turning a burst into a connect storm.
+          if (this.reconnectTimer) return
+          if (!this.connect()) return
+        }
+
+        const port = this.activePort
+        if (!port) return
+
+        try {
+          port.postMessage(this.queue[0])
+
+          // onDisconnect can race synchronously with postMessage in tests and
+          // browser implementations. Delivery is then ambiguous: retain the
+          // head for at-least-once retry instead of creating a silent gap.
+          if (this.activePort !== port) return
+
+          this.queue.shift()
+        } catch (error) {
+          this.handleDisconnect(port)
+          this.options.onSendError?.(error)
+
+          if (isExtensionContextInvalidated(error)) {
+            this.failPermanently(error)
+          }
+          return
+        }
+      }
+    } finally {
+      this.isFlushing = false
+    }
   }
 
   private handleDisconnect(port: chrome.runtime.Port): void {
@@ -79,11 +146,27 @@ export class RuntimePortManager {
   }
 
   private scheduleReconnect(): void {
-    if (this.reconnectTimer) return
+    if (this.reconnectTimer || this.fatal) return
 
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null
       this.connect()
     }, this.options.reconnectDelayMs)
+  }
+
+  private clearReconnectTimer(): void {
+    if (!this.reconnectTimer) return
+    clearTimeout(this.reconnectTimer)
+    this.reconnectTimer = null
+  }
+
+  private failPermanently(error: unknown): void {
+    if (this.fatal) return
+
+    this.fatal = true
+    this.clearReconnectTimer()
+    this.activePort = null
+    this.queue.length = 0
+    this.options.onFatalError?.(error)
   }
 }


### PR DESCRIPTION
## Summary

- buffer captured WebSocket events in arrival order while the runtime Port reconnects
- retain and resend the exact event whose `postMessage()` throws before later queued events
- treat a disconnect racing `postMessage()` as ambiguous and retry at-least-once, relying on Raw Event Lake content deduplication for possible duplicates
- bound the queue at 1,000 events and reload on overflow or extension-context invalidation instead of silently dropping later traffic

## Invariants / risk gate

- FIFO: later captures cannot pass a failed head event
- At least once on transport ambiguity: a send/disconnect race retains the head for replacement-Port retry
- Bounded failure: connect failures do not create a reconnect storm; overflow and invalidated contexts enter a single fatal recovery path
- Stale disconnect callbacks cannot detach a replacement Port

Failure-injection coverage exercises synchronous send throws, multiple queued events, disconnect-during-send ambiguity, stale disconnects, connection failures, queue overflow, and invalidated extension contexts.

## Validation

- `npm test -- --runInBand src/utils/runtime-port-manager.test.ts` (12 tests)
- `npm run typecheck`
- `npm test -- --runInBand` (135 suites, 1307 tests)

## Head

`c85ac811691908e259c83dd863a20cba449704a4`