### PR TITLE
test(db): enforce cursor durability invariants

### DIFF
--- a/src/background/import-export.full-rebuild.test.ts
+++ b/src/background/import-export.full-rebuild.test.ts
@@ -313,6 +313,49 @@ describe('importData() full rebuild after overlapping imports (audit finding #7,
     })
   })
 
+  test('a write-phase transaction abort rolls back derived rows and rebuildStatus together', async () => {
+    await runWithFreshDb(async ({ db, handlers }) => {
+      await db.apiEvents.bulkAdd([ENTRY_QUEUED, ...HAND1_EVENTS] as never[])
+      await handlers.rebuildAllData()
+
+      const beforeDerived = await snapshotDerived(db)
+      const beforeStatus = await db.meta.get('rebuildStatus')
+      expect(beforeDerived.hands.map(hand => hand.id)).toEqual([HAND1_ID])
+      expect(beforeStatus?.value).toMatchObject({ totalHands: 1 })
+
+      // A second complete hand makes the next canonical rebuild materially
+      // different. Fail only after the transaction has issued every derived
+      // write and the new completion marker write: fake-indexeddb must abort
+      // the complete transaction, not expose new rows with an old marker (or
+      // a new marker over partially durable rows).
+      await db.apiEvents.bulkAdd(HAND2_EVENTS as never[])
+      const realMetaPut = db.meta.put.bind(db.meta)
+      const putSpy = jest.spyOn(db.meta, 'put').mockImplementation(record =>
+        realMetaPut(record).then(key => {
+          if (record.id === 'rebuildStatus') {
+            throw new Error('synthetic rebuild transaction abort after completion write')
+          }
+          return key
+        })
+      )
+
+      await expect(handlers.rebuildAllData()).rejects.toThrow(
+        'synthetic rebuild transaction abort after completion write'
+      )
+      putSpy.mockRestore()
+
+      expect(await snapshotDerived(db)).toEqual(beforeDerived)
+      expect(await db.meta.get('rebuildStatus')).toEqual(beforeStatus)
+      expect(await db.apiEvents.count()).toBe(1 + HAND1_EVENTS.length + HAND2_EVENTS.length)
+
+      const messages = (chrome.runtime.sendMessage as jest.Mock).mock.calls
+        .map(([message]) => message as { action?: string, state?: string })
+        .filter(message => message.action === 'rebuildProgress')
+      expect(messages.some(message => message.state === 'error')).toBe(true)
+      expect(messages.at(-1)?.state).toBe('error')
+    })
+  })
+
   describe('service-worker keepalive during an import-triggered rebuild (codex PR #207 P2 pass-3, "Keep the worker alive during import-triggered rebuilds")', () => {
     afterEach(() => {
       jest.restoreAllMocks()

--- a/src/services/auto-sync-service.test.ts
+++ b/src/services/auto-sync-service.test.ts
@@ -2115,5 +2115,76 @@ describe('AutoSyncService cloud downloads', () => {
       // cloud watermark.
       expect((await db.meta.get('syncUnparseableFloor'))?.value).toBe(200)
     })
+
+    test('four-page upload retries from the durable watermark after a middle-page failure without omitting a same-ms boundary row', async () => {
+      (DATABASE_CONSTANTS as any).SYNC_CHUNK_SIZE = 2
+
+      const rows = [
+        { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO, Id: 'p1-a', IsRetire: false, timestamp: 100, sequence: 0 },
+        { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO, Id: 'p1-b', IsRetire: false, timestamp: 101, sequence: 0 },
+        // Three rows in one exact (timestamp, ApiTypeId) group span pages 2
+        // and 3. A timestamp-only cursor loses sequence=2 after page 2.
+        { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO, Id: 'tie-0', IsRetire: false, timestamp: 102, sequence: 0 },
+        { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO, Id: 'tie-1', IsRetire: false, timestamp: 102, sequence: 1 },
+        { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO, Id: 'tie-2', IsRetire: false, timestamp: 102, sequence: 2 },
+        { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO, Id: 'p3-b', IsRetire: false, timestamp: 103, sequence: 0 },
+        { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO, Id: 'p4-a', IsRetire: false, timestamp: 104, sequence: 0 },
+        { ApiTypeId: ApiType.EVT_ENTRY_QUEUED, Code: 0, BattleType: BattleType.SIT_AND_GO, Id: 'p4-b', IsRetire: false, timestamp: 105, sequence: 0 }
+      ] as ApiEvent[]
+      await db.apiEvents.bulkAdd(rows)
+
+      const oldCompletion = '2026-01-01T00:00:00.000Z'
+      await chrome.storage.local.set({ autoSyncLastTime: oldCompletion })
+
+      let cloudMax: number | null = null
+      jest.spyOn(firestoreBackupService, 'getCloudMaxTimestamp')
+        .mockImplementation(async () => cloudMax)
+
+      const acknowledged = new Set<string>()
+      const attempts: string[][] = []
+      let failThirdPage = true
+      const syncBatchSpy = jest.spyOn(firestoreBackupService, 'syncToCloudBatch')
+        .mockImplementation(async (chunk: ApiEvent[]) => {
+          const ids = chunk.map(event => event.Id as string)
+          attempts.push(ids)
+          expect(new Set(ids).size).toBe(ids.length)
+
+          if (failThirdPage && attempts.length === 3) {
+            failThirdPage = false
+            throw new Error('synthetic Firestore page-3 failure')
+          }
+
+          for (const event of chunk) acknowledged.add(event.Id as string)
+          cloudMax = Math.max(
+            cloudMax ?? Number.MIN_SAFE_INTEGER,
+            ...chunk.map(event => event.timestamp!)
+          )
+          return { totalEvents: chunk.length, syncedEvents: chunk.length, lastSyncTime: new Date() }
+        })
+
+      const service = new AutoSyncService(db)
+      await service.performSync('upload')
+
+      expect(service.getSyncState().status).toBe('error')
+      expect(service.getSyncState().error).toContain('synthetic Firestore page-3 failure')
+      expect(acknowledged).toEqual(new Set(['p1-a', 'p1-b', 'tie-0', 'tie-1']))
+      expect(cloudMax).toBe(102)
+      expect((await chrome.storage.local.get('autoSyncLastTime')).autoSyncLastTime).toBe(oldCompletion)
+
+      await service.performSync('upload')
+
+      expect(service.getSyncState().status).toBe('success')
+      expect(acknowledged).toEqual(new Set(rows.map(event => event.Id as string)))
+      expect(syncBatchSpy).toHaveBeenCalledTimes(6)
+      // The retry starts inclusively at the durable timestamp watermark.
+      // Already-acknowledged tie rows may be re-offered idempotently, but the
+      // unacknowledged sequence=2 row and every later page must be present.
+      expect(attempts.slice(3).flat()).toEqual([
+        'tie-0', 'tie-1',
+        'tie-2', 'p3-b',
+        'p4-a', 'p4-b'
+      ])
+      expect((await chrome.storage.local.get('autoSyncLastTime')).autoSyncLastTime).not.toBe(oldCompletion)
+    })
   })
 })

--- a/src/utils/database-utils.chunking.test.ts
+++ b/src/utils/database-utils.chunking.test.ts
@@ -32,6 +32,13 @@ import { processInChunks, processInReplayChunks, filterValidApplicationEvents, s
 import { PokerChaseDB } from '../db/poker-chase-db'
 import { EntityConverter } from '../entity-converter'
 import type { Session } from '../types/entities'
+import {
+  API_EVENT_PRIMARY_KEY,
+  getApiEventKey,
+  mergeApiEvents,
+  type ApiEventKey,
+  type RawApiEvent
+} from './api-event-key'
 
 // A known-good hand (EVT_DEAL -> 3x EVT_ACTION -> EVT_HAND_RESULTS), copied
 // verbatim from src/app.test.ts's event_timeline fixture (also reused by
@@ -90,6 +97,71 @@ describe('processInChunks (cursor-based pagination over a real Dexie table)', ()
     const seenIds = chunks.flat().map((r: any) => r.id as number)
     expect(seenIds.slice().sort((a, b) => a - b)).toEqual(rows.map(r => r.id))
     expect(new Set(seenIds).size).toBe(12) // every id exactly once, no dupes
+  })
+
+  test('durable checkpoint resumes after a mid-scan transaction abort without omissions or duplicates across four real pages', async () => {
+    const uniqueRows: RawApiEvent[] = [
+      { timestamp: 100, ApiTypeId: 201, marker: 'a' },
+      { timestamp: 101, ApiTypeId: 201, marker: 'b' },
+      { timestamp: 102, ApiTypeId: 201, marker: 'c' },
+      // A same-millisecond, same-type burst crosses the 3-row page boundary.
+      // All callers must cursor on the complete primary key, including sequence.
+      { timestamp: 103, ApiTypeId: 304, marker: 'burst-0' },
+      { timestamp: 103, ApiTypeId: 304, marker: 'burst-1' },
+      { timestamp: 103, ApiTypeId: 304, marker: 'burst-2' },
+      { timestamp: 104, ApiTypeId: 306, marker: 'd' },
+      { timestamp: 105, ApiTypeId: 201, marker: 'e' },
+      { timestamp: 106, ApiTypeId: 306, marker: 'f' },
+      { timestamp: 107, ApiTypeId: 201, marker: 'g' },
+      { timestamp: 108, ApiTypeId: 306, marker: 'h' },
+      { timestamp: 109, ApiTypeId: 201, marker: 'i' }
+    ]
+    const duplicate = structuredClone(uniqueRows[4]!)
+    const merged = await mergeApiEvents(db, [...uniqueRows, duplicate])
+    expect(merged.added).toHaveLength(uniqueRows.length)
+    expect(merged.duplicates).toBe(1)
+
+    const checkpointId = 'cursorInvariantConsumer'
+    let failOnce = true
+    const consumeFrom = async (afterKey?: ApiEventKey): Promise<void> => {
+      for await (const chunk of processInChunks(db.apiEvents, 3, { afterKey })) {
+        await db.transaction('rw', db.meta, async () => {
+          const previous = await db.meta.get(checkpointId)
+          const durableKeys = (previous?.value?.keys ?? []) as ApiEventKey[]
+          const chunkKeys = (chunk as unknown as RawApiEvent[]).map(getApiEventKey)
+          await db.meta.put({
+            id: checkpointId,
+            value: {
+              keys: [...durableKeys, ...chunkKeys],
+              afterKey: chunkKeys[chunkKeys.length - 1]
+            },
+            updatedAt: Date.now()
+          })
+
+          // Fail after the second page's writes have been issued. The real
+          // fake-indexeddb transaction must roll back both the processed-key
+          // record and its cursor, so the retry starts from the last durable
+          // page rather than skipping the aborted page.
+          if (failOnce && chunk.some(row => (row as RawApiEvent).marker === 'burst-2')) {
+            failOnce = false
+            throw new Error('synthetic consumer transaction abort')
+          }
+        })
+      }
+    }
+
+    await expect(consumeFrom()).rejects.toThrow('synthetic consumer transaction abort')
+    const afterAbort = await db.meta.get(checkpointId)
+    expect(afterAbort?.value.keys).toHaveLength(3)
+
+    await consumeFrom(afterAbort?.value.afterKey as ApiEventKey)
+
+    const durable = await db.meta.get(checkpointId)
+    const durableKeys = durable?.value.keys as ApiEventKey[]
+    const expectedKeys = (await db.apiEvents.orderBy(API_EVENT_PRIMARY_KEY).toArray() as unknown as RawApiEvent[])
+      .map(getApiEventKey)
+    expect(durableKeys).toEqual(expectedKeys)
+    expect(new Set(durableKeys.map(key => key.join(':'))).size).toBe(expectedKeys.length)
   })
 
   test('yields nothing for an empty table', async () => {
@@ -198,6 +270,73 @@ describe('processInChunks (cursor-based pagination over a real Dexie table)', ()
     for await (const chunk of processInReplayChunks(db.apiEvents as any, 1)) chunks.push(chunk)
 
     expect(chunks.flat().map(row => row.marker)).toEqual(['turn-card', 'turn-action', 'result'])
+  })
+
+  test('snapshot replay keeps a causal equal-ms group whole across three pages and excludes rows inserted mid-scan', async () => {
+    await db.apiEvents.bulkAdd([
+      { timestamp: 100, ApiTypeId: 201, marker: 'before-1' },
+      { timestamp: 101, ApiTypeId: 201, marker: 'before-2' },
+      {
+        timestamp: 200,
+        ApiTypeId: 304,
+        SeatIndex: 4,
+        BetChip: 1_379,
+        Chip: 28_428,
+        Progress: { Phase: 2, Pot: 5_558 },
+        marker: 'turn-action'
+      },
+      {
+        timestamp: 200,
+        ApiTypeId: 305,
+        Progress: { Phase: 2, Pot: 4_179, NextActionSeat: 4 },
+        OtherPlayers: [{ SeatIndex: 4, BetChip: 0, Chip: 29_807 }],
+        marker: 'turn-card'
+      },
+      { timestamp: 201, ApiTypeId: 306, marker: 'result' },
+      { timestamp: 202, ApiTypeId: 201, marker: 'after-1' },
+      { timestamp: 203, ApiTypeId: 306, marker: 'after-2' }
+    ] as any)
+
+    const snapshotKeys = await db.apiEvents
+      .orderBy(API_EVENT_PRIMARY_KEY)
+      .primaryKeys() as ApiEventKey[]
+    const iterator = processInReplayChunks(db.apiEvents as any, 3, { snapshotKeys })
+    const first = await iterator.next()
+    expect(first.done).toBe(false)
+    const firstPage = first.value as RawApiEvent[]
+    expect(firstPage.map(row => row.marker)).toEqual(['before-1', 'before-2'])
+
+    // One row sorts behind the current cursor and one ahead. Neither belongs
+    // to the export/replay snapshot captured above, so neither may leak into
+    // the current pass or perturb its page/group boundaries.
+    await mergeApiEvents(db, [
+      { timestamp: 99, ApiTypeId: 201, marker: 'concurrent-low' },
+      { timestamp: 204, ApiTypeId: 201, marker: 'concurrent-high' }
+    ])
+
+    const remaining: RawApiEvent[] = []
+    while (true) {
+      const next = await iterator.next()
+      if (next.done) break
+      remaining.push(...next.value as RawApiEvent[])
+    }
+
+    const replayed = [...firstPage, ...remaining]
+    expect(replayed.map(row => row.marker)).toEqual([
+      'before-1',
+      'before-2',
+      // The pair was split between raw pages 1 and 2, then resolved only
+      // after the complete timestamp group was available.
+      'turn-card',
+      'turn-action',
+      'result',
+      'after-1',
+      'after-2'
+    ])
+    const replayedKeySet = new Set(replayed.map(row => getApiEventKey(row).join(':')))
+    expect(replayedKeySet).toEqual(new Set(snapshotKeys.map(key => key.join(':'))))
+    expect(replayedKeySet.size).toBe(snapshotKeys.length)
+    expect(await db.apiEvents.count()).toBe(snapshotKeys.length + 2)
   })
 
   test('same-millisecond same-type events both survive storage and entity derivation', async () => {


### PR DESCRIPTION
## Scope

Adds a real fake-indexeddb invariant gate for Dexie cursor and durability behavior without changing production code, package metadata, or CI.

- verifies four-page compound-key traversal, duplicate rejection, and durable resume after a transaction abort
- verifies replay snapshots exclude mid-scan inserts while preserving complete equal-millisecond causal groups
- verifies derived rows and `rebuildStatus` roll back atomically on a write-phase abort
- verifies upload retry resumes from the durable cloud watermark and does not advance completion bookkeeping before success

## Mutation evidence

- Reusing an accumulating Dexie `Collection` (the PR #29/#195 regression shape) makes the new durable checkpoint test fail before the abort boundary is reached.
- Replacing compound-key pagination with timestamp-only pagination makes both the existing boundary test and the new four-page retry test fail, omitting `tie-2`.

## Validation

- `npm run typecheck`
- `npm test -- --runInBand src/utils/database-utils.chunking.test.ts src/background/import-export.full-rebuild.test.ts src/services/auto-sync-service.test.ts` (67 tests)
- `npm test -- --runInBand` (136 suites, 1,354 tests)
- `npm run build`

Head: `7aae1126f16da8b377c3c8635f3a6a5adb78d75b`