### PR TITLE
refactor(ui): HandLogレイアウトを単一状態機械へ再構築

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -461,6 +461,20 @@ See individual files in `src/utils/` for implementation details.
 
 Components are modularized with feature-specific sub-components in `hud/` and `popup/` directories.
 
+**Hand-log layout lifecycle**: `HandLog.tsx` owns movement, resizing, scale,
+viewport dimensions, async device-layout loading, normalization, and
+persistence in one component-local state machine. The machine's concrete
+`HandLogLayout` is the only rendered layout source. Every input enters through
+`transitionHandLogLayout()`, which keeps a new viewport/scale pending during an
+active pointer interaction, rejects layout-load callbacks bound to an older
+request or scale, and emits at most one persistence effect from the common
+interaction exit. Do not add another effect/ref that mutates or saves hand-log
+coordinates outside that transition outlet. The header is the move handle; the
+lower-right corner is resize-only. Normalization keeps the full vertical panel
+and a usable horizontal portion of the header reachable, caps height to the
+scaled viewport, and applies to loaded, default, reset, external, pointer, and
+viewport/scale-driven layouts.
+
 **Popup theming**: `src/components/popup/theme.ts` defines two MUI themes -- `dark-felt` (default look, shares the HUD overlay's dark/gold palette) and `modern-light`. Which one renders is controlled by the `popupTheme` setting (`'auto' | 'dark' | 'light'`, default `'auto'`; テーマ control in `PopupHeader.tsx`, a 自動/ダーク/ライト 3-way `SegmentRadio`). `'auto'` resolves against the live OS `prefers-color-scheme` via `useMediaQuery` in `Popup.tsx` (`resolvePopupThemeVariant()` in `theme.ts` is the pure resolver, unit-tested independent of the DOM). Persisted to its own `chrome.storage.sync` key (`popupTheme`, see `popup-theme-storage.ts`) -- deliberately **not** a field on `UIConfig`, because `UIScaleSection`/`HudDisplaySection` broadcast every `uiConfig` write to all open game tabs (`chrome.tabs.sendMessage(..., 'updateUIConfig')`) to trigger a HUD re-render; the popup's own chrome has nothing to do with the HUD overlay, so nesting it there would fire that broadcast on every theme change for no reason. `popup.ts` pre-fetches the persisted mode before the first `render()` call so the popup never paints with the wrong theme and then swaps.
 
 ## Statistics System

--- a/src/components/HandLog.test.tsx
+++ b/src/components/HandLog.test.tsx
@@ -39,6 +39,30 @@ const mockChromeRuntimeSendMessage = chrome.runtime.sendMessage as jest.Mock
 const moveMouseWithPrimaryButton = (clientX: number, clientY: number) => {
   fireEvent.mouseMove(document, { buttons: 1, clientX, clientY })
 }
+const setViewport = (width: number, height: number) => {
+  Object.defineProperty(window, 'innerWidth', {
+    value: width,
+    writable: true,
+    configurable: true,
+  })
+  Object.defineProperty(window, 'innerHeight', {
+    value: height,
+    writable: true,
+    configurable: true,
+  })
+}
+const updateLayout = (layout: {
+  left: number
+  top: number
+  width: number
+  height: number
+}) => {
+  fireEvent(window, new CustomEvent('updateHandLogLayout', { detail: layout }))
+}
+const savedLayoutCalls = () =>
+  mockChromeRuntimeSendMessage.mock.calls.filter(
+    ([message]) => message.action === 'setDeviceHandLogLayout'
+  )
 
 describe('HandLog', () => {
   const mockEntries: HandLogEntry[] = [
@@ -76,6 +100,7 @@ describe('HandLog', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    setViewport(1024, 768)
     mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
       if (message.action === 'getDeviceHandLogLayout') {
         callback({ success: true })
@@ -168,47 +193,69 @@ describe('HandLog', () => {
     expect(logContainer.style.height).toBe(`${DEFAULT_HAND_LOG_CONFIG.height}px`)
   })
 
-  it('HUDと重なっても右下gripを掴めるstacking順を維持する', () => {
+  it('HUDと重なってもヘッダーとリサイズ角を掴めるstacking順を維持する', () => {
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
 
     expect(Number(logContainer.style.zIndex)).toBeGreaterThan(9999)
-    expect(screen.getByTestId('hand-log-move-grip')).toBeInTheDocument()
+    expect(screen.getByTestId('hand-log-header')).toBeInTheDocument()
+    expect(screen.getByTestId('hand-log-resize-corner')).toBeInTheDocument()
+    expect(screen.queryByTestId('hand-log-move-grip')).not.toBeInTheDocument()
   })
 
-  it('右下グリップの本体をドラッグして移動し端末ローカルへ保存する', () => {
+  it('ヘッダーをドラッグして移動し端末ローカルへ一度だけ保存する', () => {
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
-    logContainer.getBoundingClientRect = jest.fn(() => ({
-      left: 500,
-      top: 400,
-      width: 400,
-      height: 100,
-      right: 900,
-      bottom: 500,
-      x: 500,
-      y: 400,
-      toJSON: () => {},
-    }))
+    updateLayout({ left: 500, top: 400, width: 400, height: 100 })
 
-    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
+    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
       button: 0,
-      clientX: 880,
-      clientY: 480,
+      clientX: 600,
+      clientY: 414,
     })
-    moveMouseWithPrimaryButton(830, 450)
+    moveMouseWithPrimaryButton(550, 384)
 
     expect(logContainer.style.left).toBe('450px')
     expect(logContainer.style.top).toBe('370px')
 
     fireEvent.mouseUp(document)
-    expect(mockChromeRuntimeSendMessage).toHaveBeenCalledWith(
-      {
-        action: 'setDeviceHandLogLayout',
-        layout: { left: 450, top: 370, width: 400, height: 100 },
-      },
-      expect.any(Function)
-    )
+    expect(savedLayoutCalls()).toEqual([
+      [
+        {
+          action: 'setDeviceHandLogLayout',
+          layout: { left: 450, top: 370, width: 400, height: 100 },
+        },
+        expect.any(Function),
+      ],
+    ])
+  })
+
+  it('本文からは移動を開始しない', () => {
+    const { container } = render(<HandLog entries={mockEntries} />)
+    const logContainer = container.firstChild as HTMLElement
+
+    fireEvent.mouseDown(screen.getByTestId('virtual-list'), {
+      button: 0,
+      clientX: 700,
+      clientY: 580,
+    })
+    moveMouseWithPrimaryButton(650, 550)
+    fireEvent.mouseUp(document)
+
+    expect(logContainer.style.left).toBe('614px')
+    expect(logContainer.style.top).toBe('533px')
+    expect(savedLayoutCalls()).toHaveLength(0)
+  })
+
+  it('ヘッダーとリサイズ角のdouble-clickでログを誤消去しない', async () => {
+    const user = userEvent.setup()
+    render(<HandLog entries={mockEntries} onClearLog={mockOnClearLog} />)
+
+    await user.dblClick(screen.getByTestId('hand-log-header'))
+    await user.dblClick(screen.getByTestId('hand-log-resize-corner'))
+
+    expect(mockOnClearLog).not.toHaveBeenCalled()
+    expect(mockWriteText).not.toHaveBeenCalled()
   })
 
   it('ドラッグ開始後に届いた古い保存layoutで移動を巻き戻さない', () => {
@@ -222,24 +269,13 @@ describe('HandLog', () => {
     })
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
-    logContainer.getBoundingClientRect = jest.fn(() => ({
-      left: 500,
-      top: 400,
-      width: 400,
-      height: 100,
-      right: 900,
-      bottom: 500,
-      x: 500,
-      y: 400,
-      toJSON: () => {},
-    }))
 
-    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
+    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
       button: 0,
-      clientX: 880,
-      clientY: 480,
+      clientX: 700,
+      clientY: 540,
     })
-    moveMouseWithPrimaryButton(830, 450)
+    moveMouseWithPrimaryButton(650, 510)
     act(() => {
       resolveInitialLoad({
         success: true,
@@ -247,15 +283,15 @@ describe('HandLog', () => {
       })
     })
 
-    expect(logContainer.style.left).toBe('450px')
-    expect(logContainer.style.top).toBe('370px')
+    expect(logContainer.style.left).toBe('564px')
+    expect(logContainer.style.top).toBe('503px')
     fireEvent.mouseUp(document)
   })
 
   it.each([
-    { testId: 'hand-log-move-grip', startX: 880, startY: 480 },
-    { testId: 'hand-log-resize-corner', startX: 900, startY: 500 },
-  ])('gripの微小jitterでは遅れて届いた保存layoutを無効化しない', ({
+    { testId: 'hand-log-header', startX: 700, startY: 540 },
+    { testId: 'hand-log-resize-corner', startX: 1014, startY: 633 },
+  ])('操作の微小jitterでは遅れて届いた保存layoutを無効化しない', ({
     testId,
     startX,
     startY,
@@ -270,24 +306,12 @@ describe('HandLog', () => {
     })
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
-    logContainer.getBoundingClientRect = jest.fn(() => ({
-      left: 500,
-      top: 400,
-      width: 400,
-      height: 100,
-      right: 900,
-      bottom: 500,
-      x: 500,
-      y: 400,
-      toJSON: () => {},
-    }))
 
     fireEvent.mouseDown(screen.getByTestId(testId), {
       button: 0,
       clientX: startX,
       clientY: startY,
     })
-    moveMouseWithPrimaryButton(startX, startY)
     moveMouseWithPrimaryButton(startX + 2, startY + 2)
     fireEvent.mouseUp(document)
     act(() => {
@@ -300,53 +324,219 @@ describe('HandLog', () => {
     expect(logContainer.style.left).toBe('120px')
     expect(logContainer.style.top).toBe('80px')
     expect(logContainer.style.width).toBe('520px')
-    expect(mockChromeRuntimeSendMessage).not.toHaveBeenCalledWith(
-      expect.objectContaining({ action: 'setDeviceHandLogLayout' }),
-      expect.any(Function)
-    )
+    expect(savedLayoutCalls()).toHaveLength(0)
   })
 
-  it('移動中だけ右下グリップが画面外へ消えないようにする', () => {
+  it('旧レイアウトの負値topを読んでもヘッダーを画面内へ復帰させる', () => {
+    mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
+      if (message.action === 'getDeviceHandLogLayout') {
+        callback({
+          success: true,
+          layout: { left: 200, top: -72, width: 400, height: 100 },
+        })
+      } else {
+        callback?.({ success: true })
+      }
+    })
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
-    logContainer.getBoundingClientRect = jest.fn(() => ({
-      left: 500,
-      top: 400,
-      width: 400,
-      height: 100,
-      right: 900,
-      bottom: 500,
-      x: 500,
-      y: 400,
-      toJSON: () => {},
-    }))
 
-    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
+    expect(logContainer.style.top).toBe('0px')
+    expect(screen.getByTestId('hand-log-header')).toBeInTheDocument()
+  })
+
+  it('画面高を超える保存heightを上限へ戻しリサイズ角を画面内へ復帰させる', () => {
+    mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
+      if (message.action === 'getDeviceHandLogLayout') {
+        callback({
+          success: true,
+          layout: { left: 100, top: 400, width: 400, height: 1100 },
+        })
+      } else {
+        callback?.({ success: true })
+      }
+    })
+    const { container } = render(<HandLog entries={mockEntries} />)
+    const logContainer = container.firstChild as HTMLElement
+    const resizeCorner = screen.getByTestId('hand-log-resize-corner')
+
+    expect(logContainer.style.top).toBe('0px')
+    expect(logContainer.style.height).toBe('768px')
+
+    fireEvent.mouseDown(resizeCorner, {
       button: 0,
-      clientX: 880,
-      clientY: 480,
+      clientX: 500,
+      clientY: 768,
+    })
+    moveMouseWithPrimaryButton(500, 688)
+    fireEvent.mouseUp(document)
+
+    expect(logContainer.style.height).toBe('688px')
+    expect(savedLayoutCalls()).toHaveLength(1)
+  })
+
+  it('mount後のviewport縮小でもヘッダーとリサイズ角を画面内へ正規化する', () => {
+    mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
+      if (message.action === 'getDeviceHandLogLayout') {
+        callback({
+          success: true,
+          layout: { left: 100, top: 500, width: 400, height: 200 },
+        })
+      } else {
+        callback?.({ success: true })
+      }
+    })
+    const { container } = render(<HandLog entries={mockEntries} />)
+    const logContainer = container.firstChild as HTMLElement
+
+    setViewport(640, 480)
+    fireEvent(window, new Event('resize'))
+
+    expect(logContainer.style.top).toBe('280px')
+    expect(logContainer.style.height).toBe('200px')
+  })
+
+  it('保存layoutがない狭い初期viewportでも既定layoutを即時に正規化する', () => {
+    setViewport(320, 120)
+    const { container } = render(<HandLog entries={mockEntries} />)
+    const logContainer = container.firstChild as HTMLElement
+
+    expect(logContainer.style.left).toBe('-90px')
+    expect(logContainer.style.top).toBe('0px')
+    expect(logContainer.style.width).toBe('400px')
+    expect(logContainer.style.height).toBe('100px')
+  })
+
+  it('旧scaleに束縛された非同期load結果を新scaleのlayoutへ適用しない', () => {
+    const loadCallbacks: Array<(response: unknown) => void> = []
+    mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
+      if (message.action === 'getDeviceHandLogLayout') {
+        loadCallbacks.push(callback)
+      } else {
+        callback?.({ success: true })
+      }
+    })
+    const { container, rerender } = render(
+      <HandLog entries={mockEntries} scale={1} />
+    )
+    const logContainer = container.firstChild as HTMLElement
+
+    rerender(<HandLog entries={mockEntries} scale={2} />)
+    expect(loadCallbacks).toHaveLength(2)
+
+    act(() => {
+      loadCallbacks[1]!({
+        success: true,
+        layout: { left: 40, top: 30, width: 200, height: 100 },
+      })
+      loadCallbacks[0]!({
+        success: true,
+        layout: { left: 300, top: 200, width: 500, height: 600 },
+      })
+    })
+
+    expect(logContainer.style.left).toBe('40px')
+    expect(logContainer.style.top).toBe('30px')
+    expect(logContainer.style.width).toBe('200px')
+    expect(logContainer.style.height).toBe('100px')
+    expect(logContainer.style.transform).toContain('scale(2)')
+  })
+
+  it('操作中のviewport変更をmouseupまで保持し正規化後layoutを一度だけ保存する', () => {
+    mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
+      if (message.action === 'getDeviceHandLogLayout') {
+        callback({
+          success: true,
+          layout: { left: 100, top: 500, width: 400, height: 200 },
+        })
+      } else {
+        callback?.({ success: true })
+      }
+    })
+    const { container } = render(<HandLog entries={mockEntries} />)
+    const logContainer = container.firstChild as HTMLElement
+
+    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
+      button: 0,
+      clientX: 200,
+      clientY: 514,
+    })
+    setViewport(640, 480)
+    fireEvent(window, new Event('resize'))
+
+    expect(logContainer.style.top).toBe('500px')
+    fireEvent.mouseUp(document)
+
+    expect(logContainer.style.top).toBe('280px')
+    expect(savedLayoutCalls()).toEqual([
+      [
+        {
+          action: 'setDeviceHandLogLayout',
+          layout: { left: 100, top: 280, width: 400, height: 200 },
+        },
+        expect.any(Function),
+      ],
+    ])
+  })
+
+  it('操作中のscale変更をmouseupまで保持しpointer移動なしでも一度だけ保存する', () => {
+    mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
+      if (message.action === 'getDeviceHandLogLayout') {
+        callback({
+          success: true,
+          layout: { left: 100, top: 500, width: 400, height: 200 },
+        })
+      } else {
+        callback?.({ success: true })
+      }
+    })
+    const { container, rerender } = render(
+      <HandLog entries={mockEntries} scale={1} />
+    )
+    const logContainer = container.firstChild as HTMLElement
+
+    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
+      button: 0,
+      clientX: 200,
+      clientY: 514,
+    })
+    rerender(<HandLog entries={mockEntries} scale={2} />)
+
+    expect(logContainer.style.top).toBe('500px')
+    fireEvent.mouseUp(document)
+
+    expect(logContainer.style.top).toBe('368px')
+    expect(logContainer.style.height).toBe('200px')
+    expect(savedLayoutCalls()).toHaveLength(1)
+    expect(savedLayoutCalls()[0]![0].layout).toEqual({
+      left: 100,
+      top: 368,
+      width: 400,
+      height: 200,
+    })
+  })
+
+  it('移動中もヘッダーの一部と縦方向全体を画面内へ保つ', () => {
+    const { container } = render(<HandLog entries={mockEntries} />)
+    const logContainer = container.firstChild as HTMLElement
+    updateLayout({ left: 500, top: 400, width: 400, height: 100 })
+
+    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
+      button: 0,
+      clientX: 600,
+      clientY: 414,
     })
     moveMouseWithPrimaryButton(-2000, -2000)
 
-    expect(logContainer.style.left).toBe('-372px')
-    expect(logContainer.style.top).toBe('-72px')
+    expect(logContainer.style.left).toBe('-320px')
+    expect(logContainer.style.top).toBe('0px')
     fireEvent.mouseUp(document)
   })
 
-  it('同じグリップの右下角で縦横をリサイズし最小値だけを適用する', () => {
+  it('右下角で縦横をリサイズし最小値と画面高上限を適用する', () => {
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
-    logContainer.getBoundingClientRect = jest.fn(() => ({
-      left: 500,
-      top: 400,
-      width: 400,
-      height: 100,
-      right: 900,
-      bottom: 500,
-      x: 500,
-      y: 400,
-      toJSON: () => {},
-    }))
+    updateLayout({ left: 500, top: 400, width: 400, height: 100 })
     const resizeCorner = screen.getByTestId('hand-log-resize-corner')
 
     fireEvent.mouseDown(resizeCorner, {
@@ -357,13 +547,14 @@ describe('HandLog', () => {
     moveMouseWithPrimaryButton(1900, 1500)
 
     expect(logContainer.style.width).toBe('1400px')
-    expect(logContainer.style.height).toBe('1100px')
+    expect(logContainer.style.height).toBe('768px')
+    expect(logContainer.style.top).toBe('0px')
     fireEvent.mouseUp(document)
 
     fireEvent.mouseDown(resizeCorner, {
       button: 0,
       clientX: 1900,
-      clientY: 1500,
+      clientY: 768,
     })
     moveMouseWithPrimaryButton(0, 0)
 
@@ -375,17 +566,7 @@ describe('HandLog', () => {
   it('画面端を越えてもmouseupまではリサイズを継続する', () => {
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
-    logContainer.getBoundingClientRect = jest.fn(() => ({
-      left: 500,
-      top: 400,
-      width: 400,
-      height: 100,
-      right: 900,
-      bottom: 500,
-      x: 500,
-      y: 400,
-      toJSON: () => {},
-    }))
+    updateLayout({ left: 500, top: 400, width: 400, height: 100 })
 
     fireEvent.mouseDown(screen.getByTestId('hand-log-resize-corner'), {
       button: 0,
@@ -397,37 +578,17 @@ describe('HandLog', () => {
     moveMouseWithPrimaryButton(1900, 1500)
 
     expect(logContainer.style.width).toBe('1400px')
-    expect(logContainer.style.height).toBe('1100px')
-    expect(mockChromeRuntimeSendMessage).not.toHaveBeenCalledWith(
-      expect.objectContaining({ action: 'setDeviceHandLogLayout' }),
-      expect.any(Function)
-    )
+    expect(logContainer.style.height).toBe('768px')
+    expect(savedLayoutCalls()).toHaveLength(0)
 
     fireEvent.mouseUp(document)
-
-    expect(mockChromeRuntimeSendMessage).toHaveBeenCalledWith(
-      {
-        action: 'setDeviceHandLogLayout',
-        layout: { left: 500, top: 400, width: 1400, height: 1100 },
-      },
-      expect.any(Function)
-    )
+    expect(savedLayoutCalls()).toHaveLength(1)
   })
 
-  it('window外でmouseupを取りこぼしても無押下の再入場時にリサイズを終了する', () => {
+  it('window外でmouseupを取りこぼしても無押下の再入場時に操作を終了する', () => {
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
-    logContainer.getBoundingClientRect = jest.fn(() => ({
-      left: 500,
-      top: 400,
-      width: 400,
-      height: 100,
-      right: 900,
-      bottom: 500,
-      x: 500,
-      y: 400,
-      toJSON: () => {},
-    }))
+    updateLayout({ left: 500, top: 400, width: 400, height: 100 })
 
     fireEvent.mouseDown(screen.getByTestId('hand-log-resize-corner'), {
       button: 0,
@@ -435,7 +596,6 @@ describe('HandLog', () => {
       clientY: 500,
     })
     moveMouseWithPrimaryButton(910, 510)
-    fireEvent.mouseLeave(document)
     fireEvent.mouseMove(document, {
       buttons: 0,
       clientX: 1900,
@@ -446,103 +606,61 @@ describe('HandLog', () => {
     expect(logContainer.style.height).toBe('110px')
     expect(document.body.style.cursor).toBe('')
     expect(document.body.style.userSelect).toBe('')
-    expect(mockChromeRuntimeSendMessage).toHaveBeenCalledWith(
-      {
-        action: 'setDeviceHandLogLayout',
-        layout: { left: 500, top: 400, width: 410, height: 110 },
-      },
-      expect.any(Function)
-    )
+    expect(savedLayoutCalls()).toHaveLength(1)
 
     fireEvent.mouseMove(document, {
       buttons: 0,
       clientX: 2000,
       clientY: 1600,
     })
-    fireEvent.mouseDown(document, { button: 0 })
     fireEvent.mouseUp(document)
-
-    expect(logContainer.style.width).toBe('410px')
-    expect(logContainer.style.height).toBe('110px')
-    expect(mockChromeRuntimeSendMessage).toHaveBeenCalledTimes(2)
+    expect(savedLayoutCalls()).toHaveLength(1)
   })
 
-  it('window外で操作が中断されても最後の位置を保存してdrag状態を解除する', () => {
+  it('window blurでも最後の位置を一度だけ保存してdrag状態を解除する', () => {
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
-    logContainer.getBoundingClientRect = jest.fn(() => ({
-      left: 500,
-      top: 400,
-      width: 400,
-      height: 100,
-      right: 900,
-      bottom: 500,
-      x: 500,
-      y: 400,
-      toJSON: () => {},
-    }))
+    updateLayout({ left: 500, top: 400, width: 400, height: 100 })
 
-    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
+    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
       button: 0,
-      clientX: 880,
-      clientY: 480,
+      clientX: 600,
+      clientY: 414,
     })
-    moveMouseWithPrimaryButton(830, 450)
+    moveMouseWithPrimaryButton(550, 384)
     fireEvent(window, new Event('blur'))
 
-    expect(mockChromeRuntimeSendMessage).toHaveBeenCalledWith(
-      {
-        action: 'setDeviceHandLogLayout',
-        layout: { left: 450, top: 370, width: 400, height: 100 },
-      },
-      expect.any(Function)
-    )
-    expect(document.body.style.cursor).toBe('')
-    expect(document.body.style.userSelect).toBe('')
-
-    fireEvent.mouseMove(document, {
-      clientX: 700,
-      clientY: 700,
-    })
     expect(logContainer.style.left).toBe('450px')
     expect(logContainer.style.top).toBe('370px')
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+    expect(savedLayoutCalls()).toHaveLength(1)
   })
 
-  it('HUD切替で操作中にunmountしても最後の位置を保存する', () => {
-    const { container, unmount } = render(<HandLog entries={mockEntries} />)
-    const logContainer = container.firstChild as HTMLElement
-    logContainer.getBoundingClientRect = jest.fn(() => ({
-      left: 500,
-      top: 400,
-      width: 400,
-      height: 100,
-      right: 900,
-      bottom: 500,
-      x: 500,
-      y: 400,
-      toJSON: () => {},
-    }))
+  it('HUD切替で操作中にunmountしても最後の位置を一度だけ保存する', () => {
+    const { unmount } = render(<HandLog entries={mockEntries} />)
+    updateLayout({ left: 500, top: 400, width: 400, height: 100 })
 
-    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
+    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
       button: 0,
-      clientX: 880,
-      clientY: 480,
+      clientX: 600,
+      clientY: 414,
     })
-    moveMouseWithPrimaryButton(830, 450)
+    moveMouseWithPrimaryButton(550, 384)
     unmount()
 
-    expect(mockChromeRuntimeSendMessage).toHaveBeenCalledWith(
-      {
-        action: 'setDeviceHandLogLayout',
-        layout: { left: 450, top: 370, width: 400, height: 100 },
-      },
-      expect.any(Function)
-    )
+    expect(savedLayoutCalls()).toHaveLength(1)
+    expect(savedLayoutCalls()[0]![0].layout).toEqual({
+      left: 450,
+      top: 370,
+      width: 400,
+      height: 100,
+    })
     expect(document.body.style.cursor).toBe('')
     expect(document.body.style.userSelect).toBe('')
   })
 
-  it('ポップアップからのリセットで既定の位置とサイズへ即時に戻す', () => {
+  it('ポップアップからのリセットで既定の具体座標とサイズへ即時に戻す', () => {
     mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
       if (message.action === 'getDeviceHandLogLayout') {
         callback({
@@ -556,28 +674,20 @@ describe('HandLog', () => {
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
 
-    expect(logContainer.style.left).toBe('120px')
-    expect(logContainer.style.width).toBe('520px')
-
     fireEvent(window, new CustomEvent('resetHandLogLayout'))
 
-    expect(logContainer.style.left).toBe('')
-    expect(logContainer.style.right).toBeTruthy()
+    expect(logContainer.style.left).toBe('614px')
+    expect(logContainer.style.top).toBe('533px')
     expect(logContainer.style.width).toBe(`${DEFAULT_HAND_LOG_CONFIG.width}px`)
     expect(logContainer.style.height).toBe(`${DEFAULT_HAND_LOG_CONFIG.height}px`)
   })
 
-  it('遅延reset後の保存済みlayout配信で表示を最新値へ戻す', () => {
+  it('reset後の保存済みlayout配信を同じ状態機械へ取り込む', () => {
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
-    const latestLayout = { left: 80, top: 60, width: 520, height: 240 }
 
     fireEvent(window, new CustomEvent('resetHandLogLayout'))
-    expect(logContainer.style.left).toBe('')
-
-    fireEvent(window, new CustomEvent('updateHandLogLayout', {
-      detail: latestLayout,
-    }))
+    updateLayout({ left: 80, top: 60, width: 520, height: 240 })
 
     expect(logContainer.style.left).toBe('80px')
     expect(logContainer.style.top).toBe('60px')
@@ -585,33 +695,18 @@ describe('HandLog', () => {
     expect(logContainer.style.height).toBe('240px')
   })
 
-  it('進行中の新しいドラッグを古い保存済みlayout配信で上書きしない', () => {
+  it('進行中のドラッグを古い保存済みlayout配信で上書きしない', () => {
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
-    logContainer.getBoundingClientRect = jest.fn(() => ({
-      left: 500,
-      top: 400,
-      width: 400,
-      height: 100,
-      right: 900,
-      bottom: 500,
-      x: 500,
-      y: 400,
-      toJSON: () => {},
-    }))
+    updateLayout({ left: 500, top: 400, width: 400, height: 100 })
 
-    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
+    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
       button: 0,
-      clientX: 880,
-      clientY: 480,
+      clientX: 600,
+      clientY: 414,
     })
-    moveMouseWithPrimaryButton(830, 450)
-    expect(logContainer.style.left).toBe('450px')
-    expect(logContainer.style.top).toBe('370px')
-
-    fireEvent(window, new CustomEvent('updateHandLogLayout', {
-      detail: { left: 80, top: 60, width: 520, height: 240 },
-    }))
+    moveMouseWithPrimaryButton(550, 384)
+    updateLayout({ left: 80, top: 60, width: 520, height: 240 })
 
     expect(logContainer.style.left).toBe('450px')
     expect(logContainer.style.top).toBe('370px')
@@ -620,11 +715,11 @@ describe('HandLog', () => {
 
   it.each([
     {
-      testId: 'hand-log-move-grip',
-      startX: 620,
-      startY: 300,
-      movedX: 650,
-      movedY: 330,
+      testId: 'hand-log-header',
+      startX: 220,
+      startY: 94,
+      movedX: 250,
+      movedY: 124,
     },
     {
       testId: 'hand-log-resize-corner',
@@ -652,17 +747,6 @@ describe('HandLog', () => {
     })
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
-    logContainer.getBoundingClientRect = jest.fn(() => ({
-      left: 120,
-      top: 80,
-      width: 520,
-      height: 240,
-      right: 640,
-      bottom: 320,
-      x: 120,
-      y: 80,
-      toJSON: () => {},
-    }))
 
     fireEvent.mouseDown(screen.getByTestId(testId), {
       button: 0,
@@ -672,8 +756,8 @@ describe('HandLog', () => {
     moveMouseWithPrimaryButton(movedX, movedY)
     fireEvent(window, new CustomEvent('resetHandLogLayout'))
 
-    expect(logContainer.style.left).toBe('')
-    expect(logContainer.style.right).toBeTruthy()
+    expect(logContainer.style.left).toBe('614px')
+    expect(logContainer.style.top).toBe('533px')
     expect(logContainer.style.width).toBe(`${DEFAULT_HAND_LOG_CONFIG.width}px`)
     expect(logContainer.style.height).toBe(`${DEFAULT_HAND_LOG_CONFIG.height}px`)
     expect(document.body.style.cursor).toBe('')
@@ -684,13 +768,7 @@ describe('HandLog', () => {
       clientY: movedY + 100,
     })
     fireEvent.mouseUp(document)
-
-    expect(logContainer.style.left).toBe('')
-    expect(logContainer.style.right).toBeTruthy()
-    expect(mockChromeRuntimeSendMessage).not.toHaveBeenCalledWith(
-      expect.objectContaining({ action: 'setDeviceHandLogLayout' }),
-      expect.any(Function)
-    )
+    expect(savedLayoutCalls()).toHaveLength(0)
   })
 
   it('旧sync configの位置とサイズを端末レイアウトへ流用しない', () => {
@@ -702,19 +780,58 @@ describe('HandLog', () => {
     )
     const logContainer = container.firstChild as HTMLElement
 
-    expect(logContainer.style.bottom).toBeTruthy()
-    expect(logContainer.style.right).toBeTruthy()
-    expect(logContainer.style.top).toBe('')
-    expect(logContainer.style.left).toBe('')
+    expect(logContainer.style.left).toBe('614px')
+    expect(logContainer.style.top).toBe('533px')
     expect(logContainer.style.width).toBe(`${DEFAULT_HAND_LOG_CONFIG.width}px`)
     expect(logContainer.style.height).toBe(`${DEFAULT_HAND_LOG_CONFIG.height}px`)
   })
 
-  it('スケールが適用される', () => {
+  it('スケールが表示と正規化の共通environmentに適用される', () => {
     const { container } = render(<HandLog entries={mockEntries} scale={1.5} />)
     const logContainer = container.firstChild as HTMLElement
-    
+
     expect(logContainer.style.transform).toContain('scale(1.5)')
+    expect(logContainer.style.left).toBe('414px')
+    expect(logContainer.style.top).toBe('483px')
+  })
+
+  it('保存済みouter heightを維持してヘッダー分だけ本文を短くする', () => {
+    mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
+      if (message.action === 'getDeviceHandLogLayout') {
+        callback({
+          success: true,
+          layout: { left: 120, top: 80, width: 520, height: 240 },
+        })
+      } else {
+        callback?.({ success: true })
+      }
+    })
+    const { container } = render(<HandLog entries={mockEntries} />)
+    const logContainer = container.firstChild as HTMLElement
+
+    expect(logContainer.style.width).toBe('520px')
+    expect(logContainer.style.height).toBe('240px')
+    expect(screen.getByTestId('hand-log-header')).toHaveStyle({ height: '28px' })
+    expect(screen.getByTestId('virtual-list')).toHaveStyle({
+      width: '520px',
+      height: '212px',
+    })
+  })
+
+  it('リサイズdeltaを操作開始時のscaleで補正する', () => {
+    const { container } = render(<HandLog entries={mockEntries} scale={2} />)
+    const logContainer = container.firstChild as HTMLElement
+
+    fireEvent.mouseDown(screen.getByTestId('hand-log-resize-corner'), {
+      button: 0,
+      clientX: 1214,
+      clientY: 683,
+    })
+    moveMouseWithPrimaryButton(1414, 783)
+
+    expect(logContainer.style.width).toBe('500px')
+    expect(logContainer.style.height).toBe('150px')
+    fireEvent.mouseUp(document)
   })
 
   it('スクロール位置が最新エントリに移動する', () => {

--- a/src/components/HandLog.test.tsx
+++ b/src/components/HandLog.test.tsx
@@ -408,7 +408,7 @@ describe('HandLog', () => {
     expect(logContainer.style.height).toBe('100px')
   })
 
-  it('最小高さより狭いviewportでは正規化時だけ高さを画面内へ収める', () => {
+  it('最小高さより狭いviewportでは表示だけ縮め保存heightを有効値に保つ', () => {
     setViewport(320, 120)
     const { container } = render(<HandLog entries={mockEntries} scale={2} />)
     const logContainer = container.firstChild as HTMLElement
@@ -417,6 +417,18 @@ describe('HandLog', () => {
     expect(logContainer.style.height).toBe('60px')
     expect(logContainer.style.transform).toContain('scale(2)')
     expect(screen.getByTestId('hand-log-resize-corner')).toBeInTheDocument()
+
+    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
+      button: 0,
+      clientX: 100,
+      clientY: 20,
+    })
+    moveMouseWithPrimaryButton(110, 30)
+    fireEvent.mouseUp(document)
+
+    expect(savedLayoutCalls()).toHaveLength(1)
+    expect(savedLayoutCalls()[0]![0].layout.height).toBe(80)
+    expect(logContainer.style.height).toBe('60px')
   })
 
   it('layout読込timeout後も同じloadの権威的応答を適用する', () => {
@@ -486,6 +498,51 @@ describe('HandLog', () => {
     expect(logContainer.style.transform).toContain('scale(2)')
   })
 
+  it('操作中に保留した新scaleのlayout読込を終了後に再開する', () => {
+    const loadCallbacks: Array<(response: unknown) => void> = []
+    mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
+      if (message.action === 'getDeviceHandLogLayout') {
+        loadCallbacks.push(callback)
+      } else {
+        callback?.({ success: true })
+      }
+    })
+    const { container, rerender } = render(
+      <HandLog entries={mockEntries} scale={1} />
+    )
+    const logContainer = container.firstChild as HTMLElement
+
+    expect(loadCallbacks).toHaveLength(1)
+    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
+      button: 0,
+      clientX: 700,
+      clientY: 550,
+    })
+    rerender(<HandLog entries={mockEntries} scale={2} />)
+    expect(loadCallbacks).toHaveLength(1)
+
+    fireEvent.mouseUp(document)
+    expect(loadCallbacks).toHaveLength(2)
+    expect(savedLayoutCalls()).toHaveLength(0)
+
+    act(() => {
+      loadCallbacks[1]!({
+        success: true,
+        layout: { left: 40, top: 30, width: 500, height: 200 },
+      })
+      loadCallbacks[0]!({
+        success: true,
+        layout: { left: 300, top: 200, width: 500, height: 600 },
+      })
+    })
+
+    expect(logContainer.style.left).toBe('40px')
+    expect(logContainer.style.top).toBe('30px')
+    expect(logContainer.style.width).toBe('500px')
+    expect(logContainer.style.height).toBe('200px')
+    expect(logContainer.style.transform).toContain('scale(2)')
+  })
+
   it('操作中のviewport変更をmouseupまで保持し正規化後layoutを一度だけ保存する', () => {
     mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
       if (message.action === 'getDeviceHandLogLayout') {
@@ -525,9 +582,11 @@ describe('HandLog', () => {
     ])
   })
 
-  it('操作中のscale変更をmouseupまで保持しpointer移動なしでも一度だけ保存する', () => {
+  it('操作中のscale変更をmouseupまで保持しpointer移動なしなら再読込する', () => {
+    let loadCount = 0
     mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
       if (message.action === 'getDeviceHandLogLayout') {
+        loadCount += 1
         callback({
           success: true,
           layout: { left: 100, top: 500, width: 400, height: 200 },
@@ -555,13 +614,8 @@ describe('HandLog', () => {
     expect(logContainer.style.top).toBe('368px')
     expect(logContainer.style.height).toBe('200px')
     expect(logContainer.style.transform).toContain('scale(2)')
-    expect(savedLayoutCalls()).toHaveLength(1)
-    expect(savedLayoutCalls()[0]![0].layout).toEqual({
-      left: 100,
-      top: 368,
-      width: 400,
-      height: 200,
-    })
+    expect(loadCount).toBe(2)
+    expect(savedLayoutCalls()).toHaveLength(0)
   })
 
   it('移動中もヘッダーの一部と縦方向全体を画面内へ保つ', () => {

--- a/src/components/HandLog.test.tsx
+++ b/src/components/HandLog.test.tsx
@@ -2,6 +2,7 @@ import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import HandLog from './HandLog'
 import { HandLogEntry, HandLogEntryType, HandLogConfig, DEFAULT_HAND_LOG_CONFIG } from '../types/hand-log'
+import { DEVICE_LAYOUT_MESSAGE_TIMEOUT_MS } from '../utils/ui-config-storage'
 
 // Mock react-window v2 API
 jest.mock('react-window', () => {
@@ -407,6 +408,49 @@ describe('HandLog', () => {
     expect(logContainer.style.height).toBe('100px')
   })
 
+  it('最小高さより狭いviewportでは正規化時だけ高さを画面内へ収める', () => {
+    setViewport(320, 120)
+    const { container } = render(<HandLog entries={mockEntries} scale={2} />)
+    const logContainer = container.firstChild as HTMLElement
+
+    expect(logContainer.style.top).toBe('0px')
+    expect(logContainer.style.height).toBe('60px')
+    expect(logContainer.style.transform).toContain('scale(2)')
+    expect(screen.getByTestId('hand-log-resize-corner')).toBeInTheDocument()
+  })
+
+  it('layout読込timeout後も同じloadの権威的応答を適用する', () => {
+    jest.useFakeTimers()
+    const loadCallbacks: Array<(response: unknown) => void> = []
+    mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
+      if (message.action === 'getDeviceHandLogLayout') {
+        loadCallbacks.push(callback)
+      } else {
+        callback?.({ success: true })
+      }
+    })
+    const { container } = render(<HandLog entries={mockEntries} />)
+    const logContainer = container.firstChild as HTMLElement
+
+    act(() => {
+      jest.advanceTimersByTime(DEVICE_LAYOUT_MESSAGE_TIMEOUT_MS)
+    })
+    expect(logContainer.style.left).toBe('614px')
+
+    act(() => {
+      loadCallbacks[0]!({
+        success: true,
+        layout: { left: 40, top: 30, width: 500, height: 200 },
+      })
+    })
+
+    expect(logContainer.style.left).toBe('40px')
+    expect(logContainer.style.top).toBe('30px')
+    expect(logContainer.style.width).toBe('500px')
+    expect(logContainer.style.height).toBe('200px')
+    jest.useRealTimers()
+  })
+
   it('旧scaleに束縛された非同期load結果を新scaleのlayoutへ適用しない', () => {
     const loadCallbacks: Array<(response: unknown) => void> = []
     mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
@@ -697,6 +741,30 @@ describe('HandLog', () => {
     expect(logContainer.style.top).toBe('60px')
     expect(logContainer.style.width).toBe('520px')
     expect(logContainer.style.height).toBe('240px')
+  })
+
+  it('操作中のresetはpending scaleを採用して既定layoutを正規化する', () => {
+    const { container, rerender } = render(
+      <HandLog entries={mockEntries} scale={1} />
+    )
+    const logContainer = container.firstChild as HTMLElement
+
+    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
+      button: 0,
+      clientX: 700,
+      clientY: 550,
+    })
+    rerender(<HandLog entries={mockEntries} scale={2} />)
+    expect(logContainer.style.transform).toContain('scale(1)')
+
+    fireEvent(window, new CustomEvent('resetHandLogLayout'))
+
+    expect(logContainer.style.left).toBe('214px')
+    expect(logContainer.style.top).toBe('433px')
+    expect(logContainer.style.width).toBe(`${DEFAULT_HAND_LOG_CONFIG.width}px`)
+    expect(logContainer.style.height).toBe(`${DEFAULT_HAND_LOG_CONFIG.height}px`)
+    expect(logContainer.style.transform).toContain('scale(2)')
+    expect(savedLayoutCalls()).toHaveLength(0)
   })
 
   it('進行中のドラッグを古い保存済みlayout配信で上書きしない', () => {

--- a/src/components/HandLog.test.tsx
+++ b/src/components/HandLog.test.tsx
@@ -465,6 +465,8 @@ describe('HandLog', () => {
     fireEvent(window, new Event('resize'))
 
     expect(logContainer.style.top).toBe('500px')
+    moveMouseWithPrimaryButton(210, 524)
+    expect(logContainer.style.top).toBe('510px')
     fireEvent.mouseUp(document)
 
     expect(logContainer.style.top).toBe('280px')
@@ -472,7 +474,7 @@ describe('HandLog', () => {
       [
         {
           action: 'setDeviceHandLogLayout',
-          layout: { left: 100, top: 280, width: 400, height: 200 },
+          layout: { left: 110, top: 280, width: 400, height: 200 },
         },
         expect.any(Function),
       ],
@@ -503,10 +505,12 @@ describe('HandLog', () => {
     rerender(<HandLog entries={mockEntries} scale={2} />)
 
     expect(logContainer.style.top).toBe('500px')
+    expect(logContainer.style.transform).toContain('scale(1)')
     fireEvent.mouseUp(document)
 
     expect(logContainer.style.top).toBe('368px')
     expect(logContainer.style.height).toBe('200px')
+    expect(logContainer.style.transform).toContain('scale(2)')
     expect(savedLayoutCalls()).toHaveLength(1)
     expect(savedLayoutCalls()[0]![0].layout).toEqual({
       left: 100,

--- a/src/components/HandLog.test.tsx
+++ b/src/components/HandLog.test.tsx
@@ -498,6 +498,43 @@ describe('HandLog', () => {
     expect(logContainer.style.transform).toContain('scale(2)')
   })
 
+  it('旧effectのresize listenerも最新scaleでviewportを更新する', () => {
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener')
+    const loadCallbacks: Array<(response: unknown) => void> = []
+    mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
+      if (message.action === 'getDeviceHandLogLayout') {
+        loadCallbacks.push(callback)
+      } else {
+        callback?.({ success: true })
+      }
+    })
+
+    try {
+      const { container, rerender } = render(
+        <HandLog entries={mockEntries} scale={1} />
+      )
+      const logContainer = container.firstChild as HTMLElement
+      const staleResizeListener = addEventListenerSpy.mock.calls.find(
+        ([type]) => type === 'resize'
+      )?.[1] as EventListener
+
+      rerender(<HandLog entries={mockEntries} scale={2} />)
+      act(() => {
+        staleResizeListener(new Event('resize'))
+        loadCallbacks[1]!({
+          success: true,
+          layout: { left: 40, top: 30, width: 500, height: 200 },
+        })
+      })
+
+      expect(logContainer.style.left).toBe('40px')
+      expect(logContainer.style.top).toBe('30px')
+      expect(logContainer.style.transform).toContain('scale(2)')
+    } finally {
+      addEventListenerSpy.mockRestore()
+    }
+  })
+
   it('操作中に保留した新scaleのlayout読込を終了後に再開する', () => {
     const loadCallbacks: Array<(response: unknown) => void> = []
     mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {

--- a/src/components/HandLog.tsx
+++ b/src/components/HandLog.tsx
@@ -170,20 +170,38 @@ const transitionHandLogLayout = (
 ): HandLogTransition => {
   switch (action.type) {
     case 'environmentChanged': {
+      if (state.interaction.phase === 'interacting') {
+        const pendingEnvironment = sameEnvironment(
+          state.environment,
+          action.environment
+        )
+          ? null
+          : action.environment
+        if (
+          (state.pendingEnvironment === null && pendingEnvironment === null) ||
+          (
+            state.pendingEnvironment !== null &&
+            pendingEnvironment !== null &&
+            sameEnvironment(state.pendingEnvironment, pendingEnvironment)
+          )
+        ) {
+          return { state }
+        }
+        return {
+          state: {
+            ...state,
+            pendingEnvironment,
+            activeLoad:
+              state.environment.scale !== action.environment.scale
+                ? null
+                : state.activeLoad,
+          },
+        }
+      }
       if (sameEnvironment(state.environment, action.environment)) {
         return { state }
       }
       const scaleChanged = state.environment.scale !== action.environment.scale
-      if (state.interaction.phase === 'interacting') {
-        return {
-          state: {
-            ...state,
-            environment: action.environment,
-            pendingEnvironment: action.environment,
-            activeLoad: scaleChanged ? null : state.activeLoad,
-          },
-        }
-      }
       return {
         state: {
           ...state,
@@ -336,9 +354,10 @@ const transitionHandLogLayout = (
 
     case 'interactionFinished': {
       if (state.interaction.phase !== 'interacting') return { state }
+      const environment = state.pendingEnvironment ?? state.environment
       const layout = normalizeHandLogLayout(
         state.layout,
-        state.environment
+        environment
       )
       const shouldPersist =
         state.interaction.moved || state.pendingEnvironment !== null
@@ -346,6 +365,7 @@ const transitionHandLogLayout = (
         state: {
           ...state,
           layout,
+          environment,
           interaction: { phase: 'idle' },
           pendingEnvironment: null,
           activeLoad: shouldPersist ? null : state.activeLoad,
@@ -531,8 +551,9 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
   }, [processedItems, config.fontSize])
 
   // Prop scale and viewport dimensions are inputs to the same layout machine
-  // as pointer interaction. useLayoutEffect updates scale before paint so the
-  // rendered transform and the reachability normalization cannot diverge.
+  // as pointer interaction. useLayoutEffect updates scale before paint while
+  // idle; an active interaction keeps rendering its start environment and
+  // applies the pending environment through the common finish transition.
   useLayoutEffect(() => {
     commitLayoutAction({
       type: 'environmentChanged',

--- a/src/components/HandLog.tsx
+++ b/src/components/HandLog.tsx
@@ -111,9 +111,11 @@ const normalizeHandLogLayout = (
   environment: HandLogEnvironment
 ): HandLogLayout => {
   const { scale, viewportWidth, viewportHeight } = environment
-  const height = Math.min(
+  const maximumHeight = viewportHeight / scale
+  const height = clamp(
     layout.height,
-    Math.max(HAND_LOG_MIN_HEIGHT, viewportHeight / scale)
+    Math.min(HAND_LOG_MIN_HEIGHT, maximumHeight),
+    maximumHeight
   )
   const renderedWidth = layout.width * scale
   const renderedHeight = height * scale
@@ -231,7 +233,7 @@ const transitionHandLogLayout = (
         return { state }
       }
       if (!action.layout) {
-        return { state: { ...state, activeLoad: null } }
+        return { state }
       }
       if (
         state.interaction.phase === 'interacting' &&
@@ -280,16 +282,19 @@ const transitionHandLogLayout = (
       }
     }
 
-    case 'reset':
+    case 'reset': {
+      const environment = state.pendingEnvironment ?? state.environment
       return {
         state: {
           ...state,
-          layout: createDefaultHandLogLayout(state.environment),
+          layout: createDefaultHandLogLayout(environment),
+          environment,
           interaction: { phase: 'idle' },
           pendingEnvironment: null,
           activeLoad: null,
         },
       }
+    }
 
     case 'interactionStarted':
       if (state.interaction.phase === 'interacting') return { state }

--- a/src/components/HandLog.tsx
+++ b/src/components/HandLog.tsx
@@ -605,9 +605,10 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
 
   useEffect(() => {
     const handleViewportResize = () => {
+      // A stale passive-effect listener may fire after a new scale render.
       commitLayoutAction({
         type: 'environmentChanged',
-        environment: readHandLogEnvironment(scale),
+        environment: readHandLogEnvironment(latestScaleRef.current),
       })
     }
     const handleReset = () => {

--- a/src/components/HandLog.tsx
+++ b/src/components/HandLog.tsx
@@ -3,7 +3,7 @@
  * バーチャル化を使用したリアルタイムハンド履歴ログオーバーレイ
  */
 
-import React, { useState, useEffect, useRef, CSSProperties, useCallback, useMemo, memo } from 'react'
+import React, { useState, useEffect, useLayoutEffect, useRef, CSSProperties, useCallback, useMemo, memo } from 'react'
 import { List, useListRef } from 'react-window'
 import {
   HandLogEntry,
@@ -29,40 +29,332 @@ interface HandLogProps {
   scrollToLatest?: boolean
 }
 
-const getPositionStyles = (position: string): CSSProperties => {
-  const offset = 10
-  const bottomOffset = 135  // 125px持ち上げるため、10 + 125 = 135
-  const defaultPosition: CSSProperties = { bottom: bottomOffset, right: offset }
-
-  switch (position) {
-    case 'bottom-right':
-      return { bottom: bottomOffset, right: offset }
-    case 'bottom-left':
-      return { bottom: bottomOffset, left: offset }
-    case 'top-right':
-      return { top: offset, right: offset }
-    case 'top-left':
-      return { top: offset, left: offset }
-    default:
-      return defaultPosition
-  }
-}
-
-const HAND_LOG_GRIP_SIZE = 28
+const HAND_LOG_HEADER_HEIGHT = 28
+const HAND_LOG_HEADER_REACHABLE_WIDTH = 80
 const HAND_LOG_DRAG_THRESHOLD = 4
+const HAND_LOG_DEFAULT_RIGHT = 10
+const HAND_LOG_DEFAULT_BOTTOM = 135
 
 type HandLogInteractionMode = 'move' | 'resize'
 
-interface HandLogInteraction {
+interface HandLogEnvironment {
+  scale: number
+  viewportWidth: number
+  viewportHeight: number
+}
+
+interface ActiveHandLogInteraction {
+  phase: 'interacting'
   mode: HandLogInteractionMode
   startX: number
   startY: number
   startLayout: HandLogLayout
+  startEnvironment: HandLogEnvironment
   moved: boolean
+}
+
+interface IdleHandLogInteraction {
+  phase: 'idle'
+}
+
+type HandLogInteraction =
+  | IdleHandLogInteraction
+  | ActiveHandLogInteraction
+
+interface HandLogLoad {
+  id: number
+  scale: number
+}
+
+interface HandLogLayoutMachine {
+  layout: HandLogLayout
+  environment: HandLogEnvironment
+  interaction: HandLogInteraction
+  pendingEnvironment: HandLogEnvironment | null
+  activeLoad: HandLogLoad | null
+}
+
+type HandLogMachineAction =
+  | { type: 'environmentChanged', environment: HandLogEnvironment }
+  | { type: 'loadStarted', load: HandLogLoad }
+  | { type: 'loadResolved', load: HandLogLoad, layout: HandLogLayout | undefined }
+  | { type: 'externalLayout', layout: HandLogLayout }
+  | { type: 'reset' }
+  | { type: 'interactionStarted', mode: HandLogInteractionMode, x: number, y: number }
+  | { type: 'pointerMoved', x: number, y: number }
+  | { type: 'interactionFinished' }
+
+interface HandLogTransition {
+  state: HandLogLayoutMachine
+  persist?: HandLogLayout
 }
 
 const clamp = (value: number, min: number, max: number): number =>
   Math.min(max, Math.max(min, value))
+
+const sameEnvironment = (
+  left: HandLogEnvironment,
+  right: HandLogEnvironment
+): boolean =>
+  left.scale === right.scale &&
+  left.viewportWidth === right.viewportWidth &&
+  left.viewportHeight === right.viewportHeight
+
+const readHandLogEnvironment = (scale: number): HandLogEnvironment => ({
+  scale,
+  viewportWidth: window.innerWidth,
+  viewportHeight: window.innerHeight,
+})
+
+const normalizeHandLogLayout = (
+  layout: HandLogLayout,
+  environment: HandLogEnvironment
+): HandLogLayout => {
+  const { scale, viewportWidth, viewportHeight } = environment
+  const height = Math.min(
+    layout.height,
+    Math.max(HAND_LOG_MIN_HEIGHT, viewportHeight / scale)
+  )
+  const renderedWidth = layout.width * scale
+  const renderedHeight = height * scale
+  const reachableWidth = Math.min(
+    HAND_LOG_HEADER_REACHABLE_WIDTH * scale,
+    viewportWidth
+  )
+
+  return {
+    ...layout,
+    left: clamp(
+      layout.left,
+      reachableWidth - renderedWidth,
+      viewportWidth - reachableWidth
+    ),
+    top: clamp(
+      layout.top,
+      0,
+      Math.max(0, viewportHeight - renderedHeight)
+    ),
+    height,
+  }
+}
+
+const createDefaultHandLogLayout = (
+  environment: HandLogEnvironment
+): HandLogLayout =>
+  normalizeHandLogLayout({
+    left:
+      environment.viewportWidth -
+      HAND_LOG_DEFAULT_RIGHT -
+      DEFAULT_HAND_LOG_CONFIG.width * environment.scale,
+    top:
+      environment.viewportHeight -
+      HAND_LOG_DEFAULT_BOTTOM -
+      DEFAULT_HAND_LOG_CONFIG.height * environment.scale,
+    width: DEFAULT_HAND_LOG_CONFIG.width,
+    height: DEFAULT_HAND_LOG_CONFIG.height,
+  }, environment)
+
+const createHandLogLayoutMachine = (
+  environment: HandLogEnvironment
+): HandLogLayoutMachine => ({
+  layout: createDefaultHandLogLayout(environment),
+  environment,
+  interaction: { phase: 'idle' },
+  pendingEnvironment: null,
+  activeLoad: null,
+})
+
+const transitionHandLogLayout = (
+  state: HandLogLayoutMachine,
+  action: HandLogMachineAction
+): HandLogTransition => {
+  switch (action.type) {
+    case 'environmentChanged': {
+      if (sameEnvironment(state.environment, action.environment)) {
+        return { state }
+      }
+      const scaleChanged = state.environment.scale !== action.environment.scale
+      if (state.interaction.phase === 'interacting') {
+        return {
+          state: {
+            ...state,
+            environment: action.environment,
+            pendingEnvironment: action.environment,
+            activeLoad: scaleChanged ? null : state.activeLoad,
+          },
+        }
+      }
+      return {
+        state: {
+          ...state,
+          layout: normalizeHandLogLayout(state.layout, action.environment),
+          environment: action.environment,
+          pendingEnvironment: null,
+          activeLoad: scaleChanged ? null : state.activeLoad,
+        },
+      }
+    }
+
+    case 'loadStarted':
+      if (state.interaction.phase === 'interacting') return { state }
+      return {
+        state: {
+          ...state,
+          activeLoad: action.load,
+        },
+      }
+
+    case 'loadResolved': {
+      if (
+        state.activeLoad?.id !== action.load.id ||
+        state.activeLoad.scale !== action.load.scale ||
+        state.environment.scale !== action.load.scale
+      ) {
+        return { state }
+      }
+      if (!action.layout) {
+        return { state: { ...state, activeLoad: null } }
+      }
+      if (
+        state.interaction.phase === 'interacting' &&
+        state.interaction.moved
+      ) {
+        return { state: { ...state, activeLoad: null } }
+      }
+      const layout = normalizeHandLogLayout(
+        action.layout,
+        state.environment
+      )
+      return {
+        state: {
+          ...state,
+          layout,
+          interaction:
+            state.interaction.phase === 'interacting'
+              ? { ...state.interaction, startLayout: layout }
+              : state.interaction,
+          activeLoad: null,
+        },
+      }
+    }
+
+    case 'externalLayout': {
+      if (
+        state.interaction.phase === 'interacting' &&
+        state.interaction.moved
+      ) {
+        return { state }
+      }
+      const layout = normalizeHandLogLayout(
+        action.layout,
+        state.environment
+      )
+      return {
+        state: {
+          ...state,
+          layout,
+          interaction:
+            state.interaction.phase === 'interacting'
+              ? { ...state.interaction, startLayout: layout }
+              : state.interaction,
+          activeLoad: null,
+        },
+      }
+    }
+
+    case 'reset':
+      return {
+        state: {
+          ...state,
+          layout: createDefaultHandLogLayout(state.environment),
+          interaction: { phase: 'idle' },
+          pendingEnvironment: null,
+          activeLoad: null,
+        },
+      }
+
+    case 'interactionStarted':
+      if (state.interaction.phase === 'interacting') return { state }
+      return {
+        state: {
+          ...state,
+          interaction: {
+            phase: 'interacting',
+            mode: action.mode,
+            startX: action.x,
+            startY: action.y,
+            startLayout: state.layout,
+            startEnvironment: state.environment,
+            moved: false,
+          },
+        },
+      }
+
+    case 'pointerMoved': {
+      if (state.interaction.phase !== 'interacting') return { state }
+      const deltaX = action.x - state.interaction.startX
+      const deltaY = action.y - state.interaction.startY
+      if (
+        !state.interaction.moved &&
+        Math.hypot(deltaX, deltaY) < HAND_LOG_DRAG_THRESHOLD
+      ) {
+        return { state }
+      }
+      const { startLayout, startEnvironment } = state.interaction
+      const proposedLayout =
+        state.interaction.mode === 'move'
+          ? {
+              ...startLayout,
+              left: startLayout.left + deltaX,
+              top: startLayout.top + deltaY,
+            }
+          : {
+              ...startLayout,
+              width: Math.max(
+                HAND_LOG_MIN_WIDTH,
+                startLayout.width + deltaX / startEnvironment.scale
+              ),
+              height: Math.max(
+                HAND_LOG_MIN_HEIGHT,
+                startLayout.height + deltaY / startEnvironment.scale
+              ),
+            }
+      return {
+        state: {
+          ...state,
+          layout: normalizeHandLogLayout(
+            proposedLayout,
+            state.environment
+          ),
+          interaction: {
+            ...state.interaction,
+            moved: true,
+          },
+        },
+      }
+    }
+
+    case 'interactionFinished': {
+      if (state.interaction.phase !== 'interacting') return { state }
+      const layout = normalizeHandLogLayout(
+        state.layout,
+        state.environment
+      )
+      const shouldPersist =
+        state.interaction.moved || state.pendingEnvironment !== null
+      return {
+        state: {
+          ...state,
+          layout,
+          interaction: { phase: 'idle' },
+          pendingEnvironment: null,
+          activeLoad: shouldPersist ? null : state.activeLoad,
+        },
+        persist: shouldPersist ? layout : undefined,
+      }
+    }
+  }
+}
 
 const entryTypeColors: Record<HandLogEntryType, string> = {
   [HandLogEntryType.HEADER]: '#ffffff',
@@ -169,20 +461,34 @@ const EntryRow = ({ index, style, items, showTimestamps, copiedHandId, onEntryCl
 const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, scale = 1, scrollToLatest }) => {
   const config = useMemo(() => ({ ...DEFAULT_HAND_LOG_CONFIG, ...userConfig }), [userConfig])
   const listRef = useListRef(null)
-  const containerRef = useRef<HTMLDivElement>(null)
   const [copiedHandId, setCopiedHandId] = useState<number | null>(null)
-  const [layout, setLayout] = useState<HandLogLayout | null>(null)
-  const layoutRef = useRef<HandLogLayout | null>(null)
-  const layoutEditGenerationRef = useRef(0)
-  const interactionRef = useRef<HandLogInteraction | null>(null)
-  const [interactionMode, setInteractionMode] = useState<HandLogInteractionMode | null>(null)
+  const [layoutMachine, setLayoutMachine] =
+    useState<HandLogLayoutMachine>(() =>
+      createHandLogLayoutMachine(readHandLogEnvironment(scale))
+    )
+  const layoutMachineRef = useRef(layoutMachine)
+  const loadSequenceRef = useRef(0)
   const [showCopied, setShowCopied] = useState(false)
   const [showCleared, setShowCleared] = useState(false)
   const lastClickTimeRef = useRef<number>(0)
 
-  const applyLayout = useCallback((nextLayout: HandLogLayout | null) => {
-    layoutRef.current = nextLayout
-    setLayout(nextLayout)
+  const commitLayoutAction = useCallback((
+    action: HandLogMachineAction,
+    render = true
+  ) => {
+    const transition = transitionHandLogLayout(
+      layoutMachineRef.current,
+      action
+    )
+    if (transition.state !== layoutMachineRef.current) {
+      layoutMachineRef.current = transition.state
+      if (render) {
+        setLayoutMachine(transition.state)
+      }
+    }
+    if (transition.persist) {
+      saveHandLogLayout(transition.persist)
+    }
   }, [])
 
   // セパレーターを追加するためエントリを処理
@@ -224,61 +530,55 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
     return lines * (config.fontSize * 1.2) + 2
   }, [processedItems, config.fontSize])
 
-  // Position and size are device-local. Read once on mount; another tab does
-  // not need live synchronization because PokerChase permits one active login.
-  useEffect(() => {
-    const loadGeneration = layoutEditGenerationRef.current
-    loadHandLogLayout(savedLayout => {
-      if (
-        savedLayout &&
-        layoutEditGenerationRef.current === loadGeneration
-      ) {
-        const pendingInteraction = interactionRef.current
-        if (pendingInteraction && !pendingInteraction.moved) {
-          pendingInteraction.startLayout = savedLayout
-        }
-        applyLayout(savedLayout)
-      }
+  // Prop scale and viewport dimensions are inputs to the same layout machine
+  // as pointer interaction. useLayoutEffect updates scale before paint so the
+  // rendered transform and the reachability normalization cannot diverge.
+  useLayoutEffect(() => {
+    commitLayoutAction({
+      type: 'environmentChanged',
+      environment: readHandLogEnvironment(scale),
     })
-  }, [applyLayout])
+  }, [scale, commitLayoutAction])
 
-  // The popup reset is delivered to open game tabs after the local value is
-  // removed. A reload is not required for the visible panel to recover.
   useEffect(() => {
+    const load = {
+      id: ++loadSequenceRef.current,
+      scale,
+    }
+    commitLayoutAction({ type: 'loadStarted', load })
+    loadHandLogLayout(savedLayout => {
+      commitLayoutAction({
+        type: 'loadResolved',
+        load,
+        layout: savedLayout,
+      })
+    })
+  }, [scale, commitLayoutAction])
+
+  useEffect(() => {
+    const handleViewportResize = () => {
+      commitLayoutAction({
+        type: 'environmentChanged',
+        environment: readHandLogEnvironment(scale),
+      })
+    }
     const handleReset = () => {
-      // A reset is authoritative over an in-progress move/resize. Clear the
-      // interaction before applying the default layout so the still-mounted
-      // document listeners cannot revive and persist the stale start layout.
-      interactionRef.current = null
-      setInteractionMode(null)
-      document.body.style.cursor = ''
-      document.body.style.userSelect = ''
-      layoutEditGenerationRef.current += 1
-      applyLayout(null)
+      commitLayoutAction({ type: 'reset' })
     }
     const handleUpdate = (event: Event) => {
       const nextLayout = (event as CustomEvent<unknown>).detail
       if (!isValidHandLogLayout(nextLayout)) return
-
-      const pendingInteraction = interactionRef.current
-      if (pendingInteraction?.moved) {
-        // The visible drag/resize is newer than this persisted broadcast. Its
-        // eventual save will publish the next authoritative layout.
-        return
-      }
-      if (pendingInteraction) {
-        pendingInteraction.startLayout = nextLayout
-      }
-      layoutEditGenerationRef.current += 1
-      applyLayout(nextLayout)
+      commitLayoutAction({ type: 'externalLayout', layout: nextLayout })
     }
+    window.addEventListener('resize', handleViewportResize)
     window.addEventListener('resetHandLogLayout', handleReset)
     window.addEventListener('updateHandLogLayout', handleUpdate)
     return () => {
+      window.removeEventListener('resize', handleViewportResize)
       window.removeEventListener('resetHandLogLayout', handleReset)
       window.removeEventListener('updateHandLogLayout', handleUpdate)
     }
-  }, [applyLayout])
+  }, [scale, commitLayoutAction])
 
   // 新しいエントリが到着したとき自動的に下にスクロール
   useEffect(() => {
@@ -330,7 +630,7 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
 
   // コンテナクリックを処理 - ダブルクリックでクリア
   const handleContainerClick = useCallback((_e: React.MouseEvent) => {
-    if (interactionMode) return
+    if (layoutMachineRef.current.interaction.phase === 'interacting') return
 
     const currentTime = Date.now()
     const timeSinceLastClick = currentTime - lastClickTimeRef.current
@@ -341,7 +641,7 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
       setShowCleared(true)
       setTimeout(() => setShowCleared(false), 1500)
     }
-  }, [interactionMode, onClearLog])
+  }, [onClearLog])
 
   const handleInteractionStart = useCallback((
     mode: HandLogInteractionMode,
@@ -351,50 +651,29 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
     e.preventDefault()
     e.stopPropagation()
 
-    const rect = containerRef.current?.getBoundingClientRect()
-    if (!rect) return
-
-    const currentLayout = layoutRef.current
-    interactionRef.current = {
+    commitLayoutAction({
+      type: 'interactionStarted',
       mode,
-      startX: e.clientX,
-      startY: e.clientY,
-      startLayout: {
-        left: currentLayout?.left ?? rect.left,
-        top: currentLayout?.top ?? rect.top,
-        width: currentLayout?.width ?? DEFAULT_HAND_LOG_CONFIG.width,
-        height: currentLayout?.height ?? DEFAULT_HAND_LOG_CONFIG.height,
-      },
-      moved: false,
-    }
-    setInteractionMode(mode)
-  }, [])
+      x: e.clientX,
+      y: e.clientY,
+    })
+  }, [commitLayoutAction])
 
   useEffect(() => {
+    const interaction = layoutMachine.interaction
+    const interactionMode =
+      interaction.phase === 'interacting' ? interaction.mode : null
     if (!interactionMode) return
 
     const cursor = interactionMode === 'move' ? 'grabbing' : 'nwse-resize'
     document.body.style.cursor = cursor
     document.body.style.userSelect = 'none'
 
-    const finalizeInteraction = () => {
-      const interaction = interactionRef.current
-      const finalLayout = layoutRef.current
-      if (interaction?.moved && finalLayout) {
-        saveHandLogLayout(finalLayout)
-      }
-      interactionRef.current = null
-    }
-
     const finishInteraction = () => {
-      finalizeInteraction()
-      setInteractionMode(null)
+      commitLayoutAction({ type: 'interactionFinished' })
     }
 
     const handleMouseMove = (event: MouseEvent) => {
-      const interaction = interactionRef.current
-      if (!interaction) return
-
       // A mouseup released outside the browser may never reach the document.
       // The first move after re-entry exposes the released primary button, so
       // finish without applying that stale pointer position.
@@ -402,56 +681,11 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
         finishInteraction()
         return
       }
-
-      const deltaX = event.clientX - interaction.startX
-      const deltaY = event.clientY - interaction.startY
-      if (
-        !interaction.moved &&
-        Math.hypot(deltaX, deltaY) < HAND_LOG_DRAG_THRESHOLD
-      ) {
-        return
-      }
-      const { startLayout } = interaction
-      let nextLayout: HandLogLayout
-
-      if (interaction.mode === 'move') {
-        const renderedWidth = startLayout.width * scale
-        const renderedHeight = startLayout.height * scale
-        nextLayout = {
-          ...startLayout,
-          // Clamp only while the user is moving the panel. This keeps the
-          // lower-right grip reachable without reacting to later viewport
-          // changes or rewriting the saved coordinates on load.
-          left: clamp(
-            startLayout.left + deltaX,
-            HAND_LOG_GRIP_SIZE - renderedWidth,
-            window.innerWidth - renderedWidth
-          ),
-          top: clamp(
-            startLayout.top + deltaY,
-            HAND_LOG_GRIP_SIZE - renderedHeight,
-            window.innerHeight - renderedHeight
-          ),
-        }
-      } else {
-        nextLayout = {
-          ...startLayout,
-          width: Math.max(
-            HAND_LOG_MIN_WIDTH,
-            startLayout.width + deltaX / scale
-          ),
-          height: Math.max(
-            HAND_LOG_MIN_HEIGHT,
-            startLayout.height + deltaY / scale
-          ),
-        }
-      }
-
-      if (!interaction.moved) {
-        layoutEditGenerationRef.current += 1
-        interaction.moved = true
-      }
-      applyLayout(nextLayout)
+      commitLayoutAction({
+        type: 'pointerMoved',
+        x: event.clientX,
+        y: event.clientY,
+      })
     }
 
     document.addEventListener('mousemove', handleMouseMove)
@@ -461,27 +695,39 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
       document.removeEventListener('mousemove', handleMouseMove)
       document.removeEventListener('mouseup', finishInteraction)
       window.removeEventListener('blur', finishInteraction)
-      // Cleanup also runs when the HUD shortcut unmounts HandLog while the
-      // mouse is still held. Persist the last visible layout before refs and
-      // listeners disappear.
-      finalizeInteraction()
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
     }
-  }, [applyLayout, interactionMode, scale])
+  }, [
+    layoutMachine.interaction.phase,
+    layoutMachine.interaction.phase === 'interacting'
+      ? layoutMachine.interaction.mode
+      : null,
+    commitLayoutAction,
+  ])
+
+  // Unmount uses the exact same transition/persistence outlet as
+  // mouseup/blur, but skips the render after the component is gone.
+  useEffect(() => () => {
+    commitLayoutAction({ type: 'interactionFinished' }, false)
+  }, [commitLayoutAction])
 
   // 無効の場合はレンダリングしない
   if (!config.enabled) return null
 
-  const width = layout?.width ?? DEFAULT_HAND_LOG_CONFIG.width
-  const height = layout?.height ?? DEFAULT_HAND_LOG_CONFIG.height
+  const { layout, environment } = layoutMachine
+  const { width, height } = layout
+  const interactionMode =
+    layoutMachine.interaction.phase === 'interacting'
+      ? layoutMachine.interaction.mode
+      : null
+  const bodyHeight = Math.max(0, height - HAND_LOG_HEADER_HEIGHT)
 
   // コンテナスタイル
   const containerStyle: CSSProperties = {
     position: 'fixed',
-    ...(layout
-      ? { left: layout.left, top: layout.top }
-      : getPositionStyles(DEFAULT_HAND_LOG_CONFIG.position)),
+    left: layout.left,
+    top: layout.top,
     width: width,
     height,
     backgroundColor: `rgba(0, 0, 0, ${config.opacity})`,
@@ -489,42 +735,42 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
     border: '1px solid rgba(255, 255, 255, 0.2)',
     borderRadius: '4px',
     padding: '0',
-    transform: `scale(${scale})`,
-    transformOrigin: layout
-      ? 'top left'
-      : DEFAULT_HAND_LOG_CONFIG.position.replace('-', ' '),
+    transform: `scale(${environment.scale})`,
+    transformOrigin: 'top left',
     overflowY: 'hidden',
     overflowX: 'hidden',
     fontFamily: 'Consolas, Monaco, "Courier New", monospace',
     fontSize: config.fontSize,
     color: '#ffffff',
-    // The lower-right grip is the only way to move or resize this window.
-    // Keep its stacking context above player HUD panels (z-index 9999) so an
-    // overlap can never make the grip unreachable.
+    // Keep the header and resize corner above player HUD panels (z-index
+    // 9999) so an overlap cannot make either interaction unreachable.
     zIndex: 10000,
     boxShadow: '0 2px 4px rgba(0, 0, 0, 0.3)',
-    cursor: 'pointer'
+    cursor: 'default'
   }
 
-  // One visible lower-right control owns both interactions: drag the main
-  // surface to move, or drag its triangular outer corner to resize.
-  const gripStyle: CSSProperties = {
-    position: 'absolute',
-    right: 0,
-    bottom: 0,
-    width: HAND_LOG_GRIP_SIZE,
-    height: HAND_LOG_GRIP_SIZE,
+  const headerStyle: CSSProperties = {
+    boxSizing: 'border-box',
+    width: '100%',
+    height: HAND_LOG_HEADER_HEIGHT,
+    padding: '0 8px',
     cursor: interactionMode === 'move' ? 'grabbing' : 'grab',
-    backgroundColor: 'rgba(255, 255, 255, 0.14)',
-    borderTopLeftRadius: 6,
-    color: 'rgba(255, 255, 255, 0.75)',
+    backgroundColor: 'rgba(255, 255, 255, 0.12)',
+    borderBottom: '1px solid rgba(255, 255, 255, 0.2)',
+    color: 'rgba(255, 255, 255, 0.9)',
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'center',
-    fontSize: 15,
+    gap: 7,
+    fontSize: Math.max(11, config.fontSize - 1),
+    fontWeight: 600,
     lineHeight: 1,
     userSelect: 'none',
-    zIndex: 2,
+  }
+
+  const headerGripIconStyle: CSSProperties = {
+    color: 'rgba(255, 255, 255, 0.65)',
+    fontSize: 14,
+    letterSpacing: -2,
   }
 
   const resizeCornerStyle: CSSProperties = {
@@ -535,6 +781,7 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
     height: 12,
     cursor: 'nwse-resize',
     background: 'linear-gradient(135deg, transparent 48%, rgba(255, 255, 255, 0.9) 50%)',
+    zIndex: 2,
   }
 
   const rowProps: EntryRowData = {
@@ -547,10 +794,20 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
 
   return (
     <div
-      ref={containerRef}
       style={containerStyle}
       onClick={handleContainerClick}
     >
+      <div
+        data-testid="hand-log-header"
+        title="ドラッグしてハンドログを移動"
+        style={headerStyle}
+        onMouseDown={(event) => handleInteractionStart('move', event)}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <span aria-hidden="true" style={headerGripIconStyle}>⠿</span>
+        <span>ハンドログ</span>
+      </div>
+
       {processedItems.length > 0 ? (
         <List
           listRef={listRef}
@@ -558,37 +815,31 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
           rowHeight={getItemSize}
           rowComponent={EntryRow}
           rowProps={rowProps}
-          style={{ height, width }}
+          style={{ height: bodyHeight, width }}
         />
       ) : (
         <div style={{
+          height: bodyHeight,
+          boxSizing: 'border-box',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
           color: '#666666',
           textAlign: 'center',
-          marginTop: '40%',
-          transform: 'translateY(-50%)',
           fontSize: config.fontSize - 1
         }}>
           Waiting for hand...
         </div>
       )}
 
-      {/* 右下の移動兼リサイズグリップ */}
+      {/* 右下はリサイズ専用。移動は上部ヘッダーだけが開始する。 */}
       <div
-        data-testid="hand-log-move-grip"
-        title="ドラッグしてハンドログを移動"
-        style={gripStyle}
-        onMouseDown={(event) => handleInteractionStart('move', event)}
+        data-testid="hand-log-resize-corner"
+        title="ドラッグしてハンドログのサイズを変更"
+        style={resizeCornerStyle}
+        onMouseDown={(event) => handleInteractionStart('resize', event)}
         onClick={(event) => event.stopPropagation()}
-      >
-        ⠿
-        <div
-          data-testid="hand-log-resize-corner"
-          title="ドラッグしてハンドログのサイズを変更"
-          style={resizeCornerStyle}
-          onMouseDown={(event) => handleInteractionStart('resize', event)}
-          onClick={(event) => event.stopPropagation()}
-        />
-      </div>
+      />
 
       {/* ステータスインジケーター */}
       {showCopied && (

--- a/src/components/HandLog.tsx
+++ b/src/components/HandLog.tsx
@@ -82,7 +82,7 @@ type HandLogMachineAction =
   | { type: 'reset' }
   | { type: 'interactionStarted', mode: HandLogInteractionMode, x: number, y: number }
   | { type: 'pointerMoved', x: number, y: number }
-  | { type: 'interactionFinished' }
+  | { type: 'interactionFinished', deferPersistenceForLoad?: boolean }
 
 interface HandLogTransition {
   state: HandLogLayoutMachine
@@ -106,19 +106,30 @@ const readHandLogEnvironment = (scale: number): HandLogEnvironment => ({
   viewportHeight: window.innerHeight,
 })
 
+const getHandLogDisplayHeight = (
+  layout: HandLogLayout,
+  environment: HandLogEnvironment
+): number =>
+  Math.min(layout.height, environment.viewportHeight / environment.scale)
+
 const normalizeHandLogLayout = (
   layout: HandLogLayout,
   environment: HandLogEnvironment
 ): HandLogLayout => {
   const { scale, viewportWidth, viewportHeight } = environment
   const maximumHeight = viewportHeight / scale
+  // A sub-minimum viewport temporarily shrinks only the rendered panel.
+  // Keep state/persistence at HAND_LOG_MIN_HEIGHT or above; see PR #304.
   const height = clamp(
     layout.height,
-    Math.min(HAND_LOG_MIN_HEIGHT, maximumHeight),
-    maximumHeight
+    HAND_LOG_MIN_HEIGHT,
+    Math.max(HAND_LOG_MIN_HEIGHT, maximumHeight)
   )
   const renderedWidth = layout.width * scale
-  const renderedHeight = height * scale
+  const renderedHeight = getHandLogDisplayHeight(
+    { ...layout, height },
+    environment
+  ) * scale
   const reachableWidth = Math.min(
     HAND_LOG_HEADER_REACHABLE_WIDTH * scale,
     viewportWidth
@@ -189,14 +200,12 @@ const transitionHandLogLayout = (
         ) {
           return { state }
         }
+        // The active environment is intentionally unchanged until finish, so
+        // its in-flight load remains valid during the interaction.
         return {
           state: {
             ...state,
             pendingEnvironment,
-            activeLoad:
-              state.environment.scale !== action.environment.scale
-                ? null
-                : state.activeLoad,
           },
         }
       }
@@ -365,7 +374,11 @@ const transitionHandLogLayout = (
         environment
       )
       const shouldPersist =
-        state.interaction.moved || state.pendingEnvironment !== null
+        (
+          state.interaction.moved ||
+          state.pendingEnvironment !== null
+        ) &&
+        !action.deferPersistenceForLoad
       return {
         state: {
           ...state,
@@ -493,6 +506,9 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
     )
   const layoutMachineRef = useRef(layoutMachine)
   const loadSequenceRef = useRef(0)
+  const requestedLoadScaleRef = useRef<number | null>(null)
+  const latestScaleRef = useRef(scale)
+  latestScaleRef.current = scale
   const [showCopied, setShowCopied] = useState(false)
   const [showCleared, setShowCleared] = useState(false)
   const lastClickTimeRef = useRef<number>(0)
@@ -567,6 +583,12 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
   }, [scale, commitLayoutAction])
 
   useEffect(() => {
+    // A scale change during pointer interaction is loaded only after the
+    // interaction ends. This avoids adding another layout-machine lifecycle
+    // branch while ensuring the latest scale still gets an authoritative load.
+    if (layoutMachine.interaction.phase === 'interacting') return
+    if (requestedLoadScaleRef.current === scale) return
+    requestedLoadScaleRef.current = scale
     const load = {
       id: ++loadSequenceRef.current,
       scale,
@@ -579,7 +601,7 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
         layout: savedLayout,
       })
     })
-  }, [scale, commitLayoutAction])
+  }, [scale, layoutMachine.interaction.phase, commitLayoutAction])
 
   useEffect(() => {
     const handleViewportResize = () => {
@@ -685,6 +707,34 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
     })
   }, [commitLayoutAction])
 
+  const finishLayoutInteraction = useCallback((render = true) => {
+    const current = layoutMachineRef.current
+    if (current.interaction.phase !== 'interacting') return
+
+    const deferredScaleLoad =
+      requestedLoadScaleRef.current !== latestScaleRef.current
+    const deferPersistenceForLoad =
+      !current.interaction.moved &&
+      (
+        deferredScaleLoad ||
+        (
+          current.pendingEnvironment !== null &&
+          current.activeLoad !== null
+        )
+      )
+
+    if (current.interaction.moved && deferredScaleLoad) {
+      // An intentional move/resize wins over the deferred saved layout.
+      // Mark the new scale handled so the post-finish effect cannot rewind it.
+      requestedLoadScaleRef.current = latestScaleRef.current
+    }
+
+    commitLayoutAction({
+      type: 'interactionFinished',
+      deferPersistenceForLoad,
+    }, render)
+  }, [commitLayoutAction])
+
   useEffect(() => {
     const interaction = layoutMachine.interaction
     const interactionMode =
@@ -696,7 +746,7 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
     document.body.style.userSelect = 'none'
 
     const finishInteraction = () => {
-      commitLayoutAction({ type: 'interactionFinished' })
+      finishLayoutInteraction()
     }
 
     const handleMouseMove = (event: MouseEvent) => {
@@ -729,20 +779,22 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
     layoutMachine.interaction.phase === 'interacting'
       ? layoutMachine.interaction.mode
       : null,
-    commitLayoutAction,
+    finishLayoutInteraction,
   ])
 
   // Unmount uses the exact same transition/persistence outlet as
   // mouseup/blur, but skips the render after the component is gone.
   useEffect(() => () => {
-    commitLayoutAction({ type: 'interactionFinished' }, false)
-  }, [commitLayoutAction])
+    finishLayoutInteraction(false)
+  }, [finishLayoutInteraction])
 
   // 無効の場合はレンダリングしない
   if (!config.enabled) return null
 
   const { layout, environment } = layoutMachine
-  const { width, height } = layout
+  const { width } = layout
+  // Display-only shrink: the layout kept by the machine remains persistable.
+  const height = getHandLogDisplayHeight(layout, environment)
   const interactionMode =
     layoutMachine.interaction.phase === 'interacting'
       ? layoutMachine.interaction.mode


### PR DESCRIPTION
## 概要

close 済み #301 の代替実装です。HandLog の位置・サイズ・scale・viewport・非同期レイアウト読込・操作中状態を、コンポーネント内の単一状態機械へ集約しました。

## 変更内容

- 移動ハンドルを右下グリップから上部ヘッダーへ変更
- 右下角はリサイズ専用として維持
- 正規化と端末ローカル保存を共通の状態遷移出口へ集約
- 旧 scale に束縛された非同期 load callback を request id + scale で棄却
- 操作中の viewport/scale 変更を pending environment として保持し、共通終了時に正規化して一度だけ保存
- #301 で accept 済みだった負値 top、画面高超 height、表示中 viewport 縮小、未保存の既定配置、狭い初期 viewport の回帰を防止
- 状態機械の不変条件を `AGENTS.md` に記録

## スコープ

変更は `HandLog.tsx`、同コンポーネントのテスト、対応する `AGENTS.md` 記述に限定しています。イベント取り込み、統計パイプライン、background protocol、保存 schema、他コンポーネントには変更を加えていません。

## Validation

- `npm run test -- --runInBand src/components/HandLog.test.tsx` — 40 passed
- `npm run test -- --runInBand` — 1578 passed / 157 suites
- `npm run typecheck` — passed
- `npm run build` — passed
- `git diff --check` — passed

## Risk

状態機械の境界は stale scale load、操作中 viewport/scale 変更、mousemove なし終了、blur/unmount/missed mouseup を対象テストで固定しています。ローカルでは実 PokerChase セッションによる手動確認は行っていないため、browser-e2e/CI を integration 確認として扱います。

Closes the replacement scope for #301; #301 itself remains closed.
