### PR TITLE
fix(hud): cap pot odds at effective call

### DIFF
--- a/src/realtime-stats/calculate-all-players-stats.test.ts
+++ b/src/realtime-stats/calculate-all-players-stats.test.ts
@@ -118,15 +118,17 @@ describe('calculateAllPlayersStats', () => {
 
     // Player 1 (current turn, limited stack)
     expect(result.playerStats[1]?.spr).toBe(0.1)
-    expect(result.playerStats[1]?.potOdds?.pot).toBe(1800)
-    expect(result.playerStats[1]?.potOdds?.call).toBe(300)
-    expect(result.playerStats[1]?.potOdds?.percentage).toBeCloseTo(16.7, 1)
-    expect(result.playerStats[1]?.potOdds?.ratio).toBe('5:1')
+    expect(result.playerStats[1]?.potOdds?.pot).toBe(1700)
+    expect(result.playerStats[1]?.potOdds?.call).toBe(200)
+    expect(result.playerStats[1]?.potOdds?.percentage).toBeCloseTo(11.8, 1)
+    expect(result.playerStats[1]?.potOdds?.ratio).toBe('15:2')
     expect(result.playerStats[1]?.potOdds?.isPlayerTurn).toBe(true)
 
-    // All-in players should have SPR 0
+    // All-in players should have SPR 0 and no impossible call amount.
     expect(result.playerStats[0]?.spr).toBe(0)
     expect(result.playerStats[2]?.spr).toBe(0)
+    expect(result.playerStats[0]?.potOdds?.call).toBe(0)
+    expect(result.playerStats[2]?.potOdds?.call).toBe(0)
   })
 
   it('should handle empty seatUserIds array', () => {

--- a/src/realtime-stats/calculate-all-players-stats.test.ts
+++ b/src/realtime-stats/calculate-all-players-stats.test.ts
@@ -4,6 +4,7 @@
 
 import { RealTimeStatsService } from './realtime-stats-service'
 import type { RealTimeStats } from './realtime-stats-service'
+import { BetStatusType } from '../types/game'
 
 describe('calculateAllPlayersStats', () => {
   const mockHeroStats: RealTimeStats = {
@@ -113,15 +114,23 @@ describe('calculateAllPlayersStats', () => {
       progress,
       seatBetAmounts,
       seatChips,
-      mockHeroStats
+      mockHeroStats,
+      [
+        BetStatusType.ALL_IN,
+        BetStatusType.BET_ABLE,
+        BetStatusType.ALL_IN,
+        BetStatusType.BET_ABLE,
+        undefined,
+        undefined
+      ]
     )
 
     // Player 1 (current turn, limited stack)
     expect(result.playerStats[1]?.spr).toBe(0.1)
-    expect(result.playerStats[1]?.potOdds?.pot).toBe(1700)
+    expect(result.playerStats[1]?.potOdds?.pot).toBe(1500)
     expect(result.playerStats[1]?.potOdds?.call).toBe(200)
-    expect(result.playerStats[1]?.potOdds?.percentage).toBeCloseTo(11.8, 1)
-    expect(result.playerStats[1]?.potOdds?.ratio).toBe('15:2')
+    expect(result.playerStats[1]?.potOdds?.percentage).toBeCloseTo(13.3, 1)
+    expect(result.playerStats[1]?.potOdds?.ratio).toBe('13:2')
     expect(result.playerStats[1]?.potOdds?.isPlayerTurn).toBe(true)
 
     // All-in players should have SPR 0 and no impossible call amount.

--- a/src/realtime-stats/calculate-player-pot-odds.test.ts
+++ b/src/realtime-stats/calculate-player-pot-odds.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { calculatePlayerPotOdds } from './pot-odds'
+import { BetStatusType } from '../types/game'
 
 describe('calculatePlayerPotOdds', () => {
   it('should calculate pot odds for any player when it is their turn', () => {
@@ -49,7 +50,7 @@ describe('calculatePlayerPotOdds', () => {
     })
   })
 
-  it('should calculate pot odds even when player has no chips', () => {
+  it('should not offer a call to a player who is already all-in', () => {
     const playerSeatIndex = 4
     const progress = {
       NextActionSeat: 3,
@@ -62,12 +63,165 @@ describe('calculatePlayerPotOdds', () => {
 
     const result = calculatePlayerPotOdds(playerSeatIndex, progress, seatBetAmounts, seatChips)
 
-    expect(result?.pot).toBe(60)
-    expect(result?.call).toBe(10)
-    expect(result?.percentage).toBeCloseTo(16.7, 1)
-    expect(result?.ratio).toBe('5:1')
+    expect(result?.pot).toBe(50)
+    expect(result?.call).toBe(0)
+    expect(result?.percentage).toBe(0)
+    expect(result?.ratio).toBe('')
     expect(result?.isPlayerTurn).toBe(false)
     expect(result?.spr).toBe(0)
+  })
+
+  it('caps a short-stack call at the remaining stack', () => {
+    const result = calculatePlayerPotOdds(
+      0,
+      {
+        NextActionSeat: 0,
+        Pot: 300,
+        SidePot: [],
+        Phase: 1
+      },
+      [0, 100],
+      [50, 900],
+      [BetStatusType.BET_ABLE, BetStatusType.BET_ABLE]
+    )
+
+    expect(result).toEqual({
+      pot: 350,
+      call: 50,
+      percentage: 50 / 350 * 100,
+      ratio: '6:1',
+      isPlayerTurn: true,
+      spr: 0.2
+    })
+  })
+
+  it('keeps all existing pot tiers available to an active short stack', () => {
+    const result = calculatePlayerPotOdds(
+      0,
+      {
+        NextActionSeat: 0,
+        Pot: 300,
+        SidePot: [120, 80],
+        Phase: 2
+      },
+      [0, 100],
+      [50, 900],
+      [BetStatusType.BET_ABLE, BetStatusType.BET_ABLE]
+    )
+
+    // A BET_ABLE player has already funded every existing tier. Only the new
+    // call is capped; the main pot and both existing side pots stay playable.
+    expect(result).toMatchObject({
+      pot: 550,
+      call: 50,
+      percentage: 50 / 550 * 100,
+      ratio: '10:1'
+    })
+  })
+
+  it.each([
+    BetStatusType.NOT_IN_PLAY,
+    BetStatusType.FOLDED,
+    BetStatusType.ALL_IN,
+    BetStatusType.ELIMINATED
+  ])('does not display pot odds for non-acting BetStatus %s', (betStatus) => {
+    const result = calculatePlayerPotOdds(
+      0,
+      {
+        NextActionSeat: 1,
+        Pot: 300,
+        SidePot: [],
+        Phase: 1
+      },
+      [0, 100],
+      [500, 900],
+      [betStatus, BetStatusType.BET_ABLE]
+    )
+
+    expect(result).toMatchObject({
+      pot: 300,
+      call: 0,
+      percentage: 0,
+      ratio: '',
+      isPlayerTurn: false
+    })
+  })
+
+  it('does not offer odds to an ante all-in seat when forced posts already created side pots', () => {
+    const result = calculatePlayerPotOdds(
+      0,
+      {
+        NextActionSeat: 1,
+        Pot: 250,
+        SidePot: [50],
+        Phase: 0
+      },
+      [0, 100],
+      [0, 900],
+      [BetStatusType.ALL_IN, BetStatusType.BET_ABLE]
+    )
+
+    expect(result).toMatchObject({
+      pot: 300,
+      call: 0,
+      percentage: 0,
+      ratio: '',
+      isPlayerTurn: false,
+      spr: 0
+    })
+  })
+
+  it('preserves hypothetical odds for a BET_ABLE player waiting on another seat', () => {
+    const result = calculatePlayerPotOdds(
+      0,
+      {
+        NextActionSeat: 1,
+        Pot: 300,
+        SidePot: [],
+        Phase: 1
+      },
+      [0, 100],
+      [500, 900],
+      [BetStatusType.BET_ABLE, BetStatusType.BET_ABLE]
+    )
+
+    expect(result).toMatchObject({
+      pot: 400,
+      call: 100,
+      percentage: 25,
+      ratio: '3:1',
+      isPlayerTurn: false
+    })
+  })
+
+  it('maintains 0 <= call <= remainingStack across stack and bet boundaries', () => {
+    const stacks = [0, 1, 49, 50, 99, 100, 101, 500, 10_000]
+    const playerBets = [0, 50, 100, 500]
+    const opposingBets = [0, 25, 100, 1_000, 20_000]
+
+    for (const remainingStack of stacks) {
+      for (const playerBet of playerBets) {
+        for (const opposingBet of opposingBets) {
+          const result = calculatePlayerPotOdds(
+            0,
+            {
+              NextActionSeat: 0,
+              Pot: 300,
+              SidePot: [100],
+              Phase: 1
+            },
+            [playerBet, opposingBet],
+            [remainingStack, 100_000],
+            [BetStatusType.BET_ABLE, BetStatusType.BET_ABLE]
+          )
+
+          expect(result).not.toBeNull()
+          expect(result!.call).toBeGreaterThanOrEqual(0)
+          expect(result!.call).toBeLessThanOrEqual(remainingStack)
+          expect(result!.pot).toBe(400 + result!.call)
+        }
+      }
+    }
   })
 
   it('should handle when call amount is 0', () => {

--- a/src/realtime-stats/calculate-player-pot-odds.test.ts
+++ b/src/realtime-stats/calculate-player-pot-odds.test.ts
@@ -61,7 +61,20 @@ describe('calculatePlayerPotOdds', () => {
     const seatBetAmounts = [10, 10, 5, 0, 0, 0]
     const seatChips = [100, 150, 200, 300, 0, 0]
 
-    const result = calculatePlayerPotOdds(playerSeatIndex, progress, seatBetAmounts, seatChips)
+    const result = calculatePlayerPotOdds(
+      playerSeatIndex,
+      progress,
+      seatBetAmounts,
+      seatChips,
+      [
+        BetStatusType.BET_ABLE,
+        BetStatusType.BET_ABLE,
+        BetStatusType.BET_ABLE,
+        BetStatusType.BET_ABLE,
+        BetStatusType.ALL_IN,
+        BetStatusType.NOT_IN_PLAY
+      ]
+    )
 
     expect(result?.pot).toBe(50)
     expect(result?.call).toBe(0)
@@ -86,12 +99,36 @@ describe('calculatePlayerPotOdds', () => {
     )
 
     expect(result).toEqual({
-      pot: 350,
+      pot: 300,
       call: 50,
-      percentage: 50 / 350 * 100,
-      ratio: '6:1',
+      percentage: 50 / 300 * 100,
+      ratio: '5:1',
       isPlayerTurn: true,
       spr: 0.2
+    })
+  })
+
+  it('excludes an unmatched overbet already included in Progress.Pot', () => {
+    const result = calculatePlayerPotOdds(
+      0,
+      {
+        NextActionSeat: 0,
+        Pot: 1_300,
+        SidePot: [],
+        Phase: 1
+      },
+      [0, 1_000],
+      [50, 5_000],
+      [BetStatusType.BET_ABLE, BetStatusType.BET_ABLE]
+    )
+
+    // The event pot is 300 prior chips + the full 1000 bet. Hero can win only
+    // 50 of that bet and adds a 50 call: 1300 - 950 + 50 = 400.
+    expect(result).toMatchObject({
+      pot: 400,
+      call: 50,
+      percentage: 12.5,
+      ratio: '7:1'
     })
   })
 
@@ -109,13 +146,37 @@ describe('calculatePlayerPotOdds', () => {
       [BetStatusType.BET_ABLE, BetStatusType.BET_ABLE]
     )
 
-    // A BET_ABLE player has already funded every existing tier. Only the new
-    // call is capped; the main pot and both existing side pots stay playable.
+    // Existing tiers stay available, while the unmatched 50 from the current
+    // street belongs above this player's all-in cap and is excluded.
     expect(result).toMatchObject({
-      pot: 550,
+      pot: 500,
       call: 50,
-      percentage: 50 / 550 * 100,
-      ratio: '10:1'
+      percentage: 10,
+      ratio: '9:1'
+    })
+  })
+
+  it('removes every opponent contribution above the short stack cap in a multiway pot', () => {
+    const result = calculatePlayerPotOdds(
+      0,
+      {
+        NextActionSeat: 0,
+        Pot: 800,
+        SidePot: [200],
+        Phase: 2
+      },
+      [0, 100, 100],
+      [50, 900, 700],
+      [BetStatusType.BET_ABLE, BetStatusType.BET_ABLE, BetStatusType.BET_ABLE]
+    )
+
+    // Both opponents have 50 chips in the deeper current-street tier:
+    // 1000 total - 100 unmatched + 50 effective call = 950 playable.
+    expect(result).toMatchObject({
+      pot: 950,
+      call: 50,
+      percentage: 50 / 950 * 100,
+      ratio: '18:1'
     })
   })
 
@@ -218,7 +279,8 @@ describe('calculatePlayerPotOdds', () => {
           expect(result).not.toBeNull()
           expect(result!.call).toBeGreaterThanOrEqual(0)
           expect(result!.call).toBeLessThanOrEqual(remainingStack)
-          expect(result!.pot).toBe(400 + result!.call)
+          expect(result!.pot).toBeGreaterThanOrEqual(result!.call)
+          expect(result!.pot).toBeLessThanOrEqual(400 + result!.call)
         }
       }
     }

--- a/src/realtime-stats/pot-odds.test.ts
+++ b/src/realtime-stats/pot-odds.test.ts
@@ -76,9 +76,9 @@ describe('Pot Odds Calculation', () => {
 
     expect(odds).toHaveLength(2)
     expect(odds[0]).toMatchObject({
-      pot: 350,
+      pot: 300,
       call: 50,
-      percentage: 50 / 350 * 100
+      percentage: 50 / 300 * 100
     })
     expect(odds[1]).toMatchObject({
       pot: 400,

--- a/src/realtime-stats/pot-odds.test.ts
+++ b/src/realtime-stats/pot-odds.test.ts
@@ -17,6 +17,141 @@ describe('Pot Odds Calculation', () => {
     stream.reset()
   })
 
+  test('short-stack call cap is cleared through a ring spectator hand before rebuy', async () => {
+    const deal = (timestamp: number, heroChip: number): ApiHandEvent => ({
+      ApiTypeId: ApiType.EVT_DEAL,
+      timestamp,
+      SeatUserIds: [101, 102, -1, -1, -1, -1],
+      Player: {
+        SeatIndex: 0,
+        BetStatus: 1,
+        HoleCards: [48, 49],
+        Chip: heroChip,
+        BetChip: 0
+      },
+      OtherPlayers: [
+        { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 900, BetChip: 100 }
+      ],
+      Game: {
+        CurrentBlindLv: 1,
+        NextBlindUnixSeconds: 0,
+        Ante: 0,
+        SmallBlind: 50,
+        BigBlind: 100,
+        ButtonSeat: 0,
+        SmallBlindSeat: 0,
+        BigBlindSeat: 1
+      },
+      Progress: {
+        Phase: PhaseType.PREFLOP,
+        NextActionSeat: 0,
+        NextActionTypes: [2, 3, 4, 5],
+        NextExtraLimitSeconds: 30,
+        MinRaise: 200,
+        Pot: 300,
+        SidePot: []
+      }
+    })
+
+    const outputs: any[] = []
+    stream.on('data', data => outputs.push(data))
+
+    stream.write(deal(100, 50))
+    stream.write({
+      ...deal(150, 0),
+      SeatUserIds: [201, 202, -1, -1, -1, -1],
+      Player: undefined,
+      OtherPlayers: [
+        { SeatIndex: 0, Status: 0, BetStatus: 1, Chip: 900, BetChip: 0 },
+        { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 900, BetChip: 100 }
+      ]
+    } as ApiHandEvent)
+    stream.write(deal(200, 1_000))
+    stream.end()
+    await new Promise<void>(resolve => stream.once('end', resolve))
+
+    const odds = outputs
+      .map(output => output.stats.heroStats.potOdds?.value)
+      .filter(Boolean)
+
+    expect(odds).toHaveLength(2)
+    expect(odds[0]).toMatchObject({
+      pot: 350,
+      call: 50,
+      percentage: 50 / 350 * 100
+    })
+    expect(odds[1]).toMatchObject({
+      pot: 400,
+      call: 100,
+      percentage: 25
+    })
+  })
+
+  test('fold action suppresses odds while preserving the contributed pot snapshot', async () => {
+    const outputs: any[] = []
+    stream.on('data', data => outputs.push(data))
+
+    stream.write({
+      ApiTypeId: ApiType.EVT_DEAL,
+      timestamp: 100,
+      SeatUserIds: [101, 102, -1, -1, -1, -1],
+      Player: {
+        SeatIndex: 0,
+        BetStatus: 1,
+        HoleCards: [48, 49],
+        Chip: 500,
+        BetChip: 0
+      },
+      OtherPlayers: [
+        { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 900, BetChip: 100 }
+      ],
+      Game: {
+        CurrentBlindLv: 1,
+        NextBlindUnixSeconds: 0,
+        Ante: 0,
+        SmallBlind: 50,
+        BigBlind: 100,
+        ButtonSeat: 0,
+        SmallBlindSeat: 0,
+        BigBlindSeat: 1
+      },
+      Progress: {
+        Phase: PhaseType.PREFLOP,
+        NextActionSeat: 0,
+        NextActionTypes: [2, 3, 4, 5],
+        NextExtraLimitSeconds: 30,
+        MinRaise: 200,
+        Pot: 300,
+        SidePot: []
+      }
+    } as ApiHandEvent)
+    stream.write({
+      ApiTypeId: ApiType.EVT_ACTION,
+      timestamp: 110,
+      SeatIndex: 0,
+      ActionType: 2,
+      Chip: 500,
+      BetChip: 0,
+      Progress: {
+        Phase: PhaseType.PREFLOP,
+        NextActionSeat: 1,
+        NextActionTypes: [0, 1, 5],
+        NextExtraLimitSeconds: 30,
+        MinRaise: 0,
+        Pot: 300,
+        SidePot: []
+      }
+    } as ApiHandEvent)
+    stream.end()
+    await new Promise<void>(resolve => stream.once('end', resolve))
+
+    const beforeFold = outputs[1].stats.heroStats.potOdds.value
+    const afterFold = outputs[2].stats.heroStats.potOdds.value
+    expect(beforeFold).toMatchObject({ pot: 400, call: 100, percentage: 25 })
+    expect(afterFold).toMatchObject({ pot: 300, call: 0, percentage: 0, ratio: '' })
+    expect(outputs[2].stats.playerStats[0].potOdds.call).toBe(0)
+  })
+
   test('ヒーローがベットに直面した時にポットオッズを計算する', (done) => {
     /**
      * シナリオ: プリフロップでBBのヒーローがUTGのレイズに直面

--- a/src/realtime-stats/pot-odds.ts
+++ b/src/realtime-stats/pot-odds.ts
@@ -104,9 +104,22 @@ export function calculatePlayerPotOdds(
   const callAmount = canAct
     ? Math.min(fullCallAmount, effectiveStack ?? fullCallAmount)
     : 0
+
+  // Progress already contains every current-street contribution. When this
+  // seat cannot cover the highest bet, chips above its reachable contribution
+  // belong to a deeper side-pot tier (or become an uncalled return) and cannot
+  // be won by this seat. Remove that excess from every contributor before
+  // adding the effective call.
+  const reachableBet = playerBet + callAmount
+  const unmatchedExcess = canAct
+    ? seatBetAmounts.reduce((sum, betAmount) => (
+      sum + Math.max(0, (betAmount || 0) - reachableBet)
+    ), 0)
+    : 0
+  const eligiblePot = Math.max(0, totalPot - unmatchedExcess)
   
   // Calculate the total pot that player would be playing for
-  const playablePot = totalPot + callAmount
+  const playablePot = eligiblePot + callAmount
   
   const result: PlayerPotOddsResult = {
     pot: playablePot,
@@ -126,7 +139,7 @@ export function calculatePlayerPotOdds(
   
   // Calculate pot odds if there's a call amount
   if (callAmount > 0) {
-    const odds = calculatePotOdds(callAmount, totalPot)
+    const odds = calculatePotOdds(callAmount, eligiblePot)
     result.percentage = odds.percentage
     result.ratio = odds.ratio
   }

--- a/src/realtime-stats/pot-odds.ts
+++ b/src/realtime-stats/pot-odds.ts
@@ -6,6 +6,16 @@
  */
 
 import type { StatDefinition, StatCalculationContext, StatValue } from '../types/stats'
+import { BetStatusType } from '../types/game'
+
+export interface PlayerPotOddsResult {
+  pot: number
+  call: number
+  percentage: number
+  ratio: string
+  isPlayerTurn: boolean
+  spr?: number
+}
 
 /**
  * Calculate pot odds
@@ -42,26 +52,22 @@ function calculatePotOdds(callAmount: number, potSize: number): {
  * @param progress Current game progress
  * @param seatBetAmounts Bet amounts for each seat
  * @param seatChips Chip stacks for each seat
+ * @param seatBetStatuses Current action eligibility for each seat
  * @returns Pot odds and SPR data for the specified player
  */
 export function calculatePlayerPotOdds(
   playerSeatIndex: number,
   progress: any,
   seatBetAmounts: number[],
-  seatChips: number[]
-): {
-  pot: number
-  call: number
-  percentage: number
-  ratio: string
-  isPlayerTurn: boolean
-  spr?: number
-} | null {
+  seatChips: number[],
+  seatBetStatuses?: Array<BetStatusType | undefined>
+): PlayerPotOddsResult | null {
   if (!progress || !seatBetAmounts) {
     return null
   }
   
-  // Calculate total pot including all side pots
+  // A BET_ABLE player has already funded every existing pot tier, so all
+  // current side pots remain playable. Only the player's new call is capped.
   let totalPot = progress.Pot || 0
   if (progress.SidePot && Array.isArray(progress.SidePot)) {
     for (const sidePot of progress.SidePot) {
@@ -81,13 +87,28 @@ export function calculatePlayerPotOdds(
   // Player's current bet
   const playerBet = seatBetAmounts[playerSeatIndex] || 0
   
-  // Call amount is the difference
-  const callAmount = maxBet - playerBet
+  // A player can call only while still eligible to act. EVT_DEAL and
+  // EVT_DEAL_ROUND provide authoritative BetStatus snapshots; EVT_ACTION
+  // updates folds/all-ins between those snapshots.
+  const playerBetStatus = seatBetStatuses?.[playerSeatIndex]
+  const canAct = playerBetStatus === undefined || playerBetStatus === BetStatusType.BET_ABLE
+
+  // Pot odds use the amount the player can actually put in, not the full bet
+  // difference. Chip is the post-action/post-forced-post remaining stack in
+  // PokerChase events, so a short call is capped directly by this value.
+  const fullCallAmount = Math.max(0, maxBet - playerBet)
+  const remainingStack = seatChips?.[playerSeatIndex]
+  const effectiveStack = typeof remainingStack === 'number' && Number.isFinite(remainingStack)
+    ? Math.max(0, remainingStack)
+    : undefined
+  const callAmount = canAct
+    ? Math.min(fullCallAmount, effectiveStack ?? fullCallAmount)
+    : 0
   
   // Calculate the total pot that player would be playing for
   const playablePot = totalPot + callAmount
   
-  const result: any = {
+  const result: PlayerPotOddsResult = {
     pot: playablePot,
     call: callAmount,
     percentage: 0,
@@ -97,10 +118,9 @@ export function calculatePlayerPotOdds(
   }
   
   // Calculate SPR if we have chip data
-  if (seatChips && seatChips[playerSeatIndex] !== undefined) {
-    const playerStack = seatChips[playerSeatIndex]
+  if (effectiveStack !== undefined) {
     if (totalPot > 0) {
-      result.spr = Math.round((playerStack / totalPot) * 10) / 10
+      result.spr = Math.round((effectiveStack / totalPot) * 10) / 10
     }
   }
   
@@ -119,66 +139,34 @@ export const potOddsStat: StatDefinition = {
   name: 'POT ODDS',
   description: 'Pot odds when facing a bet',
   
-  calculate(context: StatCalculationContext & { progress?: any; heroSeatIndex?: number; seatBetAmounts?: number[]; seatChips?: number[] }): StatValue {
+  calculate(context: StatCalculationContext & {
+    progress?: any
+    heroSeatIndex?: number
+    seatBetAmounts?: number[]
+    seatChips?: number[]
+    seatBetStatuses?: Array<BetStatusType | undefined>
+  }): StatValue {
     // Use real-time Progress data from WebSocket events
-    const { progress, heroSeatIndex, seatBetAmounts, seatChips } = context
+    const { progress, heroSeatIndex, seatBetAmounts, seatChips, seatBetStatuses } = context
     
     if (!progress || heroSeatIndex === undefined || !seatBetAmounts) {
       return '-'
     }
-    
-    // Calculate total pot including all side pots
-    let totalPot = progress.Pot || 0
-    if (progress.SidePot && Array.isArray(progress.SidePot)) {
-      for (const sidePot of progress.SidePot) {
-        totalPot += sidePot || 0
-      }
+
+    const playerResult = calculatePlayerPotOdds(
+      heroSeatIndex,
+      progress,
+      seatBetAmounts,
+      seatChips ?? [],
+      seatBetStatuses
+    )
+    if (!playerResult) return '-'
+
+    const { isPlayerTurn, ...odds } = playerResult
+    return {
+      ...odds,
+      isHeroTurn: isPlayerTurn
     }
-    
-    // Calculate call amount regardless of whose turn it is
-    // Find the highest bet amount
-    let maxBet = 0
-    for (let i = 0; i < seatBetAmounts.length; i++) {
-      const betAmount = seatBetAmounts[i]
-      if (betAmount !== undefined && betAmount > maxBet) {
-        maxBet = betAmount
-      }
-    }
-    
-    // Hero's current bet
-    const heroBet = seatBetAmounts[heroSeatIndex] || 0
-    
-    // Call amount is the difference
-    const callAmount = maxBet - heroBet
-    
-    // Calculate the total pot that hero would be playing for
-    const playablePot = totalPot + callAmount
-    
-    const result: any = {
-      pot: playablePot,  // Show the pot hero would be playing for
-      call: callAmount,
-      percentage: 0,
-      ratio: '',
-      isHeroTurn: progress.NextActionSeat === heroSeatIndex,
-      spr: undefined  // Stack to Pot Ratio
-    }
-    
-    // Calculate SPR if we have chip data
-    if (seatChips && seatChips[heroSeatIndex] !== undefined) {
-      const heroStack = seatChips[heroSeatIndex]
-      if (totalPot > 0) {
-        result.spr = Math.round((heroStack / totalPot) * 10) / 10  // Round to 1 decimal
-      }
-    }
-    
-    // Calculate pot odds if there's a call amount
-    if (callAmount > 0) {
-      const odds = calculatePotOdds(callAmount, totalPot)
-      result.percentage = odds.percentage
-      result.ratio = odds.ratio
-    }
-    
-    return result
   },
   
   format(value) {

--- a/src/realtime-stats/realtime-stats-service.ts
+++ b/src/realtime-stats/realtime-stats-service.ts
@@ -7,6 +7,7 @@
 
 import type { StatResult } from '../types/stats'
 import type { Action, Phase, Hand } from '../types/entities'
+import type { BetStatusType } from '../types/game'
 import { potOddsStat, handImprovementStat } from './index'
 import { calculatePlayerPotOdds } from './pot-odds'
 
@@ -54,7 +55,8 @@ export class RealTimeStatsService {
     progress?: any,
     heroSeatIndex?: number,
     seatBetAmounts?: number[],
-    seatChips?: number[]
+    seatChips?: number[],
+    seatBetStatuses?: Array<BetStatusType | undefined>
   ): RealTimeStats {
     const context = {
       playerId,
@@ -75,7 +77,8 @@ export class RealTimeStatsService {
       progress,  // Progress data from WebSocket events
       heroSeatIndex,  // Hero's seat index
       seatBetAmounts,  // Bet amounts for each seat
-      seatChips  // Chip stacks for each seat
+      seatChips,  // Chip stacks for each seat
+      seatBetStatuses  // Whether each seat is still eligible to act
     }
 
     const stats: RealTimeStats = {}
@@ -134,7 +137,8 @@ export class RealTimeStatsService {
     progress: any,
     seatBetAmounts: number[],
     seatChips: number[],
-    heroStats: RealTimeStats
+    heroStats: RealTimeStats,
+    seatBetStatuses?: Array<BetStatusType | undefined>
   ): AllPlayersRealTimeStats {
     const result: AllPlayersRealTimeStats = {
       heroStats,
@@ -152,7 +156,8 @@ export class RealTimeStatsService {
         seatIndex,
         progress,
         seatBetAmounts,
-        seatChips
+        seatChips,
+        seatBetStatuses
       )
       
       if (playerPotOdds) {

--- a/src/streams/realtime-stats-stream.test.ts
+++ b/src/streams/realtime-stats-stream.test.ts
@@ -281,23 +281,6 @@ describe('RealTimeStatsStream', () => {
           }
         },
         {
-          ApiTypeId: ApiType.EVT_ACTION,
-          timestamp: 150,
-          SeatIndex: 5,
-          ActionType: 2,
-          Chip: 10000,
-          BetChip: 100,
-          Progress: {
-            Phase: PhaseType.PREFLOP,
-            NextActionSeat: 1,
-            NextActionTypes: [2, 3, 4, 5],
-            NextExtraLimitSeconds: 30,
-            MinRaise: 400,
-            Pot: 300,
-            SidePot: []
-          }
-        },
-        {
           ApiTypeId: ApiType.EVT_DEAL_ROUND,
           timestamp: 200,
           CommunityCards: [49, 33, 21], // A♥ 9♥ 6♥
@@ -323,6 +306,23 @@ describe('RealTimeStatsStream', () => {
             Pot: 300,
             SidePot: []
           }
+        },
+        {
+          ApiTypeId: ApiType.EVT_ACTION,
+          timestamp: 250,
+          SeatIndex: 1,
+          ActionType: 1,
+          Chip: 9100,
+          BetChip: 100,
+          Progress: {
+            Phase: PhaseType.FLOP,
+            NextActionSeat: 0,
+            NextActionTypes: [2, 3, 4, 5],
+            NextExtraLimitSeconds: 30,
+            MinRaise: 200,
+            Pot: 400,
+            SidePot: []
+          }
         }
       ]
 
@@ -333,7 +333,7 @@ describe('RealTimeStatsStream', () => {
 
       stream.on('end', () => {
         // フロップ時の統計
-        const flopStats = results[results.length - 1]
+        const flopStats = results[2]
         expect(flopStats.stats.heroStats.communityCards).toEqual([49, 33, 21])
         expect(flopStats.stats.heroStats.holeCards).toEqual([16, 19])
         // New-street snapshots reset every BetChip and carry the current
@@ -346,9 +346,13 @@ describe('RealTimeStatsStream', () => {
           spr: 30.7,
           potOdds: { call: 0 }
         })
-        // Seat 5 folded preflop and is omitted from EVT_DEAL_ROUND. Its old
-        // small blind must still be cleared at the street boundary.
+        // Seat 5's timeout/disconnect fold has no EVT_ACTION and the seat is
+        // omitted from EVT_DEAL_ROUND. Its old small blind must be cleared and
+        // its BET_ABLE state must not survive into the new street.
         expect(flopStats.stats.playerStats[5].potOdds.call).toBe(0)
+        const afterFlopBet = results[results.length - 1]
+        expect(afterFlopBet.stats.playerStats[0].potOdds.call).toBe(100)
+        expect(afterFlopBet.stats.playerStats[5].potOdds.call).toBe(0)
 
         done()
       })

--- a/src/streams/realtime-stats-stream.ts
+++ b/src/streams/realtime-stats-stream.ts
@@ -141,8 +141,11 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
           if (event.CommunityCards && event.CommunityCards.length > 0) {
             // A new street resets every seat's cumulative street bet. Folded
             // players can be omitted from the round snapshot, so reset the
-            // full array before applying the seats that are present.
+            // full arrays before applying the seats that are present. A
+            // timeout/disconnect fold can also omit EVT_ACTION, making absence
+            // from this authoritative snapshot the only eligibility signal.
             this.seatBetAmounts = this.seatBetAmounts.map(() => 0)
+            this.seatBetStatuses = this.seatBetStatuses.map(() => BetStatusType.FOLDED)
 
             // EVT_DEAL_ROUND may send only new cards, not all community cards
             // Append new cards to existing community cards

--- a/src/streams/realtime-stats-stream.ts
+++ b/src/streams/realtime-stats-stream.ts
@@ -7,7 +7,7 @@
 
 import { SimpleTransform } from './simple-transform'
 import type { ApiEvent, ApiHandEvent } from '../types'
-import { ApiType, PhaseType } from '../types'
+import { ActionType, ApiType, BetStatusType, PhaseType } from '../types'
 import { RealTimeStatsService } from '../realtime-stats/realtime-stats-service'
 import type { RealTimeStats, AllPlayersRealTimeStats } from '../realtime-stats/realtime-stats-service'
 import { setHandImprovementHeroHoleCards } from '../realtime-stats'
@@ -33,6 +33,7 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
   private heroSeatIndex?: number  // Store hero's seat index
   private seatBetAmounts: number[] = []  // Track bet amounts for each seat
   private seatChips: number[] = []  // Track chip stacks for each seat
+  private seatBetStatuses: Array<BetStatusType | undefined> = []  // Track whether each seat can still act
   private seatUserIds: number[] = []  // Track user IDs for each seat
 
   constructor() {
@@ -77,6 +78,7 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
           this.heroSeatIndex = undefined
           this.seatBetAmounts = [0, 0, 0, 0, 0, 0]  // Reset bet amounts
           this.seatChips = [0, 0, 0, 0, 0, 0]  // Reset chip stacks
+          this.seatBetStatuses = [undefined, undefined, undefined, undefined, undefined, undefined]
           this.seatUserIds = [-1, -1, -1, -1, -1, -1]  // Reset user IDs
 
           // Emit empty stats to clear previous hand's display
@@ -116,10 +118,12 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
             // Hero's bet and chips
             this.seatBetAmounts[event.Player.SeatIndex] = event.Player.BetChip || 0
             this.seatChips[event.Player.SeatIndex] = event.Player.Chip || 0
+            this.seatBetStatuses[event.Player.SeatIndex] = event.Player.BetStatus
             // Other players' bets and chips
             for (const player of event.OtherPlayers) {
               this.seatBetAmounts[player.SeatIndex] = player.BetChip || 0
               this.seatChips[player.SeatIndex] = player.Chip || 0
+              this.seatBetStatuses[player.SeatIndex] = player.BetStatus
             }
           }
 
@@ -177,6 +181,7 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
               // odds and SPR look cached until each seat acts again.
               this.seatBetAmounts[event.Player.SeatIndex] = event.Player.BetChip ?? 0
               this.seatChips[event.Player.SeatIndex] = event.Player.Chip ?? 0
+              this.seatBetStatuses[event.Player.SeatIndex] = event.Player.BetStatus
 
               // Check hero's status
               if (event.Player.BetStatus === 1 || event.Player.BetStatus === 3) {
@@ -187,6 +192,7 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
               for (const player of event.OtherPlayers) {
                 this.seatBetAmounts[player.SeatIndex] = player.BetChip ?? 0
                 this.seatChips[player.SeatIndex] = player.Chip ?? 0
+                this.seatBetStatuses[player.SeatIndex] = player.BetStatus
                 if (player.BetStatus === 1 || player.BetStatus === 3) {
                   activeCount++
                 }
@@ -249,9 +255,16 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
             this.seatChips[event.SeatIndex] = event.Chip
           }
 
+          if (event.ActionType === ActionType.FOLD) {
+            this.seatBetStatuses[event.SeatIndex] = BetStatusType.FOLDED
+          } else if (event.ActionType === ActionType.ALL_IN || event.Chip === 0) {
+            this.seatBetStatuses[event.SeatIndex] = BetStatusType.ALL_IN
+          } else {
+            this.seatBetStatuses[event.SeatIndex] = BetStatusType.BET_ABLE
+          }
 
           // Update active player count on fold
-          if (event.ActionType === 2) { // FOLD
+          if (event.ActionType === ActionType.FOLD) {
             this.activePlayerCount = Math.max(1, this.activePlayerCount - 1)
           }
 
@@ -312,7 +325,8 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
       this.currentProgress,
       this.heroSeatIndex,
       this.seatBetAmounts,
-      this.seatChips
+      this.seatChips,
+      this.seatBetStatuses
     )
 
 
@@ -323,7 +337,8 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
         this.currentProgress,
         this.seatBetAmounts,
         this.seatChips,
-        stats  // Hero stats
+        stats,  // Hero stats
+        this.seatBetStatuses
       )
 
       const output: { handId?: number; stats: AllPlayersRealTimeStats; timestamp: number } = {
@@ -400,6 +415,7 @@ export class RealTimeStatsStream extends SimpleTransform<ApiEvent, { handId?: nu
     this.heroSeatIndex = undefined
     this.seatBetAmounts = []
     this.seatChips = []
+    this.seatBetStatuses = []
     this.seatUserIds = []
   }
 }


### PR DESCRIPTION
## Summary

- cap each displayed call by that seat's event-reported remaining stack
- remove current-street overbet tiers above the seat's reachable contribution, including multiway excess
- suppress pot odds for folded, all-in, not-in-play, and eliminated seats while preserving muted hypothetical odds for BET_ABLE seats waiting to act
- reset omitted-seat eligibility at street boundaries and clear state across hand/spectator/rebuy boundaries

## Why

PokerChase `EVT_ACTION.Progress.Pot` already includes the acting player's full contribution. A short caller can wager only its remaining `Chip`, and cannot win any current-street contribution above that reachable bet. Pot odds therefore need both an effective-call cap and removal of unmatched deeper tiers before adding the call.

`EVT_ACTION` can also be absent for timeout/disconnect folds. `EVT_DEAL_ROUND` is therefore the authoritative eligibility snapshot: seats omitted from it must not retain prior-street `BET_ABLE`.

## Validation

- `npm test -- --runInBand src/realtime-stats/calculate-player-pot-odds.test.ts src/realtime-stats/calculate-all-players-stats.test.ts src/realtime-stats/pot-odds.test.ts src/streams/realtime-stats-stream.test.ts` (49 tests)
- `npm test -- --runInBand` (135 suites, 1311 tests)
- `npm run typecheck`
- `npm run build`
- targeted risk gate: `0 <= call <= remainingStack` across stack/bet boundaries, unmatched single/multiway overbets, side-pot tiers, folded/all-in, omitted timeout folds, ante all-in, and ring spectator-to-rebuy regressions

Base: `b20c4a22261705bf04f46937be3c9672775d14cc`