### PR TITLE
fix(export): report ring hand rake from settlement

### DIFF
--- a/src/utils/hand-chip-accounting.test.ts
+++ b/src/utils/hand-chip-accounting.test.ts
@@ -154,6 +154,24 @@ describe('derivePlayerHandChipAccounting', () => {
     )).toBeNull()
   })
 
+  test('malformed legacy Ring snapshot stays unknown instead of throwing', () => {
+    const malformedResult = {
+      ...uncalledReturnResult,
+      OtherPlayers: undefined,
+    } as unknown as ApiEvent<ApiType.EVT_HAND_RESULTS>
+
+    expect(() => deriveHandRakeAccounting(
+      uncalledReturnDeal,
+      malformedResult,
+      BattleType.RING_GAME
+    )).not.toThrow()
+    expect(deriveHandRakeAccounting(
+      uncalledReturnDeal,
+      malformedResult,
+      BattleType.RING_GAME
+    )).toBeNull()
+  })
+
   test('Ring side-pot settlement preserves rake across uncalled return, split, and odd chip payouts', () => {
     // Real-equivalent endpoint shape:
     // contributions 101 + 301 + 501 = 903

--- a/src/utils/hand-chip-accounting.test.ts
+++ b/src/utils/hand-chip-accounting.test.ts
@@ -1,7 +1,11 @@
 import type { ApiEvent } from '../types/api'
 import { ApiType } from '../types/api'
 import { BattleType, BetStatusType } from '../types/game'
-import { derivePlayerHandChipAccounting, deriveStartingStack } from './hand-chip-accounting'
+import {
+  deriveHandRakeAccounting,
+  derivePlayerHandChipAccounting,
+  deriveStartingStack,
+} from './hand-chip-accounting'
 
 const uncalledReturnDeal = {
   ApiTypeId: ApiType.EVT_DEAL,
@@ -126,6 +130,81 @@ describe('derivePlayerHandChipAccounting', () => {
       '2': { grossPayout: 0, totalContribution: 100, netChips: -100 },
     })
     expect(Object.values(result).reduce((sum, entry) => sum + (entry?.netChips ?? 0), 0)).toBe(-10)
+    expect(deriveHandRakeAccounting(deal, handResult, BattleType.RING_GAME)).toEqual({
+      totalContribution: 200,
+      totalPayout: 190,
+      rake: 10,
+    })
+    expect(
+      Object.values(result).reduce((sum, entry) => sum + entry!.netChips, 0) +
+      deriveHandRakeAccounting(deal, handResult, BattleType.RING_GAME)!.rake
+    ).toBe(0)
+  })
+
+  test('Ring rake stays unknown when any endpoint seat snapshot is missing', () => {
+    const incompleteResult = {
+      ...uncalledReturnResult,
+      OtherPlayers: uncalledReturnResult.OtherPlayers.slice(0, -1),
+    } as ApiEvent<ApiType.EVT_HAND_RESULTS>
+
+    expect(deriveHandRakeAccounting(
+      uncalledReturnDeal,
+      incompleteResult,
+      BattleType.RING_GAME
+    )).toBeNull()
+  })
+
+  test('Ring side-pot settlement preserves rake across uncalled return, split, and odd chip payouts', () => {
+    // Real-equivalent endpoint shape:
+    // contributions 101 + 301 + 501 = 903
+    // uncalled return 200, contested gross pot 703
+    // contested payouts 151 + 150 + 367 = 668 (odd chip included)
+    // rake 703 - 668 = 35
+    const deal = {
+      ...uncalledReturnDeal,
+      SeatUserIds: [1, 2, 3],
+      Game: {
+        ...uncalledReturnDeal.Game,
+        Ante: 0,
+        SmallBlind: 50,
+        BigBlind: 100,
+        SmallBlindSeat: 0,
+        BigBlindSeat: 1,
+      },
+      Player: { SeatIndex: 0, BetStatus: 1, Chip: 899, BetChip: 101, HoleCards: [0, 1] },
+      OtherPlayers: [
+        { SeatIndex: 1, Status: 0, BetStatus: 1, Chip: 899, BetChip: 101 },
+        { SeatIndex: 2, Status: 0, BetStatus: 1, Chip: 699, BetChip: 301 },
+      ],
+      Progress: { ...uncalledReturnDeal.Progress, Pot: 303, SidePot: [400] },
+    } as unknown as ApiEvent<ApiType.EVT_DEAL>
+    const handResult = {
+      ...uncalledReturnResult,
+      Pot: 301,
+      SidePot: [367, 200],
+      Results: [
+        { ...uncalledReturnResult.Results[0], UserId: 1, RewardChip: 151 },
+        { ...uncalledReturnResult.Results[1], UserId: 2, RewardChip: 150 },
+        { ...uncalledReturnResult.Results[1], UserId: 3, RewardChip: 567 },
+      ],
+      Player: { SeatIndex: 0, BetStatus: -1, Chip: 1050, BetChip: 0 },
+      OtherPlayers: [
+        { SeatIndex: 1, Status: 0, BetStatus: -1, Chip: 849, BetChip: 0 },
+        { SeatIndex: 2, Status: 0, BetStatus: -1, Chip: 1066, BetChip: 0 },
+      ],
+    } as unknown as ApiEvent<ApiType.EVT_HAND_RESULTS>
+
+    const players = derivePlayerHandChipAccounting(deal, handResult, BattleType.RING_GAME)
+    const rake = deriveHandRakeAccounting(deal, handResult, BattleType.RING_GAME)
+
+    expect(players).toEqual({
+      '1': { grossPayout: 151, totalContribution: 101, netChips: 50 },
+      '2': { grossPayout: 150, totalContribution: 301, netChips: -151 },
+      '3': { grossPayout: 567, totalContribution: 501, netChips: 66 },
+    })
+    expect(rake).toEqual({ totalContribution: 903, totalPayout: 868, rake: 35 })
+    expect(Object.values(players).reduce((sum, entry) => sum + entry!.netChips, 0) + rake!.rake).toBe(0)
+    expect(rake!.totalContribution - 200).toBe((rake!.totalPayout - 200) + rake!.rake)
   })
 
   test.each([

--- a/src/utils/hand-chip-accounting.ts
+++ b/src/utils/hand-chip-accounting.ts
@@ -23,6 +23,15 @@ export interface PlayerHandChipAccounting {
 
 export type PlayerHandChipAccountingMap = Record<string, PlayerHandChipAccounting | null>
 
+export interface HandRakeAccounting {
+  /** Every chip committed during the hand, including an uncalled return. */
+  totalContribution: number
+  /** EVT_HAND_RESULTS gross payouts, including an uncalled return. */
+  totalPayout: number
+  /** Chips removed from the table: totalContribution - totalPayout. */
+  rake: number
+}
+
 const getDealSnapshot = (event: DealEvent, seatIndex: number): ChipSnapshot | undefined => {
   if (event.Player?.SeatIndex === seatIndex) return event.Player
   return event.OtherPlayers.find(player => player.SeatIndex === seatIndex)
@@ -211,4 +220,61 @@ export const derivePlayerHandChipAccounting = (
   }
 
   return accounting
+}
+
+/**
+ * Derive an exact Ring-game rake from the same complete endpoint snapshots
+ * used for signed player results. A partial snapshot is deliberately unknown:
+ * treating an unobserved seat as zero contribution would falsely report
+ * `Rake 0` in exported hand histories.
+ *
+ * This helper is intentionally Ring-only. Tournament rake is paid outside the
+ * table chip economy and HandLogProcessor preserves its existing `Rake 0`
+ * summary behavior separately.
+ */
+export const deriveHandRakeAccounting = (
+  deal: DealEvent,
+  results: HandResultsEvent,
+  battleType: BattleType | undefined
+): HandRakeAccounting | null => {
+  const isRing = battleType === BattleType.RING_GAME || battleType === BattleType.FRIEND_RING_GAME
+  if (!isRing) return null
+
+  const occupiedSeatIndexes = deal.SeatUserIds
+    .map((userId, seatIndex) => ({ userId, seatIndex }))
+    .filter(({ userId }) => userId !== -1)
+    .map(({ seatIndex }) => seatIndex)
+  const occupiedSeatSet = new Set(occupiedSeatIndexes)
+  const dealtUserIds = deal.SeatUserIds.filter(userId => userId !== -1)
+  const dealSeats = [
+    ...(deal.Player ? [deal.Player] : []),
+    ...deal.OtherPlayers,
+  ]
+  const resultSeats = [
+    ...(results.Player ? [results.Player] : []),
+    ...results.OtherPlayers,
+  ]
+  const isExactSnapshot = (snapshots: ChipSnapshot[]): boolean =>
+    snapshots.length === occupiedSeatIndexes.length &&
+    new Set(snapshots.map(snapshot => snapshot.SeatIndex)).size === snapshots.length &&
+    snapshots.every(snapshot => occupiedSeatSet.has(snapshot.SeatIndex))
+
+  if (new Set(dealtUserIds).size !== dealtUserIds.length ||
+      !isExactSnapshot(dealSeats) ||
+      !isExactSnapshot(resultSeats)) return null
+
+  const accounting = derivePlayerHandChipAccounting(deal, results, battleType)
+  const entries = Object.values(accounting)
+  if (entries.length === 0 || entries.some(entry => entry === null)) return null
+
+  const totalContribution = entries.reduce((sum, entry) => sum + entry!.totalContribution, 0)
+  const totalPayout = entries.reduce((sum, entry) => sum + entry!.grossPayout, 0)
+  const rake = totalContribution - totalPayout
+
+  if (!Number.isSafeInteger(totalContribution) ||
+      !Number.isSafeInteger(totalPayout) ||
+      !Number.isSafeInteger(rake) ||
+      rake < 0) return null
+
+  return { totalContribution, totalPayout, rake }
 }

--- a/src/utils/hand-chip-accounting.ts
+++ b/src/utils/hand-chip-accounting.ts
@@ -240,6 +240,13 @@ export const deriveHandRakeAccounting = (
   const isRing = battleType === BattleType.RING_GAME || battleType === BattleType.FRIEND_RING_GAME
   if (!isRing) return null
 
+  // Imported legacy/test rows can bypass the current API parser. Guard every
+  // collection before iterating or spreading so malformed snapshots remain an
+  // unknown rake rather than aborting hand-log generation.
+  if (!Array.isArray(deal.SeatUserIds) ||
+      !Array.isArray(deal.OtherPlayers) ||
+      !Array.isArray(results.OtherPlayers)) return null
+
   const occupiedSeatIndexes = deal.SeatUserIds
     .map((userId, seatIndex) => ({ userId, seatIndex }))
     .filter(({ userId }) => userId !== -1)

--- a/src/utils/hand-log-processor.test.ts
+++ b/src/utils/hand-log-processor.test.ts
@@ -1028,6 +1028,38 @@ describe('キャッシュゲーム + サイドポット', () => {
     expect(lines).toContain('Total pot 300 | Rake 10')
   })
 
+  test('Ring side pot componentsはnet payoutのままrakeとgross totalへ整合する', () => {
+    const sidePotResult = {
+      ApiTypeId: ApiType.EVT_HAND_RESULTS,
+      timestamp: 1700000009000,
+      CommunityCards: [0, 4, 8, 12, 16],
+      Pot: 300,
+      SidePot: [365],
+      ResultType: 0,
+      DefeatStatus: 0,
+      HandId: 999006,
+      HandLog: '',
+      Results: [
+        { UserId: 100, HoleCards: [20, 21], RankType: 6, Hands: [20, 21, 0, 4, 8], HandRanking: 1, Ranking: -2, RewardChip: 300 },
+        { UserId: 200, HoleCards: [48, 49], RankType: 8, Hands: [48, 49, 0, 4, 8], HandRanking: 2, Ranking: -2, RewardChip: 365 },
+        { UserId: 300, HoleCards: [24, 25], RankType: 9, Hands: [24, 25, 0, 4, 8], HandRanking: -1, Ranking: -2, RewardChip: 0 },
+      ],
+      Player: { SeatIndex: 1, BetStatus: -1, Chip: 1065, BetChip: 0 },
+      OtherPlayers: [
+        { SeatIndex: 0, Status: 0, BetStatus: -1, Chip: 300, BetChip: 0 },
+        { SeatIndex: 2, Status: 0, BetStatus: -1, Chip: 700, BetChip: 0 },
+      ],
+    } as unknown as ApiEvent
+    const processor = new HandLogProcessor(createContext(
+      createSession(players, { battleType: BattleType.RING_GAME })
+    ))
+    const totalPotLine = getLines(processor, [events[0]!, sidePotResult])
+      .find(line => line.includes('Total pot'))
+
+    expect(totalPotLine).toBe('Total pot 700 Main pot 300. Side pot 365. | Rake 35')
+    expect(300 + 365 + 35).toBe(700)
+  })
+
   test('Ring endpoint snapshot欠損時はrake 0やgross potを断定しない', () => {
     const incompleteEvents = events.map(event => {
       if (event.ApiTypeId !== ApiType.EVT_HAND_RESULTS) return event

--- a/src/utils/hand-log-processor.test.ts
+++ b/src/utils/hand-log-processor.test.ts
@@ -1007,6 +1007,48 @@ describe('キャッシュゲーム + サイドポット', () => {
     const totalPotLine = lines.find(l => l.includes('Total pot'))
     expect(totalPotLine).toBe('Total pot 300 | Rake 0')
   })
+
+  test('complete Ring endpoint snapshotからgross potと実rakeを出力する', () => {
+    const rakeEvents = events.map(event => {
+      if (event.ApiTypeId !== ApiType.EVT_HAND_RESULTS) return event
+      return {
+        ...event,
+        Pot: 290,
+        Results: event.Results.map(result =>
+          result.UserId === 200 ? { ...result, RewardChip: 290 } : result),
+        Player: { ...event.Player, Chip: 1190 },
+      } as ApiEvent
+    })
+    const processor = new HandLogProcessor(createContext(
+      createSession(players, { battleType: BattleType.RING_GAME })
+    ))
+    const lines = getLines(processor, rakeEvents)
+
+    expect(lines).toContain('Hero collected 290 from pot')
+    expect(lines).toContain('Total pot 300 | Rake 10')
+  })
+
+  test('Ring endpoint snapshot欠損時はrake 0やgross potを断定しない', () => {
+    const incompleteEvents = events.map(event => {
+      if (event.ApiTypeId !== ApiType.EVT_HAND_RESULTS) return event
+      return {
+        ...event,
+        Pot: 290,
+        Results: event.Results.map(result =>
+          result.UserId === 200 ? { ...result, RewardChip: 290 } : result),
+        Player: { ...event.Player, Chip: 1190 },
+        OtherPlayers: event.OtherPlayers.filter(player => player.SeatIndex !== 2),
+      } as ApiEvent
+    })
+    const processor = new HandLogProcessor(createContext(
+      createSession(players, { battleType: BattleType.RING_GAME })
+    ))
+    const totalPotLine = getLines(processor, incompleteEvents)
+      .find(line => line.includes('Total pot'))
+
+    expect(totalPotLine).toBe('Total pot unknown (net payout 290) | Rake unknown')
+    expect(totalPotLine).not.toContain('Rake 0')
+  })
 })
 
 // ============================================================

--- a/src/utils/hand-log-processor.ts
+++ b/src/utils/hand-log-processor.ts
@@ -1596,11 +1596,6 @@ export class HandLogProcessor {
         }
       }
 
-      // PokerChase settlement amounts are payouts after rake. Attribute the
-      // table-level deduction to the main pot so the PokerStars gross pot
-      // breakdown remains additive without inventing a side-pot split.
-      if (rake !== null) mainPot += rake
-      
       let breakdown = `Total pot ${totalPot} Main pot ${mainPot}.`
       if (sidePots.length === 1) {
         breakdown += ` Side pot ${sidePots[0]}.`

--- a/src/utils/hand-log-processor.ts
+++ b/src/utils/hand-log-processor.ts
@@ -10,6 +10,7 @@ import { ActionType, RankType, PhaseType, isShowdownParticipant } from '../types
 import { HandLogConfig, HandLogEntry, HandLogEntryType, HandLogState } from '../types/hand-log'
 import { formatCards } from './card-utils'
 import {
+  deriveHandRakeAccounting,
   deriveStartingStack as deriveSharedStartingStack,
   getPlayerChipsAfterAnte as getSharedPlayerChipsAfterAnte,
   isAnteContributor as isSharedAnteContributor,
@@ -33,6 +34,7 @@ export interface HandLogContext {
 
 export class HandLogProcessor {
   private currentHand: HandLogState | null = null
+  private currentDealEvent: ApiEvent<ApiType.EVT_DEAL> | null = null
   private communityCards: number[] = []
   private context: HandLogContext
   private firstHandId: number | null = null
@@ -113,6 +115,7 @@ export class HandLogProcessor {
    */
   resetHandState(): void {
     this.currentHand = null
+    this.currentDealEvent = null
     this.communityCards = []
     this._anteAllInChipsMap = null
     this._anteAllInContribTiers = null
@@ -135,6 +138,7 @@ export class HandLogProcessor {
     }
 
     this.communityCards = []
+    this.currentDealEvent = event
 
     this.currentHand = {
       entries: [],
@@ -1540,28 +1544,37 @@ export class HandLogProcessor {
     const summaryEntry = this.createEntry('*** SUMMARY ***', HandLogEntryType.SUMMARY)
     entries.push(summaryEntry)
 
-    // Calculate total pot, accounting for uncalled bets
-    let totalPot = event.Pot + event.SidePot.reduce((sum, pot) => sum + pot, 0)
-    
     // Check if there was an uncalled bet in the hand result entries
     const uncalledBetEntry = handResultEntries.find(e => 
       e.text.includes('Uncalled bet (') && e.text.includes(') returned to')
     )
-    
+    let uncalledAmount = 0
     if (uncalledBetEntry) {
-      // Extract uncalled amount and subtract from total pot
       const uncalledMatch = uncalledBetEntry.text.match(/Uncalled bet \((\d+)\)/)
       if (uncalledMatch?.[1]) {
-        const uncalledAmount = parseInt(uncalledMatch[1])
-        totalPot -= uncalledAmount
+        uncalledAmount = parseInt(uncalledMatch[1])
       }
     }
     
     const isCashGame = this.context.session.battleType !== undefined && [4, 5].includes(this.context.session.battleType)
+    const rakeAccounting = isCashGame && this.currentDealEvent
+      ? deriveHandRakeAccounting(this.currentDealEvent, event, this.context.session.battleType)
+      : null
+    const rake = isCashGame ? rakeAccounting?.rake ?? null : 0
+
+    // PokerStars Total pot is the gross contested pot: uncalled returns are
+    // excluded and Ring rake is included even though it is absent from payout.
+    const netPayoutPot = event.Pot + event.SidePot.reduce((sum, pot) => sum + pot, 0) - uncalledAmount
+    const totalPot = netPayoutPot + (rake ?? 0)
     const hasSidePots = event.SidePot.length > 0
     
     let potText: string
-    if (hasSidePots) {
+    if (isCashGame && rake === null) {
+      // Without a complete endpoint snapshot the observed settlement is only
+      // the net payout pot. Do not mislabel it as a PokerStars gross total or
+      // assert zero rake.
+      potText = `Total pot unknown (net payout ${netPayoutPot}) | Rake unknown`
+    } else if (hasSidePots) {
       // サイドポットあり: "Total pot X Main pot Y. Side pot Z." 形式
       // uncalled betがある場合、最も大きいインデックスのサイドポットから差し引く
       let mainPot = event.Pot
@@ -1582,6 +1595,11 @@ export class HandLogProcessor {
           }
         }
       }
+
+      // PokerChase settlement amounts are payouts after rake. Attribute the
+      // table-level deduction to the main pot so the PokerStars gross pot
+      // breakdown remains additive without inventing a side-pot split.
+      if (rake !== null) mainPot += rake
       
       let breakdown = `Total pot ${totalPot} Main pot ${mainPot}.`
       if (sidePots.length === 1) {
@@ -1591,9 +1609,11 @@ export class HandLogProcessor {
           breakdown += ` Side pot-${i + 1} ${sidePots[i]}.`
         }
       }
-      potText = `${breakdown} | Rake 0`
+      potText = `${breakdown} | Rake ${rake ?? 'unknown'}`
     } else {
-      potText = isCashGame ? `Total pot ${totalPot} | Rake 0` : `Total pot ${totalPot}`
+      potText = isCashGame
+        ? `Total pot ${totalPot} | Rake ${rake ?? 'unknown'}`
+        : `Total pot ${totalPot}`
     }
     const potEntry = this.createEntry(potText, HandLogEntryType.SUMMARY)
     entries.push(potEntry)


### PR DESCRIPTION
## Summary

- derive exact Ring-game rake from complete `EVT_DEAL` / `EVT_HAND_RESULTS` endpoint snapshots
- render PokerStars-style gross total pot plus the actual rake while preserving SNG/MTT `Rake 0` behavior
- mark Ring rake and gross total as unknown when any seat snapshot is incomplete instead of asserting zero
- keep signed per-player accounting and rake on one conservation model

## Validation

- `npm test -- --runInBand src/utils/hand-chip-accounting.test.ts src/utils/hand-log-processor.test.ts` (59 tests)
- `npm test -- --runInBand` (135 suites, 1302 tests)
- `npm run typecheck`
- `npm run build`

## Risk gate

A real-equivalent Ring settlement fixture covers side pots, an uncalled return, a split payout with an odd chip, and exact endpoint stacks. It asserts both `sum(player net) + rake = 0` and `gross contested pot = collected payout + rake`. Missing endpoint seats fail closed to unknown rake.

## Latest main integration validation\n- composed Ring rake accounting with the merged contested-award settlement resolver and odd-chip export logic\n- `npm test -- --runInBand` (136 suites, 1347 tests)\n- `npm run typecheck`\n- `npm run build`