### PR TITLE
fix(stats): exclude uncalled returns from winners

### DIFF
--- a/docs/api-event-examples.md
+++ b/docs/api-event-examples.md
@@ -183,6 +183,107 @@ ORDER BY observer_ref, event_ts_ms;
 この例は、強制投稿オールインを自発的なall-in actionとして統計計上しないこと、
 追加投入0でも304が届く場合があること、306で`Pot`と全`SidePot`を合算することのfixtureになる。
 
+<a id="rewardchip-uncalled-return-example"></a>
+
+### RewardChip > 0でも敗者となるuncalled return（HandId=269804225）
+
+出典は`pokerchase_raw_data_2026-07-04T18-31-12-252Z.ndjson`。UserIdとtimestampだけを
+匿名化し、会計に使うチップ値、seat、ブラインド、アンテ、Pot、SidePot、HandRanking、
+RewardChipは実イベント値を保持した抜粋である。
+
+```json
+{
+  "ApiTypeId": 303,
+  "SeatUserIds": [1001, -1, -1, 1002, -1, -1],
+  "Game": {
+    "Ante": 3200,
+    "SmallBlind": 6500,
+    "BigBlind": 13000,
+    "ButtonSeat": 3,
+    "SmallBlindSeat": 3,
+    "BigBlindSeat": 0
+  },
+  "Player": {
+    "SeatIndex": 0,
+    "BetStatus": 1,
+    "Chip": 162012,
+    "BetChip": 13000
+  },
+  "OtherPlayers": [
+    {
+      "SeatIndex": 3,
+      "BetStatus": 3,
+      "Chip": 0,
+      "BetChip": 0
+    }
+  ],
+  "Progress": {
+    "Phase": 0,
+    "Pot": 3576,
+    "SidePot": [14412]
+  }
+}
+```
+
+```json
+{
+  "ApiTypeId": 306,
+  "HandId": 269804225,
+  "Pot": 3576,
+  "SidePot": [14412],
+  "Results": [
+    {
+      "UserId": 1002,
+      "HandRanking": 1,
+      "RewardChip": 3576
+    },
+    {
+      "UserId": 1001,
+      "HandRanking": 2,
+      "RewardChip": 14412
+    }
+  ],
+  "OtherPlayers": [
+    {
+      "SeatIndex": 3,
+      "Chip": 3576,
+      "BetChip": 0
+    }
+  ]
+}
+```
+
+rawから直接観測できる値:
+
+- seat 0（UserId 1001）は`Chip=162,012`、`BetChip=13,000`
+- seat 3（UserId 1002）は`Chip=0`、`BetChip=0`の強制投稿オールイン
+- `Ante=3,200`、`Pot=3,576`、`SidePot=[14,412]`
+- seat 3の終了スタックは3,576
+- payout総額は`3,576 + 14,412 = 17,988`で、
+  `Pot + SidePot = 3,576 + 14,412 = 17,988`と一致
+
+上記の直接値とチップ保存則から一意に復元できる値:
+
+- seat 0の開始スタックは
+  `Chip 162,012 + BetChip 13,000 + Ante 3,200 = 178,212`
+- seat 3はアンテでショートオールインしているため、メインティア
+  `Pot 3,576 / 2人 = 1,788`が開始スタック
+
+seat 0の終了snapshotは306から欠落している。ただしトーナメントで開始総額が
+`178,212 + 1,788 = 180,000`、既知のseat 3終了額が3,576、欠落seatが1つだけなので、
+強整合なゼロサム会計からseat 0の終了額は`180,000 - 3,576 = 176,424`と一意に復元できる。
+ここから拠出額を計算する。
+
+| seat | startingStack | RewardChip | finalStack | totalContribution | netChips |
+|---|---:|---:|---:|---:|---:|
+| 0（UserId 1001） | 178,212 | 14,412 | 176,424 | 16,200 | -1,788 |
+| 3（UserId 1002） | 1,788 | 3,576 | 3,576 | 1,788 | +1,788 |
+
+最初の1,788ずつ、合計3,576だけが2人で争われたメインティアである。seat 0の残り
+`16,200 - 1,788 = 14,412`は対戦相手のいない単独拠出ティアであり、そのままseat 0へ
+返されたuncalled returnとなる。したがってseat 0は`RewardChip=14,412 > 0`でも敗者で、
+勝者は`contestedAward=3,576`を得たseat 3だけである。
+
 ## 303→304→306→309: 終端BBブラインドオールイン
 
 調査キー: `HandId=530473403`、後続309の受信`timestamp=1784560697458`

--- a/docs/api-events.md
+++ b/docs/api-events.md
@@ -215,6 +215,29 @@ EVT_DEAL 時点の `Chip` / `BetChip` は **アンテおよびブラインドが
 
 **強制投稿オールイン時の Pot/SidePot キャップ（例外）**: アンテまたはブラインドの強制投稿で `Chip=0` となるプレイヤーがいる場合、deal 時点の `Pot`/`SidePot` は既にオールイン上限を反映したティア別スナップショットになる。最短オールイン総額までの各プレイヤーの拠出は `Pot` に残るため、ブラインドオールイン本人の短縮ブラインドと相手の同額までのブラインドも `Pot` に含まれ、上限を超える分だけが `SidePot` に入る。これは `BetChip=0` のアンテのみオールインに限らず、`BetChip>0` のブラインドオールインでも発生する（下記 #55・#56・#59 は deal 時点から `SidePot` が非空）。アンテのみオールインでは、`Pot` は最短オールインスタック s1 でキャップされ（`Pot = s1 × アンテ拠出者数` が厳密成立 — 2026-07-04 キャプチャの全アンテオールイン51ハンド中、追跡可能な50ハンドすべてで検証）、各 `SidePot[k]` も上位ティアでキャップされる。この場合のブラインドは**最上位（キャップなし）のサイドポットにのみ**積まれる。実例: hand 260147134 は `SidePot[1]=5000` = アンテ超過分 1,200 + BB 3,800、hand 296039468 は `SidePot[1]=1,877,752` = アンテ超過分 377,752 + ブラインド 1,500,000。したがって上記の `Progress.Pot / アンテ拠出者数` によるアンテ推定はブラインドで水増しされない正確な値であり、ここから `Σ BetChip` を差し引く「修正」を加えてはならない（poker-warehouse `marts__fct_player_hand_results` のティア推定はこの性質に依存し、DuckDB 実測でグラウンドトゥルース一致を確認済み）。なお保存則そのもの（`Σ Chip + Pot + Σ SidePot` が Pot と**全** SidePot を合算する形）はキャップの有無に関わらず成立する。
 
+### EVT_HAND_RESULTS: RewardChip と uncalled return
+
+`Results[].RewardChip` は**勝利額ではなくgross payout**であり、争われたポットの獲得額に加えて、
+相手にコールされなかった超過拠出の返却（uncalled return）も含む。そのため
+`RewardChip > 0` は勝者であることを意味しない。敗者が争われたポットを一切獲得せず、
+自分だけが拠出した最上位ティアを返されて `RewardChip > 0` になる実例がある。
+
+rawにはuncalled return専用フィールドがないため、`Pot`、`SidePot[]`、`HandRanking`、
+`RewardChip`のいずれか単独から勝者を決めてはならない。ポーカーのチップ会計は強整合性を
+持つため、完全な因果関係を持つ`EVT_DEAL`→`EVT_HAND_RESULTS`の開始・終了スタックから
+各プレイヤーの総拠出額を復元し、拠出ティアを次の2種類へ分離する。
+
+- 2人以上が拠出したティア: `contestedAward`（勝敗判定の対象）
+- 1人だけが拠出した最上位ティア: `uncalledReturn`（本人への返却であり勝利ではない）
+
+完全なseat snapshotでは、各プレイヤーについて
+`totalContribution = startingStack + RewardChip - finalStack`、
+`netChips = RewardChip - totalContribution`が成立する。勝者依存統計は
+`RewardChip > 0`ではなく`contestedAward > 0`を使う。snapshotが欠けて拠出額を一意に
+復元できない場合は、推測せず未解決として扱う。
+
+実イベントと計算過程は[HandId=269804225の実例](api-event-examples.md#rewardchip-uncalled-return-example)を参照。
+
 ### EVT_DEAL: Player フィールドの欠落
 
 - **観戦モード**: Player フィールド自体が undefined

--- a/docs/pokerstars-export.md
+++ b/docs/pokerstars-export.md
@@ -150,6 +150,8 @@ PlayerA collected 200 from main pot
 
 `EVT_HAND_RESULTS` はポット単位の内訳（どのポットを誰が獲得したか）を直接は提供しない
 （`Pot` / `SidePot[]` の金額列と、プレイヤーごとの `HandRanking` / `RewardChip` 合計のみ）。
+さらに`RewardChip`は争われたポットの獲得額だけでなくuncalled returnも含むため、
+`RewardChip > 0`を勝者判定には使えない。
 collected 行の帰属は以下の前提から復元する:
 
 - **参加資格は入れ子構造**: メインポット ⊇ side pot-1 ⊇ side pot-2 …（早くオールインした
@@ -160,12 +162,15 @@ collected 行の帰属は以下の前提から復元する:
   メイン+side1 を獲得し、side2 は HandRanking=2 が獲得するケース。実データ
   Hand #296039758 で確認済み）
 
-実装（`buildCollectedEntries`）: 勝者（`RewardChip > 0`、NO_CALL 勝者は先頭扱い）を
+実装（`buildCollectedEntries`）: まず検出したuncalled betを最上位の`SidePot`から差し引き、
+争われたポットだけを分配対象にする。次にpayout候補（`RewardChip > 0`、NO_CALLは先頭扱い）を
 `HandRanking` 昇順に並べ、メインポットから順に、残 `RewardChip` を持つ最強グループへ
-ポットを割り当てて残額を消費していく貪欲法。同点スプリット時の端数（オッドチップ）は
-残額が最小のメンバーに寄せることで、後続ポットの資格判定（残額 > 0）が壊れないように
-している。検算の不変条件は `Pot + sum(SidePot) == sum(RewardChip)`（実データで 100% 成立、
-docs/api-events.md 参照）。
+ポットを割り当てて残額を消費していく。ここで`RewardChip > 0`は候補の列挙条件であり、
+勝者の定義ではない。uncalled returnしかないプレイヤーには`collected`行を出力しない。
+同点スプリット時の端数（オッドチップ）は残額が最小のメンバーに寄せ、後続ポットの
+資格判定（残額 > 0）が壊れないようにしている。raw全体の検算では
+`Pot + sum(SidePot) == sum(RewardChip)`（uncalled returnを含む。実データで100%成立）を使い、
+勝者依存統計では別途`contestedAward > 0`を使う（docs/api-events.md参照）。
 
 ### Summary 行
 

--- a/src/constants/database.ts
+++ b/src/constants/database.ts
@@ -92,9 +92,14 @@ export type DbOperationType = 'import' | 'export' | 'sync' | 'rebuild'
  * `Hand.playerChipAccounting`は書き込み時に導出するため、既存handにも
  * Raw Event Lakeからの再構築が必要。
  *
+ * version 6: `Hand.winningPlayerIds`をgross `RewardChip > 0`から、
+ * contribution tierでuncalled returnを分離したcontested award基準へ変更。
+ * WWSF/W$SD/RIVER_CALL_WONなど既存handの勝者依存統計を修復するため、
+ * Raw Event Lakeからの再構築が必要。
+ *
  * インクリメントすると、拡張機能の更新後に既存ユーザーへ一度だけ
  * 「データ再構築」の実行を促すアドバイソリーが表示される
  * （`src/background/rebuild-advisory.ts`参照）。単なるUI変更やバグ修正でも
  * 書き込み時の導出結果に影響しないものはバンプ不要。
  */
-export const REBUILD_ADVISORY_VERSION = 5
+export const REBUILD_ADVISORY_VERSION = 6

--- a/src/entity-converter.test.ts
+++ b/src/entity-converter.test.ts
@@ -2464,6 +2464,7 @@ describe('EntityConverter', () => {
       const dbMock = new PokerChaseDB(indexedDB, IDBKeyRange)
       const service = new PokerChaseService({ db: dbMock })
       await service.ready
+      service.session.setBattleType(BattleType.SIT_AND_GO)
       for (const event of events) service.handAggregateStream.write(event)
       await service.handAggregateStream.whenIdle()
 
@@ -2906,23 +2907,23 @@ describe('EntityConverter', () => {
     })
 
     /**
-     * サイドポット勝者の不一致（scenario b）。
+     * uncalled returnを勝利と誤認する不一致（scenario b）。
      *
      * 実データ（pokerchase_raw_data_2026-07-04T18-31-12-252Z.ndjson、HandId=269804225）
      * から抽出したハンドを匿名化したもの。ヘッズアップでプリフロップオールイン、
-     * アンテ差によるサイドポットが発生し、メインポット勝者（HandRanking=1、
-     * RewardChip=3576）とサイドポット勝者（HandRanking=2、RewardChip=14412）が
-     * 異なるプレイヤーになる。
+     * アンテオールインにより、メインポット勝者（HandRanking=1、
+     * RewardChip=3576）とは別の敗者に、コールされなかった超過分14412が
+     * RewardChipとして返る。後者はcontested potを獲得していない。
      *
      * `Pot(3576) + SidePot(14412) === sum(RewardChip)(3576+14412)` の不変条件を維持。
      */
-    it('unifies main-pot and side-pot winners under RewardChip>0 in BOTH pipelines (scenario b)', async () => {
+    it('excludes an uncalled-only payout from winners in BOTH pipelines (scenario b)', async () => {
       const WINNER_MAIN = 850121266 // メインポット勝者（HandRanking=1）
-      const WINNER_SIDE = 561384657 // サイドポットのみの勝者（HandRanking=2、RewardChip>0）
+      const UNCALLED_LOSER = 561384657 // 超過分のみ返却された敗者（HandRanking=2、RewardChip>0）
       const events: ApiEvent[] = [
         createEvent(ApiType.EVT_DEAL, {
           timestamp: 50000,
-          SeatUserIds: [WINNER_SIDE, -1, -1, WINNER_MAIN, -1, -1],
+          SeatUserIds: [UNCALLED_LOSER, -1, -1, WINNER_MAIN, -1, -1],
           Game: {
             CurrentBlindLv: 12,
             NextBlindUnixSeconds: 1729100631,
@@ -2953,7 +2954,7 @@ describe('EntityConverter', () => {
             { SeatIndex: 3, Status: 0, BetStatus: 3, Chip: 0, BetChip: 0 }
           ]
         }, { skipValidation: true }),
-        // ヒーロー(seat0, WINNER_SIDE)がオールイン後のチェック扱い（進行イベント）
+        // ヒーロー(seat0, UNCALLED_LOSER)がオールイン後のチェック扱い（進行イベント）
         createEvent(ApiType.EVT_ACTION, {
           timestamp: 50001,
           SeatIndex: 0,
@@ -2989,7 +2990,7 @@ describe('EntityConverter', () => {
               RewardChip: 3576
             },
             {
-              UserId: WINNER_SIDE,
+              UserId: UNCALLED_LOSER,
               HoleCards: [49, 8],
               RankType: RankType.TWO_PAIR,
               Hands: [49, 40, 39, 33, 8],
@@ -3013,6 +3014,7 @@ describe('EntityConverter', () => {
       const dbMock = new PokerChaseDB(indexedDB, IDBKeyRange)
       const service = new PokerChaseService({ db: dbMock })
       await service.ready
+      service.session.setBattleType(BattleType.SIT_AND_GO)
 
       // --- インポート/リビルドパイプライン: EntityConverter経由 ---
       const importResult = converter.convertEventsToEntities(events)
@@ -3029,19 +3031,209 @@ describe('EntityConverter', () => {
         { description: 'dbMock.hands row 269804225 with winningPlayerIds populated' }
       )
 
-      // 修正前のWES（HandRanking===1）ではWINNER_SIDEを見逃していたが、
-      // 修正後はRewardChip>0に統一されているため、両者ともサイドポット勝者を含む
+      // RewardChip>0だけではUNCALLED_LOSERを勝者に含めるが、settlement resolverは
+      // contribution tier 14412を対戦相手のいないuncalled returnとして除外する。
       expect(liveHand).toBeDefined()
       expect(importHand).toBeDefined()
-      expect(new Set(liveHand!.winningPlayerIds)).toEqual(new Set([WINNER_MAIN, WINNER_SIDE]))
-      expect(new Set(importHand!.winningPlayerIds)).toEqual(new Set([WINNER_MAIN, WINNER_SIDE]))
+      expect(new Set(liveHand!.winningPlayerIds)).toEqual(new Set([WINNER_MAIN]))
+      expect(new Set(importHand!.winningPlayerIds)).toEqual(new Set([WINNER_MAIN]))
       expect(new Set(importHand!.winningPlayerIds)).toEqual(new Set(liveHand!.winningPlayerIds))
 
-      // 旧HandRanking===1定義ではWINNER_SIDEが漏れることの確認（回帰防止のドキュメント）
-      const oldDefinitionWinners = new Set(
-        resultsEvt.Results!.filter(r => r.HandRanking === 1).map(r => r.UserId)
+      const rewardOnlyWinners = new Set(
+        resultsEvt.Results!.filter(r => r.RewardChip > 0).map(r => r.UserId)
       )
-      expect(oldDefinitionWinners.has(WINNER_SIDE)).toBe(false)
+      expect(rewardOnlyWinners.has(UNCALLED_LOSER)).toBe(true)
+    })
+
+    it('does not tag an uncalled-only river caller as RIVER_CALL_WON in either pipeline', async () => {
+      const WINNER = 7001
+      const UNCALLED_LOSER = 7002
+      const HAND_ID = 999040
+      const events: ApiEvent[] = [
+        createEvent(ApiType.EVT_DEAL, {
+          timestamp: 55000,
+          SeatUserIds: [WINNER, UNCALLED_LOSER, -1, -1],
+          Game: {
+            CurrentBlindLv: 1,
+            NextBlindUnixSeconds: 0,
+            Ante: 0,
+            SmallBlind: 1,
+            BigBlind: 2,
+            ButtonSeat: 0,
+            SmallBlindSeat: 0,
+            BigBlindSeat: 1
+          },
+          Player: {
+            SeatIndex: 0,
+            BetStatus: BetStatusType.BET_ABLE,
+            HoleCards: [0, 1],
+            Chip: 100,
+            BetChip: 0
+          },
+          OtherPlayers: [
+            { SeatIndex: 1, Status: 0, BetStatus: BetStatusType.BET_ABLE, Chip: 100, BetChip: 0 }
+          ],
+          Progress: {
+            Phase: PhaseType.PREFLOP,
+            NextActionSeat: 0,
+            NextActionTypes: [ActionType.CHECK, ActionType.BET],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 2,
+            Pot: 0,
+            SidePot: []
+          }
+        }),
+        createEvent(ApiType.EVT_DEAL_ROUND, {
+          timestamp: 55001,
+          CommunityCards: [0, 4, 8],
+          Player: {
+            SeatIndex: 0,
+            BetStatus: BetStatusType.BET_ABLE,
+            HoleCards: [0, 1],
+            Chip: 100,
+            BetChip: 0
+          },
+          OtherPlayers: [
+            { SeatIndex: 1, Status: 0, BetStatus: BetStatusType.BET_ABLE, Chip: 100, BetChip: 0 }
+          ],
+          Progress: {
+            Phase: PhaseType.RIVER,
+            NextActionSeat: 0,
+            NextActionTypes: [ActionType.CHECK, ActionType.BET],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 0,
+            Pot: 0,
+            SidePot: []
+          }
+        }),
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 55002,
+          SeatIndex: 0,
+          ActionType: ActionType.BET,
+          Chip: 90,
+          BetChip: 10,
+          Progress: {
+            Phase: PhaseType.RIVER,
+            NextActionSeat: 1,
+            NextActionTypes: [ActionType.CALL, ActionType.FOLD, ActionType.RAISE],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 20,
+            Pot: 10,
+            SidePot: []
+          }
+        }),
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 55003,
+          SeatIndex: 1,
+          ActionType: ActionType.CALL,
+          Chip: 90,
+          BetChip: 10,
+          Progress: {
+            Phase: PhaseType.RIVER,
+            NextActionSeat: 0,
+            NextActionTypes: [ActionType.CHECK, ActionType.BET],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 20,
+            Pot: 20,
+            SidePot: []
+          }
+        }),
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 55004,
+          SeatIndex: 0,
+          ActionType: ActionType.RAISE,
+          Chip: 70,
+          BetChip: 30,
+          Progress: {
+            Phase: PhaseType.RIVER,
+            NextActionSeat: 1,
+            NextActionTypes: [ActionType.CALL, ActionType.FOLD, ActionType.RAISE],
+            NextExtraLimitSeconds: 15,
+            MinRaise: 50,
+            Pot: 40,
+            SidePot: []
+          }
+        }),
+        createEvent(ApiType.EVT_ACTION, {
+          timestamp: 55005,
+          SeatIndex: 1,
+          ActionType: ActionType.RAISE,
+          Chip: 50,
+          BetChip: 50,
+          Progress: {
+            Phase: PhaseType.RIVER,
+            NextActionSeat: -2,
+            NextActionTypes: [],
+            NextExtraLimitSeconds: 0,
+            MinRaise: 0,
+            Pot: 60,
+            SidePot: [20]
+          }
+        }),
+        createEvent(ApiType.EVT_HAND_RESULTS, {
+          timestamp: 55006,
+          HandId: HAND_ID,
+          CommunityCards: [12, 16],
+          Pot: 60,
+          SidePot: [20],
+          ResultType: 0,
+          DefeatStatus: 0,
+          Results: [
+            {
+              UserId: WINNER,
+              HoleCards: [0, 1],
+              RankType: RankType.ONE_PAIR,
+              Hands: [0, 1, 4, 8, 12],
+              HandRanking: 1,
+              Ranking: -2,
+              RewardChip: 60
+            },
+            {
+              UserId: UNCALLED_LOSER,
+              HoleCards: [2, 3],
+              RankType: RankType.HIGH_CARD,
+              Hands: [2, 3, 4, 8, 12],
+              HandRanking: 2,
+              Ranking: -2,
+              RewardChip: 20
+            }
+          ],
+          Player: { SeatIndex: 0, BetStatus: -1, Chip: 130, BetChip: 0 },
+          OtherPlayers: [
+            { SeatIndex: 1, Status: 0, BetStatus: -1, Chip: 70, BetChip: 0 }
+          ]
+        })
+      ]
+
+      const importResult = converter.convertEventsToEntities(events)
+      const importHand = importResult.hands.find(hand => hand.id === HAND_ID)
+      const importRiverCall = importResult.actions.find(action =>
+        action.handId === HAND_ID &&
+        action.playerId === UNCALLED_LOSER &&
+        action.phase === PhaseType.RIVER &&
+        action.actionType === ActionType.CALL)
+      expect(importHand?.winningPlayerIds).toEqual([WINNER])
+      expect(importRiverCall?.actionDetails).toContain(ActionDetail.RIVER_CALL)
+      expect(importRiverCall?.actionDetails).not.toContain(ActionDetail.RIVER_CALL_WON)
+
+      const dbMock = new PokerChaseDB(indexedDB, IDBKeyRange)
+      const service = new PokerChaseService({ db: dbMock })
+      await service.ready
+      service.session.setBattleType(BattleType.SIT_AND_GO)
+      const liveActions = await pipeEventsAndWaitForActions(service, dbMock, events, {
+        handId: HAND_ID,
+        minCount: importResult.actions.filter(action => action.handId === HAND_ID).length
+      })
+      const liveHand = await dbMock.hands.get(HAND_ID)
+      const liveRiverCall = liveActions.find(action =>
+        action.playerId === UNCALLED_LOSER &&
+        action.phase === PhaseType.RIVER &&
+        action.actionType === ActionType.CALL)
+
+      expect(liveHand?.winningPlayerIds).toEqual([WINNER])
+      expect(liveRiverCall?.actionDetails).toContain(ActionDetail.RIVER_CALL)
+      expect(liveRiverCall?.actionDetails).not.toContain(ActionDetail.RIVER_CALL_WON)
+      expect(liveRiverCall?.actionDetails).toEqual(importRiverCall?.actionDetails)
     })
 
     /**
@@ -3346,6 +3538,7 @@ describe('EntityConverter', () => {
       const dbMock = new PokerChaseDB(indexedDB, IDBKeyRange)
       const service = new PokerChaseService({ db: dbMock })
       await service.ready
+      service.session.setBattleType(BattleType.SIT_AND_GO)
       const liveHandActions = await pipeEventsAndWaitForActions(service, dbMock, events, {
         handId: 271929009,
         minCount: importResult.actions.filter(a => a.handId === 271929009).length

--- a/src/entity-converter.ts
+++ b/src/entity-converter.ts
@@ -31,7 +31,7 @@ import type {
 
 import { defaultRegistry } from './stats'
 import { getPositionMap, getBigBlindUserId } from './utils/position-utils'
-import { derivePlayerHandChipAccounting } from './utils/hand-chip-accounting'
+import { deriveHandSettlement } from './utils/hand-chip-accounting'
 
 /**
  * エンティティバンドル（一括保存用）
@@ -438,14 +438,13 @@ export class EntityConverter {
             }
           }
 
-          // ハンド結果の更新
-          handState.hand.winningPlayerIds = event.Results
-            ?.filter(result => result.RewardChip > 0)
-            .map(result => result.UserId) || []
           handState.hand.results = event.Results || []
-          handState.hand.playerChipAccounting = dealEvent
-            ? derivePlayerHandChipAccounting(dealEvent, event, handState.hand.session.battleType)
-            : Object.fromEntries(handState.hand.seatUserIds.filter(userId => userId !== -1).map(userId => [String(userId), null]))
+          const settlement = dealEvent
+            ? deriveHandSettlement(dealEvent, event, handState.hand.session.battleType)
+            : null
+          handState.hand.winningPlayerIds = settlement?.winningPlayerIds ?? []
+          handState.hand.playerChipAccounting = settlement?.playerChipAccounting ??
+            Object.fromEntries(handState.hand.seatUserIds.filter(userId => userId !== -1).map(userId => [String(userId), null]))
           // RIVER_CALLで勝利したアクションにRIVER_CALL_WONを付与する
           // （WriteEntityStreamと同一ロジック。River Call Accuracy統計が参照する）
           handState.actions.forEach(action => {

--- a/src/streams/write-entity-stream.ts
+++ b/src/streams/write-entity-stream.ts
@@ -21,7 +21,7 @@ import { ErrorHandler } from '../utils/error-handler'
 import { getPositionMap, getBigBlindUserId } from '../utils/position-utils'
 import { defaultRegistry } from '../stats'
 import type { ErrorContext } from '../types/errors'
-import { derivePlayerHandChipAccounting } from '../utils/hand-chip-accounting'
+import { deriveHandSettlement } from '../utils/hand-chip-accounting'
 
 /**
  * エンティティ書き込みStream（パイプライン第2段階）
@@ -316,16 +316,13 @@ export class WriteEntityStream extends SimpleTransform<ApiHandEvent[], number[]>
             })
           }
           handState.hand.id = event.HandId
-          // 勝者定義: RewardChip > 0（獲得チップがあるプレイヤー）。
-          // HandRanking === 1（最強役）ではサイドポットのみを獲得したプレイヤーを
-          // 見逃す（メインポット勝者の役が最強でも、サイドポット勝者は別役の場合がある）。
-          // WWSF/W$SDはPT4の定義上「ポットの一部でも獲得したか」を問うため、
-          // RewardChip基準がこれらの統計と整合する。
-          handState.hand.winningPlayerIds = event.Results.filter(({ RewardChip }) => RewardChip > 0).map(({ UserId }) => UserId)
           handState.hand.results = event.Results
-          handState.hand.playerChipAccounting = dealEvent
-            ? derivePlayerHandChipAccounting(dealEvent, event, handState.hand.session.battleType)
-            : Object.fromEntries(handState.hand.seatUserIds.filter(userId => userId !== -1).map(userId => [String(userId), null]))
+          const settlement = dealEvent
+            ? deriveHandSettlement(dealEvent, event, handState.hand.session.battleType)
+            : null
+          handState.hand.winningPlayerIds = settlement?.winningPlayerIds ?? []
+          handState.hand.playerChipAccounting = settlement?.playerChipAccounting ??
+            Object.fromEntries(handState.hand.seatUserIds.filter(userId => userId !== -1).map(userId => [String(userId), null]))
 
           // Update actions with handId and add RIVER_CALL_WON for winning river calls
           handState.actions = handState.actions.map(action => {

--- a/src/tools/verify-stats.test.ts
+++ b/src/tools/verify-stats.test.ts
@@ -20,7 +20,7 @@ import { runPipeline } from './verify-stats/pipeline'
 import { runOracle } from './verify-stats/oracle'
 import { compareResults, formatReport } from './verify-stats/compare'
 import { ApiType, apiEventSchemas } from '../types/api'
-import { ActionType } from '../types/game'
+import { ActionType, BattleType, BetStatusType, PhaseType, RankType } from '../types/game'
 import type { ApiEvent } from '../types'
 
 // Mirrors the createEvent() helper in entity-converter.test.ts: parses through
@@ -256,6 +256,110 @@ describe('verify-stats harness', () => {
     const rendered = formatReport(report)
     expect(rendered).toContain('Mismatches for vpip')
     expect(rendered).toContain(`player ${PLAYER_A}`)
+  })
+
+  it('oracle infers one omitted tournament result snapshot and keeps a net-loss side-pot winner', async () => {
+    const events = [
+      { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, timestamp: 2000, BattleType: BattleType.SIT_AND_GO, Code: 0, Id: 'test', IsRetire: false },
+      {
+        ApiTypeId: ApiType.EVT_DEAL,
+        timestamp: 2001,
+        SeatUserIds: [201, 202, 203, -1],
+        Game: { Ante: 0, SmallBlind: 1, BigBlind: 2, ButtonSeat: 0, SmallBlindSeat: 1, BigBlindSeat: 2 },
+        Player: { SeatIndex: 0, BetStatus: BetStatusType.BET_ABLE, Chip: 100, BetChip: 0 },
+        OtherPlayers: [
+          { SeatIndex: 1, BetStatus: BetStatusType.BET_ABLE, Chip: 100, BetChip: 0 },
+          { SeatIndex: 2, BetStatus: BetStatusType.BET_ABLE, Chip: 100, BetChip: 0 },
+        ],
+        Progress: { Phase: PhaseType.PREFLOP, NextActionTypes: [], Pot: 0, SidePot: [] },
+      },
+      {
+        ApiTypeId: ApiType.EVT_DEAL_ROUND,
+        timestamp: 2002,
+        CommunityCards: [0, 4, 8],
+        Player: { SeatIndex: 0, BetStatus: BetStatusType.ALL_IN, Chip: 10, BetChip: 0 },
+        OtherPlayers: [
+          { SeatIndex: 1, BetStatus: BetStatusType.ALL_IN, Chip: 0, BetChip: 0 },
+          { SeatIndex: 2, BetStatus: BetStatusType.ALL_IN, Chip: 0, BetChip: 0 },
+        ],
+        Progress: { Phase: PhaseType.FLOP, NextActionTypes: [], Pot: 270, SidePot: [20] },
+      },
+      {
+        ApiTypeId: ApiType.EVT_HAND_RESULTS,
+        timestamp: 2003,
+        HandId: 999002,
+        CommunityCards: [12, 16],
+        Pot: 270,
+        SidePot: [20],
+        Results: [
+          { UserId: 201, RankType: RankType.ONE_PAIR, HandRanking: 1, RewardChip: 270 },
+          { UserId: 202, RankType: RankType.HIGH_CARD, HandRanking: 2, RewardChip: 20 },
+          { UserId: 203, RankType: RankType.HIGH_CARD, HandRanking: -1, RewardChip: 0 },
+        ],
+        Player: { SeatIndex: 0, BetStatus: BetStatusType.HAND_ENDED, Chip: 280, BetChip: 0 },
+        // seat 1 (the side-pot winner) is intentionally omitted.
+        OtherPlayers: [
+          { SeatIndex: 2, BetStatus: BetStatusType.HAND_ENDED, Chip: 0, BetChip: 0 },
+        ],
+      },
+    ] as unknown as ApiEvent[]
+
+    const pipeline = await runPipeline(events)
+    const oracle = runOracle(events)
+
+    expect(pipeline.get(202)?.stats.wwsf).toEqual([1, 1])
+    expect(oracle.get(202)?.stats.wwsf).toEqual([1, 1])
+  })
+
+  it('oracle re-derives a short ante all-in tier instead of treating the returned excess as a win', async () => {
+    const events = [
+      { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, timestamp: 3000, BattleType: BattleType.SIT_AND_GO, Code: 0, Id: 'test', IsRetire: false },
+      {
+        ApiTypeId: ApiType.EVT_DEAL,
+        timestamp: 3001,
+        SeatUserIds: [301, 302, -1, -1],
+        Game: { Ante: 100, SmallBlind: 1, BigBlind: 2, ButtonSeat: 0, SmallBlindSeat: 0, BigBlindSeat: 1 },
+        Player: { SeatIndex: 0, BetStatus: BetStatusType.ALL_IN, Chip: 0, BetChip: 0 },
+        OtherPlayers: [
+          { SeatIndex: 1, BetStatus: BetStatusType.BET_ABLE, Chip: 100, BetChip: 0 },
+        ],
+        Progress: { Phase: PhaseType.PREFLOP, NextActionTypes: [], Pot: 60, SidePot: [70] },
+      },
+      {
+        ApiTypeId: ApiType.EVT_DEAL_ROUND,
+        timestamp: 3002,
+        CommunityCards: [0, 4, 8],
+        Player: { SeatIndex: 0, BetStatus: BetStatusType.ALL_IN, Chip: 0, BetChip: 0 },
+        OtherPlayers: [
+          { SeatIndex: 1, BetStatus: BetStatusType.BET_ABLE, Chip: 80, BetChip: 20 },
+        ],
+        Progress: { Phase: PhaseType.FLOP, NextActionTypes: [], Pot: 60, SidePot: [90] },
+      },
+      {
+        ApiTypeId: ApiType.EVT_HAND_RESULTS,
+        timestamp: 3003,
+        HandId: 999003,
+        CommunityCards: [12, 16],
+        Pot: 60,
+        SidePot: [90],
+        Results: [
+          { UserId: 301, RankType: RankType.ONE_PAIR, HandRanking: 1, RewardChip: 60 },
+          { UserId: 302, RankType: RankType.HIGH_CARD, HandRanking: 2, RewardChip: 90 },
+        ],
+        Player: { SeatIndex: 0, BetStatus: BetStatusType.HAND_ENDED, Chip: 60, BetChip: 0 },
+        OtherPlayers: [
+          { SeatIndex: 1, BetStatus: BetStatusType.HAND_ENDED, Chip: 170, BetChip: 0 },
+        ],
+      },
+    ] as unknown as ApiEvent[]
+
+    const pipeline = await runPipeline(events)
+    const oracle = runOracle(events)
+
+    expect(pipeline.get(301)?.stats.wwsf).toEqual([1, 1])
+    expect(oracle.get(301)?.stats.wwsf).toEqual([1, 1])
+    expect(pipeline.get(302)?.stats.wwsf).toEqual([0, 1])
+    expect(oracle.get(302)?.stats.wwsf).toEqual([0, 1])
   })
 
   it('counts a missing/non-fraction stat as a mismatch, not a silent skip', () => {

--- a/src/tools/verify-stats/oracle.ts
+++ b/src/tools/verify-stats/oracle.ts
@@ -91,15 +91,18 @@
  *  (c) Showdown participation is gated on RankType: NO_CALL and FOLD_OPEN
  *      are excluded, everything else (0-9 real ranks, SHOWDOWN_MUCK)
  *      counts as a showdown.
- *  (d) Winners are players with RewardChip > 0 in EVT_HAND_RESULTS.Results.
+ *  (d) Winners are players with a positive contested award. RewardChip also
+ *      includes uncalled excess returns, so the oracle independently rebuilds
+ *      contribution tiers from DEAL/RESULTS stack snapshots and removes every
+ *      tier reached by only one contributor.
  *  (e) River Call Accuracy (RCA): numerator is river CALL actions by a player
- *      in hands where that player ends up with RewardChip > 0; denominator is
+ *      in hands where that player wins a contested award; denominator is
  *      all river CALL actions by that player -- mirroring
  *      src/stats/core/river-call-accuracy.ts's RIVER_CALL/RIVER_CALL_WON
  *      ActionDetail tagging (RIVER_CALL is set when a CALL action occurs on
  *      the river; RIVER_CALL_WON is added post-hoc, in EVT_HAND_RESULTS, to
- *      any RIVER_CALL action taken by a player who ends up with
- *      RewardChip > 0 for that hand -- see entity-converter.ts /
+ *      any RIVER_CALL action taken by a player who wins a contested award
+ *      for that hand -- see entity-converter.ts /
  *      write-entity-stream.ts).
  *  (f) VPIP·F (vpipF, opt-in HUD-original stat, see hand-over
  *      workspace/reports/pokerchase-hud-vpip-f-handover.md): same VPIP
@@ -120,17 +123,22 @@ type ActionTypeNum = Exclude<ActionType, ActionType.ALL_IN>
 interface RawSeatPlayer {
   SeatIndex: number
   BetStatus: BetStatusType
+  Chip?: number
+  BetChip?: number
 }
 interface RawGame {
   ButtonSeat: number
   SmallBlindSeat: number
   BigBlindSeat: number
+  Ante?: number
 }
 interface RawDealEvent {
   ApiTypeId: ApiType.EVT_DEAL
   SeatUserIds: number[]
   Game: RawGame
   Progress: RawProgress
+  Player?: RawSeatPlayer
+  OtherPlayers?: RawSeatPlayer[]
 }
 interface RawProgress {
   NextActionTypes: number[]
@@ -153,6 +161,7 @@ interface RawDealRoundEvent {
 interface RawResultEntry {
   UserId: number
   RankType: RankType
+  HandRanking?: number
   RewardChip: number
 }
 interface RawHandResultsEvent {
@@ -160,8 +169,95 @@ interface RawHandResultsEvent {
   HandId: number
   Results: RawResultEntry[]
   CommunityCards?: number[]
+  Pot?: number
+  SidePot?: number[]
+  Player?: RawSeatPlayer
+  OtherPlayers?: RawSeatPlayer[]
 }
 type RawEvent = RawDealEvent | RawActionEvent | RawDealRoundEvent | RawHandResultsEvent | { ApiTypeId: number }
+
+const rawSeatSnapshot = (
+  event: { Player?: RawSeatPlayer, OtherPlayers?: RawSeatPlayer[] },
+  seatIndex: number
+): RawSeatPlayer | undefined => {
+  if (event.Player?.SeatIndex === seatIndex) return event.Player
+  return event.OtherPlayers?.find(player => player.SeatIndex === seatIndex)
+}
+
+/**
+ * Independent winner resolution for the verification oracle.
+ *
+ * This deliberately does not import the production settlement helper. Exact
+ * endpoint contributions are `start + payout - final`; contribution levels
+ * reached by one player are uncalled returns, while levels reached by two or
+ * more players are contested. Abbreviated legacy rows retain only an explicit
+ * main-pot/NO_CALL winner signal.
+ */
+const resolveContestedWinners = (
+  deal: RawDealEvent,
+  results: RawHandResultsEvent
+): Set<number> => {
+  const fallback = () => new Set(
+    results.Results
+      .filter(result =>
+        result.RewardChip > 0 &&
+        (result.HandRanking === 1 || result.RankType === RankType.NO_CALL))
+      .map(result => result.UserId)
+  )
+  if (!Array.isArray(results.Results) ||
+      !Array.isArray(results.SidePot) ||
+      !Number.isSafeInteger(results.Pot)) return fallback()
+
+  const userIds = deal.SeatUserIds.filter(userId => userId !== -1)
+  const resultByUserId = new Map(results.Results.map(result => [result.UserId, result]))
+  const contributions = new Map<number, number>()
+  for (let seatIndex = 0; seatIndex < deal.SeatUserIds.length; seatIndex++) {
+    const userId = deal.SeatUserIds[seatIndex]
+    if (userId === undefined || userId === -1) continue
+    const start = rawSeatSnapshot(deal, seatIndex)
+    const final = rawSeatSnapshot(results, seatIndex)
+    if (start?.Chip === undefined || start.BetChip === undefined ||
+        final?.Chip === undefined || final.BetChip === undefined) return fallback()
+
+    const paysAnte = start.BetStatus === BetStatusType.BET_ABLE ||
+      start.BetStatus === BetStatusType.ALL_IN
+    const startingStack = start.Chip + start.BetChip + (paysAnte ? (deal.Game.Ante ?? 0) : 0)
+    const finalStack = final.Chip + final.BetChip
+    const payout = resultByUserId.get(userId)?.RewardChip ?? 0
+    const contribution = startingStack + payout - finalStack
+    if (!Number.isSafeInteger(contribution) || contribution < 0 || contribution > startingStack) return fallback()
+    contributions.set(userId, contribution)
+  }
+
+  const grossPot = results.Pot! + results.SidePot!.reduce((sum, pot) => sum + pot, 0)
+  const grossPayout = results.Results.reduce((sum, result) => sum + result.RewardChip, 0)
+  const totalContribution = [...contributions.values()].reduce((sum, contribution) => sum + contribution, 0)
+  if (!Number.isSafeInteger(grossPot) ||
+      grossPot !== grossPayout ||
+      totalContribution < grossPayout) return fallback()
+
+  const uncalledReturns = new Map<number, number>(userIds.map(userId => [userId, 0]))
+  const levels = [...new Set(contributions.values())]
+    .filter(contribution => contribution > 0)
+    .sort((a, b) => a - b)
+  let previousLevel = 0
+  for (const level of levels) {
+    const contributors = userIds.filter(userId => contributions.get(userId)! >= level)
+    if (contributors.length === 1) {
+      const userId = contributors[0]!
+      uncalledReturns.set(userId, uncalledReturns.get(userId)! + (level - previousLevel))
+    }
+    previousLevel = level
+  }
+
+  const winners = new Set<number>()
+  for (const result of results.Results) {
+    const contestedAward = result.RewardChip - (uncalledReturns.get(result.UserId) ?? 0)
+    if (!Number.isSafeInteger(contestedAward) || contestedAward < 0) return fallback()
+    if (contestedAward > 0) winners.add(result.UserId)
+  }
+  return winners
+}
 
 /** Fraction-valued stat: [numerator, denominator]. */
 export type OracleFraction = [number, number]
@@ -600,11 +696,11 @@ export function runOracle(events: unknown[], options: RunOracleOptions = {}): Or
 
     // Showdown / WTSD / WSD / WWSF determination from Results.
     const results = resultsEvt.Results || []
-    // Semantic-sync (d): winners are players with RewardChip > 0.
-    const winners = new Set(results.filter(r => r.RewardChip > 0).map(r => r.UserId))
+    // Semantic-sync (d): independently remove uncalled-only contribution tiers.
+    const winners = resolveContestedWinners(dealEvt, resultsEvt)
 
     // Semantic-sync (e): RIVER_CALL_WON is added to every RIVER_CALL action
-    // taken by a player who ends up with RewardChip > 0 for this hand.
+    // taken by a player who wins a contested award in this hand.
     for (const [pid, count] of riverCallsThisHand) {
       if (winners.has(pid)) acc(pid).riverCallWon += count
     }

--- a/src/tools/verify-stats/oracle.ts
+++ b/src/tools/verify-stats/oracle.ts
@@ -115,7 +115,7 @@
  *      imported, per this file's independence contract.
  */
 import { ApiType } from '../../types/api'
-import { ActionType, BetStatusType, PhaseType, RankType } from '../../types/game'
+import { ActionType, BattleType, BetStatusType, PhaseType, RankType } from '../../types/game'
 
 type ActionTypeNum = Exclude<ActionType, ActionType.ALL_IN>
 
@@ -143,6 +143,8 @@ interface RawDealEvent {
 interface RawProgress {
   NextActionTypes: number[]
   Phase?: number
+  Pot?: number
+  SidePot?: number[]
 }
 interface RawActionEvent {
   ApiTypeId: ApiType.EVT_ACTION
@@ -174,7 +176,11 @@ interface RawHandResultsEvent {
   Player?: RawSeatPlayer
   OtherPlayers?: RawSeatPlayer[]
 }
-type RawEvent = RawDealEvent | RawActionEvent | RawDealRoundEvent | RawHandResultsEvent | { ApiTypeId: number }
+interface RawSessionStartEvent {
+  ApiTypeId: ApiType.EVT_ENTRY_QUEUED
+  BattleType: BattleType
+}
+type RawEvent = RawDealEvent | RawActionEvent | RawDealRoundEvent | RawHandResultsEvent | RawSessionStartEvent | { ApiTypeId: number }
 
 const rawSeatSnapshot = (
   event: { Player?: RawSeatPlayer, OtherPlayers?: RawSeatPlayer[] },
@@ -182,6 +188,43 @@ const rawSeatSnapshot = (
 ): RawSeatPlayer | undefined => {
   if (event.Player?.SeatIndex === seatIndex) return event.Player
   return event.OtherPlayers?.find(player => player.SeatIndex === seatIndex)
+}
+
+const rawPaysAnte = (deal: RawDealEvent, seatIndex: number): boolean => {
+  const betStatus = rawSeatSnapshot(deal, seatIndex)?.BetStatus
+  return betStatus === undefined ||
+    betStatus === BetStatusType.BET_ABLE ||
+    betStatus === BetStatusType.ALL_IN
+}
+
+const rawStartingStack = (deal: RawDealEvent, seatIndex: number): number | null => {
+  const snapshot = rawSeatSnapshot(deal, seatIndex)
+  if (snapshot?.Chip === undefined || snapshot.BetChip === undefined) return null
+
+  const chipsAfterAnte = snapshot.Chip + snapshot.BetChip
+  if (!rawPaysAnte(deal, seatIndex)) return chipsAfterAnte
+
+  const ante = deal.Game.Ante ?? 0
+  if (chipsAfterAnte > 0 || ante === 0) return chipsAfterAnte + ante
+
+  const anteAllInSeats = deal.SeatUserIds
+    .map((userId, index) => ({ userId, index }))
+    .filter(({ userId, index }) =>
+      userId !== -1 &&
+      rawPaysAnte(deal, index) &&
+      (rawSeatSnapshot(deal, index)?.Chip ?? 0) +
+        (rawSeatSnapshot(deal, index)?.BetChip ?? 0) === 0)
+  if (anteAllInSeats.length > 1 && (deal.Progress.SidePot?.length ?? 0) > 0) return null
+
+  const contributorCount = deal.SeatUserIds.reduce((count, userId, index) =>
+    userId !== -1 && rawPaysAnte(deal, index) ? count + 1 : count, 0)
+  const pot = deal.Progress.Pot
+  if (pot === undefined || contributorCount <= 0 || pot % contributorCount !== 0) return null
+
+  const inferredStack = pot / contributorCount
+  return Number.isSafeInteger(inferredStack) && inferredStack > 0 && inferredStack <= ante
+    ? inferredStack
+    : null
 }
 
 /**
@@ -195,7 +238,8 @@ const rawSeatSnapshot = (
  */
 const resolveContestedWinners = (
   deal: RawDealEvent,
-  results: RawHandResultsEvent
+  results: RawHandResultsEvent,
+  battleType: BattleType | undefined
 ): Set<number> => {
   const fallback = () => new Set(
     results.Results
@@ -210,19 +254,51 @@ const resolveContestedWinners = (
 
   const userIds = deal.SeatUserIds.filter(userId => userId !== -1)
   const resultByUserId = new Map(results.Results.map(result => [result.UserId, result]))
+  const starts = new Map<number, number>()
+  const finalStacks = new Map<number, number>()
+  for (let seatIndex = 0; seatIndex < deal.SeatUserIds.length; seatIndex++) {
+    const userId = deal.SeatUserIds[seatIndex]
+    if (userId === undefined || userId === -1) continue
+    const startingStack = rawStartingStack(deal, seatIndex)
+    if (startingStack !== null) starts.set(seatIndex, startingStack)
+
+    const final = rawSeatSnapshot(results, seatIndex)
+    if (final?.Chip !== undefined && final.BetChip !== undefined) {
+      finalStacks.set(seatIndex, final.Chip + final.BetChip)
+    }
+  }
+
+  const occupiedSeatIndexes = deal.SeatUserIds
+    .map((userId, seatIndex) => ({ userId, seatIndex }))
+    .filter(({ userId }) => userId !== -1)
+    .map(({ seatIndex }) => seatIndex)
+  const isTournament = battleType === BattleType.SIT_AND_GO ||
+    battleType === BattleType.TOURNAMENT ||
+    battleType === BattleType.FRIEND_SIT_AND_GO ||
+    battleType === BattleType.CLUB_MATCH
+  const missingFinalSeatIndexes = occupiedSeatIndexes.filter(seatIndex => !finalStacks.has(seatIndex))
+  if (isTournament &&
+      missingFinalSeatIndexes.length === 1 &&
+      occupiedSeatIndexes.every(seatIndex => starts.has(seatIndex))) {
+    const missingSeatIndex = missingFinalSeatIndexes[0]!
+    const missingUserId = deal.SeatUserIds[missingSeatIndex]
+    if (missingUserId !== undefined && results.Results.some(result => result.UserId === missingUserId)) {
+      const totalStartingStack = occupiedSeatIndexes.reduce((sum, seatIndex) => sum + starts.get(seatIndex)!, 0)
+      const knownFinalStack = occupiedSeatIndexes.reduce((sum, seatIndex) => sum + (finalStacks.get(seatIndex) ?? 0), 0)
+      const inferredFinalStack = totalStartingStack - knownFinalStack
+      if (!Number.isSafeInteger(inferredFinalStack) || inferredFinalStack < 0) return fallback()
+      finalStacks.set(missingSeatIndex, inferredFinalStack)
+    }
+  }
+
   const contributions = new Map<number, number>()
   for (let seatIndex = 0; seatIndex < deal.SeatUserIds.length; seatIndex++) {
     const userId = deal.SeatUserIds[seatIndex]
     if (userId === undefined || userId === -1) continue
-    const start = rawSeatSnapshot(deal, seatIndex)
-    const final = rawSeatSnapshot(results, seatIndex)
-    if (start?.Chip === undefined || start.BetChip === undefined ||
-        final?.Chip === undefined || final.BetChip === undefined) return fallback()
+    const startingStack = starts.get(seatIndex)
+    const finalStack = finalStacks.get(seatIndex)
+    if (startingStack === undefined || finalStack === undefined) return fallback()
 
-    const paysAnte = start.BetStatus === BetStatusType.BET_ABLE ||
-      start.BetStatus === BetStatusType.ALL_IN
-    const startingStack = start.Chip + start.BetChip + (paysAnte ? (deal.Game.Ante ?? 0) : 0)
-    const finalStack = final.Chip + final.BetChip
     const payout = resultByUserId.get(userId)?.RewardChip ?? 0
     const contribution = startingStack + payout - finalStack
     if (!Number.isSafeInteger(contribution) || contribution < 0 || contribution > startingStack) return fallback()
@@ -440,8 +516,10 @@ export function runOracle(events: unknown[], options: RunOracleOptions = {}): Or
   const traceHandIds = options.traceHandIds ?? new Set<number>()
 
   let currentHand: RawEvent[] = []
+  let currentBattleType: BattleType | undefined
+  let currentHandBattleType: BattleType | undefined
 
-  function processHand(handEvents: RawEvent[]): void {
+  function processHand(handEvents: RawEvent[], battleType: BattleType | undefined): void {
     const dealEvt = handEvents.find((e): e is RawDealEvent => e.ApiTypeId === ApiType.EVT_DEAL)
     const resultsEvt = handEvents.find((e): e is RawHandResultsEvent => e.ApiTypeId === ApiType.EVT_HAND_RESULTS)
     // Incomplete hand (session boundary / dropped event) -- excluded, same as the
@@ -697,7 +775,7 @@ export function runOracle(events: unknown[], options: RunOracleOptions = {}): Or
     // Showdown / WTSD / WSD / WWSF determination from Results.
     const results = resultsEvt.Results || []
     // Semantic-sync (d): independently remove uncalled-only contribution tiers.
-    const winners = resolveContestedWinners(dealEvt, resultsEvt)
+    const winners = resolveContestedWinners(dealEvt, resultsEvt, battleType)
 
     // Semantic-sync (e): RIVER_CALL_WON is added to every RIVER_CALL action
     // taken by a player who wins a contested award in this hand.
@@ -767,18 +845,22 @@ export function runOracle(events: unknown[], options: RunOracleOptions = {}): Or
 
   for (const raw of events) {
     const e = raw as RawEvent
+    if (e.ApiTypeId === ApiType.EVT_ENTRY_QUEUED) {
+      currentBattleType = (e as RawSessionStartEvent).BattleType
+    }
     if (e.ApiTypeId === ApiType.EVT_DEAL) {
-      if (currentHand.length > 0) processHand(currentHand)
+      if (currentHand.length > 0) processHand(currentHand, currentHandBattleType)
       currentHand = [e]
+      currentHandBattleType = currentBattleType
     } else if (currentHand.length > 0) {
       currentHand.push(e)
       if (e.ApiTypeId === ApiType.EVT_HAND_RESULTS) {
-        processHand(currentHand)
+        processHand(currentHand, currentHandBattleType)
         currentHand = []
       }
     }
   }
-  if (currentHand.length > 0) processHand(currentHand)
+  if (currentHand.length > 0) processHand(currentHand, currentHandBattleType)
 
   const result: OracleResult = new Map()
   for (const [pid, a] of players.entries()) {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -342,10 +342,10 @@ export const apiEventSchemas = {
         ※[-1,-1]パターンは未観測（0件）`),
       Ranking: z.union([z.literal(-2), z.literal(-1), z.int().nonnegative()]).describe('-2=In-Play（継続中）, -1=Multiway敗退（複数人脱落時）, 正の数=このプレイヤーの**トーナメント最終着順**（脱落したこのハンドで確定、以降のハンドに再登場しない — poker-warehouse SNG継続性監査 I3 で全数検証: BQ本番839-857セッション+2キャプチャ全てゼロ違反）。優勝者はトーナメント最終ハンドでRanking=1になる（監査対象の全終端セッションで278/278）。同着（同一ハンドでの複数バスト）もサーバー側が個別の着順に割り振る場合があり、スタック残量など公開フィールドからは再現できないタイブレークが働いている'),
       RankType: z.enum(RankType).describe('成立役。0-9=ポーカーハンド（0=ロイヤルフラッシュ〜9=ハイカード）。10=NO_CALL（無競争勝利）, 11=SHOWDOWN_MUCK（ショーダウンで敗北しマック）, 12=FOLD_OPEN（フォールド後に自発的にカード公開）'),
-      RewardChip: z.int().nonnegative().describe('このプレイヤーが獲得したチップ量。0=敗北。サイドポットがある場合は各ポットからの獲得合計'),
+      RewardChip: z.int().nonnegative().describe('このプレイヤーへのgross payout。争われたポットの獲得額に加え、相手にコールされなかった超過拠出の返却（uncalled return）も含む。したがってRewardChip>0だけでは勝者と判定できず、0は獲得・返却ともにないことを示す。勝者判定は開始/終了stackから拠出tierを復元し、contested awardが正のプレイヤーを使う'),
       UserId: z.int().nonnegative().describe('プレイヤーID。EVT_DEAL.SeatUserIdsの値と一致。タイムアウト/切断プレイヤーはResults[]に含まれない場合がある'),
     })).min(1).max(6).describe(`ハンド結果の配列。フォールドしなかったプレイヤーのみ（FOLD_OPEN除く）。最大6人（6-handed全員ショーダウン時）。
-      並び順: 通常はHandRanking昇順（1=最強が先頭）。サイドポット発生時はポット単位でグルーピング（メインポット勝者→その敗者→サイドポット勝者→…）となり、HandRanking昇順が崩れる場合がある（25,322ハンド中12ハンドで観測）。
+      並び順: 通常はHandRanking昇順（1=最強が先頭）。サイドポット発生時はポット単位でグルーピング（メインポット勝者→その敗者→サイドポット勝者→…）となり、HandRanking昇順が崩れる場合がある（25,322ハンド中12ハンドで観測）。uncalled returnだけを受け取った敗者もRewardChip>0で含まれうるため、RewardChipの正値を勝者集合として扱わない。
       RankTypeによる結果パターン:
       - ShowDown (RankType 0-9): Hands=5枚, HoleCards=2枚 or [-1,-1]（マック時）
       - NoCall (RankType 10): Hands=空配列, HoleCards=空配列 or [-1,-1]
@@ -354,7 +354,7 @@ export const apiEventSchemas = {
       ※フォールド済みプレイヤーはFOLD_OPENしない限りResults[]に含まれない`),
     ResultType: z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3), z.literal(4)]).describe('0=通常結果(98.5%、早期脱落を含む), 1=トーナメント終了遷移の観測値(0.8%、優勝/敗退の双方で出現するが全脱落を網羅しない), 2=テーブル移動(0.4%、MTT), 3=休憩開始(0.1%、MTT), 4=テーブル離脱/対戦相手不在(0.2%、Ring退出時など)。ヒーロー脱落/最終順位はResultType単独で判定せずResults[].RankingとDefeatStatusを使う'),
     SidePot: z.array(z.int().nonnegative()).max(4).describe('サイドポット額の配列（最終値）。Pot=メインポット、SidePot[0]=第1サイドポット、SidePot[1]=第2サイドポット。不変条件: Pot + sum(SidePot) == sum(Results[].RewardChip)（100%成立）。ハンドの7.5%で発生（1サイドポット:95%, 2:5%, 3:<0.1%）'),
-  }).describe('ハンド結果 - ハンド集約の終端。HandIdはここでのみ取得可能（EVT_DEAL→EVT_HAND_RESULTSが1ハンドの境界）。Results[]はHandRanking昇順で勝者→敗者の順。フォールド済みプレイヤーはResults[]に含まれない（FOLD_OPEN除く）'),
+  }).describe('ハンド結果 - ハンド集約の終端。HandIdはここでのみ取得可能（EVT_DEAL→EVT_HAND_RESULTSが1ハンドの境界）。Results[]は原則HandRanking順だが、RewardChipにはuncalled returnも含まれる。フォールド済みプレイヤーはResults[]に含まれない（FOLD_OPEN除く）'),
 
   [307]: baseSchema.extend({
     ApiTypeId: z.literal(307),

--- a/src/utils/hand-chip-accounting.test.ts
+++ b/src/utils/hand-chip-accounting.test.ts
@@ -394,6 +394,13 @@ describe('deriveHandSettlement', () => {
     expect(settlement.playerChipAccounting['2']?.netChips).toBe(-50)
     expect(settlement.playerSettlements['1']).toEqual({ contestedAward: 95, uncalledReturn: 0 })
     expect(settlement.winningPlayerIds).toEqual([1])
+
+    const beforeSessionMetadata = deriveHandSettlement(fixture.deal, fixture.results, undefined)
+    expect(beforeSessionMetadata.playerSettlements['1']).toEqual({
+      contestedAward: 95,
+      uncalledReturn: 0,
+    })
+    expect(beforeSessionMetadata.winningPlayerIds).toEqual([1])
   })
 
   test('real ante all-in settlement separates the returned top tier from the contested main pot', () => {

--- a/src/utils/hand-chip-accounting.test.ts
+++ b/src/utils/hand-chip-accounting.test.ts
@@ -1,7 +1,7 @@
 import type { ApiEvent } from '../types/api'
 import { ApiType } from '../types/api'
 import { BattleType, BetStatusType } from '../types/game'
-import { derivePlayerHandChipAccounting, deriveStartingStack } from './hand-chip-accounting'
+import { deriveHandSettlement, derivePlayerHandChipAccounting, deriveStartingStack } from './hand-chip-accounting'
 
 const uncalledReturnDeal = {
   ApiTypeId: ApiType.EVT_DEAL,
@@ -182,12 +182,17 @@ describe('derivePlayerHandChipAccounting', () => {
       .toEqual([null, null])
   })
 
-  test('unknown BattleType fails closed', () => {
-    expect(Object.values(derivePlayerHandChipAccounting(
+  test('unknown BattleType accepts a complete zero-sum settlement valid under either game rule', () => {
+    expect(derivePlayerHandChipAccounting(
       uncalledReturnDeal,
       uncalledReturnResult,
       undefined
-    ))).toEqual([null, null, null, null])
+    )).toEqual({
+      '156012369': { grossPayout: 4756, totalContribution: 1558, netChips: 3198 },
+      '561384657': { grossPayout: 2132, totalContribution: 3690, netChips: -1558 },
+      '578444683': { grossPayout: 0, totalContribution: 410, netChips: -410 },
+      '805494763': { grossPayout: 0, totalContribution: 1230, netChips: -1230 },
+    })
   })
 
   test('multiple short ante all-ins with side-pot tiers stay unknown when the seat-to-tier assignment is ambiguous', () => {
@@ -236,5 +241,197 @@ describe('derivePlayerHandChipAccounting', () => {
 
     expect(result['578444683']).toBeNull()
     expect(result['561384657']?.netChips).toBe(-1558)
+  })
+})
+
+describe('deriveHandSettlement', () => {
+  const buildSettlementEvents = ({
+    contributions,
+    rewards,
+    handRankings,
+    battleType = BattleType.SIT_AND_GO,
+  }: {
+    contributions: number[]
+    rewards: number[]
+    handRankings: number[]
+    battleType?: BattleType
+  }) => {
+    const userIds = contributions.map((_, index) => index + 1)
+    const startingStack = 100
+    const deal = {
+      ApiTypeId: ApiType.EVT_DEAL,
+      timestamp: 1,
+      SeatUserIds: userIds,
+      Game: {
+        CurrentBlindLv: 1,
+        NextBlindUnixSeconds: 0,
+        Ante: 0,
+        SmallBlind: 1,
+        BigBlind: 2,
+        ButtonSeat: 0,
+        SmallBlindSeat: 0,
+        BigBlindSeat: 1,
+      },
+      Player: {
+        SeatIndex: 0,
+        BetStatus: BetStatusType.BET_ABLE,
+        Chip: startingStack,
+        BetChip: 0,
+        HoleCards: [0, 1],
+      },
+      OtherPlayers: userIds.slice(1).map((_, index) => ({
+        SeatIndex: index + 1,
+        Status: 0,
+        BetStatus: BetStatusType.BET_ABLE,
+        Chip: startingStack,
+        BetChip: 0,
+      })),
+      Progress: {
+        Phase: 0,
+        NextActionSeat: 0,
+        NextActionTypes: [],
+        NextExtraLimitSeconds: 0,
+        MinRaise: 0,
+        Pot: 0,
+        SidePot: [],
+      },
+    } as unknown as ApiEvent<ApiType.EVT_DEAL>
+    const results = {
+      ApiTypeId: ApiType.EVT_HAND_RESULTS,
+      timestamp: 2,
+      HandId: 1,
+      CommunityCards: [0, 4, 8, 12, 16],
+      Pot: rewards.reduce((sum, reward) => sum + reward, 0),
+      SidePot: [],
+      ResultType: 0,
+      DefeatStatus: 0,
+      Results: userIds.map((userId, index) => ({
+        UserId: userId,
+        HoleCards: [index * 2, index * 2 + 1],
+        RankType: 1,
+        Hands: [0, 4, 8, 12, 16],
+        HandRanking: handRankings[index]!,
+        Ranking: -2,
+        RewardChip: rewards[index]!,
+      })),
+      Player: {
+        SeatIndex: 0,
+        BetStatus: -1,
+        Chip: startingStack - contributions[0]! + rewards[0]!,
+        BetChip: 0,
+      },
+      OtherPlayers: userIds.slice(1).map((_, index) => ({
+        SeatIndex: index + 1,
+        Status: 0,
+        BetStatus: -1,
+        Chip: startingStack - contributions[index + 1]! + rewards[index + 1]!,
+        BetChip: 0,
+      })),
+    } as unknown as ApiEvent<ApiType.EVT_HAND_RESULTS>
+
+    return { deal, results, battleType }
+  }
+
+  test('excludes a loser whose only payout is an uncalled excess return', () => {
+    const fixture = buildSettlementEvents({
+      contributions: [30, 50],
+      rewards: [60, 20],
+      handRankings: [1, 2],
+    })
+
+    const settlement = deriveHandSettlement(fixture.deal, fixture.results, fixture.battleType)
+
+    expect(settlement.playerChipAccounting).toEqual({
+      '1': { grossPayout: 60, totalContribution: 30, netChips: 30 },
+      '2': { grossPayout: 20, totalContribution: 50, netChips: -30 },
+    })
+    expect(settlement.playerSettlements).toEqual({
+      '1': { contestedAward: 60, uncalledReturn: 0 },
+      '2': { contestedAward: 0, uncalledReturn: 20 },
+    })
+    expect(settlement.winningPlayerIds).toEqual([1])
+  })
+
+  test('keeps a side-pot winner even when the hand is a net loss', () => {
+    const fixture = buildSettlementEvents({
+      contributions: [90, 100, 100],
+      rewards: [270, 20, 0],
+      handRankings: [1, 2, -1],
+    })
+
+    const settlement = deriveHandSettlement(fixture.deal, fixture.results, fixture.battleType)
+
+    expect(settlement.playerChipAccounting['2']?.netChips).toBe(-80)
+    expect(settlement.playerSettlements['2']).toEqual({ contestedAward: 20, uncalledReturn: 0 })
+    expect(settlement.winningPlayerIds).toEqual([1, 2])
+  })
+
+  test('preserves tied split-pot winners when an odd chip makes payouts unequal', () => {
+    const fixture = buildSettlementEvents({
+      contributions: [5, 5, 5],
+      rewards: [8, 7, 0],
+      handRankings: [1, 1, -1],
+    })
+
+    const settlement = deriveHandSettlement(fixture.deal, fixture.results, fixture.battleType)
+
+    expect(settlement.playerSettlements['1']).toEqual({ contestedAward: 8, uncalledReturn: 0 })
+    expect(settlement.playerSettlements['2']).toEqual({ contestedAward: 7, uncalledReturn: 0 })
+    expect(settlement.winningPlayerIds).toEqual([1, 2])
+  })
+
+  test('allows Ring rake while retaining the contested winner', () => {
+    const fixture = buildSettlementEvents({
+      contributions: [50, 50],
+      rewards: [95, 0],
+      handRankings: [1, -1],
+      battleType: BattleType.RING_GAME,
+    })
+
+    const settlement = deriveHandSettlement(fixture.deal, fixture.results, fixture.battleType)
+
+    expect(settlement.playerChipAccounting['1']?.netChips).toBe(45)
+    expect(settlement.playerChipAccounting['2']?.netChips).toBe(-50)
+    expect(settlement.playerSettlements['1']).toEqual({ contestedAward: 95, uncalledReturn: 0 })
+    expect(settlement.winningPlayerIds).toEqual([1])
+  })
+
+  test('real ante all-in settlement separates the returned top tier from the contested main pot', () => {
+    const settlement = deriveHandSettlement(
+      uncalledReturnDeal,
+      uncalledReturnResult,
+      BattleType.SIT_AND_GO
+    )
+
+    expect(settlement.playerSettlements['156012369']).toEqual({
+      contestedAward: 4756,
+      uncalledReturn: 0,
+    })
+    expect(settlement.playerSettlements['561384657']).toEqual({
+      contestedAward: 0,
+      uncalledReturn: 2132,
+    })
+    expect(settlement.winningPlayerIds).toEqual([156012369])
+    expect(
+      Object.values(settlement.playerSettlements)
+        .reduce((sum, entry) => sum + (entry?.contestedAward ?? 0) + (entry?.uncalledReturn ?? 0), 0)
+    ).toBe(uncalledReturnResult.Pot + uncalledReturnResult.SidePot.reduce((sum, pot) => sum + pot, 0))
+  })
+
+  test('fails winner resolution closed when settlement conservation is invalid', () => {
+    const fixture = buildSettlementEvents({
+      contributions: [30, 30],
+      rewards: [60, 0],
+      handRankings: [1, -1],
+    })
+    const corrupt = {
+      ...fixture.results,
+      Player: { ...fixture.results.Player!, Chip: fixture.results.Player!.Chip + 1 },
+    } as ApiEvent<ApiType.EVT_HAND_RESULTS>
+
+    const settlement = deriveHandSettlement(fixture.deal, corrupt, fixture.battleType)
+
+    expect(settlement.winningPlayerIds).toEqual([])
+    expect(Object.values(settlement.playerSettlements)).toEqual([null, null])
   })
 })

--- a/src/utils/hand-chip-accounting.test.ts
+++ b/src/utils/hand-chip-accounting.test.ts
@@ -400,6 +400,10 @@ describe('deriveHandSettlement', () => {
       contestedAward: 95,
       uncalledReturn: 0,
     })
+    expect(beforeSessionMetadata.playerChipAccounting).toEqual({
+      '1': { grossPayout: 95, totalContribution: 50, netChips: 45 },
+      '2': { grossPayout: 0, totalContribution: 50, netChips: -50 },
+    })
     expect(beforeSessionMetadata.winningPlayerIds).toEqual([1])
   })
 

--- a/src/utils/hand-chip-accounting.ts
+++ b/src/utils/hand-chip-accounting.ts
@@ -1,6 +1,6 @@
 import type { ApiEvent } from '../types/api'
 import { ApiType } from '../types/api'
-import { BattleType, BetStatusType } from '../types/game'
+import { BattleType, BetStatusType, RankType } from '../types/game'
 
 type DealEvent = ApiEvent<ApiType.EVT_DEAL>
 type HandResultsEvent = ApiEvent<ApiType.EVT_HAND_RESULTS>
@@ -23,14 +23,30 @@ export interface PlayerHandChipAccounting {
 
 export type PlayerHandChipAccountingMap = Record<string, PlayerHandChipAccounting | null>
 
+export interface PlayerHandSettlement {
+  /** Chips won from tiers contested by at least two contributors. */
+  contestedAward: number
+  /** Chips returned from a contribution tier with no opposing contribution. */
+  uncalledReturn: number
+}
+
+export type PlayerHandSettlementMap = Record<string, PlayerHandSettlement | null>
+
+export interface HandSettlement {
+  playerChipAccounting: PlayerHandChipAccountingMap
+  playerSettlements: PlayerHandSettlementMap
+  /** Players who received a positive contested award. */
+  winningPlayerIds: number[]
+}
+
 const getDealSnapshot = (event: DealEvent, seatIndex: number): ChipSnapshot | undefined => {
   if (event.Player?.SeatIndex === seatIndex) return event.Player
-  return event.OtherPlayers.find(player => player.SeatIndex === seatIndex)
+  return event.OtherPlayers?.find(player => player.SeatIndex === seatIndex)
 }
 
 const getResultSnapshot = (event: HandResultsEvent, seatIndex: number): ChipSnapshot | undefined => {
   if (event.Player?.SeatIndex === seatIndex) return event.Player
-  return event.OtherPlayers.find(player => player.SeatIndex === seatIndex)
+  return event.OtherPlayers?.find(player => player.SeatIndex === seatIndex)
 }
 
 /**
@@ -100,6 +116,9 @@ export const deriveStartingStack = (event: DealEvent, seatIndex: number): number
 const emptyAccounting = (event: DealEvent): PlayerHandChipAccountingMap =>
   Object.fromEntries(event.SeatUserIds.filter(userId => userId !== -1).map(userId => [String(userId), null]))
 
+const emptySettlements = (event: DealEvent): PlayerHandSettlementMap =>
+  Object.fromEntries(event.SeatUserIds.filter(userId => userId !== -1).map(userId => [String(userId), null]))
+
 /**
  * Derive exact signed per-player chip results from one causal DEAL -> RESULTS
  * pair. `RewardChip` is gross payout (and can be an uncalled return), so:
@@ -115,8 +134,8 @@ const emptyAccounting = (event: DealEvent): PlayerHandChipAccountingMap =>
  * player remains null rather than receiving an estimated loss. Complete table
  * snapshots must also obey the game type's chip-conservation rule: tournament
  * chips are zero-sum, while Ring rake may remove chips but can never create
- * them. An unknown BattleType cannot select either rule and therefore fails
- * closed.
+ * them. An unknown BattleType is accepted only when complete snapshots prove
+ * a zero-sum settlement, which is valid under either rule.
  */
 export const derivePlayerHandChipAccounting = (
   deal: DealEvent,
@@ -130,8 +149,6 @@ export const derivePlayerHandChipAccounting = (
     battleType === BattleType.TOURNAMENT ||
     battleType === BattleType.FRIEND_SIT_AND_GO ||
     battleType === BattleType.CLUB_MATCH
-
-  if (!isRing && !isTournament) return accounting
 
   // Imported legacy/test rows can bypass the current API parser. Missing
   // settlement fields are an unknown result, never a reason to throw or infer.
@@ -174,8 +191,30 @@ export const derivePlayerHandChipAccounting = (
     .map((userId, seatIndex) => ({ userId, seatIndex }))
     .filter(({ userId }) => userId !== -1)
     .map(({ seatIndex }) => seatIndex)
+
+  // Tournament RESULTS commonly omits the local player's final snapshot even
+  // when that player appears in Results[]. With complete starts and exactly
+  // one such missing result seat, zero-sum conservation determines that final
+  // stack exactly. Do not apply this to Ring (rake is unknown) or to a missing
+  // folded seat whose contribution cannot be tied to a result row.
+  const missingFinalSeatIndexes = occupiedSeatIndexes.filter(seatIndex => !finalStacks.has(seatIndex))
+  if (isTournament &&
+      missingFinalSeatIndexes.length === 1 &&
+      occupiedSeatIndexes.every(seatIndex => starts.has(seatIndex))) {
+    const missingSeatIndex = missingFinalSeatIndexes[0]!
+    const missingUserId = deal.SeatUserIds[missingSeatIndex]
+    if (missingUserId !== undefined && results.Results.some(result => result.UserId === missingUserId)) {
+      const totalStartingStack = occupiedSeatIndexes.reduce((sum, seatIndex) => sum + starts.get(seatIndex)!, 0)
+      const knownFinalStack = occupiedSeatIndexes.reduce((sum, seatIndex) => sum + (finalStacks.get(seatIndex) ?? 0), 0)
+      const inferredFinalStack = totalStartingStack - knownFinalStack
+      if (!Number.isSafeInteger(inferredFinalStack) || inferredFinalStack < 0) return accounting
+      finalStacks.set(missingSeatIndex, inferredFinalStack)
+    }
+  }
+
   const hasCompleteTableSnapshots = occupiedSeatIndexes.every(seatIndex =>
     starts.has(seatIndex) && finalStacks.has(seatIndex))
+  if (!isRing && !isTournament && !hasCompleteTableSnapshots) return accounting
 
   if (hasCompleteTableSnapshots) {
     const totalStartingStack = occupiedSeatIndexes.reduce((sum, seatIndex) => sum + starts.get(seatIndex)!, 0)
@@ -184,7 +223,8 @@ export const derivePlayerHandChipAccounting = (
 
     const chipDelta = totalFinalStack - totalStartingStack
     if ((isTournament && chipDelta !== 0) ||
-        (isRing && chipDelta > 0)) return accounting
+        (isRing && chipDelta > 0) ||
+        (!isTournament && !isRing && chipDelta !== 0)) return accounting
   }
 
   for (let seatIndex = 0; seatIndex < deal.SeatUserIds.length; seatIndex++) {
@@ -192,11 +232,10 @@ export const derivePlayerHandChipAccounting = (
     if (userId === undefined || userId === -1) continue
 
     const startingStack = starts.get(seatIndex)
-    const finalSnapshot = getResultSnapshot(results, seatIndex)
-    if (startingStack === undefined || !finalSnapshot) continue
+    const finalStack = finalStacks.get(seatIndex)
+    if (startingStack === undefined || finalStack === undefined) continue
 
     const payout = results.Results.find(result => result.UserId === userId)?.RewardChip ?? 0
-    const finalStack = finalStacks.get(seatIndex)!
     const totalContribution = startingStack + payout - finalStack
     if (!Number.isSafeInteger(totalContribution) || totalContribution < 0 || totalContribution > startingStack) continue
 
@@ -211,4 +250,123 @@ export const derivePlayerHandChipAccounting = (
   }
 
   return accounting
+}
+
+/**
+ * Resolve gross payouts into contested awards and uncalled returns.
+ *
+ * A positive RewardChip is not sufficient to identify a winner: PokerChase
+ * includes an unmatched excess contribution in RewardChip. Contribution tiers
+ * make that distinction explicit. A tier reached by one contributor is an
+ * uncalled return; a tier reached by two or more contributors is a contested
+ * pot, whose eligible players are the result rows that reached that tier.
+ *
+ * The exact accounting gate intentionally runs first. If any contribution is
+ * unknown, abbreviated legacy rows retain only their HandRanking=1 main-pot
+ * winner signal; complete but inconsistent rows fail closed. Neither path
+ * guesses from RewardChip alone. The gate also shares the tournament zero-sum
+ * / Ring rake validation with Recent Hands. Exact winners are players with a
+ * positive payout after their uncalled return is removed. The HandRanking
+ * eligibility check prevents a payout from being attributed to a tier the
+ * player could not have won, while still allowing a lower-ranked player to win
+ * a side pot after the main-pot winner is no longer eligible.
+ */
+export const deriveHandSettlement = (
+  deal: DealEvent,
+  results: HandResultsEvent,
+  battleType: BattleType | undefined
+): HandSettlement => {
+  const playerChipAccounting = derivePlayerHandChipAccounting(deal, results, battleType)
+  const dealtSeatIndexes = deal.SeatUserIds
+    .map((userId, seatIndex) => ({ userId, seatIndex }))
+    .filter(({ userId }) => userId !== -1)
+    .map(({ seatIndex }) => seatIndex)
+  const hasIncompleteSnapshots = dealtSeatIndexes.some(seatIndex =>
+    getDealSnapshot(deal, seatIndex) === undefined ||
+    getResultSnapshot(results, seatIndex) === undefined)
+  const unresolved = (): HandSettlement => ({
+    playerChipAccounting,
+    playerSettlements: emptySettlements(deal),
+    // Imported legacy rows and intentionally abbreviated tests may omit seat
+    // snapshots needed for exact tiers. Preserve only the unambiguous main-pot
+    // winner signal in that compatibility case; never fall back to
+    // RewardChip>0, which is the bug this resolver exists to prevent. Complete
+    // but inconsistent settlements fail closed with no winners.
+    winningPlayerIds: hasIncompleteSnapshots
+      ? results.Results
+          .filter(result =>
+            result.RewardChip > 0 &&
+            (result.HandRanking === 1 || result.RankType === RankType.NO_CALL))
+          .map(result => result.UserId)
+      : [],
+  })
+
+  const dealtUserIds = deal.SeatUserIds.filter(userId => userId !== -1)
+  if (dealtUserIds.some(userId => playerChipAccounting[String(userId)] === null)) return unresolved()
+
+  const contributions = new Map<number, number>(
+    dealtUserIds.map(userId => [
+      userId,
+      playerChipAccounting[String(userId)]!.totalContribution,
+    ])
+  )
+  const resultByUserId = new Map(results.Results.map(result => [result.UserId, result]))
+  const uncalledReturns = new Map<number, number>(dealtUserIds.map(userId => [userId, 0]))
+  const eligibleContestedWinners = new Set<number>()
+
+  const contributionLevels = [...new Set(contributions.values())]
+    .filter(contribution => contribution > 0)
+    .sort((a, b) => a - b)
+  let previousLevel = 0
+
+  for (const level of contributionLevels) {
+    const contributors = dealtUserIds.filter(userId => contributions.get(userId)! >= level)
+    const tierAmount = (level - previousLevel) * contributors.length
+    if (!Number.isSafeInteger(tierAmount) || tierAmount <= 0) return unresolved()
+
+    if (contributors.length === 1) {
+      const userId = contributors[0]!
+      uncalledReturns.set(userId, uncalledReturns.get(userId)! + tierAmount)
+    } else {
+      const eligibleResults = contributors
+        .map(userId => resultByUserId.get(userId))
+        .filter((result): result is NonNullable<typeof result> =>
+          result !== undefined &&
+          (result.HandRanking > 0 ||
+            (result.RankType === RankType.NO_CALL && result.RewardChip > 0)))
+      if (eligibleResults.length === 0) return unresolved()
+
+      const bestHandRanking = Math.min(...eligibleResults.map(result =>
+        result.HandRanking > 0 ? result.HandRanking : 1))
+      for (const result of eligibleResults) {
+        const handRanking = result.HandRanking > 0 ? result.HandRanking : 1
+        if (handRanking === bestHandRanking) eligibleContestedWinners.add(result.UserId)
+      }
+    }
+
+    previousLevel = level
+  }
+
+  const playerSettlements: PlayerHandSettlementMap = {}
+  let componentPayout = 0
+  for (const userId of dealtUserIds) {
+    const grossPayout = playerChipAccounting[String(userId)]!.grossPayout
+    const uncalledReturn = uncalledReturns.get(userId)!
+    const contestedAward = grossPayout - uncalledReturn
+    if (!Number.isSafeInteger(contestedAward) || contestedAward < 0) return unresolved()
+    if (contestedAward > 0 && !eligibleContestedWinners.has(userId)) return unresolved()
+
+    playerSettlements[String(userId)] = { contestedAward, uncalledReturn }
+    componentPayout += contestedAward + uncalledReturn
+  }
+
+  const grossPayout = results.Results.reduce((sum, result) => sum + result.RewardChip, 0)
+  if (!Number.isSafeInteger(componentPayout) || componentPayout !== grossPayout) return unresolved()
+
+  return {
+    playerChipAccounting,
+    playerSettlements,
+    winningPlayerIds: dealtUserIds.filter(userId =>
+      (playerSettlements[String(userId)]?.contestedAward ?? 0) > 0),
+  }
 }

--- a/src/utils/hand-chip-accounting.ts
+++ b/src/utils/hand-chip-accounting.ts
@@ -134,8 +134,9 @@ const emptySettlements = (event: DealEvent): PlayerHandSettlementMap =>
  * player remains null rather than receiving an estimated loss. Complete table
  * snapshots must also obey the game type's chip-conservation rule: tournament
  * chips are zero-sum, while Ring rake may remove chips but can never create
- * them. An unknown BattleType is accepted only when complete snapshots prove
- * a zero-sum settlement, which is valid under either rule.
+ * them. An unknown BattleType uses the Ring-safe rule (outflow is allowed,
+ * chip creation is not) so a capture that starts before session metadata does
+ * not erase legitimate raked winners.
  */
 export const derivePlayerHandChipAccounting = (
   deal: DealEvent,
@@ -224,7 +225,7 @@ export const derivePlayerHandChipAccounting = (
     const chipDelta = totalFinalStack - totalStartingStack
     if ((isTournament && chipDelta !== 0) ||
         (isRing && chipDelta > 0) ||
-        (!isTournament && !isRing && chipDelta !== 0)) return accounting
+        (!isTournament && !isRing && chipDelta > 0)) return accounting
   }
 
   for (let seatIndex = 0; seatIndex < deal.SeatUserIds.length; seatIndex++) {


### PR DESCRIPTION
## Summary

- resolve hand settlement from exact per-player contribution tiers
- separate contested awards from single-contributor uncalled returns before populating winningPlayerIds
- share the resolver across live ingestion and EntityConverter rebuilds, and keep the independent stats oracle aligned
- prompt a derived-data rebuild (advisory v6) so existing WWSF, W$SD, and RIVER_CALL_WON data is corrected
- document that RewardChip is gross payout, add the anonymized HandId=269804225 reconstruction, and align the API/PokerStars export descriptions

## Correctness

The resolver preserves genuine main-pot, side-pot, split-pot, tie, odd-chip, Ring-rake, and ante all-in winners. It does not use net chips as the winner definition, so a player may still be a winner after taking a side pot while losing chips overall.

Settlement validation requires payout/pot consistency, exact endpoint contributions, game-type chip conservation, contribution-tier eligibility, and component conservation between contested awards plus uncalled returns and gross payouts. Complete raked settlements remain usable when capture begins before session metadata; the independent oracle also re-derives short-ante starts and one omitted tournament final snapshot.

The event documentation now separates directly observed values from deterministic reconstruction and interpretation. It records that `RewardChip > 0` is not a winner predicate because PokerChase includes uncalled returns in gross payout.

## Validation

- `npm test -- --runInBand src/types/api.test.ts src/utils/hand-chip-accounting.test.ts src/entity-converter.test.ts src/tools/verify-stats.test.ts` (4 suites, 82 tests)
- `npm test -- --runInBand src/utils/hand-log-processor.test.ts` (1 suite, 42 tests)
- `npm test -- --runInBand` (135 suites, 1307 tests)
- `npm run typecheck`
- `npm run build`

Head: `7c3ba3d972c8565128be9b6d9f2c252e48db9fdf`
