### PR TITLE
fix(e2e): restore compositor keepalive before HUD wait

### DIFF
--- a/e2e/harness.ts
+++ b/e2e/harness.ts
@@ -411,6 +411,10 @@ const buildHelpers = (browser: Browser, gamePage: Page): HarnessHelpers => {
   }
 
   const waitForHudMount = async (timeoutMs = 15000): Promise<void> => {
+    // A caller may navigate the fixture page after launchHarness(), which
+    // removes the keepalive injected at initial load. Restore it before
+    // waitForFunction's animation-frame polling and later screenshots can run.
+    await ensureCompositorKeepalive(gamePage)
     await gamePage.waitForFunction(
       () => {
         const container = document.querySelector('#unity-container')


### PR DESCRIPTION
## Summary

- reassert the compositor keepalive before waiting for the HUD to mount
- preserve animation-frame polling after fixture page navigation

## Root cause

`launchHarness()` injects the keepalive on the initial fixture page, but navigating to `no-replay.html` removes it. On idle CI runners, Puppeteer's animation-frame-based `waitForFunction` polling could then stall until timeout even though the HUD DOM mounted later.

## Validation

- `npm run typecheck`
- `npm run e2e:mv3-lifecycle`
- `npm run e2e:browser-gate`
- `git diff --check`
