### PR TITLE
fix(export): preserve split-pot odd chips

### DIFF
--- a/src/utils/hand-log-processor.test.ts
+++ b/src/utils/hand-log-processor.test.ts
@@ -53,6 +53,170 @@ function getLines(processor: HandLogProcessor, events: ApiEvent[]): string[] {
   return entries.map(e => e.text)
 }
 
+type SettlementResult = {
+  userId: number
+  handRanking: number
+  rewardChip: number
+}
+
+function buildSettlementEvent(
+  pot: number,
+  sidePots: number[],
+  results: SettlementResult[]
+): ApiEvent<ApiType.EVT_HAND_RESULTS> {
+  return {
+    ApiTypeId: ApiType.EVT_HAND_RESULTS,
+    timestamp: 1700000000000,
+    CommunityCards: [0, 4, 8, 12, 16],
+    Pot: pot,
+    SidePot: sidePots,
+    ResultType: 0,
+    DefeatStatus: 0,
+    HandId: 999900,
+    HandLog: '',
+    Results: results.map(result => ({
+      UserId: result.userId,
+      HoleCards: [0, 1],
+      RankType: 9,
+      Hands: [0, 1, 4, 8, 12],
+      HandRanking: result.handRanking,
+      Ranking: -2,
+      RewardChip: result.rewardChip,
+    })),
+    Player: { SeatIndex: 0, BetStatus: -1, Chip: 0, BetChip: 0 },
+    OtherPlayers: [],
+  } as ApiEvent<ApiType.EVT_HAND_RESULTS>
+}
+
+function buildCollectedLines(
+  event: ApiEvent<ApiType.EVT_HAND_RESULTS>,
+  uncalledBetAmount = 0
+): string[] {
+  const players = event.Results.map(result => ({
+    userId: result.UserId,
+    name: `Player${result.UserId}`,
+  }))
+  const processor = new HandLogProcessor(createContext(createSession(players)))
+  const collectedEntries = (processor as unknown as {
+    buildCollectedEntries: (
+      resultEvent: ApiEvent<ApiType.EVT_HAND_RESULTS>,
+      uncalledAmount?: number
+    ) => HandLogEntry[]
+  }).buildCollectedEntries(event, uncalledBetAmount)
+  return collectedEntries.map(entry => entry.text)
+}
+
+function sumCollected(lines: string[]): number {
+  return lines.reduce((sum, line) => {
+    const amount = line.match(/ collected (\d+) from /)?.[1]
+    return sum + (amount ? Number(amount) : 0)
+  }, 0)
+}
+
+function expectCollectedToReconcile(
+  event: ApiEvent<ApiType.EVT_HAND_RESULTS>,
+  lines: string[],
+  uncalledBetAmount = 0
+): void {
+  const totalReward = event.Results.reduce((sum, result) => sum + result.RewardChip, 0)
+  expect(sumCollected(lines) + uncalledBetAmount).toBe(totalReward)
+}
+
+describe('split-pot collected allocation invariants', () => {
+  test('main-pot odd chip follows the API RewardChip recipient', () => {
+    // PokerStars awards an indivisible chip by position. PokerChase has already
+    // applied that seat rule in RewardChip: Player100 receives 3, Player200 2.
+    const event = buildSettlementEvent(5, [], [
+      { userId: 100, handRanking: 1, rewardChip: 3 },
+      { userId: 200, handRanking: 1, rewardChip: 2 },
+    ])
+
+    const lines = buildCollectedLines(event)
+
+    expect(lines).toEqual([
+      'Player100 collected 3 from pot',
+      'Player200 collected 2 from pot',
+    ])
+    expectCollectedToReconcile(event, lines)
+  })
+
+  test('main pot 5 split 3/2 plus side pot 3 emits all 8 chips', () => {
+    const event = buildSettlementEvent(5, [3], [
+      { userId: 100, handRanking: 1, rewardChip: 3 },
+      { userId: 200, handRanking: 1, rewardChip: 2 },
+      { userId: 300, handRanking: 2, rewardChip: 3 },
+    ])
+
+    const lines = buildCollectedLines(event)
+
+    expect(lines).toEqual([
+      'Player300 collected 3 from side pot',
+      'Player100 collected 3 from main pot',
+      'Player200 collected 2 from main pot',
+    ])
+    expectCollectedToReconcile(event, lines)
+  })
+
+  test('side-pot odd chip follows the API RewardChip recipient', () => {
+    const event = buildSettlementEvent(4, [5], [
+      { userId: 100, handRanking: 1, rewardChip: 4 },
+      { userId: 200, handRanking: 2, rewardChip: 3 },
+      { userId: 300, handRanking: 2, rewardChip: 2 },
+    ])
+
+    const lines = buildCollectedLines(event)
+
+    expect(lines).toEqual([
+      'Player200 collected 3 from side pot',
+      'Player300 collected 2 from side pot',
+      'Player100 collected 4 from main pot',
+    ])
+    expectCollectedToReconcile(event, lines)
+  })
+
+  test('multiple tied pots preserve every per-pot odd-chip allocation', () => {
+    const event = buildSettlementEvent(5, [5, 3], [
+      { userId: 100, handRanking: 1, rewardChip: 3 },
+      { userId: 200, handRanking: 1, rewardChip: 2 },
+      { userId: 300, handRanking: 2, rewardChip: 3 },
+      { userId: 400, handRanking: 2, rewardChip: 2 },
+      { userId: 500, handRanking: 3, rewardChip: 3 },
+    ])
+
+    const lines = buildCollectedLines(event)
+
+    expect(lines).toEqual([
+      'Player500 collected 3 from side pot-2',
+      'Player300 collected 3 from side pot-1',
+      'Player400 collected 2 from side pot-1',
+      'Player100 collected 3 from main pot',
+      'Player200 collected 2 from main pot',
+    ])
+    expectCollectedToReconcile(event, lines)
+  })
+
+  test('uncalled return plus collected payouts equals RewardChip total', () => {
+    // Ring settlement amounts are net of rake. RewardChip still includes the
+    // uncalled return, so the exported conservation boundary is:
+    // collected + uncalled == sum(RewardChip).
+    const uncalledBetAmount = 1
+    const event = buildSettlementEvent(5, [4], [
+      { userId: 100, handRanking: 1, rewardChip: 3 },
+      { userId: 200, handRanking: 1, rewardChip: 2 },
+      { userId: 300, handRanking: 2, rewardChip: 4 },
+    ])
+
+    const lines = buildCollectedLines(event, uncalledBetAmount)
+
+    expect(lines).toEqual([
+      'Player300 collected 3 from side pot',
+      'Player100 collected 3 from main pot',
+      'Player200 collected 2 from main pot',
+    ])
+    expectCollectedToReconcile(event, lines, uncalledBetAmount)
+  })
+})
+
 // ============================================================
 // Test 1: Hero not participating (table move, empty HoleCards)
 // Hand #435351195 — Hero has empty HoleCards after MTT table move

--- a/src/utils/hand-log-processor.test.ts
+++ b/src/utils/hand-log-processor.test.ts
@@ -90,7 +90,8 @@ function buildSettlementEvent(
 
 function buildCollectedLines(
   event: ApiEvent<ApiType.EVT_HAND_RESULTS>,
-  uncalledBetAmount = 0
+  uncalledBetAmount = 0,
+  uncalledBetUserId?: number
 ): string[] {
   const players = event.Results.map(result => ({
     userId: result.UserId,
@@ -100,9 +101,10 @@ function buildCollectedLines(
   const collectedEntries = (processor as unknown as {
     buildCollectedEntries: (
       resultEvent: ApiEvent<ApiType.EVT_HAND_RESULTS>,
-      uncalledAmount?: number
+      uncalledAmount?: number,
+      uncalledUserId?: number
     ) => HandLogEntry[]
-  }).buildCollectedEntries(event, uncalledBetAmount)
+  }).buildCollectedEntries(event, uncalledBetAmount, uncalledBetUserId)
   return collectedEntries.map(entry => entry.text)
 }
 
@@ -242,12 +244,28 @@ describe('split-pot collected allocation invariants', () => {
       { userId: 300, handRanking: 2, rewardChip: 4 },
     ])
 
-    const lines = buildCollectedLines(event, uncalledBetAmount)
+    const lines = buildCollectedLines(event, uncalledBetAmount, 300)
 
     expect(lines).toEqual([
       'Player300 collected 3 from side pot',
       'Player100 collected 3 from main pot',
       'Player200 collected 2 from main pot',
+    ])
+    expectCollectedToReconcile(event, lines, uncalledBetAmount)
+  })
+
+  test('uncalled return stays reserved for the named tied winner', () => {
+    const uncalledBetAmount = 1
+    const event = buildSettlementEvent(5, [1], [
+      { userId: 100, handRanking: 1, rewardChip: 3 },
+      { userId: 200, handRanking: 1, rewardChip: 3 },
+    ])
+
+    const lines = buildCollectedLines(event, uncalledBetAmount, 100)
+
+    expect(lines).toEqual([
+      'Player100 collected 2 from main pot',
+      'Player200 collected 3 from main pot',
     ])
     expectCollectedToReconcile(event, lines, uncalledBetAmount)
   })

--- a/src/utils/hand-log-processor.test.ts
+++ b/src/utils/hand-log-processor.test.ts
@@ -195,6 +195,23 @@ describe('split-pot collected allocation invariants', () => {
     expectCollectedToReconcile(event, lines)
   })
 
+  test('tied winners continuing into a side pot keep their RewardChip totals', () => {
+    const event = buildSettlementEvent(5, [8], [
+      { userId: 100, handRanking: 1, rewardChip: 7 },
+      { userId: 200, handRanking: 1, rewardChip: 6 },
+    ])
+
+    const lines = buildCollectedLines(event)
+
+    expect(lines).toEqual([
+      'Player100 collected 4 from side pot',
+      'Player200 collected 4 from side pot',
+      'Player100 collected 3 from main pot',
+      'Player200 collected 2 from main pot',
+    ])
+    expectCollectedToReconcile(event, lines)
+  })
+
   test('uncalled return plus collected payouts equals RewardChip total', () => {
     // Ring settlement amounts are net of rake. RewardChip still includes the
     // uncalled return, so the exported conservation boundary is:

--- a/src/utils/hand-log-processor.test.ts
+++ b/src/utils/hand-log-processor.test.ts
@@ -212,6 +212,25 @@ describe('split-pot collected allocation invariants', () => {
     expectCollectedToReconcile(event, lines)
   })
 
+  test('odd-chip allocation looks ahead across pot-tier eligibility boundaries', () => {
+    const event = buildSettlementEvent(15, [21, 2, 18], [
+      { userId: 100, handRanking: 2, rewardChip: 19 },
+      { userId: 200, handRanking: 2, rewardChip: 37 },
+    ])
+
+    const lines = buildCollectedLines(event)
+
+    expect(lines).toEqual([
+      'Player200 collected 18 from side pot-3',
+      'Player200 collected 2 from side pot-2',
+      'Player100 collected 11 from side pot-1',
+      'Player200 collected 10 from side pot-1',
+      'Player100 collected 8 from main pot',
+      'Player200 collected 7 from main pot',
+    ])
+    expectCollectedToReconcile(event, lines)
+  })
+
   test('uncalled return plus collected payouts equals RewardChip total', () => {
     // Ring settlement amounts are net of rake. RewardChip still includes the
     // uncalled return, so the exported conservation boundary is:

--- a/src/utils/hand-log-processor.ts
+++ b/src/utils/hand-log-processor.ts
@@ -597,7 +597,10 @@ export class HandLogProcessor {
       }))
       .sort((a, b) => a.handRanking - b.handRanking)
 
-    const potWinners: Map<number, { userIds: number[], amount: number }> = new Map()
+    const potWinners: Map<number, {
+      allocations: Array<{ userId: number, amount: number }>
+      amount: number
+    }> = new Map()
 
     for (let potIdx = 0; potIdx < potAmounts.length; potIdx++) {
       const potAmount = potAmounts[potIdx]!
@@ -609,23 +612,25 @@ export class HandLogProcessor {
       const bestRanking = active[0]!.handRanking
       const group = active.filter(w => w.handRanking === bestRanking)
 
-      potWinners.set(potIdx, {
-        userIds: group.map(w => w.userId),
-        amount: potAmount
-      })
-
       // 割当分を残RewardChipから消費。端数（オッドチップ）は残額が最小の
       // メンバーに寄せる: オッドチップを受け取って退場するメンバーを
       // ちょうど0にし、後続ポットの勝者判定を狂わせないため
       const perPlayer = Math.floor(potAmount / group.length)
+      const allocations = group.map(w => ({ userId: w.userId, amount: perPlayer }))
       for (const w of group) w.remaining -= perPlayer
       let leftover = potAmount - perPlayer * group.length
       while (leftover > 0) {
         const candidates = group.filter(w => w.remaining > 0)
         if (candidates.length === 0) break
-        candidates.reduce((min, w) => w.remaining < min.remaining ? w : min).remaining -= 1
+        const recipient = candidates.reduce((min, w) => w.remaining < min.remaining ? w : min)
+        recipient.remaining -= 1
+        allocations.find(allocation => allocation.userId === recipient.userId)!.amount += 1
         leftover -= 1
       }
+
+      // RewardChipが確定しているオッドチップ受取人を出力時まで保持する。
+      // ここで受取人を捨てて均等額を再計算すると、端数がログから消失する。
+      potWinners.set(potIdx, { allocations, amount: potAmount })
     }
 
     for (let potIdx = potAmounts.length - 1; potIdx >= 0; potIdx--) {
@@ -634,21 +639,12 @@ export class HandLogProcessor {
 
       const potLabel = this.getPotLabel(potIdx, event.SidePot.length)
       
-      if (potInfo.userIds.length === 1) {
-        const playerName = this.getPlayerName(potInfo.userIds[0]!)
+      for (const allocation of potInfo.allocations) {
+        const playerName = this.getPlayerName(allocation.userId)
         entries.push(this.createEntry(
-          `${playerName} collected ${potInfo.amount} from ${potLabel}`,
+          `${playerName} collected ${allocation.amount} from ${potLabel}`,
           HandLogEntryType.SHOWDOWN
         ))
-      } else {
-        const splitAmount = Math.floor(potInfo.amount / potInfo.userIds.length)
-        for (const userId of potInfo.userIds) {
-          const playerName = this.getPlayerName(userId)
-          entries.push(this.createEntry(
-            `${playerName} collected ${splitAmount} from ${potLabel}`,
-            HandLogEntryType.SHOWDOWN
-          ))
-        }
       }
     }
 

--- a/src/utils/hand-log-processor.ts
+++ b/src/utils/hand-log-processor.ts
@@ -612,9 +612,9 @@ export class HandLogProcessor {
       const bestRanking = active[0]!.handRanking
       const group = active.filter(w => w.handRanking === bestRanking)
 
-      // 割当分を残RewardChipから消費。端数（オッドチップ）は残額が最小の
-      // メンバーに寄せる: オッドチップを受け取って退場するメンバーを
-      // ちょうど0にし、後続ポットの勝者判定を狂わせないため
+      // 割当分を残RewardChipから消費。端数（オッドチップ）は残額が最大の
+      // メンバーに寄せる。後続ポットにも同じ同点勝者が残る場合は残額を
+      // 均す必要があり、ここを最小側へ寄せると最終RewardChipが反転する。
       const perPlayer = Math.floor(potAmount / group.length)
       const allocations = group.map(w => ({ userId: w.userId, amount: perPlayer }))
       for (const w of group) w.remaining -= perPlayer
@@ -622,7 +622,7 @@ export class HandLogProcessor {
       while (leftover > 0) {
         const candidates = group.filter(w => w.remaining > 0)
         if (candidates.length === 0) break
-        const recipient = candidates.reduce((min, w) => w.remaining < min.remaining ? w : min)
+        const recipient = candidates.reduce((max, w) => w.remaining > max.remaining ? w : max)
         recipient.remaining -= 1
         allocations.find(allocation => allocation.userId === recipient.userId)!.amount += 1
         leftover -= 1

--- a/src/utils/hand-log-processor.ts
+++ b/src/utils/hand-log-processor.ts
@@ -407,6 +407,8 @@ export class HandLogProcessor {
 
     // Handle uncalled bets BEFORE showdown
     const wentToShowdown = showdownParticipants.length > 0
+    let showdownUncalledBetAmount = 0
+    let showdownUncalledBetUserId: number | undefined
     
     if (!wentToShowdown) {
       // For non-showdown wins, handle uncalled bets first
@@ -465,6 +467,11 @@ export class HandLogProcessor {
               uncalledAmount = lastSidePot
             }
             if (uncalledAmount > 0) {
+              showdownUncalledBetAmount = uncalledAmount
+              showdownUncalledBetUserId = event.Results
+                .filter(result => result.RewardChip > 0)
+                .find(result => this.getPlayerName(result.UserId) === betterName)
+                ?.UserId
               const uncalledEntry = this.createEntry(
                 `Uncalled bet (${uncalledAmount}) returned to ${betterName}`,
                 HandLogEntryType.SHOWDOWN
@@ -514,16 +521,11 @@ export class HandLogProcessor {
 
     // Handle pot collection for showdown winners and tournament finish positions
     if (wentToShowdown) {
-      // ショウダウン前のuncalled betを検出（サイドポット計算に必要）
-      const uncalledBetEntry = entries.find(e =>
-        e.text.includes('Uncalled bet (') && e.text.includes(') returned to')
-      )
-      let uncalledBetAmount = 0
-      if (uncalledBetEntry) {
-        const m = uncalledBetEntry.text.match(/Uncalled bet \((\d+)\)/)
-        if (m?.[1]) uncalledBetAmount = parseInt(m[1])
-      }
-      entries.push(...this.buildCollectedEntries(event, uncalledBetAmount))
+      entries.push(...this.buildCollectedEntries(
+        event,
+        showdownUncalledBetAmount,
+        showdownUncalledBetUserId
+      ))
     }
 
     event.Results.forEach(result => {
@@ -549,7 +551,11 @@ export class HandLogProcessor {
   /**
    * サイドポット対応の collected 行を構築
    */
-  private buildCollectedEntries(event: ApiEvent<ApiType.EVT_HAND_RESULTS>, uncalledBetAmount: number = 0): HandLogEntry[] {
+  private buildCollectedEntries(
+    event: ApiEvent<ApiType.EVT_HAND_RESULTS>,
+    uncalledBetAmount: number = 0,
+    uncalledBetUserId?: number
+  ): HandLogEntry[] {
     const entries: HandLogEntry[] = []
     const hasSidePots = event.SidePot.length > 0
 
@@ -597,6 +603,14 @@ export class HandLogProcessor {
       }))
       .sort((a, b) => a.handRanking - b.handRanking)
 
+    if (uncalledBetAmount > 0) {
+      const recipient = winners.find(w => w.userId === uncalledBetUserId)
+      if (!recipient || recipient.remaining < uncalledBetAmount) return entries
+      // RewardChipは返却分込み。pot allocationから先に予約し、同点の別winnerへ
+      // terminal residualを誤帰属しないようにする。
+      recipient.remaining -= uncalledBetAmount
+    }
+
     const potWinners: Map<number, {
       allocations: Array<{ userId: number, amount: number }>
       amount: number
@@ -604,9 +618,7 @@ export class HandLogProcessor {
 
     const allocatePots = (potIdx: number): boolean => {
       if (potIdx === potAmounts.length) {
-        const remaining = winners.filter(w => w.remaining > 0)
-        return remaining.reduce((sum, w) => sum + w.remaining, 0) === uncalledBetAmount &&
-          remaining.length <= (uncalledBetAmount > 0 ? 1 : 0)
+        return winners.every(w => w.remaining === 0)
       }
 
       const potAmount = potAmounts[potIdx]!

--- a/src/utils/hand-log-processor.ts
+++ b/src/utils/hand-log-processor.ts
@@ -602,36 +602,69 @@ export class HandLogProcessor {
       amount: number
     }> = new Map()
 
-    for (let potIdx = 0; potIdx < potAmounts.length; potIdx++) {
+    const allocatePots = (potIdx: number): boolean => {
+      if (potIdx === potAmounts.length) {
+        const remaining = winners.filter(w => w.remaining > 0)
+        return remaining.reduce((sum, w) => sum + w.remaining, 0) === uncalledBetAmount &&
+          remaining.length <= (uncalledBetAmount > 0 ? 1 : 0)
+      }
+
       const potAmount = potAmounts[potIdx]!
-      if (potAmount <= 0) continue
+      if (potAmount <= 0) return allocatePots(potIdx + 1)
 
       // 残RewardChipを持つ最強HandRankingグループが現在のポットの勝者（同点はスプリット）
       const active = winners.filter(w => w.remaining > 0)
-      if (active.length === 0) break
+      if (active.length === 0) return false
       const bestRanking = active[0]!.handRanking
       const group = active.filter(w => w.handRanking === bestRanking)
 
-      // 割当分を残RewardChipから消費。端数（オッドチップ）は残額が最大の
-      // メンバーに寄せる。後続ポットにも同じ同点勝者が残る場合は残額を
-      // 均す必要があり、ここを最小側へ寄せると最終RewardChipが反転する。
       const perPlayer = Math.floor(potAmount / group.length)
-      const allocations = group.map(w => ({ userId: w.userId, amount: perPlayer }))
+      if (group.some(w => w.remaining < perPlayer)) return false
       for (const w of group) w.remaining -= perPlayer
-      let leftover = potAmount - perPlayer * group.length
-      while (leftover > 0) {
-        const candidates = group.filter(w => w.remaining > 0)
-        if (candidates.length === 0) break
-        const recipient = candidates.reduce((max, w) => w.remaining > max.remaining ? w : max)
-        recipient.remaining -= 1
-        allocations.find(allocation => allocation.userId === recipient.userId)!.amount += 1
-        leftover -= 1
+
+      const leftover = potAmount - perPlayer * group.length
+      const candidates = group.filter(w => w.remaining > 0)
+
+      // 同じ同点グループが後続side potにも残る場合、現在のpotだけを見た
+      // greedy選択ではRewardChip合計を反転させうる。端数は最大5個のpot・
+      // 最大6人の候補だけを探索し、全pot後のAPI残額に一致する割当を選ぶ。
+      const tryOddChipRecipients = (
+        startIndex: number,
+        needed: number,
+        selected: typeof candidates
+      ): boolean => {
+        if (needed === 0) {
+          for (const winner of selected) winner.remaining -= 1
+          const allocations = group.map(w => ({
+            userId: w.userId,
+            amount: perPlayer + (selected.includes(w) ? 1 : 0)
+          }))
+          potWinners.set(potIdx, { allocations, amount: potAmount })
+
+          if (allocatePots(potIdx + 1)) return true
+
+          potWinners.delete(potIdx)
+          for (const winner of selected) winner.remaining += 1
+          return false
+        }
+
+        if (candidates.length - startIndex < needed) return false
+        for (let i = startIndex; i < candidates.length; i++) {
+          const winner = candidates[i]!
+          selected.push(winner)
+          if (tryOddChipRecipients(i + 1, needed - 1, selected)) return true
+          selected.pop()
+        }
+        return false
       }
 
-      // RewardChipが確定しているオッドチップ受取人を出力時まで保持する。
-      // ここで受取人を捨てて均等額を再計算すると、端数がログから消失する。
-      potWinners.set(potIdx, { allocations, amount: potAmount })
+      if (tryOddChipRecipients(0, leftover, [])) return true
+
+      for (const w of group) w.remaining += perPlayer
+      return false
     }
+
+    allocatePots(0)
 
     for (let potIdx = potAmounts.length - 1; potIdx >= 0; potIdx--) {
       const potInfo = potWinners.get(potIdx)


### PR DESCRIPTION
## Summary

- retain each per-user pot allocation after `RewardChip` reconciliation instead of recomputing a floored split while rendering `collected` lines
- search the bounded odd-chip recipient combinations across pot tiers so tied winners with different side-pot eligibility preserve their final API totals
- reserve an uncalled return for the exact player named by the return event before allocating contested pots

## Correctness

For every covered settlement:

```text
per-player collected + that player's uncalled return == Results[].RewardChip
```

The reported fixture now emits all 8 chips: main pot 5 as 3/2, plus side pot 3. Lookahead regressions also cover tied winners who both continue, tied winners who separate at a later side-pot tier, and a returned overbet where both final rewards are equal.

PokerStars split-pot reference: https://www.pokerstars.com/poker/games/rules/

## Validation

- `npm test -- --runInBand src/utils/hand-log-processor.test.ts` (50 tests)
- `npm test -- --runInBand` (135 suites, 1306 tests)
- `npm run typecheck`
- `npm run build`

## Risk gate

Targeted final-head conservation tests cover odd chips in the main pot, side pot, multiple pots, continuing tied winners, pot-tier eligibility boundaries, recipient-bound uncalled returns, and Ring settlement amounts after rake. Each fixture asserts exact per-player lines and the payout invariant.

## Coordination

This PR remains separate from #275. Both touch HandLog payout tests/summary code, so whichever lands second should rebase and resolve only the mechanical overlap.
