### PR TITLE
feat: 更新情報を折り畳み可能にしリリース日を表示

### DIFF
--- a/src/components/popup/PopupHeader.test.tsx
+++ b/src/components/popup/PopupHeader.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react'
+import { PopupHeader } from './PopupHeader'
+
+describe('PopupHeader', () => {
+  test('shows the manifest version with its release date', () => {
+    render(
+      <PopupHeader
+        popupThemeMode="auto"
+        onPopupThemeModeChange={jest.fn()}
+      />
+    )
+
+    expect(screen.getByText('v5.3.1（2026-07-23）')).toBeInTheDocument()
+  })
+})

--- a/src/components/popup/PopupHeader.tsx
+++ b/src/components/popup/PopupHeader.tsx
@@ -2,6 +2,7 @@ import Box from '@mui/material/Box'
 import RadioGroup from '@mui/material/RadioGroup'
 import Typography from '@mui/material/Typography'
 import manifest from '../../../manifest.json'
+import { RELEASE_DATES_BY_VERSION } from '../../constants/release-dates'
 import type { PopupThemeMode } from './theme'
 import { SegmentRadio } from './SegmentRadio'
 
@@ -42,6 +43,7 @@ export const PopupHeader = ({ popupThemeMode, onPopupThemeModeChange }: PopupHea
           sx={{ color: 'text.secondary', fontVariantNumeric: 'tabular-nums' }}
         >
           v{manifest.version}
+          {RELEASE_DATES_BY_VERSION[manifest.version] && `（${RELEASE_DATES_BY_VERSION[manifest.version]}）`}
         </Typography>
       )}
     </Box>

--- a/src/components/popup/WhatsNewSection.test.tsx
+++ b/src/components/popup/WhatsNewSection.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { WhatsNewSection } from './WhatsNewSection'
 import {
@@ -59,6 +59,47 @@ describe('WhatsNewSection', () => {
 
     expect(collapse).toHaveAttribute('aria-expanded', 'false')
     expect(document.getElementById(contentId!)).toHaveAttribute('hidden')
+    expect(chrome.storage.sync.set).toHaveBeenCalledWith({
+      [WHATS_NEW_EXPANDED_STORAGE_KEY]: false,
+    })
+  })
+
+  it('keeps the update badge unread while the restored section is hidden', async () => {
+    const user = userEvent.setup()
+    ;(chrome.storage.sync.get as jest.Mock).mockImplementation((_key, callback) => {
+      callback({ [WHATS_NEW_EXPANDED_STORAGE_KEY]: false })
+    })
+
+    render(<WhatsNewSection />)
+
+    const show = await screen.findByRole('button', { name: /表示する/ })
+    expect(mockSendMessage).not.toHaveBeenCalled()
+
+    await user.click(show)
+
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        { action: 'acknowledgeWhatsNew' },
+        expect.any(Function)
+      )
+    })
+  })
+
+  it('does not let a late storage read overwrite a newer user choice', async () => {
+    const user = userEvent.setup()
+    let finishStorageRead: ((result: Record<string, unknown>) => void) | undefined
+    ;(chrome.storage.sync.get as jest.Mock).mockImplementation((_key, callback) => {
+      finishStorageRead = callback
+    })
+
+    render(<WhatsNewSection />)
+    await user.click(screen.getByRole('button', { name: /折りたたむ/ }))
+
+    act(() => {
+      finishStorageRead?.({ [WHATS_NEW_EXPANDED_STORAGE_KEY]: true })
+    })
+
+    expect(screen.getByRole('button', { name: /表示する/ })).toHaveAttribute('aria-expanded', 'false')
     expect(chrome.storage.sync.set).toHaveBeenCalledWith({
       [WHATS_NEW_EXPANDED_STORAGE_KEY]: false,
     })

--- a/src/components/popup/WhatsNewSection.test.tsx
+++ b/src/components/popup/WhatsNewSection.test.tsx
@@ -85,6 +85,24 @@ describe('WhatsNewSection', () => {
     })
   })
 
+  it('keeps release notes hidden until the collapsed preference is restored', () => {
+    let finishStorageRead: ((result: Record<string, unknown>) => void) | undefined
+    ;(chrome.storage.sync.get as jest.Mock).mockImplementation((_key, callback) => {
+      finishStorageRead = callback
+    })
+
+    render(<WhatsNewSection />)
+
+    expect(screen.getByText(new RegExp(`v${WHATS_NEW_ENTRIES[0]!.version.replace(/\./g, '\\.')}`))).not.toBeVisible()
+
+    act(() => {
+      finishStorageRead?.({ [WHATS_NEW_EXPANDED_STORAGE_KEY]: false })
+    })
+
+    expect(screen.getByText(new RegExp(`v${WHATS_NEW_ENTRIES[0]!.version.replace(/\./g, '\\.')}`))).not.toBeVisible()
+    expect(mockSendMessage).not.toHaveBeenCalled()
+  })
+
   it('does not let a late storage read overwrite a newer user choice', async () => {
     const user = userEvent.setup()
     let finishStorageRead: ((result: Record<string, unknown>) => void) | undefined
@@ -93,15 +111,15 @@ describe('WhatsNewSection', () => {
     })
 
     render(<WhatsNewSection />)
-    await user.click(screen.getByRole('button', { name: /折りたたむ/ }))
+    await user.click(screen.getByRole('button', { name: /表示する/ }))
 
     act(() => {
-      finishStorageRead?.({ [WHATS_NEW_EXPANDED_STORAGE_KEY]: true })
+      finishStorageRead?.({ [WHATS_NEW_EXPANDED_STORAGE_KEY]: false })
     })
 
-    expect(screen.getByRole('button', { name: /表示する/ })).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.getByRole('button', { name: /折りたたむ/ })).toHaveAttribute('aria-expanded', 'true')
     expect(chrome.storage.sync.set).toHaveBeenCalledWith({
-      [WHATS_NEW_EXPANDED_STORAGE_KEY]: false,
+      [WHATS_NEW_EXPANDED_STORAGE_KEY]: true,
     })
   })
 

--- a/src/components/popup/WhatsNewSection.test.tsx
+++ b/src/components/popup/WhatsNewSection.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { WhatsNewSection } from './WhatsNewSection'
-import { WHATS_NEW_ENTRIES, GITHUB_RELEASES_URL, type WhatsNewEntry } from '../../constants/whats-new'
+import {
+  WHATS_NEW_ENTRIES,
+  GITHUB_RELEASES_URL,
+  WHATS_NEW_EXPANDED_STORAGE_KEY,
+  type WhatsNewEntry,
+} from '../../constants/whats-new'
 
 const syntheticEntry = (version: string, pointCount: number): WhatsNewEntry => ({
   version,
@@ -42,6 +47,21 @@ describe('WhatsNewSection', () => {
 
     const history = screen.getByRole('button', { name: new RegExp(`過去の更新情報（${WHATS_NEW_ENTRIES.length - 2}件）`) })
     expect(history).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('collapses the entire section and persists the space-saving choice', async () => {
+    const user = userEvent.setup()
+    render(<WhatsNewSection />)
+
+    const collapse = screen.getByRole('button', { name: /折りたたむ/ })
+    const contentId = collapse.getAttribute('aria-controls')
+    await user.click(collapse)
+
+    expect(collapse).toHaveAttribute('aria-expanded', 'false')
+    expect(document.getElementById(contentId!)).toHaveAttribute('hidden')
+    expect(chrome.storage.sync.set).toHaveBeenCalledWith({
+      [WHATS_NEW_EXPANDED_STORAGE_KEY]: false,
+    })
   })
 
   it('shows a short newest release in full while truncating the long second release', () => {

--- a/src/components/popup/WhatsNewSection.tsx
+++ b/src/components/popup/WhatsNewSection.tsx
@@ -96,7 +96,9 @@ const FeaturedEntry = ({ entry, isFirst }: { entry: WhatsNewEntry, isFirst: bool
  * 送り、拡張機能アイコンのバッジ（未読があれば）を解消する。
  */
 export const WhatsNewSection = ({ entries = WHATS_NEW_ENTRIES }: WhatsNewSectionProps) => {
-  const [sectionExpanded, setSectionExpanded] = useState(true)
+  // 保存状態が判明するまでは本文を閉じておき、折り畳み設定が false の
+  // ユーザーにリリースノート全体が一瞬表示されるのを防ぐ。
+  const [sectionExpanded, setSectionExpanded] = useState(false)
   const [sectionPreferenceRestored, setSectionPreferenceRestored] = useState(false)
   const [historyExpanded, setHistoryExpanded] = useState(false)
   const sectionChangedByUserRef = useRef(false)
@@ -112,6 +114,9 @@ export const WhatsNewSection = ({ entries = WHATS_NEW_ENTRIES }: WhatsNewSection
         typeof result[WHATS_NEW_EXPANDED_STORAGE_KEY] === 'boolean'
       ) {
         setSectionExpanded(result[WHATS_NEW_EXPANDED_STORAGE_KEY] as boolean)
+      } else if (!sectionChangedByUserRef.current) {
+        // 保存値がない既存ユーザーには従来どおり開いた状態を既定とする。
+        setSectionExpanded(true)
       }
       setSectionPreferenceRestored(true)
     })

--- a/src/components/popup/WhatsNewSection.tsx
+++ b/src/components/popup/WhatsNewSection.tsx
@@ -2,7 +2,7 @@ import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Link from '@mui/material/Link'
 import Typography from '@mui/material/Typography'
-import { useEffect, useId, useMemo, useState } from 'react'
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import {
   GITHUB_RELEASES_URL,
   WHATS_NEW_EXPANDED_STORAGE_KEY,
@@ -91,27 +91,41 @@ const FeaturedEntry = ({ entry, isFirst }: { entry: WhatsNewEntry, isFirst: bool
  * いるときは実行中バージョン以下の最新2件を表示する。長い本文はエントリ内の
  * 「続きを読む」で省略し、3件目以前は「過去の更新情報」にまとめる。
  *
- * マウント時に`acknowledgeWhatsNew`メッセージ（`message-router.ts`→
- * `src/background/whats-new-badge.ts`）を送り、拡張機能アイコンのバッジ
- * （未読があれば）を解消する。未読が無い状態で送っても副作用は無い（冪等）。
+ * 保存状態の復元後、カードが開いている場合だけ`acknowledgeWhatsNew`
+ * メッセージ（`message-router.ts`→`src/background/whats-new-badge.ts`）を
+ * 送り、拡張機能アイコンのバッジ（未読があれば）を解消する。
  */
 export const WhatsNewSection = ({ entries = WHATS_NEW_ENTRIES }: WhatsNewSectionProps) => {
   const [sectionExpanded, setSectionExpanded] = useState(true)
+  const [sectionPreferenceRestored, setSectionPreferenceRestored] = useState(false)
   const [historyExpanded, setHistoryExpanded] = useState(false)
+  const sectionChangedByUserRef = useRef(false)
   const sectionId = useId()
   const historyId = useId()
 
   useEffect(() => {
-    // Popupが開かれた = ユーザーが更新情報を目にする機会があった、という
-    // ことなのでバッジを解消する。応答は使わないので待たない（fire-and-forget）。
-    sendMessageWithTimeout<{ success: boolean }>({ action: 'acknowledgeWhatsNew' } as AcknowledgeWhatsNewMessage)
-
+    let mounted = true
     chrome.storage.sync.get(WHATS_NEW_EXPANDED_STORAGE_KEY, (result: Record<string, unknown>) => {
-      if (typeof result[WHATS_NEW_EXPANDED_STORAGE_KEY] === 'boolean') {
+      if (!mounted) return
+      if (
+        !sectionChangedByUserRef.current &&
+        typeof result[WHATS_NEW_EXPANDED_STORAGE_KEY] === 'boolean'
+      ) {
         setSectionExpanded(result[WHATS_NEW_EXPANDED_STORAGE_KEY] as boolean)
       }
+      setSectionPreferenceRestored(true)
     })
+    return () => {
+      mounted = false
+    }
   }, [])
+
+  useEffect(() => {
+    // 折り畳まれた更新情報は「読んだ」と見なさない。保存状態を復元済みで、
+    // 実際に本文が見えるときだけバッジを解消する（メッセージは冪等）。
+    if (!sectionPreferenceRestored || !sectionExpanded) return
+    sendMessageWithTimeout<{ success: boolean }>({ action: 'acknowledgeWhatsNew' } as AcknowledgeWhatsNewMessage)
+  }, [sectionExpanded, sectionPreferenceRestored])
 
   const currentVersion = useMemo(() => chrome.runtime.getManifest().version, [])
   const current = useMemo(() => selectWhatsNewEntry(currentVersion, entries), [currentVersion, entries])
@@ -142,6 +156,7 @@ export const WhatsNewSection = ({ entries = WHATS_NEW_ENTRIES }: WhatsNewSection
           aria-expanded={sectionExpanded}
           aria-controls={sectionId}
           onClick={() => {
+            sectionChangedByUserRef.current = true
             const next = !sectionExpanded
             setSectionExpanded(next)
             chrome.storage.sync.set({ [WHATS_NEW_EXPANDED_STORAGE_KEY]: next })

--- a/src/components/popup/WhatsNewSection.tsx
+++ b/src/components/popup/WhatsNewSection.tsx
@@ -5,6 +5,7 @@ import Typography from '@mui/material/Typography'
 import { useEffect, useId, useMemo, useState } from 'react'
 import {
   GITHUB_RELEASES_URL,
+  WHATS_NEW_EXPANDED_STORAGE_KEY,
   WHATS_NEW_ENTRIES,
   selectWhatsNewEntry,
   type WhatsNewEntry,
@@ -86,22 +87,30 @@ const FeaturedEntry = ({ entry, isFirst }: { entry: WhatsNewEntry, isFirst: bool
 }
 
 /**
- * 更新情報（What's New）セクション。実行中バージョン以下の最新2件を最初から
- * 表示し、長い本文だけをエントリ内の「続きを読む」で省略する。3件目以前は
- * 「過去の更新情報」にまとめ、設定操作へ早く到達できる初期高さを保つ。
+ * 更新情報（What's New）セクション。カード全体の開閉状態を保存し、開いて
+ * いるときは実行中バージョン以下の最新2件を表示する。長い本文はエントリ内の
+ * 「続きを読む」で省略し、3件目以前は「過去の更新情報」にまとめる。
  *
  * マウント時に`acknowledgeWhatsNew`メッセージ（`message-router.ts`→
  * `src/background/whats-new-badge.ts`）を送り、拡張機能アイコンのバッジ
  * （未読があれば）を解消する。未読が無い状態で送っても副作用は無い（冪等）。
  */
 export const WhatsNewSection = ({ entries = WHATS_NEW_ENTRIES }: WhatsNewSectionProps) => {
+  const [sectionExpanded, setSectionExpanded] = useState(true)
   const [historyExpanded, setHistoryExpanded] = useState(false)
+  const sectionId = useId()
   const historyId = useId()
 
   useEffect(() => {
     // Popupが開かれた = ユーザーが更新情報を目にする機会があった、という
     // ことなのでバッジを解消する。応答は使わないので待たない（fire-and-forget）。
     sendMessageWithTimeout<{ success: boolean }>({ action: 'acknowledgeWhatsNew' } as AcknowledgeWhatsNewMessage)
+
+    chrome.storage.sync.get(WHATS_NEW_EXPANDED_STORAGE_KEY, (result: Record<string, unknown>) => {
+      if (typeof result[WHATS_NEW_EXPANDED_STORAGE_KEY] === 'boolean') {
+        setSectionExpanded(result[WHATS_NEW_EXPANDED_STORAGE_KEY] as boolean)
+      }
+    })
   }, [])
 
   const currentVersion = useMemo(() => chrome.runtime.getManifest().version, [])
@@ -125,40 +134,58 @@ export const WhatsNewSection = ({ entries = WHATS_NEW_ENTRIES }: WhatsNewSection
 
   return (
     <SectionCard>
-      <SectionHeading>更新情報</SectionHeading>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <SectionHeading>更新情報</SectionHeading>
+        <Button
+          size="small"
+          variant="text"
+          aria-expanded={sectionExpanded}
+          aria-controls={sectionId}
+          onClick={() => {
+            const next = !sectionExpanded
+            setSectionExpanded(next)
+            chrome.storage.sync.set({ [WHATS_NEW_EXPANDED_STORAGE_KEY]: next })
+          }}
+          sx={{ ...disclosureButtonSx, mt: 0, mb: 1 }}
+        >
+          {sectionExpanded ? '折りたたむ ▲' : '表示する ▼'}
+        </Button>
+      </Box>
 
-      {featuredEntries.map((entry, index) => (
-        <FeaturedEntry key={entry.version} entry={entry} isFirst={index === 0} />
-      ))}
+      <Box id={sectionId} hidden={!sectionExpanded}>
+        {featuredEntries.map((entry, index) => (
+          <FeaturedEntry key={entry.version} entry={entry} isFirst={index === 0} />
+        ))}
 
-      {historyEntries.length > 0 && (
-        <Box sx={{ mt: 1.5 }}>
-          <Button
-            size="small"
-            variant="text"
-            aria-expanded={historyExpanded}
-            aria-controls={historyId}
-            onClick={() => setHistoryExpanded(currentExpanded => !currentExpanded)}
-            sx={{ ...disclosureButtonSx, mt: 0 }}
-          >
-            {historyExpanded ? '▼' : '▶'} 過去の更新情報（{historyEntries.length}件）
-          </Button>
-          <Box id={historyId} hidden={!historyExpanded}>
-            {historyEntries.map(entry => (
-              <Box component="article" key={entry.version} sx={{ mt: 1 }}>
-                <EntryHeader entry={entry} />
-                <EntryPoints points={entry.points} />
-              </Box>
-            ))}
+        {historyEntries.length > 0 && (
+          <Box sx={{ mt: 1.5 }}>
+            <Button
+              size="small"
+              variant="text"
+              aria-expanded={historyExpanded}
+              aria-controls={historyId}
+              onClick={() => setHistoryExpanded(currentExpanded => !currentExpanded)}
+              sx={{ ...disclosureButtonSx, mt: 0 }}
+            >
+              {historyExpanded ? '▼' : '▶'} 過去の更新情報（{historyEntries.length}件）
+            </Button>
+            <Box id={historyId} hidden={!historyExpanded}>
+              {historyEntries.map(entry => (
+                <Box component="article" key={entry.version} sx={{ mt: 1 }}>
+                  <EntryHeader entry={entry} />
+                  <EntryPoints points={entry.points} />
+                </Box>
+              ))}
+            </Box>
           </Box>
-        </Box>
-      )}
+        )}
 
-      <Typography variant="caption" sx={{ display: 'block', mt: 1.5 }}>
-        <Link href={GITHUB_RELEASES_URL} target="_blank" rel="noopener noreferrer" color="inherit">
-          すべての変更を見る (GitHub Releases)
-        </Link>
-      </Typography>
+        <Typography variant="caption" sx={{ display: 'block', mt: 1.5 }}>
+          <Link href={GITHUB_RELEASES_URL} target="_blank" rel="noopener noreferrer" color="inherit">
+            すべての変更を見る (GitHub Releases)
+          </Link>
+        </Typography>
+      </Box>
     </SectionCard>
   )
 }

--- a/src/constants/release-dates.ts
+++ b/src/constants/release-dates.ts
@@ -1,0 +1,11 @@
+/**
+ * manifest.jsonの実行バージョンへ対応する正式リリース日。
+ * release-pleaseがCHANGELOG.mdへ追加した日付と同時に更新する。
+ */
+export const RELEASE_DATES_BY_VERSION: Readonly<Record<string, string>> = {
+  '5.3.1': '2026-07-23',
+  '5.3.0': '2026-07-22',
+  '5.2.0': '2026-07-21',
+  '5.1.0': '2026-07-18',
+  '5.0.0': '2026-07-09',
+}

--- a/src/constants/whats-new.ts
+++ b/src/constants/whats-new.ts
@@ -179,6 +179,8 @@ export const GITHUB_RELEASES_URL = 'https://github.com/solavrc/pokerchase-hud/re
 
 /** `chrome.storage.local`のキー: 未読の更新情報が対応するバージョン（未設定なら未読なし） */
 export const WHATS_NEW_STORAGE_KEY = 'whatsNewUnseenVersion'
+/** 更新情報カード全体の開閉状態（省スペース設定）。 */
+export const WHATS_NEW_EXPANDED_STORAGE_KEY = 'whatsNewExpanded'
 
 /**
  * `currentVersion`に一致するエントリを`entries`（新しい順を前提）から選ぶ。


### PR DESCRIPTION
## 概要
- 「更新情報」カード全体を折り畳めるようにし、開閉状態を同期ストレージへ保存
- ポップアップのバージョン表記へリリース日を追加
- 折り畳み操作とバージョン表示の回帰テストを追加

## 影響範囲
ポップアップの更新情報・ヘッダー表示のみです。

## 検証
- `npm test -- --runInBand src/components/popup/PopupHeader.test.tsx src/components/popup/WhatsNewSection.test.tsx`
- `npm run typecheck`
- `git diff --check`