### PR TITLE
test(e2e): gate MV3 lifecycle in real Chrome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,40 @@ jobs:
         openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$key_file" 2>/dev/null
         xvfb-run -a npm run pack:crx -- "$key_file" "$crx_file"
         test -s "$crx_file"
+
+  browser-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      E2E_BROWSER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v7
+      with:
+        node-version: 'lts/*'
+        cache: 'npm'
+
+    - name: Cache pinned Chrome for Testing
+      uses: actions/cache@v4
+      with:
+        path: .cache/puppeteer
+        key: e2e-chrome-${{ runner.os }}-${{ hashFiles('e2e/config.ts') }}
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run bounded real-browser gate
+      run: xvfb-run -a npm run e2e:browser-gate
+
+    - name: Upload browser failure evidence
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: browser-e2e-failure-${{ github.run_id }}
+        path: e2e/out/
+        if-no-files-found: ignore
+        retention-days: 7

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -4,9 +4,9 @@ A permanent, deterministic end-to-end harness that loads the *real, built*
 extension into a *real* Chromium and drives *real* gameplay data through the
 extension's actual WebSocket interception path -- so both scripted
 assertions (`e2e:smoke`) and step-by-step AI-agent exploratory QA can run
-against a live HUD. CI runs a bounded real-browser gate (smoke, persisted
-player identity, auth-storage isolation, and MV3 Service Worker lifecycle)
-under Xvfb; the wider exploratory tooling remains local-only.
+against a live HUD. CI runs a bounded real-browser gate (smoke, auth-storage
+isolation, and MV3 Service Worker lifecycle including persisted-player cold
+restore) under Xvfb; the wider exploratory tooling remains local-only.
 
 ## Quick start
 
@@ -16,8 +16,8 @@ npm run e2e:smoke
 npm run e2e:playerid
 # Real Service Worker stop/restart failure injection:
 npm run e2e:mv3-lifecycle
-# The exact bounded set used by CI (requires an X display):
-xvfb-run -a npm run e2e:browser-gate
+# The exact bounded headless set used by CI:
+npm run e2e:browser-gate
 ```
 
 This builds the e2e extension variant, launches Chrome for Testing headless,

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -4,10 +4,9 @@ A permanent, deterministic end-to-end harness that loads the *real, built*
 extension into a *real* Chromium and drives *real* gameplay data through the
 extension's actual WebSocket interception path -- so both scripted
 assertions (`e2e:smoke`) and step-by-step AI-agent exploratory QA can run
-against a live HUD.
-
-Nothing here is wired into CI yet (the CI runner doesn't have the Chrome
-for Testing cache) -- run it locally.
+against a live HUD. CI runs a bounded real-browser gate (smoke, persisted
+player identity, auth-storage isolation, and MV3 Service Worker lifecycle)
+under Xvfb; the wider exploratory tooling remains local-only.
 
 ## Quick start
 
@@ -15,6 +14,10 @@ for Testing cache) -- run it locally.
 npm run e2e:smoke
 # Session-end persistence regression:
 npm run e2e:playerid
+# Real Service Worker stop/restart failure injection:
+npm run e2e:mv3-lifecycle
+# The exact bounded set used by CI (requires an X display):
+xvfb-run -a npm run e2e:browser-gate
 ```
 
 This builds the e2e extension variant, launches Chrome for Testing headless,
@@ -357,6 +360,19 @@ zero-event page, and verifies that the persisted hero identity still drives
 pre-game stats. It writes `playerid-before-reload.png`,
 `playerid-no-replay-hud.png`, and `playerid-no-replay-hud.txt` on success.
 
+`e2e/scenarios/mv3-service-worker-lifecycle.ts`
+(`npm run e2e:mv3-lifecycle`) is the browser-level durability gate. It uses
+CDP's `ServiceWorker.stopWorker` against the real extension worker while the
+fixture WebSocket is still sending events, verifies at least one frame crossed
+the stopped-worker interval, and compares the final IndexedDB Raw Event Lake
+against the fixture as an exact multiset. Because the first stop deliberately
+lands inside a hand, it also runs the normal canonical rebuild recovery path,
+verifies all three hands are reconstructed, and verifies the shared operation
+state returns to idle. It then stops the idle worker again, navigates to
+`no-replay.html`, and verifies the cold-restored HUD serves persisted hand
+statistics without replaying or duplicating raw rows. The stop is performed
+entirely by Chrome; there is no production test-only message.
+
 ## Flaky bits / timing waits
 
 - **Idle-compositor screenshot stall (headless Chrome for Testing 151)**:
@@ -422,6 +438,7 @@ e2e/
   fixtures/session-recent-hands.ndjson   anonymized recent-hands fixture (committed)
   scenarios/smoke.ts        scripted pass/fail smoke test
   scenarios/playerid-session-persistence.ts   persisted hero identity regression scenario
+  scenarios/mv3-service-worker-lifecycle.ts   real Service Worker stop/restart durability gate
   tools/
     generate-e2e-manifest.ts   writes e2e/.build/manifest.e2e.json
     build-e2e.ts               orchestrates the full e2e build

--- a/e2e/fixture-server.ts
+++ b/e2e/fixture-server.ts
@@ -29,6 +29,8 @@ export interface FixtureServerHandle {
   origin: string
   /** Resolves once every event in the fixture has been sent to at least one connected client. */
   replayDone: Promise<void>
+  /** Number of fixture frames sent to the connected client so far. */
+  sentEventCount: () => number
   close: () => Promise<void>
 }
 
@@ -59,6 +61,7 @@ export const startFixtureServer = async (options: FixtureServerOptions = {}): Pr
 
   let resolveReplayDone!: () => void
   const replayDone = new Promise<void>((resolve) => { resolveReplayDone = resolve })
+  let sentEventCount = 0
 
   const publicDirResolved = resolve(PUBLIC_DIR)
 
@@ -115,6 +118,7 @@ export const startFixtureServer = async (options: FixtureServerOptions = {}): Pr
       for (const event of events) {
         if (socket.readyState !== socket.OPEN) return
         socket.send(encode(event))
+        sentEventCount++
         if (replayDelayMs > 0) await sleep(replayDelayMs)
       }
       resolveReplayDone()
@@ -153,7 +157,13 @@ export const startFixtureServer = async (options: FixtureServerOptions = {}): Pr
       })
     })
 
-  return { port, origin: `http://localhost:${port}`, replayDone, close }
+  return {
+    port,
+    origin: `http://localhost:${port}`,
+    replayDone,
+    sentEventCount: () => sentEventCount,
+    close
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/e2e/fixture-server.ts
+++ b/e2e/fixture-server.ts
@@ -29,8 +29,6 @@ export interface FixtureServerHandle {
   origin: string
   /** Resolves once every event in the fixture has been sent to at least one connected client. */
   replayDone: Promise<void>
-  /** Number of fixture frames sent to the connected client so far. */
-  sentEventCount: () => number
   close: () => Promise<void>
 }
 
@@ -61,7 +59,6 @@ export const startFixtureServer = async (options: FixtureServerOptions = {}): Pr
 
   let resolveReplayDone!: () => void
   const replayDone = new Promise<void>((resolve) => { resolveReplayDone = resolve })
-  let sentEventCount = 0
 
   const publicDirResolved = resolve(PUBLIC_DIR)
 
@@ -118,7 +115,6 @@ export const startFixtureServer = async (options: FixtureServerOptions = {}): Pr
       for (const event of events) {
         if (socket.readyState !== socket.OPEN) return
         socket.send(encode(event))
-        sentEventCount++
         if (replayDelayMs > 0) await sleep(replayDelayMs)
       }
       resolveReplayDone()
@@ -161,7 +157,6 @@ export const startFixtureServer = async (options: FixtureServerOptions = {}): Pr
     port,
     origin: `http://localhost:${port}`,
     replayDone,
-    sentEventCount: () => sentEventCount,
     close
   }
 }

--- a/e2e/harness.ts
+++ b/e2e/harness.ts
@@ -366,7 +366,11 @@ export const launchHarness = async (options: LaunchOptions = {}): Promise<Harnes
         `--load-extension=${extensionDir}`,
         '--no-first-run',
         '--no-default-browser-check',
-        ...(process.env.CI ? ['--disable-dev-shm-usage'] : []),
+        // GitHub-hosted Ubuntu disables the unprivileged-user-namespace
+        // sandbox Chrome for Testing expects. The runner is disposable and
+        // only opens our localhost fixture, so disable Chrome's sandbox in CI
+        // while retaining the normal sandbox for every local/browser run.
+        ...(process.env.CI ? ['--disable-dev-shm-usage', '--no-sandbox'] : []),
         // Window size in *headed* mode only affects the outer OS window
         // (Chrome adds its own title/tab/toolbar chrome on top of this);
         // it has no effect headless, where there's no window chrome to

--- a/e2e/harness.ts
+++ b/e2e/harness.ts
@@ -81,6 +81,131 @@ export interface Harness extends HarnessHelpers {
   close: () => Promise<void>
 }
 
+export interface StoppedExtensionServiceWorker {
+  extensionId: string
+  scriptURL: string
+  versionId: string
+  targetId?: string
+}
+
+interface ServiceWorkerVersion {
+  versionId: string
+  scriptURL: string
+  runningStatus: string
+  targetId?: string
+}
+
+const withTimeout = <T,>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> =>
+  new Promise<T>((resolvePromise, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+      timeoutMs
+    )
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolvePromise(value)
+      },
+      (error) => {
+        clearTimeout(timer)
+        reject(error)
+      }
+    )
+  })
+
+/**
+ * Stops the currently-running extension Service Worker through CDP and waits
+ * until Chrome confirms that exact worker version reached `stopped`.
+ *
+ * This is intentionally a browser-level failure injection: it does not add a
+ * production-only message or test hook to the extension. A live content-script
+ * Port will observe the real disconnect and must wake/reconnect to the worker
+ * through the same path used after an MV3 idle eviction.
+ */
+export const stopExtensionServiceWorker = async (
+  browser: Browser,
+  timeoutMs = 10_000
+): Promise<StoppedExtensionServiceWorker> => {
+  const extensionTarget = await browser.waitForTarget(
+    (candidate) =>
+      candidate.type() === 'service_worker' &&
+      candidate.url().startsWith('chrome-extension://'),
+    { timeout: timeoutMs }
+  )
+  const extensionId = new URL(extensionTarget.url()).host
+  // The ServiceWorker domain is exposed on renderer/page CDP sessions in
+  // Chrome for Testing 151, not on Puppeteer's browser-target session.
+  const pages = await browser.pages()
+  const controlPage = pages[0]
+  if (!controlPage) throw new Error('Could not find a page target for ServiceWorker CDP control')
+  const session = await controlPage.createCDPSession()
+  const versions = new Map<string, ServiceWorkerVersion>()
+  let notifyVersionUpdate: (() => void) | undefined
+
+  const onVersionUpdate = (event: { versions: ServiceWorkerVersion[] }): void => {
+    for (const version of event.versions) versions.set(version.versionId, version)
+    notifyVersionUpdate?.()
+  }
+  session.on('ServiceWorker.workerVersionUpdated', onVersionUpdate)
+
+  const waitForVersion = async (
+    predicate: (version: ServiceWorkerVersion) => boolean,
+    label: string
+  ): Promise<ServiceWorkerVersion> => {
+    const findMatch = (): ServiceWorkerVersion | undefined =>
+      Array.from(versions.values()).find(predicate)
+
+    const existing = findMatch()
+    if (existing) return existing
+
+    return await withTimeout(
+      new Promise<ServiceWorkerVersion>((resolveVersion) => {
+        const check = (): void => {
+          const match = findMatch()
+          if (match) {
+            notifyVersionUpdate = undefined
+            resolveVersion(match)
+          }
+        }
+        notifyVersionUpdate = check
+        check()
+      }),
+      timeoutMs,
+      label
+    )
+  }
+
+  try {
+    // Enabling the domain emits the current registration/version inventory.
+    await session.send('ServiceWorker.enable')
+    const running = await waitForVersion(
+      (version) =>
+        version.scriptURL.startsWith(`chrome-extension://${extensionId}/`) &&
+        version.runningStatus === 'running',
+      'extension Service Worker inventory'
+    )
+
+    const stoppedPromise = waitForVersion(
+      (version) =>
+        version.versionId === running.versionId &&
+        version.runningStatus === 'stopped',
+      'extension Service Worker stop'
+    )
+    await session.send('ServiceWorker.stopWorker', { versionId: running.versionId })
+    await stoppedPromise
+
+    return {
+      extensionId,
+      scriptURL: running.scriptURL,
+      versionId: running.versionId,
+      targetId: running.targetId
+    }
+  } finally {
+    session.off('ServiceWorker.workerVersionUpdated', onVersionUpdate)
+    await session.detach().catch(() => {})
+  }
+}
+
 /** Downloads (if not already cached) and returns the path to the pinned Chrome for Testing binary. */
 export const ensureChromeForTesting = async (): Promise<string> => {
   const platform = detectBrowserPlatform()
@@ -241,6 +366,7 @@ export const launchHarness = async (options: LaunchOptions = {}): Promise<Harnes
         `--load-extension=${extensionDir}`,
         '--no-first-run',
         '--no-default-browser-check',
+        ...(process.env.CI ? ['--disable-dev-shm-usage'] : []),
         // Window size in *headed* mode only affects the outer OS window
         // (Chrome adds its own title/tab/toolbar chrome on top of this);
         // it has no effect headless, where there's no window chrome to

--- a/e2e/harness.ts
+++ b/e2e/harness.ts
@@ -88,6 +88,14 @@ export interface StoppedExtensionServiceWorker {
   targetId?: string
 }
 
+export interface StoppedExtensionServiceWorkerMonitor {
+  /** Latest CDP runningStatus observed for the stopped version. */
+  runningStatus: () => string | undefined
+  /** Re-enables the CDP domain to force a fresh version inventory. */
+  refreshRunningStatus: () => Promise<string | undefined>
+  close: () => Promise<void>
+}
+
 interface ServiceWorkerVersion {
   versionId: string
   scriptURL: string
@@ -203,6 +211,90 @@ export const stopExtensionServiceWorker = async (
   } finally {
     session.off('ServiceWorker.workerVersionUpdated', onVersionUpdate)
     await session.detach().catch(() => {})
+  }
+}
+
+/**
+ * Keeps a ServiceWorker-domain session open after a stop and tracks the exact
+ * version's runningStatus. Callers can surround browser-side evidence with
+ * this monitor and reject it if Chrome restarted the worker in the meantime.
+ *
+ * Attaching after {@link stopExtensionServiceWorker} is deliberate: if the
+ * worker already restarted during that handoff, the initial inventory is no
+ * longer `stopped` and this fails closed instead of accepting a stale stop.
+ */
+export const monitorStoppedExtensionServiceWorker = async (
+  browser: Browser,
+  stoppedWorker: StoppedExtensionServiceWorker,
+  timeoutMs = 5_000
+): Promise<StoppedExtensionServiceWorkerMonitor> => {
+  const pages = await browser.pages()
+  const controlPage = pages[0]
+  if (!controlPage) throw new Error('Could not find a page target for ServiceWorker CDP monitoring')
+  const session = await controlPage.createCDPSession()
+  const versions = new Map<string, ServiceWorkerVersion>()
+  let notifyVersionUpdate: (() => void) | undefined
+
+  const onVersionUpdate = (event: { versions: ServiceWorkerVersion[] }): void => {
+    for (const version of event.versions) versions.set(version.versionId, version)
+    notifyVersionUpdate?.()
+  }
+  session.on('ServiceWorker.workerVersionUpdated', onVersionUpdate)
+
+  const waitForVersion = async (label: string): Promise<ServiceWorkerVersion> =>
+    versions.get(stoppedWorker.versionId) ?? await withTimeout(
+      new Promise<ServiceWorkerVersion>((resolveVersion) => {
+        const check = (): void => {
+          const version = versions.get(stoppedWorker.versionId)
+          if (version) {
+            notifyVersionUpdate = undefined
+            resolveVersion(version)
+          }
+        }
+        notifyVersionUpdate = check
+        check()
+      }),
+      timeoutMs,
+      label
+    )
+
+  const close = async (): Promise<void> => {
+    session.off('ServiceWorker.workerVersionUpdated', onVersionUpdate)
+    await session.detach().catch(() => {})
+  }
+
+  try {
+    await session.send('ServiceWorker.enable')
+    const initial = await waitForVersion('stopped extension Service Worker inventory')
+
+    if (
+      initial.scriptURL !== stoppedWorker.scriptURL ||
+      initial.runningStatus !== 'stopped'
+    ) {
+      throw new Error(
+        `extension Service Worker restarted before stopped-window monitoring: ` +
+        `${initial.versionId} is ${initial.runningStatus}`
+      )
+    }
+
+    return {
+      runningStatus: () => versions.get(stoppedWorker.versionId)?.runningStatus,
+      refreshRunningStatus: async () => {
+        // The page-receipt and ServiceWorker events arrive over separate CDP
+        // sessions, so do not assume their delivery order reflects browser
+        // time. Re-enabling forces Chrome to emit a fresh inventory after the
+        // page-side evidence has resolved.
+        versions.delete(stoppedWorker.versionId)
+        await session.send('ServiceWorker.disable')
+        await session.send('ServiceWorker.enable')
+        return (await waitForVersion('refreshed extension Service Worker inventory'))
+          .runningStatus
+      },
+      close
+    }
+  } catch (error) {
+    await close()
+    throw error
   }
 }
 

--- a/e2e/scenarios/auth-storage-access.ts
+++ b/e2e/scenarios/auth-storage-access.ts
@@ -173,6 +173,19 @@ const run = async (): Promise<void> => {
     const extensionId = await extensionIdFor(harness.browser)
     const trustedPage = await openTrustedContext(harness.browser, extensionId)
 
+    // The synthetic fixture write below bypasses FirebaseAuthService's normal
+    // sign-in path, which itself awaits the storage-access restriction. Wait
+    // for that real startup barrier first so a fast hosted runner cannot place
+    // credentials into the brief default-untrusted window created by the test.
+    const initialAuthStatus = await trustedPage.evaluate(
+      async () => await chrome.runtime.sendMessage({ action: 'firebaseAuthStatus' })
+    ) as { success?: boolean, isSignedIn?: boolean, error?: string }
+    if (!initialAuthStatus.success || initialAuthStatus.isSignedIn) {
+      throw new Error(
+        `fresh profile auth boundary did not initialize: ${JSON.stringify(initialAuthStatus)}`
+      )
+    }
+
     await trustedPage.evaluate(
       async (authKey, authState, syncProbeKey) => {
         await chrome.storage.local.set({

--- a/e2e/scenarios/auth-storage-access.ts
+++ b/e2e/scenarios/auth-storage-access.ts
@@ -163,12 +163,13 @@ const stageLegacyUntrustedAccess = async (
 }
 
 const run = async (): Promise<void> => {
+  const headed = process.argv.slice(2).includes('--headed')
   const extensionDir = buildE2E()
   const profileDir = mkdtempSync(join(tmpdir(), 'pokerchase-hud-auth-storage-'))
   let harness: Harness | undefined
 
   try {
-    harness = await launchHarness({ extensionDir, userDataDir: profileDir })
+    harness = await launchHarness({ extensionDir, userDataDir: profileDir, headed })
     const extensionId = await extensionIdFor(harness.browser)
     const trustedPage = await openTrustedContext(harness.browser, extensionId)
 
@@ -205,7 +206,7 @@ const run = async (): Promise<void> => {
     await harness.close()
     harness = undefined
 
-    harness = await launchHarness({ extensionDir, userDataDir: profileDir })
+    harness = await launchHarness({ extensionDir, userDataDir: profileDir, headed })
     // Assert the upgraded profile's boundary before an explicit auth-status
     // message or popup navigation deliberately wakes/uses the Service Worker.
     await assertContentBoundary(harness, extensionId)

--- a/e2e/scenarios/mv3-service-worker-lifecycle.ts
+++ b/e2e/scenarios/mv3-service-worker-lifecycle.ts
@@ -44,6 +44,12 @@ interface PersistedServiceState {
   lastUpdated?: number
 }
 
+interface RestoredWorkerState {
+  isReady: boolean
+  playerId?: number
+  latestEvtDeal?: { SeatUserIds?: number[] }
+}
+
 const parseArgs = (argv: string[]) => ({
   headed: argv.includes('--headed'),
   screenshotDir: argv.includes('--screenshot-dir')
@@ -202,6 +208,68 @@ const waitForPersistedServiceState = async (
   )
 }
 
+const receivedReplayEventCount = async (harness: Harness): Promise<number> =>
+  await harness.evaluate(() =>
+    (window as typeof window & { __e2eReplayEvents?: number }).__e2eReplayEvents ?? 0
+  )
+
+/**
+ * Wakes the evicted worker with a message that does not inspect the database,
+ * then reads PokerChaseService after its normal `ready` restoration finishes.
+ *
+ * This intentionally runs before the no-replay HUD mount. `requestLatestStats`
+ * can infer playerId from IndexedDB when service state is absent, so the HUD
+ * alone cannot distinguish a successful chrome.storage restore from that
+ * fallback. Directly observing the fresh worker here closes that false pass.
+ */
+const readColdRestoredWorkerState = async (
+  browser: Browser,
+  trustedPage: Page,
+  extensionId: string
+): Promise<RestoredWorkerState> => {
+  const wakeResponse = await trustedPage.evaluate(
+    async () => await chrome.runtime.sendMessage({ action: 'getOperationState' })
+  ) as { success?: boolean }
+  if (!wakeResponse.success) {
+    throw new Error(`failed to wake cold Service Worker: ${JSON.stringify(wakeResponse)}`)
+  }
+
+  const target = await browser.waitForTarget(
+    async (candidate) => {
+      if (
+        candidate.type() !== 'service_worker' ||
+        !candidate.url().startsWith(`chrome-extension://${extensionId}/`)
+      ) {
+        return false
+      }
+      return await candidate.worker() !== null
+    },
+    { timeout: 15_000 }
+  )
+  const worker = await target.worker()
+  if (!worker) throw new Error('cold Service Worker target has no execution context')
+
+  return await worker.evaluate(async () => {
+    const scope = self as typeof self & {
+      service?: {
+        ready: Promise<void>
+        isReady: boolean
+        playerId?: number
+        latestEvtDeal?: { SeatUserIds?: number[] }
+      }
+    }
+    if (!scope.service) throw new Error('PokerChaseService is not exposed on the worker')
+    await scope.service.ready
+    return {
+      isReady: scope.service.isReady,
+      playerId: scope.service.playerId,
+      latestEvtDeal: scope.service.latestEvtDeal
+        ? { SeatUserIds: scope.service.latestEvtDeal.SeatUserIds }
+        : undefined
+    }
+  })
+}
+
 const canonicalize = (value: unknown): unknown => {
   if (Array.isArray(value)) return value.map(canonicalize)
   if (value && typeof value === 'object') {
@@ -304,7 +372,7 @@ const run = async (): Promise<void> => {
     // Capture only after CDP has confirmed `runningStatus: stopped`; frames
     // sent while Chrome was still locating/stopping the worker do not prove
     // the reconnect queue crossed an actual stopped-worker interval.
-    const sentBeforeStop = harness.fixtureServer.sentEventCount()
+    const receivedBeforeStop = await receivedReplayEventCount(harness)
     console.log(
       `[mv3-lifecycle] stopped worker ${firstStop.versionId} after ` +
       `${beforeStop.rawEvents.length}/${expectedEvents.length} durable raw rows`
@@ -314,9 +382,10 @@ const run = async (): Promise<void> => {
     // guarantees at least one real WebSocket frame arrives inside this
     // stopped-worker window instead of merely testing a stop between events.
     await sleep(350)
-    const sentWhileStopped = harness.fixtureServer.sentEventCount() - sentBeforeStop
-    if (sentWhileStopped < 1) {
-      throw new Error('no fixture frame crossed the stopped-worker window')
+    const receivedWhileStopped =
+      await receivedReplayEventCount(harness) - receivedBeforeStop
+    if (receivedWhileStopped < 1) {
+      throw new Error('no page-received fixture frame crossed the stopped-worker window')
     }
 
     await withTimeout(harness.waitForReplayDone(), 20_000, 'fixture replay')
@@ -374,7 +443,7 @@ const run = async (): Promise<void> => {
     )
     console.log(
       `[mv3-lifecycle] PASS - ${actualCanonical.length} raw events survived exactly once; ` +
-      `${sentWhileStopped} frame(s) crossed the stopped-worker window; ` +
+      `${receivedWhileStopped} page-received frame(s) crossed the stopped-worker window; ` +
       `${rebuilt.handCount} hands recovered canonically`
     )
 
@@ -383,6 +452,22 @@ const run = async (): Promise<void> => {
     // restore from a fresh mount.
     const secondStop = await stopExtensionServiceWorker(harness.browser)
     console.log(`[mv3-lifecycle] stopped idle worker ${secondStop.versionId}`)
+
+    const restoredWorkerState = await readColdRestoredWorkerState(
+      harness.browser,
+      trustedPage,
+      extensionId
+    )
+    if (
+      !restoredWorkerState.isReady ||
+      restoredWorkerState.playerId !== expectedPlayerId ||
+      !restoredWorkerState.latestEvtDeal?.SeatUserIds?.includes(expectedPlayerId)
+    ) {
+      throw new Error(
+        'cold worker did not restore persisted hero/deal state before DB fallback: ' +
+        JSON.stringify(restoredWorkerState)
+      )
+    }
 
     await harness.gamePage.goto(`${harness.fixtureServer.origin}/no-replay.html`, {
       waitUntil: 'domcontentloaded'

--- a/e2e/scenarios/mv3-service-worker-lifecycle.ts
+++ b/e2e/scenarios/mv3-service-worker-lifecycle.ts
@@ -19,6 +19,7 @@ import type { Browser, Page } from 'puppeteer-core'
 import { buildE2E } from '../tools/build-e2e.ts'
 import {
   launchHarness,
+  monitorStoppedExtensionServiceWorker,
   stopExtensionServiceWorker,
   type Harness
 } from '../harness.ts'
@@ -372,20 +373,44 @@ const run = async (): Promise<void> => {
     // Capture only after CDP has confirmed `runningStatus: stopped`; frames
     // sent while Chrome was still locating/stopping the worker do not prove
     // the reconnect queue crossed an actual stopped-worker interval.
-    const receivedBeforeStop = await receivedReplayEventCount(harness)
+    const stoppedWorkerMonitor = await monitorStoppedExtensionServiceWorker(
+      harness.browser,
+      firstStop
+    )
     console.log(
       `[mv3-lifecycle] stopped worker ${firstStop.versionId} after ` +
       `${beforeStop.rawEvents.length}/${expectedEvents.length} durable raw rows`
     )
 
-    // RuntimePortManager waits 500ms before reconnecting. The fixture delay
-    // guarantees at least one real WebSocket frame arrives inside this
-    // stopped-worker window instead of merely testing a stop between events.
-    await sleep(350)
-    const receivedWhileStopped =
-      await receivedReplayEventCount(harness) - receivedBeforeStop
-    if (receivedWhileStopped < 1) {
-      throw new Error('no page-received fixture frame crossed the stopped-worker window')
+    let receivedWhileStopped: number
+    try {
+      const receivedBeforeStop = await receivedReplayEventCount(harness)
+      // RuntimePortManager waits 500ms before reconnecting. Stop waiting as
+      // soon as the renderer receives the next fixture frame, then consult
+      // the still-open CDP monitor. This proves the frame arrived while the
+      // exact worker version remained stopped instead of merely sometime
+      // before this block's fixed timeout elapsed.
+      await harness.gamePage.waitForFunction(
+        (baseline) =>
+          ((window as typeof window & { __e2eReplayEvents?: number })
+            .__e2eReplayEvents ?? 0) > baseline,
+        { timeout: REPLAY_DELAY_MS * 3, polling: 10 },
+        receivedBeforeStop
+      )
+      receivedWhileStopped =
+        await receivedReplayEventCount(harness) - receivedBeforeStop
+      const statusAfterReceipt =
+        await stoppedWorkerMonitor.refreshRunningStatus()
+      if (statusAfterReceipt !== 'stopped') {
+        throw new Error(
+          `fixture frame arrived after Service Worker restart (${String(statusAfterReceipt)})`
+        )
+      }
+      if (receivedWhileStopped < 1) {
+        throw new Error('no page-received fixture frame crossed the stopped-worker window')
+      }
+    } finally {
+      await stoppedWorkerMonitor.close()
     }
 
     await withTimeout(harness.waitForReplayDone(), 20_000, 'fixture replay')

--- a/e2e/scenarios/mv3-service-worker-lifecycle.ts
+++ b/e2e/scenarios/mv3-service-worker-lifecycle.ts
@@ -1,0 +1,359 @@
+/**
+ * Real-extension MV3 lifecycle failure injection.
+ *
+ * The scenario kills the actual extension Service Worker through CDP while
+ * fixture frames are still arriving. It then proves that:
+ *   - frames really crossed the stopped-worker window;
+ *   - RuntimePortManager reconnect delivered every raw event, exactly once;
+ *   - a canonical rebuild recovered every hand from that exact Raw Lake and
+ *     returned the shared operation state to idle;
+ *   - a second idle eviction restored persisted hero/session state and served
+ *     the pre-game HUD without replaying the fixture.
+ *
+ * No production test hook is used: Chrome performs the worker stop and the
+ * normal Port disconnect/reconnect path must recover.
+ */
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import type { Browser, Page } from 'puppeteer-core'
+import { buildE2E } from '../tools/build-e2e.ts'
+import {
+  launchHarness,
+  stopExtensionServiceWorker,
+  type Harness
+} from '../harness.ts'
+import {
+  DEFAULT_OUTPUT_DIR,
+  DEFAULT_VIEWPORT,
+  E2E_DIR,
+  parseViewport
+} from '../config.ts'
+
+const FIXTURE_PATH = join(E2E_DIR, 'fixtures', 'session-3hands.ndjson')
+const MID_REPLAY_RAW_COUNT = 8
+const REPLAY_DELAY_MS = 150
+
+interface DbSnapshot {
+  rawEvents: Array<Record<string, unknown>>
+  handCount: number
+}
+
+const parseArgs = (argv: string[]) => ({
+  headed: argv.includes('--headed'),
+  screenshotDir: argv.includes('--screenshot-dir')
+    ? argv[argv.indexOf('--screenshot-dir') + 1]!
+    : DEFAULT_OUTPUT_DIR,
+  viewport: argv.includes('--viewport')
+    ? parseViewport(argv[argv.indexOf('--viewport') + 1]!)
+    : DEFAULT_VIEWPORT,
+})
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms))
+
+const withTimeout = <T,>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> =>
+  new Promise<T>((resolvePromise, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+      timeoutMs
+    )
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolvePromise(value)
+      },
+      (error) => {
+        clearTimeout(timer)
+        reject(error)
+      }
+    )
+  })
+
+const extensionIdFor = async (browser: Browser): Promise<string> => {
+  const target = await browser.waitForTarget(
+    (candidate) =>
+      candidate.type() === 'service_worker' &&
+      candidate.url().startsWith('chrome-extension://'),
+    { timeout: 15_000 }
+  )
+  return new URL(target.url()).host
+}
+
+const openTrustedContext = async (browser: Browser, extensionId: string): Promise<Page> => {
+  const page = await browser.newPage()
+  await page.goto(`chrome-extension://${extensionId}/trusted-context.html`, {
+    waitUntil: 'domcontentloaded'
+  })
+  return page
+}
+
+const readDatabase = async (page: Page): Promise<DbSnapshot> =>
+  await page.evaluate(async () => {
+    // Avoid becoming the creator of an empty unversioned database if this
+    // probe wins the race against background bootstrap. Only open after the
+    // real extension has created its schema.
+    const databases = await indexedDB.databases()
+    if (!databases.some((database) => database.name === 'PokerChaseDB')) {
+      return { rawEvents: [], handCount: 0 }
+    }
+
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('PokerChaseDB')
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(request.error ?? new Error('IndexedDB open failed'))
+      request.onblocked = () => reject(new Error('IndexedDB open was blocked'))
+    })
+
+    try {
+      const transaction = db.transaction(['apiEvents', 'hands'], 'readonly')
+      const rawRequest = transaction.objectStore('apiEvents').getAll()
+      const handCountRequest = transaction.objectStore('hands').count()
+
+      const [rawEvents, handCount] = await Promise.all([
+        new Promise<Array<Record<string, unknown>>>((resolve, reject) => {
+          rawRequest.onsuccess = () =>
+            resolve(rawRequest.result as Array<Record<string, unknown>>)
+          rawRequest.onerror = () =>
+            reject(rawRequest.error ?? new Error('apiEvents read failed'))
+        }),
+        new Promise<number>((resolve, reject) => {
+          handCountRequest.onsuccess = () => resolve(handCountRequest.result)
+          handCountRequest.onerror = () =>
+            reject(handCountRequest.error ?? new Error('hands count failed'))
+        })
+      ])
+
+      return { rawEvents, handCount }
+    } finally {
+      db.close()
+    }
+  })
+
+const waitForRawCount = async (
+  page: Page,
+  predicate: (count: number) => boolean,
+  timeoutMs: number,
+  label: string
+): Promise<DbSnapshot> => {
+  const deadline = Date.now() + timeoutMs
+  let latest = await readDatabase(page)
+  while (!predicate(latest.rawEvents.length) && Date.now() < deadline) {
+    await sleep(50)
+    latest = await readDatabase(page)
+  }
+  if (!predicate(latest.rawEvents.length)) {
+    throw new Error(`${label}: last raw count was ${latest.rawEvents.length}`)
+  }
+  return latest
+}
+
+const waitForHandCount = async (
+  page: Page,
+  expectedCount: number,
+  timeoutMs: number
+): Promise<DbSnapshot> => {
+  const deadline = Date.now() + timeoutMs
+  let latest = await readDatabase(page)
+  while (latest.handCount !== expectedCount && Date.now() < deadline) {
+    await sleep(50)
+    latest = await readDatabase(page)
+  }
+  if (latest.handCount !== expectedCount) {
+    throw new Error(
+      `derived hand count mismatch after restart: expected ${expectedCount}, got ${latest.handCount}`
+    )
+  }
+  return latest
+}
+
+const canonicalize = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, canonicalize(entry)])
+    )
+  }
+  return value
+}
+
+const canonicalEvent = (value: Record<string, unknown>): string => {
+  // The real WebSocket interceptor deliberately replaces capture timestamps
+  // with Date.now() at receipt time. Compare every stable payload field while
+  // separately asserting the exact row count, so one loss plus one duplicate
+  // still cannot cancel out.
+  const {
+    sequence: _sequence,
+    timestamp: _receiptTimestamp,
+    ...event
+  } = value
+  return JSON.stringify(canonicalize(event))
+}
+
+const maxHandCount = async (harness: Harness): Promise<number> =>
+  await harness.evaluate(() => {
+    const cells = Array.from(document.querySelectorAll('[data-stat-id="hands"]'))
+    let max = 0
+    for (const cell of cells) {
+      const match = (cell.textContent || '').match(/\d+/)
+      const value = match ? parseInt(match[0], 10) : NaN
+      if (!Number.isNaN(value)) max = Math.max(max, value)
+    }
+    return max
+  })
+
+const dumpFailureEvidence = async (
+  harness: Harness,
+  screenshotDir: string
+): Promise<void> => {
+  mkdirSync(screenshotDir, { recursive: true })
+  await harness.screenshot(join(screenshotDir, 'mv3-lifecycle-failure.png')).catch(() => {})
+  const html = await harness.domSnapshotHtml().catch(() => '')
+  if (html) writeFileSync(join(screenshotDir, 'mv3-lifecycle-failure.html'), html)
+}
+
+const run = async (): Promise<void> => {
+  const { headed, screenshotDir, viewport } = parseArgs(process.argv.slice(2))
+  const expectedEvents = readFileSync(FIXTURE_PATH, 'utf-8')
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as Record<string, unknown>)
+  const expectedCanonical = expectedEvents.map(canonicalEvent).sort()
+
+  console.log('[mv3-lifecycle] building e2e extension...')
+  const extensionDir = buildE2E()
+  let harness: Harness | undefined
+
+  try {
+    harness = await launchHarness({
+      headed,
+      extensionDir,
+      fixturePath: FIXTURE_PATH,
+      replayDelayMs: REPLAY_DELAY_MS,
+      viewport
+    })
+    // Do not let the trusted probe page become the first opener of the DB:
+    // an unversioned indexedDB.open() before background bootstrap would create
+    // an empty v1 database with no stores. HUD mount proves the real extension
+    // has initialized its schema and begun consuming the fixture.
+    await harness.waitForHudMount(15_000)
+    const extensionId = await extensionIdFor(harness.browser)
+    const trustedPage = await openTrustedContext(harness.browser, extensionId)
+
+    const beforeStop = await waitForRawCount(
+      trustedPage,
+      (count) => count >= MID_REPLAY_RAW_COUNT,
+      15_000,
+      'mid-replay raw threshold'
+    )
+    if (beforeStop.rawEvents.length >= expectedEvents.length) {
+      throw new Error('fixture completed before the mid-replay failure injection')
+    }
+
+    const sentBeforeStop = harness.fixtureServer.sentEventCount()
+    const firstStop = await stopExtensionServiceWorker(harness.browser)
+    console.log(
+      `[mv3-lifecycle] stopped worker ${firstStop.versionId} after ` +
+      `${beforeStop.rawEvents.length}/${expectedEvents.length} durable raw rows`
+    )
+
+    // RuntimePortManager waits 500ms before reconnecting. The fixture delay
+    // guarantees at least one real WebSocket frame arrives inside this
+    // stopped-worker window instead of merely testing a stop between events.
+    await sleep(350)
+    const sentWhileStopped = harness.fixtureServer.sentEventCount() - sentBeforeStop
+    if (sentWhileStopped < 1) {
+      throw new Error('no fixture frame crossed the stopped-worker window')
+    }
+
+    await withTimeout(harness.waitForReplayDone(), 20_000, 'fixture replay')
+    const completed = await waitForRawCount(
+      trustedPage,
+      (count) => count >= expectedEvents.length,
+      15_000,
+      'post-restart raw drain'
+    )
+
+    const actualCanonical = completed.rawEvents.map(canonicalEvent).sort()
+    if (actualCanonical.length !== expectedCanonical.length) {
+      throw new Error(
+        `raw event count mismatch after restart: expected ${expectedCanonical.length}, ` +
+        `received ${actualCanonical.length}`
+      )
+    }
+    if (JSON.stringify(actualCanonical) !== JSON.stringify(expectedCanonical)) {
+      throw new Error('raw event multiset changed across Service Worker restart')
+    }
+
+    // The injected stop deliberately lands inside a hand, so volatile
+    // AggregateEventsStream state is not expected to survive. Raw Event Lake
+    // is the recovery boundary: a canonical rebuild must deterministically
+    // restore every derived hand from the exact raw multiset.
+    const rebuildResponse = await withTimeout(
+      trustedPage.evaluate(
+        async () => await chrome.runtime.sendMessage({ action: 'rebuildData' })
+      ) as Promise<{ success?: boolean, error?: string }>,
+      30_000,
+      'canonical rebuild after worker restart'
+    )
+    if (!rebuildResponse.success) {
+      throw new Error(`canonical rebuild failed: ${rebuildResponse.error ?? 'unknown error'}`)
+    }
+    const rebuilt = await waitForHandCount(trustedPage, 3, 5_000)
+
+    const operationResponse = await trustedPage.evaluate(
+      async () => await chrome.runtime.sendMessage({ action: 'getOperationState' })
+    ) as {
+      success?: boolean
+      operationState?: { type?: string }
+    }
+    if (!operationResponse.success || operationResponse.operationState?.type !== 'idle') {
+      throw new Error(
+        `operation did not return to idle after rebuild: ${JSON.stringify(operationResponse)}`
+      )
+    }
+    console.log(
+      `[mv3-lifecycle] PASS - ${actualCanonical.length} raw events survived exactly once; ` +
+      `${sentWhileStopped} frame(s) crossed the stopped-worker window; ` +
+      `${rebuilt.handCount} hands recovered canonically`
+    )
+
+    // Let PokerChaseService's 500ms-debounced state persistence settle, then
+    // evict the now-idle worker and demand a cold restore from a fresh mount.
+    await sleep(750)
+    const secondStop = await stopExtensionServiceWorker(harness.browser)
+    console.log(`[mv3-lifecycle] stopped idle worker ${secondStop.versionId}`)
+
+    await harness.gamePage.goto(`${harness.fixtureServer.origin}/no-replay.html`, {
+      waitUntil: 'domcontentloaded'
+    })
+    await harness.waitForHudMount(20_000)
+    await sleep(1_000)
+    const restoredHandCount = await maxHandCount(harness)
+    if (restoredHandCount <= 0) {
+      throw new Error(`cold-restored pre-game HUD has no persisted hands: ${restoredHandCount}`)
+    }
+
+    const afterRestore = await readDatabase(trustedPage)
+    if (afterRestore.rawEvents.length !== expectedEvents.length) {
+      throw new Error(
+        `idle restart changed raw event count: expected ${expectedEvents.length}, ` +
+        `got ${afterRestore.rawEvents.length}`
+      )
+    }
+    console.log(
+      `[mv3-lifecycle] PASS - idle worker restart restored HUD state ` +
+      `(max HAND ${restoredHandCount}) without replay or duplicate raw rows`
+    )
+    console.log('[mv3-lifecycle] PASSED: all MV3 lifecycle invariants held')
+  } catch (error) {
+    console.error('[mv3-lifecycle] FAILED:', error)
+    if (harness) await dumpFailureEvidence(harness, screenshotDir)
+    process.exitCode = 1
+  } finally {
+    await harness?.close()
+  }
+}
+
+run()

--- a/e2e/scenarios/mv3-service-worker-lifecycle.ts
+++ b/e2e/scenarios/mv3-service-worker-lifecycle.ts
@@ -38,6 +38,12 @@ interface DbSnapshot {
   handCount: number
 }
 
+interface PersistedServiceState {
+  playerId?: number
+  latestEvtDeal?: { SeatUserIds?: number[] }
+  lastUpdated?: number
+}
+
 const parseArgs = (argv: string[]) => ({
   headed: argv.includes('--headed'),
   screenshotDir: argv.includes('--screenshot-dir')
@@ -166,6 +172,36 @@ const waitForHandCount = async (
   return latest
 }
 
+const waitForPersistedServiceState = async (
+  page: Page,
+  expectedPlayerId: number,
+  minimumUpdatedAt: number,
+  timeoutMs: number
+): Promise<PersistedServiceState> => {
+  const deadline = Date.now() + timeoutMs
+  let state: PersistedServiceState | undefined
+
+  while (Date.now() < deadline) {
+    state = await page.evaluate(async () => {
+      const result = await chrome.storage.local.get('pokerChaseServiceState')
+      return result.pokerChaseServiceState as PersistedServiceState | undefined
+    })
+    if (
+      state?.playerId === expectedPlayerId &&
+      state.latestEvtDeal?.SeatUserIds?.includes(expectedPlayerId) &&
+      typeof state.lastUpdated === 'number' &&
+      state.lastUpdated >= minimumUpdatedAt
+    ) {
+      return state
+    }
+    await sleep(50)
+  }
+
+  throw new Error(
+    `rebuilt service state was not durably persisted before eviction: ${JSON.stringify(state)}`
+  )
+}
+
 const canonicalize = (value: unknown): unknown => {
   if (Array.isArray(value)) return value.map(canonicalize)
   if (value && typeof value === 'object') {
@@ -220,6 +256,19 @@ const run = async (): Promise<void> => {
     .filter((line) => line.trim().length > 0)
     .map((line) => JSON.parse(line) as Record<string, unknown>)
   const expectedCanonical = expectedEvents.map(canonicalEvent).sort()
+  const playerDeal = expectedEvents.find(
+    (event) => event.ApiTypeId === 303 && event.Player
+  ) as {
+    Player?: { SeatIndex?: number }
+    SeatUserIds?: number[]
+  } | undefined
+  const playerSeatIndex = playerDeal?.Player?.SeatIndex
+  const expectedPlayerId = typeof playerSeatIndex === 'number'
+    ? playerDeal?.SeatUserIds?.[playerSeatIndex]
+    : undefined
+  if (typeof expectedPlayerId !== 'number' || expectedPlayerId < 0) {
+    throw new Error('fixture does not identify a valid hero player')
+  }
 
   console.log('[mv3-lifecycle] building e2e extension...')
   const extensionDir = buildE2E()
@@ -251,8 +300,11 @@ const run = async (): Promise<void> => {
       throw new Error('fixture completed before the mid-replay failure injection')
     }
 
-    const sentBeforeStop = harness.fixtureServer.sentEventCount()
     const firstStop = await stopExtensionServiceWorker(harness.browser)
+    // Capture only after CDP has confirmed `runningStatus: stopped`; frames
+    // sent while Chrome was still locating/stopping the worker do not prove
+    // the reconnect queue crossed an actual stopped-worker interval.
+    const sentBeforeStop = harness.fixtureServer.sentEventCount()
     console.log(
       `[mv3-lifecycle] stopped worker ${firstStop.versionId} after ` +
       `${beforeStop.rawEvents.length}/${expectedEvents.length} durable raw rows`
@@ -290,6 +342,7 @@ const run = async (): Promise<void> => {
     // AggregateEventsStream state is not expected to survive. Raw Event Lake
     // is the recovery boundary: a canonical rebuild must deterministically
     // restore every derived hand from the exact raw multiset.
+    const persistenceFloor = Date.now()
     const rebuildResponse = await withTimeout(
       trustedPage.evaluate(
         async () => await chrome.runtime.sendMessage({ action: 'rebuildData' })
@@ -313,15 +366,21 @@ const run = async (): Promise<void> => {
         `operation did not return to idle after rebuild: ${JSON.stringify(operationResponse)}`
       )
     }
+    await waitForPersistedServiceState(
+      trustedPage,
+      expectedPlayerId,
+      persistenceFloor,
+      10_000
+    )
     console.log(
       `[mv3-lifecycle] PASS - ${actualCanonical.length} raw events survived exactly once; ` +
       `${sentWhileStopped} frame(s) crossed the stopped-worker window; ` +
       `${rebuilt.handCount} hands recovered canonically`
     )
 
-    // Let PokerChaseService's 500ms-debounced state persistence settle, then
-    // evict the now-idle worker and demand a cold restore from a fresh mount.
-    await sleep(750)
+    // The poll above proves PokerChaseService's debounced, fire-and-forget
+    // storage write completed. Now evict the idle worker and demand a cold
+    // restore from a fresh mount.
     const secondStop = await stopExtensionServiceWorker(harness.browser)
     console.log(`[mv3-lifecycle] stopped idle worker ${secondStop.versionId}`)
 
@@ -331,8 +390,11 @@ const run = async (): Promise<void> => {
     await harness.waitForHudMount(20_000)
     await sleep(1_000)
     const restoredHandCount = await maxHandCount(harness)
-    if (restoredHandCount <= 0) {
-      throw new Error(`cold-restored pre-game HUD has no persisted hands: ${restoredHandCount}`)
+    if (restoredHandCount !== rebuilt.handCount) {
+      throw new Error(
+        `cold-restored pre-game HUD is incomplete: expected ${rebuilt.handCount}, ` +
+        `got ${restoredHandCount}`
+      )
     }
 
     const afterRestore = await readDatabase(trustedPage)

--- a/e2e/scenarios/smoke.ts
+++ b/e2e/scenarios/smoke.ts
@@ -147,7 +147,10 @@ const run = async (): Promise<void> => {
       page.on('pageerror', (err) => { popupError = err })
     })
     await new Promise((resolve) => setTimeout(resolve, 1000))
-    await popup.screenshot({ path: join(screenshotDir, 'smoke-popup.png') as `${string}.png` })
+    // Route through the harness so its just-in-time compositor keepalive is
+    // reasserted immediately before capture. A direct popup.screenshot() can
+    // stall under hosted-runner Xvfb even though the page remains responsive.
+    await harness.screenshot(join(screenshotDir, 'smoke-popup.png'), popup)
     const popupHasContent = await popup.evaluate(() => {
       const root = document.getElementById('popup-root')
       return !!root && root.children.length > 0 && (root.textContent?.trim().length ?? 0) > 0

--- a/e2e/scenarios/smoke.ts
+++ b/e2e/scenarios/smoke.ts
@@ -108,7 +108,13 @@ const run = async (): Promise<void> => {
     // last hand's events and push updated stats down to the content script.
     await new Promise((resolve) => setTimeout(resolve, 1500))
 
-    await harness.screenshot(join(screenshotDir, 'smoke-hud.png'))
+    // Success screenshots are exploratory evidence, not gate assertions.
+    // Hosted-runner Xvfb can leave a fully responsive page unable to produce
+    // a compositor frame until Puppeteer's 3-minute protocol timeout, so CI
+    // keeps only best-effort failure captures while local QA retains both.
+    if (!process.env.CI) {
+      await harness.screenshot(join(screenshotDir, 'smoke-hud.png'))
+    }
 
     // 2. At least one player panel shows a HAND count > 0. Selects on the
     // stable `data-stat-id="hands"` marker (StatDisplay.tsx / #143's
@@ -147,10 +153,11 @@ const run = async (): Promise<void> => {
       page.on('pageerror', (err) => { popupError = err })
     })
     await new Promise((resolve) => setTimeout(resolve, 1000))
-    // Route through the harness so its just-in-time compositor keepalive is
-    // reasserted immediately before capture. A direct popup.screenshot() can
-    // stall under hosted-runner Xvfb even though the page remains responsive.
-    await harness.screenshot(join(screenshotDir, 'smoke-popup.png'), popup)
+    if (!process.env.CI) {
+      // Route through the harness so its just-in-time compositor keepalive is
+      // reasserted immediately before capture.
+      await harness.screenshot(join(screenshotDir, 'smoke-popup.png'), popup)
+    }
     const popupHasContent = await popup.evaluate(() => {
       const root = document.getElementById('popup-root')
       return !!root && root.children.length > 0 && (root.textContent?.trim().length ?? 0) > 0
@@ -183,10 +190,14 @@ const run = async (): Promise<void> => {
     }
 
     console.log(`\n[smoke] PASSED: all ${checks.length} checks passed`)
-    console.log(
-      `[smoke] screenshots (viewport ${viewport.width}x${viewport.height}): ` +
-      `${join(screenshotDir, 'smoke-hud.png')}, ${join(screenshotDir, 'smoke-popup.png')}`
-    )
+    if (process.env.CI) {
+      console.log('[smoke] success screenshots skipped in CI; failure evidence remains enabled')
+    } else {
+      console.log(
+        `[smoke] screenshots (viewport ${viewport.width}x${viewport.height}): ` +
+        `${join(screenshotDir, 'smoke-hud.png')}, ${join(screenshotDir, 'smoke-popup.png')}`
+      )
+    }
   } catch (err) {
     console.error('[smoke] unexpected error:', err)
     if (harness) await dumpFailureEvidence(harness, screenshotDir, 'unexpected')

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "e2e:smoke": "tsx e2e/scenarios/smoke.ts",
     "e2e:auth-storage": "tsx e2e/scenarios/auth-storage-access.ts",
     "e2e:playerid": "tsx e2e/scenarios/playerid-session-persistence.ts",
+    "e2e:mv3-lifecycle": "tsx e2e/scenarios/mv3-service-worker-lifecycle.ts",
+    "e2e:browser-gate": "npm run e2e:smoke -- --headed && npm run e2e:playerid -- --headed && npm run e2e:auth-storage -- --headed && npm run e2e:mv3-lifecycle -- --headed",
     "e2e": "tsx e2e/run.ts",
     "firebase:deploy": "firebase deploy --only firestore:rules,firestore:indexes",
     "firebase:deploy:rules": "firebase deploy --only firestore:rules",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "e2e:auth-storage": "tsx e2e/scenarios/auth-storage-access.ts",
     "e2e:playerid": "tsx e2e/scenarios/playerid-session-persistence.ts",
     "e2e:mv3-lifecycle": "tsx e2e/scenarios/mv3-service-worker-lifecycle.ts",
-    "e2e:browser-gate": "npm run e2e:smoke -- --headed && npm run e2e:playerid -- --headed && npm run e2e:auth-storage -- --headed && npm run e2e:mv3-lifecycle -- --headed",
+    "e2e:browser-gate": "npm run e2e:smoke && npm run e2e:auth-storage && npm run e2e:mv3-lifecycle",
     "e2e": "tsx e2e/run.ts",
     "firebase:deploy": "firebase deploy --only firestore:rules,firestore:indexes",
     "firebase:deploy:rules": "firebase deploy --only firestore:rules",


### PR DESCRIPTION
## Summary

- add a real-Chrome MV3 lifecycle failure-injection scenario that stops the extension Service Worker through CDP while fixture events are still arriving
- prove the stopped-worker window delivered every Raw Event Lake row exactly once, then recover volatile mid-hand aggregation through the normal canonical rebuild path
- stop the idle worker a second time and verify persisted hero/session state restores into the zero-replay pre-game HUD
- add a bounded `browser-e2e` CI job under Xvfb with a cached, pinned Chrome for Testing build

## Audited boundaries

The existing Jest suite already covers the lower-level failure points, so this PR does not duplicate them:

- `event-ingestion.durability-barrier`: raw merge before downstream effects, raw-write failure, drain-before-reload, append-while-draining
- `runtime-port-manager`: disconnect, failed send retry, FIFO queueing, ambiguous delivery dedup, queue overflow
- `import-export.export-handoff`: operation remains non-idle until file/chunk acknowledgment; missing receiver and explicit failure acknowledgments fail closed
- `update-manager`: durable pending state, operation/session gating, reload commit serialization, Service Worker startup recheck

The new browser scenario closes the missing integration boundary across those units:

1. stop the real Service Worker after 8/29 fixture rows;
2. observe fixture frames continue during the stopped interval;
3. verify all 29 stable payloads exist exactly once in IndexedDB;
4. run canonical rebuild and verify 3 hands plus shared operation state `idle`;
5. stop the idle worker, navigate to `no-replay.html`, and verify cold-restored HUD `HAND=3` without new raw rows.

Review hardening on the final scenario counts frames only after CDP confirms
the worker is stopped, polls the rebuilt `pokerChaseServiceState` write before
the idle eviction, and requires the cold-restored HUD count to match all three
rebuilt hands exactly. The final head also binds renderer-received (not merely server-sent) frames to a fresh CDP inventory that still reports the exact worker version stopped and inspects the fresh worker after `service.ready` but before the HUD can use its IndexedDB player fallback.

## CI gate

`browser-e2e` runs the bounded extension scenarios under Xvfb:

- smoke
- auth-storage isolation and restart restore
- MV3 Service Worker lifecycle failure injection, including persisted-player cold restore

Chrome for Testing remains pinned by `e2e/config.ts` and is cached separately from npm dependencies. The job has a 15-minute timeout and uploads failure evidence only on failure.

## Validation

- `npm run typecheck`
- `npm test -- --runInBand --randomize` — 136 suites / 1350 tests
- `npm run build`
- `npm run e2e:browser-gate` — all three bounded headless real-Chrome scenarios passed
- `npm run e2e:browser-gate` before bounded CI adjustment — all four headed scenarios passed locally
- `CI=1 npm run e2e:mv3-lifecycle` — CI-only Chrome flags exercised locally
- `CI=1 npm run e2e:auth-storage` — passed three consecutive runs after hosted-runner startup-race fix
- `CI=1 npm run e2e:smoke` — passed three consecutive runs after compositor capture fix
- `git diff --check`

Head: `421faa02d1375f1c79c96c4b47cfc594c96c3e1f`