### PR TITLE
[codex] Generalize diagnostic copy in popup

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,61 @@
+# Privacy Policy — PokerChase HUD
+
+Last updated: July 30, 2026
+
+PokerChase HUD is an unofficial Chrome extension that displays poker statistics
+and manages hand history for PokerChase. This policy describes the data handled
+by the extension and the optional external services it uses.
+
+## Data stored locally
+
+The extension stores intercepted PokerChase game events, derived statistics,
+hand history, settings, and UI layout in the browser profile. This data remains
+local unless the user enables cloud backup or diagnostic reporting.
+
+Local data is retained until the user clears the extension's storage or
+uninstalls the extension.
+
+## Optional cloud backup
+
+When the user signs in and uses cloud backup, the extension uses Google
+authentication and Firebase to associate and synchronize game events with that
+account. The data is used only to restore and synchronize the user's HUD data.
+Signing out or uninstalling the extension does not automatically delete an
+existing cloud backup.
+
+## Optional diagnostic reporting
+
+Diagnostic reporting is disabled by default. If the user enables it, diagnostic
+information is sent to Sentry, an external error-monitoring service operated by
+Functional Software, Inc. The information is used to detect failures, diagnose
+compatibility changes, and improve extension reliability.
+
+General error reports may include the extension version, execution context,
+operation tags, error messages, and stack traces. When an API schema change is
+detected, a bounded semantic snapshot of the affected game event may also be
+sent. Direct player identifiers are pseudonymized before transmission, and
+player names, chat content, credentials, authentication tokens, and the
+byte-for-byte raw event are excluded. The client sends a non-routable placeholder
+IP address, and the monitoring project also has data and IP-address scrubbing
+enabled.
+
+Diagnostic events are retained according to the monitoring project's configured
+retention period and are not used for advertising.
+
+## Sharing and sale
+
+Data is shared only with Google/Firebase when the user uses cloud backup and
+with Sentry when the user opts in to diagnostic reporting. PokerChase HUD does
+not sell personal data or use it for advertising.
+
+## Access and deletion requests
+
+Users can delete local data by clearing the extension's storage or uninstalling
+the extension. For access or deletion requests concerning cloud backups or
+diagnostic reports, use the support contact published on the PokerChase HUD
+Chrome Web Store listing. Do not include private game data in a public issue.
+
+## Changes
+
+Material changes to this policy will be published in this repository and
+described in the corresponding GitHub Release.

--- a/docs/chrome-web-store-release.md
+++ b/docs/chrome-web-store-release.md
@@ -24,7 +24,7 @@ Before submitting a telemetry-enabled release:
    個人識別子を仮名化した対局イベント値）を、信頼性改善とAPI変更への追従目的で
    Sentry へ送信することを明示する。
 2. 既存ユーザーにも更新情報でデータ取扱いの変更を明示する。実際の送信は
-   Popup の **Sentryへエラー診断を送信** をユーザーが有効にし、Chrome の
+   Popup の **診断情報を送信** をユーザーが有効にし、Chrome の
    optional host permissionを許可した後だけ開始する。
 3. 公開中の privacy policy に収集項目、用途、Sentry への送信、保持・削除方針を
    反映し、Developer Dashboard の専用 URL 欄から到達できることを確認する。

--- a/docs/chrome-web-store-release.md
+++ b/docs/chrome-web-store-release.md
@@ -26,8 +26,10 @@ Before submitting a telemetry-enabled release:
 2. 既存ユーザーにも更新情報でデータ取扱いの変更を明示する。実際の送信は
    Popup の **診断情報を送信** をユーザーが有効にし、Chrome の
    optional host permissionを許可した後だけ開始する。
-3. 公開中の privacy policy に収集項目、用途、Sentry への送信、保持・削除方針を
-   反映し、Developer Dashboard の専用 URL 欄から到達できることを確認する。
+3. 公開中の [privacy policy](../PRIVACY.md) に収集項目、用途、Sentry への送信、
+   保持・削除方針を反映し、Developer Dashboard の専用 URL 欄と Popup の
+   診断情報セクションから到達できることを確認する。公開 URL は
+   `https://github.com/solavrc/pokerchase-hud/blob/main/PRIVACY.md` とする。
 4. repository secret `SENTRY_AUTH_TOKEN` が、個人 OAuth token ではなく
    最小権限の Sentry organization token（CI/source-map upload 用）であることを
    確認する。

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -5,7 +5,7 @@ PokerChase HUD uses the dedicated
 Sentry project for production error detection.
 
 Sentry is initialized in the background service worker, content script, and
-popup only after the user enables **Sentryへエラー診断を送信** in the popup.
+popup only after the user enables **診断情報を送信** in the popup.
 Enabling it grants the Sentry ingest origin as an optional host permission;
 existing installations are not disabled during an extension update.
 Revoking that permission in Chrome settings clears the shared consent bit and

--- a/src/components/popup/TelemetrySection.test.tsx
+++ b/src/components/popup/TelemetrySection.test.tsx
@@ -31,7 +31,13 @@ describe('TelemetrySection', () => {
     await waitFor(() => expect(toggle).toBeEnabled())
     expect(screen.getByText('診断情報')).toBeInTheDocument()
     expect(container).toHaveTextContent(
-      /不具合の調査に必要な情報を送信します。APIの変更を検知した場合は、\s*プレイヤー識別子・名前・チャットを除いた対局イベントも含まれます。/
+      /不具合の調査に必要な診断情報は、外部のエラー監視サービスへ送信されます。\s*APIの変更を検知した場合は、プレイヤー識別子・名前・チャットを除いた\s*対局イベントも含まれます。/
+    )
+    expect(
+      screen.getByRole('link', { name: 'プライバシーポリシー' })
+    ).toHaveAttribute(
+      'href',
+      'https://github.com/solavrc/pokerchase-hud/blob/main/PRIVACY.md'
     )
     expect(container).not.toHaveTextContent(/Sentry/i)
     expect(toggle).not.toBeChecked()

--- a/src/components/popup/TelemetrySection.test.tsx
+++ b/src/components/popup/TelemetrySection.test.tsx
@@ -23,12 +23,17 @@ describe('TelemetrySection', () => {
 
   it('does not enable telemetry until the user grants the optional host permission', async () => {
     const user = userEvent.setup()
-    render(<TelemetrySection />)
+    const { container } = render(<TelemetrySection />)
 
     const toggle = await screen.findByRole('switch', {
-      name: 'Sentryへエラー診断を送信'
+      name: '診断情報を送信'
     })
     await waitFor(() => expect(toggle).toBeEnabled())
+    expect(screen.getByText('診断情報')).toBeInTheDocument()
+    expect(container).toHaveTextContent(
+      /不具合の調査に必要な情報を送信します。APIの変更を検知した場合は、\s*プレイヤー識別子・名前・チャットを除いた対局イベントも含まれます。/
+    )
+    expect(container).not.toHaveTextContent(/Sentry/i)
     expect(toggle).not.toBeChecked()
 
     await user.click(toggle)
@@ -40,16 +45,27 @@ describe('TelemetrySection', () => {
   it('keeps telemetry disabled when Chrome denies the permission request', async () => {
     jest.mocked(requestSentryTelemetry).mockResolvedValue(false)
     const user = userEvent.setup()
-    render(<TelemetrySection />)
+    const { container } = render(<TelemetrySection />)
 
     const toggle = await screen.findByRole('switch', {
-      name: 'Sentryへエラー診断を送信'
+      name: '診断情報を送信'
     })
     await waitFor(() => expect(toggle).toBeEnabled())
     await user.click(toggle)
 
-    await screen.findByText('Sentryへの送信権限が許可されませんでした。')
+    await screen.findByText('診断情報の送信が許可されませんでした。')
+    expect(container).not.toHaveTextContent(/Sentry/i)
     expect(toggle).not.toBeChecked()
+  })
+
+  it('reports a generic error when the diagnostic setting cannot be loaded', async () => {
+    jest.mocked(readSentryTelemetryEnabled).mockRejectedValue(
+      new Error('storage unavailable')
+    )
+    const { container } = render(<TelemetrySection />)
+
+    await screen.findByText('診断情報の設定を読み込めませんでした。')
+    expect(container).not.toHaveTextContent(/Sentry/i)
   })
 
   it('revokes telemetry when an enabled user switches it off', async () => {
@@ -58,7 +74,7 @@ describe('TelemetrySection', () => {
     render(<TelemetrySection />)
 
     const toggle = await screen.findByRole('switch', {
-      name: 'Sentryへエラー診断を送信'
+      name: '診断情報を送信'
     })
     await waitFor(() => expect(toggle).toBeChecked())
     await user.click(toggle)
@@ -75,15 +91,16 @@ describe('TelemetrySection', () => {
       new Error('mirror write failed')
     )
     const user = userEvent.setup()
-    render(<TelemetrySection />)
+    const { container } = render(<TelemetrySection />)
 
     const toggle = await screen.findByRole('switch', {
-      name: 'Sentryへエラー診断を送信'
+      name: '診断情報を送信'
     })
     await waitFor(() => expect(toggle).toBeChecked())
     await user.click(toggle)
 
-    await screen.findByText('エラー診断の設定を更新できませんでした。')
+    await screen.findByText('診断情報の設定を更新できませんでした。')
+    expect(container).not.toHaveTextContent(/Sentry/i)
     await waitFor(() => expect(toggle).not.toBeChecked())
     expect(readSentryTelemetryEnabled).toHaveBeenCalledTimes(2)
   })

--- a/src/components/popup/TelemetrySection.tsx
+++ b/src/components/popup/TelemetrySection.tsx
@@ -1,5 +1,6 @@
 import Alert from '@mui/material/Alert'
 import FormControlLabel from '@mui/material/FormControlLabel'
+import Link from '@mui/material/Link'
 import Switch from '@mui/material/Switch'
 import Typography from '@mui/material/Typography'
 import { useEffect, useState, type ChangeEvent } from 'react'
@@ -8,6 +9,9 @@ import {
   requestSentryTelemetry,
   revokeSentryTelemetry
 } from '../../observability/telemetry-consent'
+
+const PRIVACY_POLICY_URL =
+  'https://github.com/solavrc/pokerchase-hud/blob/main/PRIVACY.md'
 
 export const TelemetrySection = () => {
   const [enabled, setEnabled] = useState(false)
@@ -81,8 +85,16 @@ export const TelemetrySection = () => {
         color="text.secondary"
         sx={{ display: 'block' }}
       >
-        不具合の調査に必要な情報を送信します。APIの変更を検知した場合は、
-        プレイヤー識別子・名前・チャットを除いた対局イベントも含まれます。
+        不具合の調査に必要な診断情報は、外部のエラー監視サービスへ送信されます。
+        APIの変更を検知した場合は、プレイヤー識別子・名前・チャットを除いた
+        対局イベントも含まれます。{' '}
+        <Link
+          href={PRIVACY_POLICY_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          プライバシーポリシー
+        </Link>
       </Typography>
       {error && (
         <Alert severity="error" sx={{ mt: 1 }}>

--- a/src/components/popup/TelemetrySection.tsx
+++ b/src/components/popup/TelemetrySection.tsx
@@ -21,7 +21,7 @@ export const TelemetrySection = () => {
         if (!cancelled) setEnabled(value)
       })
       .catch(() => {
-        if (!cancelled) setError('エラー診断の設定を読み込めませんでした。')
+        if (!cancelled) setError('診断情報の設定を読み込めませんでした。')
       })
       .finally(() => {
         if (!cancelled) setPending(false)
@@ -43,7 +43,7 @@ export const TelemetrySection = () => {
         const granted = await requestSentryTelemetry()
         setEnabled(granted)
         if (!granted) {
-          setError('Sentryへの送信権限が許可されませんでした。')
+          setError('診断情報の送信が許可されませんでした。')
         }
       } else {
         await revokeSentryTelemetry()
@@ -55,7 +55,7 @@ export const TelemetrySection = () => {
       } catch {
         // Keep the last rendered state if even reconciliation is unavailable.
       }
-      setError('エラー診断の設定を更新できませんでした。')
+      setError('診断情報の設定を更新できませんでした。')
     } finally {
       setPending(false)
     }
@@ -64,7 +64,7 @@ export const TelemetrySection = () => {
   return (
     <>
       <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
-        エラー診断
+        診断情報
       </Typography>
       <FormControlLabel
         control={
@@ -74,15 +74,15 @@ export const TelemetrySection = () => {
             onChange={handleChange}
           />
         }
-        label="Sentryへエラー診断を送信"
+        label="診断情報を送信"
       />
       <Typography
         variant="caption"
         color="text.secondary"
         sx={{ display: 'block' }}
       >
-        クラッシュ情報を送信します。API変更を検知した場合は、
-        プレイヤー識別子・名前・チャットを除いた対局イベントも送信します。
+        不具合の調査に必要な情報を送信します。APIの変更を検知した場合は、
+        プレイヤー識別子・名前・チャットを除いた対局イベントも含まれます。
       </Typography>
       {error && (
         <Alert severity="error" sx={{ mt: 1 }}>


### PR DESCRIPTION
## Summary

- replace Sentry-specific Popup wording with general 「診断情報」 labels
- preserve an accurate disclosure of what is sent and which player data is excluded
- keep backend implementation terminology intact while synchronizing documentation that quotes the Popup label
- assert that the Sentry provider name is absent from user-facing DOM in normal and error states

## User impact

The diagnostics opt-in now describes the feature in provider-neutral language without changing consent, permissions, payloads, or privacy behavior.

## Validation

- `npm run test -- --runInBand src/components/popup/TelemetrySection.test.tsx`
- `npm run test`
- `npm run typecheck`
- `npm run build`
