### PR TITLE
fix: restrict auth storage to trusted contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ npm run build
 ### Requirements and data
 
 - Chrome 140 or later is required so persisted authentication data can be
-  restricted to trusted extension contexts.
+  restricted to trusted extension contexts. Support for restricting
+  `storage.local` was added in
+  [Chromium 140](https://chromium.googlesource.com/chromium/src/+/a8f1f337c692360aaec9470a0a91f965011d37a3).
 - The in-game script runs only on `https://game.poker-chase.com/*`.
 - Hand history and HUD data are stored in the browser. JSON and PokerStars exports are saved through Chrome's download function.
 - Google sign-in is optional. When enabled, Cloud Backup synchronizes game data through the configured Firebase / Google APIs; the extension requests the Google account email and profile scopes for authentication.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ npm run build
 
 ### Requirements and data
 
-- Chrome 120 or later is required.
+- Chrome 140 or later is required so persisted authentication data can be
+  restricted to trusted extension contexts.
 - The in-game script runs only on `https://game.poker-chase.com/*`.
 - Hand history and HUD data are stored in the browser. JSON and PokerStars exports are saved through Chrome's download function.
 - Google sign-in is optional. When enabled, Cloud Backup synchronizes game data through the configured Firebase / Google APIs; the extension requests the Google account email and profile scopes for authentication.

--- a/e2e/harness.ts
+++ b/e2e/harness.ts
@@ -29,6 +29,8 @@ import { FIXTURE_PORT, EXTENSION_DIR, BROWSER_CACHE_DIR, CHROME_BUILD_ID, DEFAUL
 export interface LaunchOptions {
   /** Path to the built e2e extension directory (must contain manifest.json + dist/). */
   extensionDir?: string
+  /** Reuse a Chrome profile across launches (used by restart-persistence scenarios). */
+  userDataDir?: string
   fixturePath?: string
   replayDelayMs?: number
   port?: number
@@ -233,6 +235,7 @@ export const launchHarness = async (options: LaunchOptions = {}): Promise<Harnes
     browser = await puppeteer.launch({
       executablePath,
       headless: !headed,
+      ...(options.userDataDir ? { userDataDir: options.userDataDir } : {}),
       args: [
         `--disable-extensions-except=${extensionDir}`,
         `--load-extension=${extensionDir}`,

--- a/e2e/public/trusted-context.html
+++ b/e2e/public/trusted-context.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>E2E trusted extension context</title>
+  </head>
+  <body>Trusted extension context for E2E assertions.</body>
+</html>

--- a/e2e/scenarios/auth-storage-access.ts
+++ b/e2e/scenarios/auth-storage-access.ts
@@ -1,0 +1,251 @@
+/**
+ * Real-Chrome boundary test for persisted Firebase REST credentials.
+ *
+ * Verifies all three security/compatibility invariants:
+ *   1. the injected content-script world cannot read chrome.storage.local;
+ *   2. the same content-script world can still read chrome.storage.sync,
+ *      where its HUD settings live;
+ *   3. a persisted legacy/untrusted access level is re-restricted on browser
+ *      restart while trusted pages and the Service Worker restore auth.
+ */
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { Browser, Page } from 'puppeteer-core'
+import { buildE2E } from '../tools/build-e2e.ts'
+import { launchHarness, type Harness } from '../harness.ts'
+
+interface ContextProbe {
+  runtimeId: string | null
+  hasLocal: boolean
+}
+
+interface StorageRead {
+  value?: Record<string, unknown>
+  error?: string
+}
+
+const AUTH_KEY = 'firebaseRestAuthState'
+const SYNC_PROBE_KEY = 'authStorageSyncProbe'
+const SYNTHETIC_STATE = {
+  uid: 'e2e-auth-storage-user',
+  email: 'synthetic-auth-storage@example.com',
+  displayName: 'Synthetic Auth Storage User',
+  photoURL: null,
+  idToken: 'synthetic-id-token-not-a-real-credential',
+  refreshToken: 'synthetic-refresh-token-not-a-real-credential',
+  expiresAt: 4_102_444_800_000
+}
+
+const extensionIdFor = async (browser: Browser): Promise<string> => {
+  const target = await browser.waitForTarget(
+    (candidate) =>
+      candidate.type() === 'service_worker' &&
+      candidate.url().startsWith('chrome-extension://'),
+    { timeout: 15_000 }
+  )
+  return new URL(target.url()).host
+}
+
+const openTrustedContext = async (browser: Browser, extensionId: string): Promise<Page> => {
+  const page = await browser.newPage()
+  await page.goto(`chrome-extension://${extensionId}/trusted-context.html`, {
+    waitUntil: 'domcontentloaded'
+  })
+  return page
+}
+
+const evaluateInContentScript = async <T>(
+  page: Page,
+  extensionId: string,
+  expression: string
+): Promise<T> => {
+  const session = await page.createCDPSession()
+  const contexts: Array<{ id: number }> = []
+  session.on('Runtime.executionContextCreated', ({ context }) => {
+    contexts.push({ id: context.id })
+  })
+  await session.send('Runtime.enable')
+
+  try {
+    const deadline = Date.now() + 10_000
+    while (Date.now() < deadline) {
+      for (const context of contexts) {
+        try {
+          const probe = await session.send('Runtime.evaluate', {
+            contextId: context.id,
+            expression:
+              '({ runtimeId: globalThis.chrome?.runtime?.id ?? null, ' +
+              'hasLocal: Boolean(globalThis.chrome?.storage?.local) })',
+            returnByValue: true
+          })
+          const value = probe.result.value as ContextProbe | undefined
+          if (value?.runtimeId !== extensionId) continue
+
+          const evaluated = await session.send('Runtime.evaluate', {
+            contextId: context.id,
+            expression,
+            awaitPromise: true,
+            returnByValue: true
+          })
+          return evaluated.result.value as T
+        } catch {
+          // A navigation can invalidate a context between discovery and use.
+        }
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
+    throw new Error('Could not find the injected extension content-script execution context')
+  } finally {
+    await session.detach()
+  }
+}
+
+const assertContentBoundary = async (harness: Harness, extensionId: string): Promise<void> => {
+  const localRead = await evaluateInContentScript<StorageRead>(
+    harness.gamePage,
+    extensionId,
+    `(async () => {
+      try {
+        return { value: await chrome.storage.local.get(${JSON.stringify(AUTH_KEY)}) }
+      } catch (error) {
+        return { error: String(error) }
+      }
+    })()`
+  )
+  if (localRead.value?.[AUTH_KEY] !== undefined) {
+    throw new Error('content script exposed firebaseRestAuthState from chrome.storage.local')
+  }
+  if (!localRead.error?.includes('Access to storage is not allowed from this context')) {
+    throw new Error(
+      `content script did not receive the expected local-storage denial: ${JSON.stringify(localRead)}`
+    )
+  }
+
+  const syncRead = await evaluateInContentScript<StorageRead>(
+    harness.gamePage,
+    extensionId,
+    `(async () => {
+      try {
+        return { value: await chrome.storage.sync.get(${JSON.stringify(SYNC_PROBE_KEY)}) }
+      } catch (error) {
+        return { error: String(error) }
+      }
+    })()`
+  )
+  if (syncRead.value?.[SYNC_PROBE_KEY] !== 'sync-remains-visible') {
+    throw new Error(
+      `content script lost required chrome.storage.sync access: ${JSON.stringify(syncRead)}`
+    )
+  }
+}
+
+const stageLegacyUntrustedAccess = async (
+  harness: Harness,
+  trustedPage: Page,
+  extensionId: string
+): Promise<void> => {
+  await trustedPage.evaluate(async () => {
+    await chrome.storage.local.setAccessLevel({
+      accessLevel: 'TRUSTED_AND_UNTRUSTED_CONTEXTS'
+    })
+  })
+  const exposed = await evaluateInContentScript<StorageRead>(
+    harness.gamePage,
+    extensionId,
+    `(async () => ({ value: await chrome.storage.local.get(${JSON.stringify(AUTH_KEY)}) }))()`
+  )
+  if (exposed.value?.[AUTH_KEY] === undefined) {
+    throw new Error(
+      `could not stage the legacy content-script-readable state: ${JSON.stringify(exposed)}`
+    )
+  }
+}
+
+const run = async (): Promise<void> => {
+  const extensionDir = buildE2E()
+  const profileDir = mkdtempSync(join(tmpdir(), 'pokerchase-hud-auth-storage-'))
+  let harness: Harness | undefined
+
+  try {
+    harness = await launchHarness({ extensionDir, userDataDir: profileDir })
+    const extensionId = await extensionIdFor(harness.browser)
+    const trustedPage = await openTrustedContext(harness.browser, extensionId)
+
+    await trustedPage.evaluate(
+      async (authKey, authState, syncProbeKey) => {
+        await chrome.storage.local.set({
+          [authKey]: authState,
+          [`autoSyncLastTime:${authState.uid}`]: new Date().toISOString()
+        })
+        await chrome.storage.sync.set({ [syncProbeKey]: 'sync-remains-visible' })
+      },
+      AUTH_KEY,
+      SYNTHETIC_STATE,
+      SYNC_PROBE_KEY
+    )
+
+    const trustedRead = await trustedPage.evaluate(
+      async (authKey) => await chrome.storage.local.get(authKey),
+      AUTH_KEY
+    )
+    if (trustedRead[AUTH_KEY]?.idToken !== SYNTHETIC_STATE.idToken) {
+      throw new Error('trusted extension page could not read persisted auth state')
+    }
+
+    await assertContentBoundary(harness, extensionId)
+    console.log('[auth-storage] PASS - content script denied local auth and retained sync settings')
+
+    // Simulate a profile left by the vulnerable version: both credentials and
+    // the default untrusted local-area access level persist across restart.
+    // The fixed Service Worker must re-establish TRUSTED_CONTEXTS before it
+    // restores those credentials.
+    await stageLegacyUntrustedAccess(harness, trustedPage, extensionId)
+    await trustedPage.close()
+    await harness.close()
+    harness = undefined
+
+    harness = await launchHarness({ extensionDir, userDataDir: profileDir })
+    const restartedExtensionId = await extensionIdFor(harness.browser)
+    if (restartedExtensionId !== extensionId) {
+      throw new Error(`extension id changed across restart: ${extensionId} -> ${restartedExtensionId}`)
+    }
+
+    const restartedTrustedPage = await openTrustedContext(harness.browser, restartedExtensionId)
+    const authStatus = await restartedTrustedPage.evaluate(
+      async () => await chrome.runtime.sendMessage({ action: 'firebaseAuthStatus' })
+    ) as {
+      success?: boolean
+      isSignedIn?: boolean
+      userInfo?: { uid?: string, email?: string | null }
+      error?: string
+    }
+    if (
+      !authStatus.success ||
+      !authStatus.isSignedIn ||
+      authStatus.userInfo?.uid !== SYNTHETIC_STATE.uid ||
+      authStatus.userInfo.email !== SYNTHETIC_STATE.email
+    ) {
+      throw new Error(`Service Worker did not restore auth after restart: ${JSON.stringify(authStatus)}`)
+    }
+
+    const popup = await harness.openPopup()
+    await popup.waitForFunction(
+      (email) => document.body.innerText.includes(email),
+      { timeout: 15_000 },
+      SYNTHETIC_STATE.email
+    )
+    await assertContentBoundary(harness, restartedExtensionId)
+
+    console.log('[auth-storage] PASS - Service Worker and popup restored auth after browser restart')
+    console.log('[auth-storage] PASSED: all real-Chrome storage boundary checks passed')
+  } finally {
+    await harness?.close()
+    rmSync(profileDir, { recursive: true, force: true })
+  }
+}
+
+run().catch((error) => {
+  console.error('[auth-storage] FAILED:', error)
+  process.exitCode = 1
+})

--- a/e2e/scenarios/auth-storage-access.ts
+++ b/e2e/scenarios/auth-storage-access.ts
@@ -206,6 +206,9 @@ const run = async (): Promise<void> => {
     harness = undefined
 
     harness = await launchHarness({ extensionDir, userDataDir: profileDir })
+    // Assert the upgraded profile's boundary before an explicit auth-status
+    // message or popup navigation deliberately wakes/uses the Service Worker.
+    await assertContentBoundary(harness, extensionId)
     const restartedExtensionId = await extensionIdFor(harness.browser)
     if (restartedExtensionId !== extensionId) {
       throw new Error(`extension id changed across restart: ${extensionId} -> ${restartedExtensionId}`)
@@ -235,7 +238,6 @@ const run = async (): Promise<void> => {
       { timeout: 15_000 },
       SYNTHETIC_STATE.email
     )
-    await assertContentBoundary(harness, restartedExtensionId)
 
     console.log('[auth-storage] PASS - Service Worker and popup restored auth after browser restart')
     console.log('[auth-storage] PASSED: all real-Chrome storage boundary checks passed')

--- a/e2e/tools/build-e2e.ts
+++ b/e2e/tools/build-e2e.ts
@@ -33,6 +33,10 @@ export const buildE2E = (): string => {
 
   mkdirSync(EXTENSION_DIR, { recursive: true })
   copyFileSync(E2E_MANIFEST_PATH, join(EXTENSION_DIR, 'manifest.json'))
+  copyFileSync(
+    join(REPO_ROOT, 'e2e/public/trusted-context.html'),
+    join(EXTENSION_DIR, 'trusted-context.html')
+  )
   cpSync(join(REPO_ROOT, 'icons'), join(EXTENSION_DIR, 'icons'), { recursive: true })
 
   return EXTENSION_DIR

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
   "host_permissions": [
     "https://*.googleapis.com/*"
   ],
-  "minimum_chrome_version": "120",
+  "minimum_chrome_version": "140",
   "icons": {
     "16": "icons/icon_16px.png",
     "48": "icons/icon_48px.png",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "ccusage": "npx ccusage@latest",
     "build:e2e": "tsx e2e/tools/build-e2e.ts",
     "e2e:smoke": "tsx e2e/scenarios/smoke.ts",
+    "e2e:auth-storage": "tsx e2e/scenarios/auth-storage-access.ts",
     "e2e:playerid": "tsx e2e/scenarios/playerid-session-persistence.ts",
     "e2e": "tsx e2e/run.ts",
     "firebase:deploy": "firebase deploy --only firestore:rules,firestore:indexes",

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -1207,7 +1207,7 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
  * Chrome MV3 では 30 秒のアイドル後に Worker が停止されるため、
  * 長時間のバッチ処理中は30秒未満の間隔でExtension APIを呼び出す。
  * Chrome 110以降はExtension API呼び出しがService Workerのアイドル
- * タイマーをリセットする。manifestのminimum_chrome_versionは120。
+ * タイマーをリセットする。manifestのminimum_chrome_versionは140。
  * @returns クリーンアップ関数
  */
 export const startKeepAlive = async (): Promise<() => void> => {

--- a/src/services/firebase-auth-service.test.ts
+++ b/src/services/firebase-auth-service.test.ts
@@ -12,6 +12,71 @@
  */
 import { FirebaseAuthService } from './firebase-auth-service'
 
+describe('FirebaseAuthService storage access boundary', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('restricts local storage to trusted contexts before restoring persisted auth', async () => {
+    const stateA = {
+      uid: 'user-a',
+      email: 'a@example.com',
+      displayName: null,
+      photoURL: null,
+      idToken: 'token-a',
+      refreshToken: 'refresh-a',
+      expiresAt: Date.now() + 60 * 60 * 1000
+    }
+    await chrome.storage.local.set({ firebaseRestAuthState: stateA })
+
+    let releaseAccessRestriction!: () => void
+    const accessRestriction = new Promise<void>((resolve) => {
+      releaseAccessRestriction = resolve
+    })
+    const setAccessLevelSpy = (jest.spyOn(chrome.storage.local, 'setAccessLevel') as jest.SpyInstance)
+      .mockReturnValueOnce(accessRestriction)
+    const getSpy = jest.spyOn(chrome.storage.local, 'get')
+
+    const service = new FirebaseAuthService()
+    await Promise.resolve()
+
+    expect(setAccessLevelSpy).toHaveBeenCalledWith({ accessLevel: 'TRUSTED_CONTEXTS' })
+    expect(getSpy).not.toHaveBeenCalled()
+
+    releaseAccessRestriction()
+    await service.ready()
+
+    expect(service.getCurrentUser()?.uid).toBe('user-a')
+    expect(await service.getCurrentUser()?.getIdToken()).toBe('token-a')
+  })
+
+  test('fails closed when trusted-context storage restriction is rejected', async () => {
+    ;(jest.spyOn(chrome.storage.local, 'setAccessLevel') as jest.SpyInstance)
+      .mockRejectedValueOnce(new Error('setAccessLevel failed'))
+    const getSpy = jest.spyOn(chrome.storage.local, 'get')
+
+    const service = new FirebaseAuthService()
+
+    await expect(service.ready()).rejects.toThrow('setAccessLevel failed')
+    expect(getSpy).not.toHaveBeenCalled()
+    expect(service.getCurrentUser()).toBeNull()
+  })
+
+  test('does not let interactive sign-in bypass a failed storage restriction', async () => {
+    ;(jest.spyOn(chrome.storage.local, 'setAccessLevel') as jest.SpyInstance)
+      .mockRejectedValue(new Error('setAccessLevel failed'))
+    const identitySpy = jest.spyOn(chrome.identity, 'getAuthToken')
+    const setSpy = jest.spyOn(chrome.storage.local, 'set')
+
+    const service = new FirebaseAuthService()
+
+    await expect(service.ready()).rejects.toThrow('setAccessLevel failed')
+    await expect(service.signInWithGoogle()).rejects.toThrow('setAccessLevel failed')
+    expect(identitySpy).not.toHaveBeenCalled()
+    expect(setSpy).not.toHaveBeenCalled()
+  })
+})
+
 describe('FirebaseAuthService.getIdToken -- stale refresh handling', () => {
   afterEach(() => {
     jest.restoreAllMocks()

--- a/src/services/firebase-auth-service.test.ts
+++ b/src/services/firebase-auth-service.test.ts
@@ -72,8 +72,10 @@ describe('FirebaseAuthService storage access boundary', () => {
 
     await expect(service.ready()).rejects.toThrow('setAccessLevel failed')
     await expect(service.signInWithGoogle()).rejects.toThrow('setAccessLevel failed')
+    await expect(service.signOut()).rejects.toThrow('setAccessLevel failed')
     expect(identitySpy).not.toHaveBeenCalled()
     expect(setSpy).not.toHaveBeenCalled()
+    expect(chrome.storage.local.remove).not.toHaveBeenCalled()
   })
 })
 

--- a/src/services/firebase-auth-service.ts
+++ b/src/services/firebase-auth-service.ts
@@ -80,6 +80,7 @@ export class FirebaseAuthService {
   private static readonly GOOGLE_REVOKE_TIMEOUT_MS = 30_000
   private currentState: StoredAuthState | null = null
   private authStateListeners: ((user: AuthUser | null, source: AuthChangeSource) => void)[] = []
+  private storageAccessEstablished = false
   private storageAccessPromise: Promise<void>
   private restorePromise: Promise<void>
   /**
@@ -146,6 +147,7 @@ export class FirebaseAuthService {
       throw new Error('chrome.storage.local.setAccessLevel is required for secure auth storage')
     }
     await chrome.storage.local.setAccessLevel({ accessLevel: 'TRUSTED_CONTEXTS' })
+    this.storageAccessEstablished = true
   }
 
   /**
@@ -180,7 +182,7 @@ export class FirebaseAuthService {
     // must never ignore failure to establish the credential boundary itself.
     // Otherwise interactive sign-in could persist fresh tokens in a
     // content-script-readable area after startup restriction failed.
-    await this.storageAccessPromise
+    if (!this.storageAccessEstablished) await this.storageAccessPromise
     // A failed startup restore must not permanently poison interactive auth:
     // sign-in is the explicit recovery path. Also let an in-flight restore
     // settle before starting so it cannot publish an older stored account
@@ -303,6 +305,12 @@ export class FirebaseAuthService {
     // This is also before the first await (the Chrome token lookup), so a
     // sign-in started while that lookup is slow must wait for this operation.
     this.authGeneration++
+
+    // Removing an auth record from an unrestricted local area can disclose
+    // its oldValue through storage.onChanged. Establish the same trusted-only
+    // boundary before destructive cleanup as before every credential read or
+    // write.
+    if (!this.storageAccessEstablished) await this.storageAccessPromise
 
     // Once a sign-in's storage write has started, let every already-queued
     // commit publish (or fail) before this later user action removes state.

--- a/src/services/firebase-auth-service.ts
+++ b/src/services/firebase-auth-service.ts
@@ -80,6 +80,7 @@ export class FirebaseAuthService {
   private static readonly GOOGLE_REVOKE_TIMEOUT_MS = 30_000
   private currentState: StoredAuthState | null = null
   private authStateListeners: ((user: AuthUser | null, source: AuthChangeSource) => void)[] = []
+  private storageAccessPromise: Promise<void>
   private restorePromise: Promise<void>
   /**
    * Tail of durable sign-in commits currently in flight or queued. A later
@@ -122,7 +123,29 @@ export class FirebaseAuthService {
   private authGeneration = 0
 
   constructor() {
-    this.restorePromise = this.restoreAuthState()
+    this.storageAccessPromise = this.restrictLocalStorageAccess()
+    this.restorePromise = this.storageAccessPromise
+      .then(() => this.restoreAuthState())
+  }
+
+  /**
+   * `storage.local` is exposed to content scripts by default. This extension's
+   * local-area consumers are all trusted contexts (the Service Worker and
+   * popup); the HUD content script keeps its user-facing settings in
+   * `storage.sync`. Restrict the whole local area before reading persisted
+   * credentials so an isolated content-script context cannot obtain
+   * `firebaseRestAuthState`.
+   *
+   * Restricting local storage requires Chrome 140. The manifest enforces that
+   * floor, so there is deliberately no insecure compatibility fallback.
+   * A missing/rejected API leaves auth restoration unavailable instead of
+   * silently restoring credentials into an exposed storage area.
+   */
+  private async restrictLocalStorageAccess(): Promise<void> {
+    if (typeof chrome.storage.local.setAccessLevel !== 'function') {
+      throw new Error('chrome.storage.local.setAccessLevel is required for secure auth storage')
+    }
+    await chrome.storage.local.setAccessLevel({ accessLevel: 'TRUSTED_CONTEXTS' })
   }
 
   /**
@@ -153,6 +176,11 @@ export class FirebaseAuthService {
     // request. The conditional also makes the ordering explicit: only an
     // operation that already owns the token forces this sign-in to queue.
     if (this.pendingSignOut) await this.waitForPendingSignOut()
+    // The restore-recovery path below may ignore a failed storage read, but it
+    // must never ignore failure to establish the credential boundary itself.
+    // Otherwise interactive sign-in could persist fresh tokens in a
+    // content-script-readable area after startup restriction failed.
+    await this.storageAccessPromise
     // A failed startup restore must not permanently poison interactive auth:
     // sign-in is the explicit recovery path. Also let an in-flight restore
     // settle before starting so it cannot publish an older stored account

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -98,6 +98,7 @@ global.chrome = {
       }),
     },
     local: {
+      setAccessLevel: jest.fn().mockResolvedValue(undefined),
       get: jest.fn((keys, callback?) => {
         const result = keys ?
           (Array.isArray(keys) ?


### PR DESCRIPTION
## Summary

- restrict `chrome.storage.local` to `TRUSTED_CONTEXTS` before restoring persisted Firebase credentials
- keep the storage boundary as a separate fail-closed gate so restore, sign-in, and sign-out cannot bypass a failed restriction or leak `storage.onChanged.oldValue`
- raise the Chrome installation floor to 140 and document the requirement
- add a real-Chrome boundary test covering the actual injected isolated world, required `storage.sync` access, a persisted legacy/untrusted access level, and Service Worker/popup auth restoration after a full restart

## Compatibility provenance

Chrome documentation marks `StorageArea.setAccessLevel()` as Chrome 102 because the method first existed for `storage.session`. Chromium change [a8f1f337](https://chromium.googlesource.com/chromium/src/+/a8f1f337c692360aaec9470a0a91f965011d37a3) (`main@{#1482413}`, 2025-07-04) added support for `storage.local` and `storage.sync`. Chrome 139 branched earlier at `main@{#1477651}`; Chrome 140 branched later at `main@{#1496484}`. The manifest therefore uses Chrome 140 as the secure floor instead of providing an unsafe fallback. A Chrome for Testing 139.0.7258.154 launch also produced zero extension targets with this manifest, confirming the minimum-version gate prevents insecure loading.

## Verification

- `npm test -- --runInBand` (135 suites, 1301 tests)
- `npm run typecheck`
- `npm run build`
- `E2E_CHROME_BUILD_ID=140.0.7339.207 npm run e2e:auth-storage` (floor-pinned upgrade/restart boundary)
- `npm run e2e:auth-storage` (Chrome for Testing 151.0.7922.34)
- `npm run e2e:smoke` (7/7 checks)
- `git diff --check`

Head: `8c21e512a68a773cdb490bc3faf54bd584c1d668`

## Latest main integration validation\n- resolved the shared Service Worker keepalive integration without restoring the superseded local helper\n- `npm test -- --runInBand` (136 suites, 1344 tests)\n- `npm run typecheck`\n- `npm run build`