### PR TITLE
fix(import): keep NDJSON imports alive after popup closes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,7 +302,10 @@ on large DBs (bounded, local work; import is a rare operation).
   transfer, raw-row processing, and an import-origin post-import rebuild; the
   terminal success/error summary is also stored in
   `chrome.storage.local.lastImportResult` so either UI can restore the result
-  after being closed or reloaded.
+  after being closed or reloaded. A transfer error sends an idempotent
+  `importDataCancel` message so the in-memory chunk session releases its
+  operation slot immediately; once `importDataProcess` detaches the complete
+  session, the same message is a no-op and cannot interrupt storage/rebuild.
 - Batch mode disables real-time updates during import
 - Direct entity conversion (empty-DB path) bypasses stream overhead
 - Legacy exports without `sequence` are assigned a per-timestamp/type sequence during import; re-importing the same payload is content-deduplicated against both existing and earlier rows in the same chunk

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,6 +294,15 @@ on large DBs (bounded, local work; import is a rare operation).
 **Import Optimizations:**
 
 - Designed for processing tens of thousands of records
+- **Popup-safe import UI**: the action popup never reads or transfers the
+  selected file. Its import button opens (or focuses, without duplicating) the
+  extension-owned `dist/index.html?mode=import` tab, and that long-lived page
+  owns file selection plus the 5 MiB chunk transfer. Closing the action popup
+  therefore cannot abandon an import. `getOperationState` distinguishes file
+  transfer, raw-row processing, and an import-origin post-import rebuild; the
+  terminal success/error summary is also stored in
+  `chrome.storage.local.lastImportResult` so either UI can restore the result
+  after being closed or reloaded.
 - Batch mode disables real-time updates during import
 - Direct entity conversion (empty-DB path) bypasses stream overhead
 - Legacy exports without `sequence` are assigned a per-timestamp/type sequence during import; re-importing the same payload is content-deduplicated against both existing and earlier rows in the same chunk

--- a/src/background/import-export.full-rebuild.test.ts
+++ b/src/background/import-export.full-rebuild.test.ts
@@ -29,7 +29,7 @@
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
 import PokerChaseService, { PokerChaseDB } from '../app'
 import { createImportExportHandlers } from './import-export'
-import { setOperationState } from './operation-state'
+import { getOperationState, setOperationState, type OperationState } from './operation-state'
 import { EntityConverter } from '../entity-converter'
 import * as databaseUtils from '../utils/database-utils'
 import { getRebuildAdvisoryState, REBUILD_ADVISORY_STORAGE_KEY } from './rebuild-advisory'
@@ -247,6 +247,32 @@ describe('importData() full rebuild after overlapping imports (audit finding #7,
 
       const after = await snapshotDerived(db)
       expect(after).toEqual(before)
+    })
+  })
+
+  test('marks the post-import rebuild as import-origin before publishing its started message', async () => {
+    await runWithFreshDb(async ({ handlers }) => {
+      let stateAtRebuildStart: OperationState | undefined
+      ;(chrome.runtime.sendMessage as jest.Mock).mockImplementation((message: { action?: string, state?: string }) => {
+        if (message.action === 'rebuildProgress' && message.state === 'started') {
+          stateAtRebuildStart = getOperationState()
+        }
+        return Promise.resolve()
+      })
+
+      await handlers.importData(JSON.stringify({
+        timestamp: 1_000,
+        ApiTypeId: 9_999,
+        marker: 'raw-only',
+      }))
+
+      expect(stateAtRebuildStart).toMatchObject({
+        type: 'rebuild',
+        origin: 'import',
+        phase: 'rebuild',
+        progress: 0,
+      })
+      expect(getOperationState()).toEqual({ type: 'idle' })
     })
   })
 

--- a/src/background/import-export.ts
+++ b/src/background/import-export.ts
@@ -68,7 +68,7 @@ export const startImportSession = (totalChunks: number, fileName: string): void 
   // Own the shared operation slot for the whole file transfer, not only the
   // later parse/rebuild phase. A pending extension update or another data
   // operation must not reload/delete the worker while chunks live in memory.
-  setOperationState({ type: 'import', progress: 0, processed: 0, total: totalChunks, message: 'インポートファイル転送中...' })
+  setOperationState({ type: 'import', phase: 'transfer', progress: 0, processed: 0, total: totalChunks, message: 'インポートファイル転送中...' })
   armImportSessionTimeout()
 }
 
@@ -78,6 +78,7 @@ export const addImportChunk = (chunkIndex: number, chunkData: string): boolean =
   currentImportSession.chunks[chunkIndex] = chunkData
   setOperationState({
     type: 'import',
+    phase: 'transfer',
     progress: Math.round((currentImportSession.receivedChunks / currentImportSession.totalChunks) * 100),
     processed: currentImportSession.receivedChunks,
     total: currentImportSession.totalChunks,
@@ -118,7 +119,7 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
   const importData = async (jsonlData: string): Promise<{ successCount: number, totalLines: number, duplicateCount: number }> => {
     let batchModeEnabled = false
     try {
-      setOperationState({ type: 'import', progress: 0 })
+      setOperationState({ type: 'import', phase: 'processing', progress: 0, message: '生データを処理中...' })
       console.log('[importData] Starting import process with canonical entity rebuild')
       const startTime = performance.now()
 
@@ -195,7 +196,7 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
 
         // Send progress update
         const progress = Math.round((processed / lines.length) * 100)
-        setOperationState({ type: 'import', progress, processed, total: lines.length })
+        setOperationState({ type: 'import', phase: 'processing', progress, processed, total: lines.length, message: '生データを保存中...' })
         chrome.runtime.sendMessage<ImportProgressMessage>({
           action: 'importProgress',
           progress: progress,
@@ -270,6 +271,13 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
         // （読み手向けメモ: importProgressの0-100%は生ログ保存フェーズの
         // 進捗で完結しており、この後に続くrebuildProgressの0-100%は
         // 別フェーズとして独立に表示される）
+        setOperationState({
+          type: 'rebuild',
+          origin: 'import',
+          phase: 'rebuild',
+          progress: 0,
+          message: 'インポートにより新規データを検出、データを再構築中...'
+        })
         chrome.runtime.sendMessage<RebuildProgressMessage>({
           action: 'rebuildProgress',
           state: 'started',
@@ -278,7 +286,7 @@ export const createImportExportHandlers = (service: PokerChaseService, db: Poker
 
         try {
           const rebuildResult = await performFullRebuild((progress, message) => {
-            setOperationState({ type: 'rebuild', progress, message })
+            setOperationState({ type: 'rebuild', origin: 'import', phase: 'rebuild', progress, message })
             chrome.runtime.sendMessage<RebuildProgressMessage>({
               action: 'rebuildProgress',
               state: 'processing',

--- a/src/background/message-router.import-notifications.test.ts
+++ b/src/background/message-router.import-notifications.test.ts
@@ -3,6 +3,7 @@ import PokerChaseService, { PokerChaseDB } from '../app'
 import type { ChromeMessage, MessageResponse } from '../types/messages'
 import { registerMessageRouter } from './message-router'
 import { setOperationState } from './operation-state'
+import { IMPORT_RESULT_STORAGE_KEY } from '../constants/import-page'
 
 describe('message-router import notifications', () => {
   let db: PokerChaseDB
@@ -45,5 +46,11 @@ describe('message-router import notifications', () => {
     await expect(response).resolves.toEqual({ success: true })
     await Promise.resolve()
     expect(await db.apiEvents.count()).toBe(1)
+    expect(chrome.storage.local.set).toHaveBeenCalledWith({
+      [IMPORT_RESULT_STORAGE_KEY]: expect.objectContaining({
+        status: 'completed',
+        message: expect.stringContaining('インポートが完了しました'),
+      }),
+    })
   })
 })

--- a/src/background/message-router.operation-exclusivity.test.ts
+++ b/src/background/message-router.operation-exclusivity.test.ts
@@ -108,6 +108,32 @@ describe('message-router operation exclusivity', () => {
     }
   })
 
+  test('cancels an abandoned chunk transfer immediately and permits retry', () => {
+    listener({ action: 'importDataInit', totalChunks: 2, fileName: 'data.ndjson' }, {}, jest.fn())
+    listener({ action: 'importDataChunk', chunkIndex: 0, chunkData: 'first' }, {}, jest.fn())
+    const cancelResponse = jest.fn()
+
+    listener({ action: 'importDataCancel' }, {}, cancelResponse)
+
+    expect(cancelResponse).toHaveBeenCalledWith({ success: true })
+    expect(getCurrentImportSession()).toBeNull()
+    expect(getOperationState()).toEqual({ type: 'idle' })
+
+    const retryResponse = jest.fn()
+    listener({ action: 'importDataInit', totalChunks: 1, fileName: 'retry.ndjson' }, {}, retryResponse)
+    expect(retryResponse).toHaveBeenCalledWith({ success: true })
+    expect(getOperationState()).toMatchObject({ type: 'import', phase: 'transfer' })
+  })
+
+  test('treats a late transfer cancel as an idempotent no-op', () => {
+    const cancelResponse = jest.fn()
+
+    listener({ action: 'importDataCancel' }, {}, cancelResponse)
+
+    expect(cancelResponse).toHaveBeenCalledWith({ success: true })
+    expect(getOperationState()).toEqual({ type: 'idle' })
+  })
+
   test('preserves a completed chunk session when processing is blocked', () => {
     listener(
       { action: 'importDataInit', totalChunks: 1, fileName: 'data.ndjson' },

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -147,6 +147,13 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
 
       sendResponse({ success: true })
       return true
+    } else if (request.action === 'importDataCancel') {
+      // Idempotent transfer cleanup. Once processing begins,
+      // importDataProcess has already detached the complete session, so a
+      // late cancel cannot interrupt raw storage or its follow-up rebuild.
+      if (getCurrentImportSession()) clearImportSession()
+      sendResponse({ success: true })
+      return true
     } else if (request.action === 'importDataProcess') {
       const currentImportSession = getCurrentImportSession()
       if (!currentImportSession || currentImportSession.receivedChunks !== currentImportSession.totalChunks) {

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -17,6 +17,10 @@ import { getUndecodedEventStats, resetUndecodedEventStats } from './undecoded-ev
 import { applyUpdateNow } from './update-manager'
 import { acknowledgeWhatsNew } from './whats-new-badge'
 import {
+  IMPORT_RESULT_STORAGE_KEY,
+  type ImportResultRecord,
+} from '../constants/import-page'
+import {
   createImportExportHandlers,
   getCurrentImportSession,
   startImportSession,
@@ -58,6 +62,26 @@ const handleFirebaseSignOut = async (): Promise<void> => {
   }
 }
 
+const publishImportResult = async (
+  status: ImportResultRecord['status'],
+  message: string
+): Promise<void> => {
+  const result: ImportResultRecord = {
+    status,
+    message,
+    completedAt: Date.now(),
+  }
+  try {
+    await chrome.storage.local.set({ [IMPORT_RESULT_STORAGE_KEY]: result })
+  } catch (error) {
+    console.warn('[importData] Failed to persist import result:', error)
+  }
+  chrome.runtime.sendMessage<ImportStatusMessage>({
+    action: 'importStatus',
+    status: message,
+  }).catch(() => {})
+}
+
 /**
  * データエクスポート機能
  * `chrome.runtime.onMessage`のディスパッチを登録する。
@@ -87,25 +111,23 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
     } else if (request.action === 'importData') {
       if (rejectIfOperationBusy('importData', sendResponse)) return true
       importData(request.data)
-        .then((result) => {
-          chrome.runtime.sendMessage<ImportStatusMessage>({
-            action: 'importStatus',
-            status: `インポートが完了しました (${result.successCount.toLocaleString()}件のログ${result.duplicateCount > 0 ? `, ${result.duplicateCount.toLocaleString()}件の重複をスキップ` : ''})`
-          }).catch(() => {})
+        .then(async (result) => {
+          await publishImportResult(
+            'completed',
+            `インポートが完了しました (${result.successCount.toLocaleString()}件のログ${result.duplicateCount > 0 ? `, ${result.duplicateCount.toLocaleString()}件の重複をスキップ` : ''})`
+          )
           sendResponse({ success: true })
         })
-        .catch(error => {
+        .catch(async error => {
           console.error('Import error:', error)
-          chrome.runtime.sendMessage<ImportStatusMessage>({
-            action: 'importStatus',
-            status: 'インポートに失敗しました: ' + error.message
-          }).catch(() => {})
+          await publishImportResult('error', 'インポートに失敗しました: ' + error.message)
           sendResponse({ success: false, error: error.message })
         })
       return true // 非同期レスポンスを示す
     } else if (request.action === 'importDataInit') {
       if (rejectIfOperationBusy('importDataInit', sendResponse)) return true
       startImportSession(request.totalChunks, request.fileName)
+      chrome.storage.local.remove(IMPORT_RESULT_STORAGE_KEY).catch(() => {})
       sendResponse({ success: true })
       return true
     } else if (request.action === 'importDataChunk') {
@@ -148,19 +170,16 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
 
       // データを処理
       importData(completeData)
-        .then((result) => {
-          chrome.runtime.sendMessage<ImportStatusMessage>({
-            action: 'importStatus',
-            status: `インポートが完了しました (${result.successCount.toLocaleString()}件のログ${result.duplicateCount > 0 ? `, ${result.duplicateCount.toLocaleString()}件の重複をスキップ` : ''})`
-          }).catch(() => {})
+        .then(async (result) => {
+          await publishImportResult(
+            'completed',
+            `インポートが完了しました (${result.successCount.toLocaleString()}件のログ${result.duplicateCount > 0 ? `, ${result.duplicateCount.toLocaleString()}件の重複をスキップ` : ''})`
+          )
           sendResponse({ success: true })
         })
-        .catch(error => {
+        .catch(async error => {
           console.error('Import error:', error)
-          chrome.runtime.sendMessage<ImportStatusMessage>({
-            action: 'importStatus',
-            status: 'インポートに失敗しました: ' + error.message
-          }).catch(() => {})
+          await publishImportResult('error', 'インポートに失敗しました: ' + error.message)
           sendResponse({ success: false, error: error.message })
         })
       return true

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -127,7 +127,6 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
     } else if (request.action === 'importDataInit') {
       if (rejectIfOperationBusy('importDataInit', sendResponse)) return true
       startImportSession(request.totalChunks, request.fileName)
-      chrome.storage.local.remove(IMPORT_RESULT_STORAGE_KEY).catch(() => {})
       sendResponse({ success: true })
       return true
     } else if (request.action === 'importDataChunk') {

--- a/src/background/operation-state.test.ts
+++ b/src/background/operation-state.test.ts
@@ -12,14 +12,24 @@ describe('operation-state', () => {
   })
 
   it('reflects updates made via setOperationState', () => {
-    setOperationState({ type: 'import', progress: 0 })
-    expect(getOperationState()).toEqual({ type: 'import', progress: 0 })
+    setOperationState({ type: 'import', phase: 'transfer', progress: 0 })
+    expect(getOperationState()).toEqual({ type: 'import', phase: 'transfer', progress: 0 })
     expect(isOperationIdle()).toBe(false)
   })
 
   it('supports progress updates carrying processed/total', () => {
-    setOperationState({ type: 'import', progress: 50, processed: 5, total: 10 })
-    expect(getOperationState()).toEqual({ type: 'import', progress: 50, processed: 5, total: 10 })
+    setOperationState({ type: 'import', phase: 'processing', progress: 50, processed: 5, total: 10 })
+    expect(getOperationState()).toEqual({ type: 'import', phase: 'processing', progress: 50, processed: 5, total: 10 })
+  })
+
+  it('identifies a rebuild that is the tail of an import', () => {
+    setOperationState({ type: 'rebuild', origin: 'import', phase: 'rebuild', progress: 25 })
+    expect(getOperationState()).toEqual({
+      type: 'rebuild',
+      origin: 'import',
+      phase: 'rebuild',
+      progress: 25,
+    })
   })
 
   it('supports export state with format', () => {

--- a/src/background/operation-state.ts
+++ b/src/background/operation-state.ts
@@ -10,6 +10,8 @@
 
 export interface OperationState {
   type: 'idle' | 'export' | 'import' | 'rebuild' | 'sync' | 'delete'
+  origin?: 'import'
+  phase?: 'transfer' | 'processing' | 'rebuild'
   format?: 'json' | 'pokerstars'
   progress?: number
   processed?: number

--- a/src/components/ImportPage.test.tsx
+++ b/src/components/ImportPage.test.tsx
@@ -65,6 +65,32 @@ describe('ImportPage', () => {
     expect(await screen.findByText('インポートが完了しました (12件のログ)')).toBeInTheDocument()
   })
 
+  it('still restores the active operation when terminal-result storage cannot be read', async () => {
+    ;(chrome.runtime as any).lastError = { message: 'simulated storage failure' }
+    ;(chrome.runtime.sendMessage as jest.Mock).mockImplementation(
+      (_message: { action?: string }, callback?: (response: unknown) => void) => {
+        if (typeof callback === 'function') {
+          callback({
+            operationState: {
+              type: 'import',
+              phase: 'processing',
+              progress: 40,
+              processed: 4,
+              total: 10,
+              message: '生データを保存中...',
+            },
+          })
+          return undefined
+        }
+        return Promise.resolve({ success: true })
+      }
+    )
+
+    render(<ImportPage />)
+
+    expect(await screen.findByText('生データを保存中... 4/10 (40%)')).toBeInTheDocument()
+  })
+
   it('shows an initialization error and does not upload chunks', async () => {
     ;(chrome.runtime.sendMessage as jest.Mock).mockImplementation(
       (message: { action?: string }, callback?: (response: unknown) => void) => {

--- a/src/components/ImportPage.test.tsx
+++ b/src/components/ImportPage.test.tsx
@@ -115,6 +115,31 @@ describe('ImportPage', () => {
     const actions = (chrome.runtime.sendMessage as jest.Mock).mock.calls.map(([message]) => message.action)
     expect(actions).not.toContain('importDataChunk')
     expect(actions).not.toContain('importDataProcess')
+    expect(actions).not.toContain('importDataCancel')
+  })
+
+  it('cancels an initialized transfer when a chunk upload fails', async () => {
+    ;(chrome.runtime.sendMessage as jest.Mock).mockImplementation(
+      (message: { action?: string }, callback?: (response: unknown) => void) => {
+        if (typeof callback === 'function') {
+          callback({ operationState: { type: 'idle' } })
+          return undefined
+        }
+        if (message.action === 'importDataChunk') {
+          return Promise.resolve({ success: false, error: 'simulated chunk failure' })
+        }
+        return Promise.resolve({ success: true })
+      }
+    )
+
+    const { container } = render(<ImportPage />)
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    fireEvent.change(input, {
+      target: { files: [new File(['{}'], 'data.ndjson', { type: 'application/x-ndjson' })] },
+    })
+
+    expect(await screen.findByText('インポート失敗: simulated chunk failure')).toBeInTheDocument()
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'importDataCancel' })
   })
 
   it('preserves a UTF-8 character split across file chunk boundaries', async () => {

--- a/src/components/ImportPage.test.tsx
+++ b/src/components/ImportPage.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { TextDecoder as NodeTextDecoder } from 'util'
+import { ImportPage } from './ImportPage'
+import { IMPORT_RESULT_STORAGE_KEY } from '../constants/import-page'
+
+describe('ImportPage', () => {
+  let uploadedChunks: string[]
+
+  beforeEach(() => {
+    ;(globalThis as any).TextDecoder = NodeTextDecoder
+    uploadedChunks = []
+
+    ;(chrome.storage.local.get as jest.Mock).mockImplementation((_key, callback) => callback({}))
+    ;(chrome.storage.local.remove as jest.Mock).mockResolvedValue(undefined)
+    ;(chrome.runtime.sendMessage as jest.Mock).mockImplementation(
+      (message: { action?: string, chunkData?: string }, callback?: (response: unknown) => void) => {
+        if (typeof callback === 'function') {
+          callback(message.action === 'getOperationState'
+            ? { operationState: { type: 'idle' } }
+            : {})
+          return undefined
+        }
+        if (message.action === 'importDataChunk') uploadedChunks.push(message.chunkData ?? '')
+        return Promise.resolve({ success: true })
+      }
+    )
+  })
+
+  it('restores an import-origin rebuild without calling the normal popup game-tab flow', async () => {
+    ;(chrome.runtime.sendMessage as jest.Mock).mockImplementation(
+      (_message: { action?: string }, callback?: (response: unknown) => void) => {
+        if (typeof callback === 'function') {
+          callback({
+            operationState: {
+              type: 'rebuild',
+              origin: 'import',
+              phase: 'rebuild',
+              progress: 35,
+              message: 'インポート後のデータ再構築中...',
+            },
+          })
+          return undefined
+        }
+        return Promise.resolve({ success: true })
+      }
+    )
+
+    render(<ImportPage />)
+
+    expect(await screen.findByText('インポート後のデータ再構築中...')).toBeInTheDocument()
+    expect(chrome.tabs.query).not.toHaveBeenCalled()
+  })
+
+  it('restores a persisted completion result', async () => {
+    ;(chrome.storage.local.get as jest.Mock).mockImplementation((_key, callback) => callback({
+      [IMPORT_RESULT_STORAGE_KEY]: {
+        status: 'completed',
+        message: 'インポートが完了しました (12件のログ)',
+        completedAt: 123,
+      },
+    }))
+
+    render(<ImportPage />)
+
+    expect(await screen.findByText('インポートが完了しました (12件のログ)')).toBeInTheDocument()
+  })
+
+  it('shows an initialization error and does not upload chunks', async () => {
+    ;(chrome.runtime.sendMessage as jest.Mock).mockImplementation(
+      (message: { action?: string }, callback?: (response: unknown) => void) => {
+        if (typeof callback === 'function') {
+          callback({ operationState: { type: 'idle' } })
+          return undefined
+        }
+        if (message.action === 'importDataInit') {
+          return Promise.resolve({ success: false, error: '別の処理が実行中です' })
+        }
+        return Promise.resolve({ success: true })
+      }
+    )
+
+    const { container } = render(<ImportPage />)
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    fireEvent.change(input, {
+      target: { files: [new File(['{}'], 'data.ndjson', { type: 'application/x-ndjson' })] },
+    })
+
+    expect(await screen.findByText('インポート失敗: 別の処理が実行中です')).toBeInTheDocument()
+    const actions = (chrome.runtime.sendMessage as jest.Mock).mock.calls.map(([message]) => message.action)
+    expect(actions).not.toContain('importDataChunk')
+    expect(actions).not.toContain('importDataProcess')
+  })
+
+  it('preserves a UTF-8 character split across file chunk boundaries', async () => {
+    const chunkSize = 5 * 1024 * 1024
+    const content = `${'x'.repeat(chunkSize - 1)}あ\n`
+    const { container } = render(<ImportPage />)
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    fireEvent.change(input, {
+      target: {
+        files: [new File([content], 'utf8-boundary.ndjson', { type: 'application/x-ndjson' })],
+      },
+    })
+
+    await waitFor(() => {
+      expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'importDataProcess' })
+      )
+    })
+    expect(uploadedChunks).toHaveLength(2)
+    expect(uploadedChunks.join('')).toBe(content)
+    expect(uploadedChunks.join('')).not.toContain('\uFFFD')
+  })
+})

--- a/src/components/ImportPage.tsx
+++ b/src/components/ImportPage.tsx
@@ -17,6 +17,7 @@ import {
 } from '../constants/import-page'
 import type {
   ChromeMessage,
+  ImportDataCancelMessage,
   ImportDataChunkMessage,
   ImportDataInitMessage,
   ImportDataProcessMessage,
@@ -171,6 +172,7 @@ export const ImportPage = ({
     setDuplicates(0)
     setImported(0)
     setStatus('インポートファイル転送中...')
+    let sessionInitialized = false
     try {
       await chrome.storage.local.remove(IMPORT_RESULT_STORAGE_KEY)
     } catch (error) {
@@ -185,6 +187,7 @@ export const ImportPage = ({
         fileName: file.name,
       } satisfies ImportDataInitMessage) as MessageResponse | undefined
       requireSuccessfulResponse(initResponse, 'インポートを開始できませんでした')
+      sessionInitialized = true
 
       const decoder = new TextDecoder()
       for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
@@ -221,6 +224,15 @@ export const ImportPage = ({
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       importFlowActiveRef.current = false
+      if (sessionInitialized) {
+        try {
+          await chrome.runtime.sendMessage({
+            action: 'importDataCancel',
+          } satisfies ImportDataCancelMessage)
+        } catch (cancelError) {
+          console.warn('[ImportPage] Failed to cancel the abandoned import transfer:', cancelError)
+        }
+      }
       const result: ImportResultRecord = {
         status: 'error',
         message: `インポート失敗: ${message}`,

--- a/src/components/ImportPage.tsx
+++ b/src/components/ImportPage.tsx
@@ -83,16 +83,7 @@ export const ImportPage = ({
   const isActive = phase === 'uploading' || phase === 'processing' || phase === 'rebuilding'
 
   useEffect(() => {
-    chrome.storage.local.get(IMPORT_RESULT_STORAGE_KEY, (result: Record<string, unknown>) => {
-      if (chrome.runtime.lastError) return
-      const stored = result[IMPORT_RESULT_STORAGE_KEY] as ImportResultRecord | undefined
-      if (stored) {
-        setPhase(stored.status)
-        setStatus(stored.message)
-      }
-
-      // Read the active operation after the older persisted result so an
-      // in-flight import always wins if callbacks settle in either order.
+    const restoreActiveOperation = () => {
       chrome.runtime.sendMessage({ action: 'getOperationState' }, (response: {
         operationState?: OperationState
       }) => {
@@ -107,6 +98,21 @@ export const ImportPage = ({
         setTotal(state.total ?? 0)
         setStatus(state.message ?? '')
       })
+    }
+
+    chrome.storage.local.get(IMPORT_RESULT_STORAGE_KEY, (result: Record<string, unknown>) => {
+      if (!chrome.runtime.lastError) {
+        const stored = result[IMPORT_RESULT_STORAGE_KEY] as ImportResultRecord | undefined
+        if (stored) {
+          setPhase(stored.status)
+          setStatus(stored.message)
+        }
+      }
+
+      // Read the active operation after the older persisted result so an
+      // in-flight import always wins. A failure to read the optional terminal
+      // result must not suppress restoration of the authoritative operation.
+      restoreActiveOperation()
     })
 
     const handleMessage = (message: ChromeMessage) => {

--- a/src/components/ImportPage.tsx
+++ b/src/components/ImportPage.tsx
@@ -1,0 +1,303 @@
+import { FileUpload } from '@mui/icons-material'
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import CircularProgress from '@mui/material/CircularProgress'
+import CssBaseline from '@mui/material/CssBaseline'
+import LinearProgress from '@mui/material/LinearProgress'
+import Paper from '@mui/material/Paper'
+import { ThemeProvider } from '@mui/material/styles'
+import Typography from '@mui/material/Typography'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import { ChangeEvent, useEffect, useRef, useState } from 'react'
+import type { OperationState } from '../background/operation-state'
+import {
+  IMPORT_RESULT_STORAGE_KEY,
+  type ImportResultRecord,
+} from '../constants/import-page'
+import type {
+  ChromeMessage,
+  ImportDataChunkMessage,
+  ImportDataInitMessage,
+  ImportDataProcessMessage,
+  MessageResponse,
+} from '../types/messages'
+import type { PopupThemeMode } from './popup/theme'
+import {
+  DEFAULT_POPUP_THEME_MODE,
+  getPopupTheme,
+  resolvePopupThemeVariant,
+} from './popup/theme'
+
+const FILE_CHUNK_SIZE = 5 * 1024 * 1024
+
+type ImportPhase = 'idle' | 'uploading' | 'processing' | 'rebuilding' | 'completed' | 'error'
+
+interface ImportPageProps {
+  initialPopupThemeMode?: PopupThemeMode
+}
+
+const requireSuccessfulResponse = (
+  response: MessageResponse | undefined,
+  fallbackMessage: string
+): void => {
+  if (!response?.success) {
+    throw new Error(response?.error || fallbackMessage)
+  }
+}
+
+const phaseFromOperationState = (state: OperationState): ImportPhase | undefined => {
+  if (state.type === 'import') {
+    return state.phase === 'transfer' ? 'uploading' : 'processing'
+  }
+  if (state.type === 'rebuild' && state.origin === 'import') {
+    return 'rebuilding'
+  }
+  return undefined
+}
+
+const readBlobAsArrayBuffer = (blob: Blob): Promise<ArrayBuffer> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = event => resolve(event.target?.result as ArrayBuffer)
+    reader.onerror = () => reject(reader.error ?? new Error('ファイルを読み込めませんでした'))
+    reader.readAsArrayBuffer(blob)
+  })
+
+export const ImportPage = ({
+  initialPopupThemeMode = DEFAULT_POPUP_THEME_MODE,
+}: ImportPageProps) => {
+  const prefersDarkScheme = useMediaQuery('(prefers-color-scheme: dark)')
+  const theme = getPopupTheme(resolvePopupThemeVariant(initialPopupThemeMode, prefersDarkScheme))
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const importFlowActiveRef = useRef(false)
+  const [phase, setPhase] = useState<ImportPhase>('idle')
+  const [progress, setProgress] = useState(0)
+  const [processed, setProcessed] = useState(0)
+  const [total, setTotal] = useState(0)
+  const [duplicates, setDuplicates] = useState(0)
+  const [imported, setImported] = useState(0)
+  const [status, setStatus] = useState('')
+  const [fileName, setFileName] = useState('')
+
+  const isActive = phase === 'uploading' || phase === 'processing' || phase === 'rebuilding'
+
+  useEffect(() => {
+    chrome.storage.local.get(IMPORT_RESULT_STORAGE_KEY, (result: Record<string, unknown>) => {
+      if (chrome.runtime.lastError) return
+      const stored = result[IMPORT_RESULT_STORAGE_KEY] as ImportResultRecord | undefined
+      if (stored) {
+        setPhase(stored.status)
+        setStatus(stored.message)
+      }
+
+      // Read the active operation after the older persisted result so an
+      // in-flight import always wins if callbacks settle in either order.
+      chrome.runtime.sendMessage({ action: 'getOperationState' }, (response: {
+        operationState?: OperationState
+      }) => {
+        const state = response?.operationState
+        if (!state) return
+        const restoredPhase = phaseFromOperationState(state)
+        if (!restoredPhase) return
+        importFlowActiveRef.current = true
+        setPhase(restoredPhase)
+        setProgress(state.progress ?? 0)
+        setProcessed(state.processed ?? 0)
+        setTotal(state.total ?? 0)
+        setStatus(state.message ?? '')
+      })
+    })
+
+    const handleMessage = (message: ChromeMessage) => {
+      if (message.action === 'importProgress') {
+        importFlowActiveRef.current = true
+        setPhase('processing')
+        setProgress(message.progress)
+        setProcessed(message.processed)
+        setTotal(message.total)
+        setDuplicates(message.duplicates ?? 0)
+        setImported(message.imported ?? 0)
+        setStatus('生データを保存中...')
+      } else if (message.action === 'rebuildProgress' && (
+        importFlowActiveRef.current ||
+        message.message?.includes('インポート')
+      )) {
+        if (message.state === 'started' || message.state === 'processing') {
+          setPhase('rebuilding')
+          setProgress(message.progress ?? 0)
+          setStatus(message.message ?? 'インポート後のデータ再構築中...')
+        } else if (message.state === 'error') {
+          setPhase('error')
+          setStatus(message.message ?? 'インポート後のデータ再構築に失敗しました')
+        }
+      } else if (message.action === 'importStatus') {
+        const failed = message.status.includes('失敗')
+        importFlowActiveRef.current = false
+        setPhase(failed ? 'error' : 'completed')
+        setProgress(failed ? 0 : 100)
+        setStatus(message.status)
+      }
+    }
+
+    chrome.runtime.onMessage.addListener(handleMessage)
+    return () => chrome.runtime.onMessage.removeListener(handleMessage)
+  }, [])
+
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (!file) return
+
+    const fileSizeMB = Math.round(file.size / 1024 / 1024)
+    if (fileSizeMB > 50 && !window.confirm(
+      `ファイルサイズが${fileSizeMB}MBと大きいため、インポートに時間がかかる可能性があります。続行しますか？`
+    )) {
+      event.target.value = ''
+      return
+    }
+
+    setFileName(file.name)
+    importFlowActiveRef.current = true
+    setPhase('uploading')
+    setProgress(0)
+    setProcessed(0)
+    setTotal(0)
+    setDuplicates(0)
+    setImported(0)
+    setStatus('インポートファイル転送中...')
+    try {
+      await chrome.storage.local.remove(IMPORT_RESULT_STORAGE_KEY)
+    } catch (error) {
+      console.warn('[ImportPage] Failed to clear the previous import result:', error)
+    }
+
+    try {
+      const totalChunks = Math.ceil(file.size / FILE_CHUNK_SIZE)
+      const initResponse = await chrome.runtime.sendMessage({
+        action: 'importDataInit',
+        totalChunks,
+        fileName: file.name,
+      } satisfies ImportDataInitMessage) as MessageResponse | undefined
+      requireSuccessfulResponse(initResponse, 'インポートを開始できませんでした')
+
+      const decoder = new TextDecoder()
+      for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
+        const start = chunkIndex * FILE_CHUNK_SIZE
+        const end = Math.min(start + FILE_CHUNK_SIZE, file.size)
+        const chunkBytes = await readBlobAsArrayBuffer(file.slice(start, end))
+        const chunkData = decoder.decode(new Uint8Array(chunkBytes), {
+          stream: chunkIndex < totalChunks - 1,
+        })
+
+        const chunkResponse = await chrome.runtime.sendMessage({
+          action: 'importDataChunk',
+          chunkIndex,
+          chunkData,
+        } satisfies ImportDataChunkMessage) as MessageResponse | undefined
+        requireSuccessfulResponse(chunkResponse, 'インポートデータを送信できませんでした')
+
+        const uploadedChunks = chunkIndex + 1
+        setProcessed(uploadedChunks)
+        setTotal(totalChunks)
+        setProgress(Math.round((uploadedChunks / totalChunks) * 100))
+      }
+
+      setPhase('processing')
+      setProgress(0)
+      setProcessed(0)
+      setTotal(0)
+      setStatus('生データを処理中...')
+
+      const processResponse = await chrome.runtime.sendMessage({
+        action: 'importDataProcess',
+      } satisfies ImportDataProcessMessage) as MessageResponse | undefined
+      requireSuccessfulResponse(processResponse, 'インポートを処理できませんでした')
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      importFlowActiveRef.current = false
+      const result: ImportResultRecord = {
+        status: 'error',
+        message: `インポート失敗: ${message}`,
+        completedAt: Date.now(),
+      }
+      setPhase('error')
+      setProgress(0)
+      setStatus(result.message)
+      try {
+        await chrome.storage.local.set({ [IMPORT_RESULT_STORAGE_KEY]: result })
+      } catch (storageError) {
+        console.warn('[ImportPage] Failed to persist the import transfer error:', storageError)
+      }
+    } finally {
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+  }
+
+  const progressLabel = phase === 'uploading'
+    ? `ファイル転送中... ${processed.toLocaleString()}/${total.toLocaleString()} (${progress}%)`
+    : phase === 'processing'
+      ? `生データを保存中... ${processed.toLocaleString()}/${total.toLocaleString()} (${progress}%)`
+      : status || 'インポート後のデータ再構築中...'
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Box sx={{ maxWidth: 640, mx: 'auto', p: 3 }}>
+        <Paper elevation={3} sx={{ p: 3 }}>
+          <Typography variant="h5" component="h1" sx={{ mb: 1 }}>
+            NDJSONインポート
+          </Typography>
+          <Alert severity="info" sx={{ mb: 2 }}>
+            このタブを開いたままにしてください。拡張機能の通常ポップアップを閉じてもインポートは継続します。
+          </Alert>
+
+          <input
+            type="file"
+            accept=".ndjson"
+            style={{ display: 'none' }}
+            ref={fileInputRef}
+            onChange={handleFileChange}
+          />
+          <Button
+            variant="contained"
+            fullWidth
+            onClick={() => fileInputRef.current?.click()}
+            startIcon={isActive ? <CircularProgress size={20} color="inherit" /> : <FileUpload />}
+            disabled={isActive}
+          >
+            {isActive ? 'インポート中...' : 'NDJSONファイルを選択'}
+          </Button>
+
+          {fileName && (
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+              ファイル: {fileName}
+            </Typography>
+          )}
+
+          {isActive && (
+            <Box sx={{ mt: 2 }}>
+              <LinearProgress
+                variant={phase === 'rebuilding' && progress === 0 ? 'indeterminate' : 'determinate'}
+                value={progress}
+              />
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 1, textAlign: 'center' }}>
+                {progressLabel}
+              </Typography>
+              {phase === 'processing' && imported > 0 && (
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', textAlign: 'center' }}>
+                  新規: {imported.toLocaleString()} / 重複: {duplicates.toLocaleString()}
+                </Typography>
+              )}
+            </Box>
+          )}
+
+          {(phase === 'completed' || phase === 'error') && status && (
+            <Alert severity={phase === 'error' ? 'error' : 'success'} sx={{ mt: 2 }}>
+              {status}
+            </Alert>
+          )}
+        </Paper>
+      </Box>
+    </ThemeProvider>
+  )
+}

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -89,7 +89,6 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
   // back to `false` (no crash) in environments without `window.matchMedia`
   // (e.g. jsdom under Jest).
   const prefersDarkScheme = useMediaQuery('(prefers-color-scheme: dark)')
-  const fileInputRef = useRef<HTMLInputElement>(null)
   const popupThemeChangedByUserRef = useRef(false)
   const uiConfigChangedAfterMountRef = useRef(false)
 
@@ -629,7 +628,6 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
           importDuplicates={importDuplicates}
           importSuccess={importSuccess}
           importStartTime={importStartTime}
-          fileInputRef={fileInputRef}
           setImportStatus={setImportStatus}
           setImportProgress={setImportProgress}
           setImportProcessed={setImportProcessed}

--- a/src/components/popup/ImportExportSection.test.tsx
+++ b/src/components/popup/ImportExportSection.test.tsx
@@ -1,9 +1,8 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { TextDecoder as NodeTextDecoder } from 'util'
-import { useRef, useState } from 'react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ImportExportSection } from './ImportExportSection'
 import { REBUILD_ADVISORY_STORAGE_KEY } from '../../background/rebuild-advisory'
+import { IMPORT_RESULT_STORAGE_KEY } from '../../constants/import-page'
 
 const noop = () => {}
 
@@ -15,7 +14,6 @@ const defaultProps = {
   importDuplicates: 0,
   importSuccess: 0,
   importStartTime: 0,
-  fileInputRef: { current: null },
   setImportStatus: noop,
   setImportProgress: noop,
   setImportProcessed: noop,
@@ -25,27 +23,12 @@ const defaultProps = {
   setImportStartTime: noop,
 }
 
-const ImportStatusHarness = () => {
-  const [importStatus, setImportStatus] = useState('')
-  const fileInputRef = useRef<HTMLInputElement>(null)
-
-  return (
-    <ImportExportSection
-      {...defaultProps}
-      importStatus={importStatus}
-      fileInputRef={fileInputRef}
-      setImportStatus={setImportStatus}
-    />
-  )
-}
-
 describe('ImportExportSection - rebuild advisory banner', () => {
   let storageChangeListeners: Array<(changes: Record<string, any>, areaName: string) => void>
   let storageLocalData: Record<string, any>
   let mockSendMessage: jest.Mock
 
   beforeEach(() => {
-    ;(globalThis as any).TextDecoder = NodeTextDecoder
     storageChangeListeners = []
     storageLocalData = {}
     // Default: respond synchronously with no operationState (mirrors "nothing in
@@ -61,6 +44,7 @@ describe('ImportExportSection - rebuild advisory banner', () => {
       runtime: {
         ...global.chrome.runtime,
         sendMessage: mockSendMessage,
+        getURL: jest.fn(path => `chrome-extension://test/${path}`),
         onMessage: {
           addListener: jest.fn(),
           removeListener: jest.fn(),
@@ -70,9 +54,13 @@ describe('ImportExportSection - rebuild advisory banner', () => {
         ...global.chrome.storage,
         local: {
           get: jest.fn((_keys: any, callback: any) => {
-            callback({ [REBUILD_ADVISORY_STORAGE_KEY]: storageLocalData[REBUILD_ADVISORY_STORAGE_KEY] })
+            callback({
+              [REBUILD_ADVISORY_STORAGE_KEY]: storageLocalData[REBUILD_ADVISORY_STORAGE_KEY],
+              [IMPORT_RESULT_STORAGE_KEY]: storageLocalData[IMPORT_RESULT_STORAGE_KEY],
+            })
           }),
           set: jest.fn(),
+          remove: jest.fn(),
         },
         onChanged: {
           addListener: jest.fn((listener: any) => {
@@ -85,7 +73,12 @@ describe('ImportExportSection - rebuild advisory banner', () => {
         },
       },
       tabs: {
-        query: jest.fn(),
+        query: jest.fn().mockResolvedValue([]),
+        create: jest.fn().mockResolvedValue({}),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      windows: {
+        update: jest.fn().mockResolvedValue({}),
       },
     } as any
   })
@@ -145,67 +138,64 @@ describe('ImportExportSection - rebuild advisory banner', () => {
     })
   })
 
-  it('stops chunk upload and shows the background error when import initialization is rejected', async () => {
-    mockSendMessage.mockImplementation((message: { action?: string }, callback?: (response: unknown) => void) => {
-      if (typeof callback === 'function') {
-        callback({})
-        return undefined
-      }
-      if (message.action === 'importDataInit') {
-        return Promise.resolve({ success: false, error: '別の処理が実行中です' })
-      }
-      return Promise.resolve({ success: true })
+  it('opens the dedicated import page instead of reading a file in the popup', async () => {
+    render(<ImportExportSection {...defaultProps} />)
+
+    await userEvent.click(screen.getByRole('button', { name: '生データをインポート (NDJSON)' }))
+
+    expect(chrome.tabs.create).toHaveBeenCalledWith({
+      url: 'chrome-extension://test/dist/index.html?mode=import',
     })
-
-    const { container } = render(<ImportStatusHarness />)
-    const handleRuntimeMessage = (chrome.runtime.onMessage.addListener as jest.Mock).mock.calls[0][0]
-    act(() => {
-      handleRuntimeMessage({
-        action: 'exportProgress',
-        state: 'completed',
-        format: 'json',
-        message: 'エクスポート完了'
-      })
-    })
-    expect(screen.getByText('エクスポート完了')).toBeInTheDocument()
-
-    const input = container.querySelector('input[type="file"]') as HTMLInputElement
-    const file = new File(['{}'], 'data.ndjson', { type: 'application/x-ndjson' })
-
-    fireEvent.change(input, { target: { files: [file] } })
-
-    expect(await screen.findByText('インポート失敗: 別の処理が実行中です')).toBeInTheDocument()
-    expect(screen.queryByText('エクスポート完了')).not.toBeInTheDocument()
-    const actions = mockSendMessage.mock.calls.map(([message]) => message.action)
-    expect(actions).toContain('importDataInit')
-    expect(actions).not.toContain('importDataChunk')
-    expect(actions).not.toContain('importDataProcess')
   })
 
-  it('preserves a UTF-8 character split across file chunk boundaries', async () => {
-    const uploadedChunks: string[] = []
-    mockSendMessage.mockImplementation((message: { action?: string, chunkData?: string }, callback?: (response: unknown) => void) => {
+  it('focuses an existing import page instead of opening a duplicate tab', async () => {
+    ;(chrome.tabs.query as jest.Mock).mockResolvedValue([{
+      id: 42,
+      windowId: 7,
+      url: 'chrome-extension://test/dist/index.html?mode=import',
+    }])
+    render(<ImportExportSection {...defaultProps} />)
+
+    await userEvent.click(screen.getByRole('button', { name: '生データをインポート (NDJSON)' }))
+
+    expect(chrome.tabs.update).toHaveBeenCalledWith(42, { active: true })
+    expect(chrome.windows.update).toHaveBeenCalledWith(7, { focused: true })
+    expect(chrome.tabs.create).not.toHaveBeenCalled()
+  })
+
+  it('restores an active import transfer and keeps the import page reachable', async () => {
+    mockSendMessage.mockImplementation((message: { action?: string }, callback?: (response: unknown) => void) => {
       if (typeof callback === 'function') {
-        callback({})
-        return undefined
+        callback(message.action === 'getOperationState' ? {
+          operationState: {
+            type: 'import',
+            phase: 'transfer',
+            progress: 50,
+            processed: 1,
+            total: 2,
+            message: 'インポートファイル転送中...',
+          },
+        } : {})
       }
-      if (message.action === 'importDataChunk') uploadedChunks.push(message.chunkData ?? '')
-      return Promise.resolve({ success: true })
     })
+    render(<ImportExportSection {...defaultProps} />)
 
-    const chunkSize = 5 * 1024 * 1024
-    const content = `${'x'.repeat(chunkSize - 1)}あ\n`
-    const { container } = render(<ImportStatusHarness />)
-    const input = container.querySelector('input[type="file"]') as HTMLInputElement
-    const file = new File([content], 'utf8-boundary.ndjson', { type: 'application/x-ndjson' })
+    expect(await screen.findByRole('button', { name: 'インポートページを表示' })).toBeEnabled()
+    expect(screen.getByText(/インポートファイル転送中/)).toBeInTheDocument()
+  })
 
-    fireEvent.change(input, { target: { files: [file] } })
+  it('restores a persisted result after the popup was closed', async () => {
+    const setImportStatus = jest.fn()
+    storageLocalData[IMPORT_RESULT_STORAGE_KEY] = {
+      status: 'completed',
+      message: 'インポートが完了しました (10件のログ)',
+      completedAt: 123,
+    }
+
+    render(<ImportExportSection {...defaultProps} setImportStatus={setImportStatus} />)
 
     await waitFor(() => {
-      expect(mockSendMessage).toHaveBeenCalledWith(expect.objectContaining({ action: 'importDataProcess' }))
+      expect(setImportStatus).toHaveBeenCalledWith('インポートが完了しました (10件のログ)')
     })
-    expect(uploadedChunks).toHaveLength(2)
-    expect(uploadedChunks.join('')).toBe(content)
-    expect(uploadedChunks.join('')).not.toContain('\uFFFD')
   })
 })

--- a/src/components/popup/ImportExportSection.tsx
+++ b/src/components/popup/ImportExportSection.tsx
@@ -4,20 +4,27 @@ import Button from '@mui/material/Button'
 import CircularProgress from '@mui/material/CircularProgress'
 import LinearProgress from '@mui/material/LinearProgress'
 import Typography from '@mui/material/Typography'
-import React, { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { FileDownload, FileUpload } from '@mui/icons-material'
 import type {
   AcknowledgeRebuildAdvisoryMessage,
   ExportDataMessage,
   ExportProgressMessage,
-  ImportDataChunkMessage,
-  ImportDataInitMessage,
-  ImportDataProcessMessage,
-  MessageResponse,
   RebuildProgressMessage,
 } from '../../types/messages'
-import { isExportProgressMessage, isRebuildProgressMessage } from '../../types/messages'
+import {
+  isExportProgressMessage,
+  isImportProgressMessage,
+  isImportStatusMessage,
+  isRebuildProgressMessage,
+} from '../../types/messages'
+import type { OperationState } from '../../background/operation-state'
 import { REBUILD_ADVISORY_STORAGE_KEY, type RebuildAdvisoryState } from '../../background/rebuild-advisory'
+import {
+  getImportPageUrl,
+  IMPORT_RESULT_STORAGE_KEY,
+  type ImportResultRecord,
+} from '../../constants/import-page'
 import { sendMessageWithTimeout } from './send-message'
 
 interface ImportExportSectionProps {
@@ -28,7 +35,6 @@ interface ImportExportSectionProps {
   importDuplicates: number
   importSuccess: number
   importStartTime: number
-  fileInputRef: React.RefObject<HTMLInputElement | null>
   setImportStatus: (status: string) => void
   setImportProgress: (progress: number) => void
   setImportProcessed: (processed: number) => void
@@ -36,17 +42,6 @@ interface ImportExportSectionProps {
   setImportDuplicates: (duplicates: number) => void
   setImportSuccess: (success: number) => void
   setImportStartTime: (time: number) => void
-}
-
-const FILE_CHUNK_SIZE = 5 * 1024 * 1024 // 5MB chunks for file import
-
-const requireSuccessfulResponse = (
-  response: MessageResponse | undefined,
-  fallbackMessage: string
-): void => {
-  if (!response?.success) {
-    throw new Error(response?.error || fallbackMessage)
-  }
 }
 
 type ExportState = 'idle' | 'exporting'
@@ -60,7 +55,6 @@ export const ImportExportSection = ({
   importDuplicates,
   importSuccess,
   importStartTime,
-  fileInputRef,
   setImportStatus,
   setImportProgress,
   setImportProcessed,
@@ -78,16 +72,20 @@ export const ImportExportSection = ({
   const [rebuildProgress, setRebuildProgress] = useState(0)
   const [operationStatus, setOperationStatus] = useState('')
   const [rebuildAdvisoryPending, setRebuildAdvisoryPending] = useState(false)
+  const [importOperationActive, setImportOperationActive] = useState(false)
+  const importOperationActiveRef = useRef(false)
+  const [rebuildOrigin, setRebuildOrigin] = useState<'import' | 'manual' | null>(null)
 
-  const isImporting = importProgress > 0 && importProgress < 100
-  const isAnyOperationInProgress = isImporting || exportState !== 'idle' || rebuildState !== 'idle'
+  const isImporting = importOperationActive && rebuildOrigin !== 'import'
+  const isAnyOperationInProgress = importOperationActive || exportState !== 'idle' || rebuildState !== 'idle'
+  const isOtherOperationInProgress = exportState !== 'idle' || (rebuildState !== 'idle' && rebuildOrigin !== 'import')
 
   // Listen for export/rebuild progress messages and query state on mount
   useEffect(() => {
     // Query current operation state on mount (handles popup close/reopen).
     // Fails open: on timeout/error, leave export/rebuild state at their
     // 'idle' defaults instead of blocking the buttons or showing a spinner.
-    sendMessageWithTimeout<{ operationState?: any }>({ action: 'getOperationState' }).then((response) => {
+    sendMessageWithTimeout<{ operationState?: OperationState }>({ action: 'getOperationState' }).then((response) => {
       if (response?.operationState) {
         const state = response.operationState
         if (state.type === 'export') {
@@ -97,12 +95,25 @@ export const ImportExportSection = ({
           setExportProcessed(state.processed ?? 0)
           setExportTotal(state.total ?? 0)
           setOperationStatus(state.message ?? '')
+        } else if (state.type === 'import') {
+          importOperationActiveRef.current = true
+          setImportOperationActive(true)
+          setImportStatus('')
+          setImportProgress(state.progress ?? 0)
+          setImportProcessed(state.processed ?? 0)
+          setImportTotal(state.total ?? 0)
+          setImportStartTime(Date.now())
+          setOperationStatus(state.message ?? 'インポート中...')
         } else if (state.type === 'rebuild') {
           setRebuildState('rebuilding')
+          setRebuildOrigin(state.origin === 'import' ? 'import' : 'manual')
+          if (state.origin === 'import') {
+            importOperationActiveRef.current = true
+            setImportOperationActive(true)
+          }
           setRebuildProgress(state.progress ?? 0)
           setOperationStatus(state.message ?? '')
         }
-        // Import state is managed by parent Popup.tsx via importProgress messages
       }
     })
 
@@ -143,28 +154,57 @@ export const ImportExportSection = ({
 
       if (isRebuildProgressMessage(message)) {
         const msg = message as RebuildProgressMessage
+        const isImportRebuild = importOperationActiveRef.current || msg.message?.includes('インポート')
         switch (msg.state) {
           case 'started':
             setRebuildState('rebuilding')
+            setRebuildOrigin(isImportRebuild ? 'import' : 'manual')
+            if (isImportRebuild) {
+              importOperationActiveRef.current = true
+              setImportOperationActive(true)
+            }
             setRebuildProgress(0)
             setOperationStatus(msg.message ?? '')
             break
           case 'processing':
             setRebuildState('rebuilding')
+            setRebuildOrigin(isImportRebuild ? 'import' : 'manual')
             setRebuildProgress(msg.progress ?? 0)
             setOperationStatus(msg.message ?? '')
             break
           case 'completed':
             setRebuildState('idle')
+            setRebuildOrigin(null)
             setRebuildProgress(0)
             setOperationStatus(msg.message ?? 'データ再構築完了')
             break
           case 'error':
             setRebuildState('idle')
+            setRebuildOrigin(null)
             setRebuildProgress(0)
             setOperationStatus(msg.message ?? 'データ再構築失敗')
             break
         }
+      }
+
+      if (isImportProgressMessage(message)) {
+        importOperationActiveRef.current = true
+        setImportOperationActive(true)
+        setImportStatus('')
+        setImportProgress(message.progress)
+        setImportProcessed(message.processed)
+        setImportTotal(message.total)
+        setImportDuplicates(message.duplicates ?? 0)
+        setImportSuccess(message.imported ?? 0)
+        setOperationStatus('生データを保存中...')
+      }
+
+      if (isImportStatusMessage(message)) {
+        importOperationActiveRef.current = false
+        setImportOperationActive(false)
+        setRebuildOrigin(null)
+        setImportStatus(message.status)
+        setOperationStatus('')
       }
     }
 
@@ -177,19 +217,30 @@ export const ImportExportSection = ({
   // データ再構築アドバイザリ: マウント時に一度読み込み、以後はstorage変更を購読する
   // （rebuildAllData完了時のresolveAdvisory()によるstorage書き込みでバナーが自動的に消える）
   useEffect(() => {
-    chrome.storage.local.get(REBUILD_ADVISORY_STORAGE_KEY, (result: Record<string, any>) => {
-      if (chrome.runtime.lastError) return
-      const state = result?.[REBUILD_ADVISORY_STORAGE_KEY] as RebuildAdvisoryState | undefined
-      setRebuildAdvisoryPending(!!state?.pendingVersion)
-    })
+    chrome.storage.local.get(
+      [REBUILD_ADVISORY_STORAGE_KEY, IMPORT_RESULT_STORAGE_KEY],
+      (result: Record<string, any>) => {
+        if (chrome.runtime.lastError) return
+        const state = result?.[REBUILD_ADVISORY_STORAGE_KEY] as RebuildAdvisoryState | undefined
+        setRebuildAdvisoryPending(!!state?.pendingVersion)
+        const importResult = result?.[IMPORT_RESULT_STORAGE_KEY] as ImportResultRecord | undefined
+        if (importResult) setImportStatus(importResult.message)
+      }
+    )
 
     const handleStorageChange = (
       changes: { [key: string]: chrome.storage.StorageChange },
       areaName: string
     ) => {
-      if (areaName !== 'local' || !changes[REBUILD_ADVISORY_STORAGE_KEY]) return
-      const newState = changes[REBUILD_ADVISORY_STORAGE_KEY].newValue as RebuildAdvisoryState | undefined
-      setRebuildAdvisoryPending(!!newState?.pendingVersion)
+      if (areaName !== 'local') return
+      if (changes[REBUILD_ADVISORY_STORAGE_KEY]) {
+        const newState = changes[REBUILD_ADVISORY_STORAGE_KEY].newValue as RebuildAdvisoryState | undefined
+        setRebuildAdvisoryPending(!!newState?.pendingVersion)
+      }
+      if (changes[IMPORT_RESULT_STORAGE_KEY]?.newValue) {
+        const importResult = changes[IMPORT_RESULT_STORAGE_KEY].newValue as ImportResultRecord
+        setImportStatus(importResult.message)
+      }
     }
 
     chrome.storage.onChanged.addListener(handleStorageChange)
@@ -228,103 +279,24 @@ export const ImportExportSection = ({
     })
   }, [])
 
-  const handleImportClick = useCallback(() => {
-    fileInputRef.current?.click()
-  }, [fileInputRef])
-
-  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    if (!file) return
-
-    // Show file size warning for large files
-    const fileSizeMB = Math.round(file.size / 1024 / 1024)
-    if (fileSizeMB > 50) {
-      const confirmImport = window.confirm(
-        `ファイルサイズが${fileSizeMB}MBと大きいため、インポートに時間がかかる可能性があります。続行しますか？`
-      )
-      if (!confirmImport) {
-        if (fileInputRef.current) {
-          fileInputRef.current.value = ''
+  const handleImportClick = useCallback(async () => {
+    try {
+      const importPageUrl = getImportPageUrl()
+      const tabs = await chrome.tabs.query({})
+      const existingTab = tabs.find(tab => tab.url === importPageUrl)
+      if (existingTab?.id !== undefined) {
+        await chrome.tabs.update(existingTab.id, { active: true })
+        if (existingTab.windowId !== undefined) {
+          await chrome.windows.update(existingTab.windowId, { focused: true })
         }
         return
       }
-    }
-
-    try {
-      // Start import with progress tracking
-      setImportProgress(0)
-      setImportProcessed(0)
-      setImportTotal(0)
-      setImportDuplicates(0)
-      setImportSuccess(0)
-      setOperationStatus('')
-      setImportStatus('インポート開始...')
-      setImportStartTime(Date.now())
-
-      // For large files, we need to chunk the data before sending
-      const totalChunks = Math.ceil(file.size / FILE_CHUNK_SIZE)
-
-      // Initialize import session
-      const initResponse = await chrome.runtime.sendMessage({
-        action: 'importDataInit',
-        totalChunks: totalChunks,
-        fileName: file.name
-      } satisfies ImportDataInitMessage) as MessageResponse | undefined
-      requireSuccessfulResponse(initResponse, 'インポートを開始できませんでした')
-
-      // Read and send file in chunks
-      // Keep one decoder alive across Blob boundaries. `Blob.slice()` uses byte
-      // offsets, so decoding every 5 MiB slice independently can split a UTF-8
-      // code point (for example, a Japanese player name) and silently replace
-      // both halves with U+FFFD before the background joins the chunks.
-      const decoder = new TextDecoder()
-      for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
-        const start = chunkIndex * FILE_CHUNK_SIZE
-        const end = Math.min(start + FILE_CHUNK_SIZE, file.size)
-        const chunk = file.slice(start, end)
-        
-        const chunkBytes = await new Promise<ArrayBuffer>((resolve, reject) => {
-          const reader = new FileReader()
-          reader.onload = (e) => resolve(e.target?.result as ArrayBuffer)
-          reader.onerror = reject
-          reader.readAsArrayBuffer(chunk)
-        })
-        const chunkContent = decoder.decode(new Uint8Array(chunkBytes), {
-          stream: chunkIndex < totalChunks - 1
-        })
-
-        // Send chunk to background
-        const chunkResponse = await chrome.runtime.sendMessage({
-          action: 'importDataChunk',
-          chunkIndex: chunkIndex,
-          chunkData: chunkContent
-        } satisfies ImportDataChunkMessage) as MessageResponse | undefined
-        requireSuccessfulResponse(chunkResponse, 'インポートデータを送信できませんでした')
-
-        // Update progress
-        const fileProgress = Math.round(((chunkIndex + 1) / totalChunks) * 100)
-        setImportProgress(fileProgress)
-      }
-
-      // Process the complete data
-      const processResponse = await chrome.runtime.sendMessage({
-        action: 'importDataProcess'
-      } satisfies ImportDataProcessMessage) as MessageResponse | undefined
-      requireSuccessfulResponse(processResponse, 'インポートを処理できませんでした')
-
-      if (fileInputRef.current) {
-        fileInputRef.current.value = ''
-      }
+      await chrome.tabs.create({ url: importPageUrl })
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      setOperationStatus('')
-      setImportStatus(`インポート失敗: ${message}`)
-      setImportProgress(0)
-      if (fileInputRef.current) {
-        fileInputRef.current.value = ''
-      }
+      console.error('Failed to open the NDJSON import page:', error)
+      setImportStatus('インポートページを開けませんでした。もう一度お試しください。')
     }
-  }
+  }, [])
 
   const handleRebuildClick = useCallback(() => {
     if (window.confirm('データを再構築しますか？この処理には時間がかかる場合があります。')) {
@@ -345,7 +317,7 @@ export const ImportExportSection = ({
   }, [])
 
   // Determine status display
-  const displayStatus = operationStatus || importStatus
+  const displayStatus = isAnyOperationInProgress ? '' : operationStatus || importStatus
   const isStatusError = displayStatus.includes('失敗') || displayStatus.includes('エラー')
 
   return (
@@ -425,14 +397,6 @@ export const ImportExportSection = ({
         </Box>
       )}
 
-      <input
-        type="file"
-        accept=".ndjson"
-        style={{ display: 'none' }}
-        ref={fileInputRef}
-        onChange={handleFileChange}
-      />
-
       <Button
         variant="outlined"
         color="primary"
@@ -443,7 +407,7 @@ export const ImportExportSection = ({
             ? <CircularProgress size={20} color="inherit" />
             : <FileUpload />
         }
-        disabled={isAnyOperationInProgress}
+        disabled={isOtherOperationInProgress}
         sx={{
           marginBottom: '10px',
           '&.Mui-disabled': {
@@ -451,7 +415,7 @@ export const ImportExportSection = ({
           }
         }}
       >
-        {isImporting ? 'インポート中...' : '生データをインポート (NDJSON)'}
+        {importOperationActive ? 'インポートページを表示' : '生データをインポート (NDJSON)'}
       </Button>
 
       {isImporting && (
@@ -462,7 +426,7 @@ export const ImportExportSection = ({
             color="textSecondary"
             style={{ marginTop: '5px', textAlign: 'center' }}
           >
-            インポート中... {importProcessed.toLocaleString()}/{importTotal.toLocaleString()} ({importProgress}%)
+            {operationStatus || 'インポート中...'} {importProcessed.toLocaleString()}/{importTotal.toLocaleString()} ({importProgress}%)
           </Typography>
           {importSuccess > 0 && (
             <Typography

--- a/src/constants/import-page.test.ts
+++ b/src/constants/import-page.test.ts
@@ -1,0 +1,12 @@
+import { isImportPageSearch } from './import-page'
+
+describe('isImportPageSearch', () => {
+  test.each([
+    ['?mode=import', true],
+    ['?mode=import&source=popup', true],
+    ['', false],
+    ['?mode=settings', false],
+  ])('returns %s for %s', (search, expected) => {
+    expect(isImportPageSearch(search)).toBe(expected)
+  })
+})

--- a/src/constants/import-page.ts
+++ b/src/constants/import-page.ts
@@ -1,0 +1,14 @@
+export const IMPORT_PAGE_MODE = 'import'
+export const IMPORT_RESULT_STORAGE_KEY = 'lastImportResult'
+
+export interface ImportResultRecord {
+  status: 'completed' | 'error'
+  message: string
+  completedAt: number
+}
+
+export const getImportPageUrl = (): string =>
+  chrome.runtime.getURL(`dist/index.html?mode=${IMPORT_PAGE_MODE}`)
+
+export const isImportPageSearch = (search: string): boolean =>
+  new URLSearchParams(search).get('mode') === IMPORT_PAGE_MODE

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,6 +1,8 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import Popup, { type PopupProps } from './components/Popup'
+import { ImportPage } from './components/ImportPage'
+import { isImportPageSearch } from './constants/import-page'
 import { loadCachedPopupThemeMode } from './components/popup/popup-theme-storage'
 
 // Render synchronously from the local theme mirror. Waiting for
@@ -8,5 +10,15 @@ import { loadCachedPopupThemeMode } from './components/popup/popup-theme-storage
 // on the extension-icon-click -> first-content critical path. Popup reconciles
 // this startup hint with the authoritative sync value after mount.
 const initialPopupThemeMode = loadCachedPopupThemeMode()
+const isImportPage = isImportPageSearch(window.location.search)
+if (isImportPage) {
+  document.body.style.width = 'auto'
+  document.body.style.minHeight = '100vh'
+  document.title = 'PokerChase HUD - NDJSONインポート'
+}
 const root = createRoot(document.getElementById('popup-root')!)
-root.render(React.createElement<PopupProps>(Popup, { initialPopupThemeMode }))
+root.render(
+  isImportPage
+    ? React.createElement(ImportPage, { initialPopupThemeMode })
+    : React.createElement<PopupProps>(Popup, { initialPopupThemeMode })
+)

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -18,6 +18,7 @@ export const MESSAGE_ACTIONS = {
   IMPORT_DATA_INIT: 'importDataInit',
   IMPORT_DATA_CHUNK: 'importDataChunk',
   IMPORT_DATA_PROCESS: 'importDataProcess',
+  IMPORT_DATA_CANCEL: 'importDataCancel',
   // Firebase Backup
   FIREBASE_AUTH_STATUS: 'firebaseAuthStatus',
   FIREBASE_SIGN_IN: 'firebaseSignIn',
@@ -104,6 +105,10 @@ export interface ImportDataChunkMessage {
 
 export interface ImportDataProcessMessage {
   action: 'importDataProcess'
+}
+
+export interface ImportDataCancelMessage {
+  action: 'importDataCancel'
 }
 
 // Filter related messages
@@ -387,6 +392,7 @@ export type ChromeMessage =
   | ImportDataInitMessage
   | ImportDataChunkMessage
   | ImportDataProcessMessage
+  | ImportDataCancelMessage
   | UpdateBattleTypeFilterMessage
   | RequestLatestStatsMessage
   | LatestStatsMessage
@@ -447,6 +453,9 @@ export const isImportDataChunkMessage = (msg: unknown): msg is ImportDataChunkMe
 
 export const isImportDataProcessMessage = (msg: unknown): msg is ImportDataProcessMessage =>
   isMessageWithAction(msg, 'importDataProcess')
+
+export const isImportDataCancelMessage = (msg: unknown): msg is ImportDataCancelMessage =>
+  isMessageWithAction(msg, 'importDataCancel')
 
 export const isUpdateBattleTypeFilterMessage = (msg: unknown): msg is UpdateBattleTypeFilterMessage =>
   isMessageWithAction(msg, 'updateBattleTypeFilter')


### PR DESCRIPTION
## Root cause

The Chrome action popup owned the entire NDJSON file read and 5 MiB chunk upload. Chrome destroys that document when the popup closes, so closing it during transfer stopped the upload and left the background import session to time out. The popup also restored export/rebuild operation state, but not import state.

## Changes

- Reuse `dist/index.html?mode=import` as a dedicated extension-owned import tab.
- Open or focus that tab from the normal popup to avoid duplicate import tabs.
- Keep file selection, UTF-8-safe chunk decoding, upload, processing progress, and post-import rebuild progress on the dedicated page.
- Restore import transfer, processing, and import-origin rebuild phases from `getOperationState`.
- Persist the terminal import success/error summary in `chrome.storage.local` so reopening either UI can show what happened while the action popup was closed.
- Preserve the existing background exclusivity, Raw Event Lake storage, deduplication, import, and canonical rebuild semantics.
- Document the popup-safe import lifecycle in `AGENTS.md`.

## Impact

Closing the action popup no longer interrupts an NDJSON import. The dedicated import tab must remain open while it reads and transfers the selected local file; it explains this requirement in the UI. Export, manual rebuild, sync, delete, and forced-update safety continue to use the same shared background operation slot.

## Validation

- `npm run test -- --runInBand` — 141 suites, 1410 tests passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `git diff --check` — passed
- `npm run verify-stats` — not run; this change does not alter statistics or entity derivation