### PR TITLE
fix: keep cloud rebuild worker alive

### DIFF
--- a/src/background/import-export.keepalive.test.ts
+++ b/src/background/import-export.keepalive.test.ts
@@ -13,11 +13,12 @@ describe('export service-worker keepalive', () => {
   test('calls an Extension API before the 30-second idle timeout and stops cleanly', async () => {
     const stop = await startKeepAlive()
 
-    jest.advanceTimersByTime(25000)
     expect(chrome.runtime.getPlatformInfo).toHaveBeenCalledTimes(1)
+    jest.advanceTimersByTime(25000)
+    expect(chrome.runtime.getPlatformInfo).toHaveBeenCalledTimes(2)
 
     stop()
     jest.advanceTimersByTime(50000)
-    expect(chrome.runtime.getPlatformInfo).toHaveBeenCalledTimes(1)
+    expect(chrome.runtime.getPlatformInfo).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -32,6 +32,9 @@ import {
 import { HandLogExporter } from '../utils/hand-log-exporter'
 import { awaitIngestionDrain } from './update-manager'
 import { runBestEffortChromeUi } from './best-effort-chrome-api'
+import { startKeepAlive } from './service-worker-keepalive'
+
+export { startKeepAlive } from './service-worker-keepalive'
 
 const IMPORT_CHUNK_SIZE = DATABASE_CONSTANTS.IMPORT_CHUNK_SIZE
 
@@ -1200,21 +1203,6 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
     getLatestSessionStats,
     rebuildAllData
   }
-}
-
-/**
- * Service Worker のアイドル停止を防止するキープアライブを開始する。
- * Chrome MV3 では 30 秒のアイドル後に Worker が停止されるため、
- * 長時間のバッチ処理中は30秒未満の間隔でExtension APIを呼び出す。
- * Chrome 110以降はExtension API呼び出しがService Workerのアイドル
- * タイマーをリセットする。manifestのminimum_chrome_versionは120。
- * @returns クリーンアップ関数
- */
-export const startKeepAlive = async (): Promise<() => void> => {
-  const id = setInterval(() => {
-    chrome.runtime.getPlatformInfo().catch(() => {})
-  }, 25000)
-  return () => clearInterval(id)
 }
 
 /**

--- a/src/background/service-worker-keepalive.ts
+++ b/src/background/service-worker-keepalive.ts
@@ -1,0 +1,16 @@
+/** !!! CONTENT_SCRIPTS、WEB_ACCESSIBLE_RESOURCESからインポートしないこと !!! */
+
+/**
+ * Service Worker のアイドル停止を防止するキープアライブを開始する。
+ * Chrome MV3 では 30 秒のアイドル後に Worker が停止されるため、
+ * 長時間のバッチ処理中は30秒未満の間隔でExtension APIを呼び出す。
+ * Chrome 110以降はExtension API呼び出しがService Workerのアイドル
+ * タイマーをリセットする。manifestのminimum_chrome_versionは120。
+ * @returns クリーンアップ関数
+ */
+export const startKeepAlive = async (): Promise<() => void> => {
+  const id = setInterval(() => {
+    chrome.runtime.getPlatformInfo().catch(() => {})
+  }, 25000)
+  return () => clearInterval(id)
+}

--- a/src/background/service-worker-keepalive.ts
+++ b/src/background/service-worker-keepalive.ts
@@ -9,8 +9,13 @@
  * @returns クリーンアップ関数
  */
 export const startKeepAlive = async (): Promise<() => void> => {
-  const id = setInterval(() => {
+  const ping = () => {
     chrome.runtime.getPlatformInfo().catch(() => {})
-  }, 25000)
+  }
+  // Scheduling an interval does not reset Chrome's idle timer. The caller may
+  // arrive here after a slow network/IDB step with little of the original
+  // 30-second budget left, so reset it before waiting for the first tick.
+  ping()
+  const id = setInterval(ping, 25000)
   return () => clearInterval(id)
 }

--- a/src/services/auto-sync-service.keepalive.test.ts
+++ b/src/services/auto-sync-service.keepalive.test.ts
@@ -33,6 +33,7 @@ describe('AutoSyncService cloud-rebuild MV3 keepalive', () => {
     ;(chrome.runtime.sendMessage as jest.Mock).mockResolvedValue(undefined)
     ;(chrome.runtime as any).getPlatformInfo = jest.fn().mockResolvedValue({})
     jest.spyOn(minVersionGate, 'isCloudSyncBlockedByMinVersionGate').mockResolvedValue(false)
+    jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp').mockResolvedValue(null)
   })
 
   afterEach(async () => {
@@ -54,10 +55,14 @@ describe('AutoSyncService cloud-rebuild MV3 keepalive', () => {
       await new Promise<void>(resolve => { releaseReplay = resolve })
       return realFilter(events)
     })
+    jest.spyOn(firestoreBackupService, 'syncFromCloud').mockImplementation(async options => {
+      await options.onBatch([CLOUD_EVENT])
+      return 1
+    })
     const clearIntervalSpy = jest.spyOn(global, 'clearInterval')
 
     const service = new AutoSyncService(db)
-    const rebuild = (service as any).rebuildLocalEntities() as Promise<void>
+    const rebuild = service.performSync('download')
     await waitUntil(() => releaseReplay !== undefined)
 
     expect(chrome.runtime.getPlatformInfo).toHaveBeenCalledTimes(1)
@@ -66,7 +71,7 @@ describe('AutoSyncService cloud-rebuild MV3 keepalive', () => {
     await jest.advanceTimersByTimeAsync(6_000)
 
     releaseReplay!()
-    await rebuild
+    await expect(rebuild).resolves.toEqual({ success: true })
 
     expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
     await jest.advanceTimersByTimeAsync(50_000)
@@ -78,12 +83,17 @@ describe('AutoSyncService cloud-rebuild MV3 keepalive', () => {
     await db.apiEvents.add(CLOUD_EVENT)
     jest.spyOn(databaseUtils, 'filterValidApplicationEvents')
       .mockRejectedValueOnce(new DOMException('replay cancelled', 'AbortError'))
+    jest.spyOn(firestoreBackupService, 'syncFromCloud').mockImplementation(async options => {
+      await options.onBatch([CLOUD_EVENT])
+      return 1
+    })
     const clearIntervalSpy = jest.spyOn(global, 'clearInterval')
 
     const service = new AutoSyncService(db)
-    await expect((service as any).rebuildLocalEntities()).rejects.toThrow(
-      `${REBUILD_AFTER_DOWNLOAD_FAILED_MESSAGE} (replay cancelled)`
-    )
+    await expect(service.performSync('download')).resolves.toEqual({
+      success: false,
+      error: `${REBUILD_AFTER_DOWNLOAD_FAILED_MESSAGE} (replay cancelled)`
+    })
 
     expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
     await jest.advanceTimersByTimeAsync(50_000)

--- a/src/services/auto-sync-service.keepalive.test.ts
+++ b/src/services/auto-sync-service.keepalive.test.ts
@@ -1,0 +1,155 @@
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import { setImmediate as nodeSetImmediate } from 'node:timers'
+import { PokerChaseDB } from '../db/poker-chase-db'
+import { BattleType, ApiType, type ApiEvent } from '../types'
+import * as databaseUtils from '../utils/database-utils'
+import { setOperationState } from '../background/operation-state'
+import { firestoreBackupService } from './firestore-backup-service'
+import * as minVersionGate from './min-version-gate'
+import { AutoSyncService, REBUILD_AFTER_DOWNLOAD_FAILED_MESSAGE } from './auto-sync-service'
+
+const CLOUD_EVENT = {
+  ApiTypeId: ApiType.EVT_ENTRY_QUEUED,
+  Code: 0,
+  BattleType: BattleType.SIT_AND_GO,
+  Id: 'cloud-rebuild-keepalive',
+  IsRetire: false,
+  timestamp: 100
+} as ApiEvent
+
+const waitUntil = async (predicate: () => boolean): Promise<void> => {
+  while (!predicate()) {
+    await new Promise<void>(resolve => nodeSetImmediate(resolve))
+  }
+}
+
+describe('AutoSyncService cloud-rebuild MV3 keepalive', () => {
+  let db: PokerChaseDB
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    setOperationState({ type: 'idle' })
+    ;(chrome.runtime.sendMessage as jest.Mock).mockResolvedValue(undefined)
+    ;(chrome.runtime as any).getPlatformInfo = jest.fn().mockResolvedValue({})
+    jest.spyOn(minVersionGate, 'isCloudSyncBlockedByMinVersionGate').mockResolvedValue(false)
+  })
+
+  afterEach(async () => {
+    setOperationState({ type: 'idle' })
+    jest.clearAllTimers()
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+    db.close()
+    await db.delete()
+  })
+
+  test('keeps a cold worker alive through a replay longer than 30 seconds and clears the timer on success', async () => {
+    jest.useFakeTimers({ doNotFake: ['setImmediate', 'nextTick', 'queueMicrotask'] })
+    await db.apiEvents.add(CLOUD_EVENT)
+
+    const realFilter = databaseUtils.filterValidApplicationEvents
+    let releaseReplay: (() => void) | undefined
+    jest.spyOn(databaseUtils, 'filterValidApplicationEvents').mockImplementationOnce(async events => {
+      await new Promise<void>(resolve => { releaseReplay = resolve })
+      return realFilter(events)
+    })
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval')
+
+    const service = new AutoSyncService(db)
+    const rebuild = (service as any).rebuildLocalEntities() as Promise<void>
+    await waitUntil(() => releaseReplay !== undefined)
+
+    await jest.advanceTimersByTimeAsync(25_000)
+    expect(chrome.runtime.getPlatformInfo).toHaveBeenCalledTimes(1)
+    await jest.advanceTimersByTimeAsync(6_000)
+
+    releaseReplay!()
+    await rebuild
+
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
+    await jest.advanceTimersByTimeAsync(50_000)
+    expect(chrome.runtime.getPlatformInfo).toHaveBeenCalledTimes(1)
+  })
+
+  test('clears the timer when replay rejects with an abort-like cancellation', async () => {
+    jest.useFakeTimers({ doNotFake: ['setImmediate', 'nextTick', 'queueMicrotask'] })
+    await db.apiEvents.add(CLOUD_EVENT)
+    jest.spyOn(databaseUtils, 'filterValidApplicationEvents')
+      .mockRejectedValueOnce(new DOMException('replay cancelled', 'AbortError'))
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval')
+
+    const service = new AutoSyncService(db)
+    await expect((service as any).rebuildLocalEntities()).rejects.toThrow(
+      `${REBUILD_AFTER_DOWNLOAD_FAILED_MESSAGE} (replay cancelled)`
+    )
+
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
+    await jest.advanceTimersByTimeAsync(50_000)
+    expect(chrome.runtime.getPlatformInfo).not.toHaveBeenCalled()
+  })
+
+  test('preserves a partial download failure as the primary error and still clears the recovery-rebuild timer', async () => {
+    jest.spyOn(firestoreBackupService, 'syncFromCloud').mockImplementation(async options => {
+      await options.onBatch([CLOUD_EVENT])
+      throw new Error('Cloud sync failed: Firestore REST request failed: 503')
+    })
+    jest.spyOn(databaseUtils, 'filterValidApplicationEvents')
+      .mockRejectedValueOnce(new Error('derived-table save failed'))
+    const setIntervalSpy = jest.spyOn(global, 'setInterval')
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval')
+
+    const service = new AutoSyncService(db)
+    const outcome = await service.performSync('download')
+
+    expect(outcome).toEqual({
+      success: false,
+      error: expect.stringContaining('Firestore REST request failed: 503')
+    })
+    expect(service.getSyncState().error).not.toContain('derived-table save failed')
+    const keepAliveCallIndex = setIntervalSpy.mock.calls.findIndex(([, delay]) => delay === 25_000)
+    expect(keepAliveCallIndex).toBeGreaterThanOrEqual(0)
+    expect(clearIntervalSpy).toHaveBeenCalledWith(setIntervalSpy.mock.results[keepAliveCallIndex]!.value)
+  })
+
+  test('does not arm a timer when the operation gate blocks sync, and an overlapping sync cannot create a second timer', async () => {
+    const setIntervalSpy = jest.spyOn(global, 'setInterval')
+
+    setOperationState({ type: 'import' })
+    const blockedService = new AutoSyncService(db)
+    await expect(blockedService.performSync('download')).resolves.toEqual({
+      success: false,
+      error: expect.stringContaining('実行中'),
+      reason: 'operation-busy'
+    })
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+
+    setOperationState({ type: 'idle' })
+    await db.apiEvents.add(CLOUD_EVENT)
+    let releaseReplay: (() => void) | undefined
+    const realFilter = databaseUtils.filterValidApplicationEvents
+    jest.spyOn(databaseUtils, 'filterValidApplicationEvents').mockImplementationOnce(async events => {
+      await new Promise<void>(resolve => { releaseReplay = resolve })
+      return realFilter(events)
+    })
+    jest.spyOn(firestoreBackupService, 'syncFromCloud').mockImplementation(async options => {
+      await options.onBatch([CLOUD_EVENT])
+      return 1
+    })
+
+    const ownerService = new AutoSyncService(db)
+    const owner = ownerService.performSync('download')
+    await waitUntil(() => releaseReplay !== undefined)
+    const overlap = await ownerService.performSync('download')
+
+    expect(overlap).toEqual({
+      success: false,
+      error: expect.stringContaining('実行中')
+    })
+    expect(setIntervalSpy.mock.calls.filter(([, delay]) => delay === 25_000)).toHaveLength(1)
+
+    releaseReplay!()
+    await expect(owner).resolves.toEqual({ success: true })
+    expect(setIntervalSpy.mock.calls.filter(([, delay]) => delay === 25_000)).toHaveLength(1)
+  })
+})

--- a/src/services/auto-sync-service.keepalive.test.ts
+++ b/src/services/auto-sync-service.keepalive.test.ts
@@ -60,8 +60,9 @@ describe('AutoSyncService cloud-rebuild MV3 keepalive', () => {
     const rebuild = (service as any).rebuildLocalEntities() as Promise<void>
     await waitUntil(() => releaseReplay !== undefined)
 
-    await jest.advanceTimersByTimeAsync(25_000)
     expect(chrome.runtime.getPlatformInfo).toHaveBeenCalledTimes(1)
+    await jest.advanceTimersByTimeAsync(25_000)
+    expect(chrome.runtime.getPlatformInfo).toHaveBeenCalledTimes(2)
     await jest.advanceTimersByTimeAsync(6_000)
 
     releaseReplay!()
@@ -69,7 +70,7 @@ describe('AutoSyncService cloud-rebuild MV3 keepalive', () => {
 
     expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
     await jest.advanceTimersByTimeAsync(50_000)
-    expect(chrome.runtime.getPlatformInfo).toHaveBeenCalledTimes(1)
+    expect(chrome.runtime.getPlatformInfo).toHaveBeenCalledTimes(2)
   })
 
   test('clears the timer when replay rejects with an abort-like cancellation', async () => {
@@ -86,7 +87,7 @@ describe('AutoSyncService cloud-rebuild MV3 keepalive', () => {
 
     expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
     await jest.advanceTimersByTimeAsync(50_000)
-    expect(chrome.runtime.getPlatformInfo).not.toHaveBeenCalled()
+    expect(chrome.runtime.getPlatformInfo).toHaveBeenCalledTimes(1)
   })
 
   test('preserves a partial download failure as the primary error and still clears the recovery-rebuild timer', async () => {

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -25,6 +25,7 @@ import {
   type RawApiEvent
 } from '../utils/api-event-key'
 import { HandLogExporter } from '../utils/hand-log-exporter'
+import { startKeepAlive } from '../background/service-worker-keepalive'
 
 /** Shown in the popup and logged when the min-version gate stops cloud sync (#forced-update). */
 export const MIN_VERSION_SYNC_BLOCKED_MESSAGE = 'このバージョンはサポートが終了しました。Chromeを再起動すると更新が適用されます'
@@ -1452,6 +1453,12 @@ export class AutoSyncService {
    *   an error always leaves the previous `importStatus` untouched.
    */
   private async rebuildLocalEntities(): Promise<void> {
+    // A cloud restore can replay the entire Raw Event Lake and repeatedly
+    // commit derived chunks. On a cold MV3 worker with no game Port, popup,
+    // or DevTools attached, that work can exceed Chrome's 30-second idle
+    // timeout. Reuse the manual rebuild/export keepalive for the complete
+    // replay, including recovery after a partially downloaded cloud page.
+    const stopKeepAlive = await startKeepAlive()
     try {
       console.log('[AutoSync] Triggering chunked data rebuild after download...')
 
@@ -1557,6 +1564,11 @@ export class AutoSyncService {
       throw new Error(
         `${REBUILD_AFTER_DOWNLOAD_FAILED_MESSAGE} (${error instanceof Error ? error.message : 'Unknown error'})`
       )
+    } finally {
+      // Every settled path (success, replay/write failure, or an abort-like
+      // rejection) owns exactly one cleanup and cannot leak the interval
+      // into the next sync attempt.
+      stopKeepAlive()
     }
   }
 

--- a/src/services/auto-sync-service.ts
+++ b/src/services/auto-sync-service.ts
@@ -1374,6 +1374,19 @@ export class AutoSyncService {
    * above -- deliberately not gated here.
    */
   private async syncFromCloud(): Promise<void> {
+    // Arm before the first Firestore await: a cold worker can already be near
+    // its idle deadline after a slow count/page request. One scoped keepalive
+    // protects the complete download + Raw Lake merge + derived replay, and
+    // its finally covers both the normal and partial-download recovery paths.
+    const stopKeepAlive = await startKeepAlive()
+    try {
+      await this.downloadAndRebuildFromCloud()
+    } finally {
+      stopKeepAlive()
+    }
+  }
+
+  private async downloadAndRebuildFromCloud(): Promise<void> {
     console.log('[AutoSync] Starting complete download from cloud...')
 
     let downloadedEvents = 0
@@ -1453,12 +1466,6 @@ export class AutoSyncService {
    *   an error always leaves the previous `importStatus` untouched.
    */
   private async rebuildLocalEntities(): Promise<void> {
-    // A cloud restore can replay the entire Raw Event Lake and repeatedly
-    // commit derived chunks. On a cold MV3 worker with no game Port, popup,
-    // or DevTools attached, that work can exceed Chrome's 30-second idle
-    // timeout. Reuse the manual rebuild/export keepalive for the complete
-    // replay, including recovery after a partially downloaded cloud page.
-    const stopKeepAlive = await startKeepAlive()
     try {
       console.log('[AutoSync] Triggering chunked data rebuild after download...')
 
@@ -1564,11 +1571,6 @@ export class AutoSyncService {
       throw new Error(
         `${REBUILD_AFTER_DOWNLOAD_FAILED_MESSAGE} (${error instanceof Error ? error.message : 'Unknown error'})`
       )
-    } finally {
-      // Every settled path (success, replay/write failure, or an abort-like
-      // rejection) owns exactly one cleanup and cannot leak the interval
-      // into the next sync attempt.
-      stopKeepAlive()
     }
   }
 

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -50,6 +50,7 @@ global.chrome = {
       addListener: jest.fn(),
     },
     requestUpdateCheck: jest.fn().mockResolvedValue({ status: 'no_update' }),
+    getPlatformInfo: jest.fn().mockResolvedValue({ os: 'mac', arch: 'arm', nacl_arch: 'arm' }),
     getManifest: jest.fn(() => ({ version: '5.1.0' })),
     getURL: jest.fn((path: string) => `chrome-extension://mock-extension-id/${path}`),
     reload: jest.fn(),


### PR DESCRIPTION
## Summary
- share the existing MV3 service-worker keepalive used by manual rebuild/export paths
- scope that keepalive around cloud-download derived-entity replay, including partial-download recovery
- always stop the interval after success, failure, or abort-like rejection without weakening the existing operation gate

## Scope
Hard service-worker termination recovery is intentionally out of scope; this PR prevents idle termination during the existing replay operation.

## Validation
- `npm test -- --runInBand src/services/auto-sync-service.test.ts src/services/auto-sync-service.rebuild-canonical.test.ts src/services/auto-sync-service.rebuild-spectator-tail.test.ts src/services/auto-sync-service.keepalive.test.ts src/background/import-export.keepalive.test.ts src/background/import-export.full-rebuild.test.ts` (63 tests)
- `npm test -- --runInBand` (136 suites, 1302 tests)
- `npm run typecheck`
- `npm run build`

## Risk gate
Fake-timer and failure-injection tests cover replay beyond the 30-second MV3 idle window, success cleanup, abort-like rejection cleanup, partial-download failure precedence, operation-gate refusal, and overlapping sync attempts.