### PR TITLE
fix(ui): ハンドログのヘッダーを右上グリップへ置換し画面内へ収める

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -481,10 +481,12 @@ viewport, so merely narrowing the window (or moving the panel) leaves the
 user's size intact and restores it when the window grows back. A *resize*
 gesture is the one path that does rewrite the stored size — it deliberately
 starts from the rendered size and is capped at the scaled viewport, so the
-result is WYSIWYG on both axes and can never store a size the user cannot see.
-An axis whose scaled viewport cannot even fit the minimum is exempt from that
-rewrite: clamping there would pin the stored value to the minimum while the
-rendered size stays put, i.e. a shrink the user never sees.
+result is WYSIWYG. That rewrite is per-axis and conditional on the rendered
+size actually changing: an axis already pinned to its viewport limit (stored
+size larger than the viewport, or a viewport too small for the minimum) keeps
+its stored value when the gesture cannot move it, so the axis the user did not
+drag — and an outward drag with nowhere to grow — cannot silently collapse a
+stored size down to the current screen.
 Position is always clamped (there is no "display-only" position), and a
 viewport dimension that reads as `0` — observed transiently right after a
 navigation — suspends only that axis' *upper* bound, never the `0` lower bound,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -482,6 +482,9 @@ user's size intact and restores it when the window grows back. A *resize*
 gesture is the one path that does rewrite the stored size — it deliberately
 starts from the rendered size and is capped at the scaled viewport, so the
 result is WYSIWYG on both axes and can never store a size the user cannot see.
+An axis whose scaled viewport cannot even fit the minimum is exempt from that
+rewrite: clamping there would pin the stored value to the minimum while the
+rendered size stays put, i.e. a shrink the user never sees.
 Position is always clamped (there is no "display-only" position), and a
 viewport dimension that reads as `0` — observed transiently right after a
 navigation — suspends only that axis' *upper* bound, never the `0` lower bound,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -470,9 +470,10 @@ active pointer interaction, rejects layout-load callbacks bound to an older
 request or scale, and emits at most one persistence effect from the common
 interaction exit. Do not add another effect/ref that mutates or saves hand-log
 coordinates outside that transition outlet. There is no header bar: the
-upper-left grip (16px, `hand-log-move-grip`) is the move handle and the
+upper-right grip (16px, `hand-log-move-grip`) is the move handle and the
 lower-right corner is resize-only, so the whole panel height belongs to the log
-body. Normalization keeps the entire rendered panel inside the viewport on both
+body. The grip is deliberately upper-*right*: it overlays the log body, and a
+line's start is always occupied by text while its end is usually blank. Normalization keeps the entire rendered panel inside the viewport on both
 axes and applies to loaded, default, reset, external, pointer, and
 viewport/scale-driven layouts. Normalization's size clamping is display-only:
 it enforces the minimums but never shrinks the stored width/height to fit the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -469,11 +469,27 @@ persistence in one component-local state machine. The machine's concrete
 active pointer interaction, rejects layout-load callbacks bound to an older
 request or scale, and emits at most one persistence effect from the common
 interaction exit. Do not add another effect/ref that mutates or saves hand-log
-coordinates outside that transition outlet. The header is the move handle; the
-lower-right corner is resize-only. Normalization keeps the full vertical panel
-and a usable horizontal portion of the header reachable, caps height to the
-scaled viewport, and applies to loaded, default, reset, external, pointer, and
-viewport/scale-driven layouts.
+coordinates outside that transition outlet. There is no header bar: the
+upper-left grip (16px, `hand-log-move-grip`) is the move handle and the
+lower-right corner is resize-only, so the whole panel height belongs to the log
+body. Normalization keeps the entire rendered panel inside the viewport on both
+axes and applies to loaded, default, reset, external, pointer, and
+viewport/scale-driven layouts. Normalization's size clamping is display-only:
+it enforces the minimums but never shrinks the stored width/height to fit the
+viewport, so merely narrowing the window (or moving the panel) leaves the
+user's size intact and restores it when the window grows back. A *resize*
+gesture is the one path that does rewrite the stored size — it deliberately
+starts from the rendered size and is capped at the scaled viewport, so the
+result is WYSIWYG on both axes and can never store a size the user cannot see.
+Position is always clamped (there is no "display-only" position), and a
+viewport dimension that reads as `0` — observed transiently right after a
+navigation — suspends only that axis' *upper* bound, never the `0` lower bound,
+so a panel cannot vanish or latch off-screen while the viewport is unknown.
+Growing past an edge is resolved by the position clamp pulling the panel back
+rather than by refusing to grow: the default bottom-right position leaves only
+10px of slack, so edge-stopping would make the panel effectively non-resizable.
+The container is `border-box` so its rendered footprint equals the clamped
+width/height exactly; the log body is that minus `HAND_LOG_BORDER_WIDTH*2`.
 
 **Popup theming**: `src/components/popup/theme.ts` defines two MUI themes -- `dark-felt` (default look, shares the HUD overlay's dark/gold palette) and `modern-light`. Which one renders is controlled by the `popupTheme` setting (`'auto' | 'dark' | 'light'`, default `'auto'`; テーマ control in `PopupHeader.tsx`, a 自動/ダーク/ライト 3-way `SegmentRadio`). `'auto'` resolves against the live OS `prefers-color-scheme` via `useMediaQuery` in `Popup.tsx` (`resolvePopupThemeVariant()` in `theme.ts` is the pure resolver, unit-tested independent of the DOM). Persisted to its own `chrome.storage.sync` key (`popupTheme`, see `popup-theme-storage.ts`) -- deliberately **not** a field on `UIConfig`, because `UIScaleSection`/`HudDisplaySection` broadcast every `uiConfig` write to all open game tabs (`chrome.tabs.sendMessage(..., 'updateUIConfig')`) to trigger a HUD re-render; the popup's own chrome has nothing to do with the HUD overlay, so nesting it there would fire that broadcast on every theme change for no reason. `popup.ts` pre-fetches the persisted mode before the first `render()` call so the popup never paints with the wrong theme and then swaps.
 

--- a/src/components/HandLog.test.tsx
+++ b/src/components/HandLog.test.tsx
@@ -519,6 +519,31 @@ describe('HandLog', () => {
     expect(logContainer.style.height).toBe('60px')
   })
 
+  it('最小サイズを収容できないviewportではリサイズしても保存サイズを縮めない', () => {
+    // 表示はviewport上限(160x60)に貼り付いていて1pxも動かせない。ここで保存値
+    // だけ最小値へ落ちると、見えない縮小になってしまう。
+    setViewport(320, 120)
+    const { container } = render(<HandLog entries={mockEntries} scale={2} />)
+    const logContainer = container.firstChild as HTMLElement
+
+    fireEvent.mouseDown(screen.getByTestId('hand-log-resize-corner'), {
+      button: 0,
+      clientX: 320,
+      clientY: 120,
+    })
+    moveMouseWithPrimaryButton(280, 100)
+    fireEvent.mouseUp(document)
+
+    expect(logContainer.style.width).toBe('160px')
+    expect(logContainer.style.height).toBe('60px')
+    expect(savedLayoutCalls()[0]![0].layout).toEqual({
+      left: 0,
+      top: 0,
+      width: 400,
+      height: 100,
+    })
+  })
+
   it('layout読込timeout後も同じloadの権威的応答を適用する', () => {
     jest.useFakeTimers()
     const loadCallbacks: Array<(response: unknown) => void> = []

--- a/src/components/HandLog.test.tsx
+++ b/src/components/HandLog.test.tsx
@@ -519,6 +519,53 @@ describe('HandLog', () => {
     expect(logContainer.style.height).toBe('60px')
   })
 
+  it('表示上限へ貼り付いた軸はリサイズしても保存サイズを縮めない', () => {
+    mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
+      if (message.action === 'getDeviceHandLogLayout') {
+        callback({
+          success: true,
+          layout: { left: 0, top: 100, width: 1400, height: 200 },
+        })
+      } else {
+        callback?.({ success: true })
+      }
+    })
+    const { container } = render(<HandLog entries={mockEntries} />)
+    const logContainer = container.firstChild as HTMLElement
+    const resizeCorner = screen.getByTestId('hand-log-resize-corner')
+
+    expect(logContainer.style.width).toBe('1024px')
+
+    // 縦だけドラッグ: 横は掴んでいないので保存幅1400を維持する。
+    fireEvent.mouseDown(resizeCorner, {
+      button: 0,
+      clientX: 1024,
+      clientY: 300,
+    })
+    moveMouseWithPrimaryButton(1024, 350)
+    fireEvent.mouseUp(document)
+
+    expect(logContainer.style.height).toBe('250px')
+    expect(savedLayoutCalls()[0]![0].layout).toEqual({
+      left: 0,
+      top: 100,
+      width: 1400,
+      height: 250,
+    })
+
+    // 外向きドラッグ: 既に上限なので表示は変わらない。保存幅も維持する。
+    fireEvent.mouseDown(resizeCorner, {
+      button: 0,
+      clientX: 1024,
+      clientY: 350,
+    })
+    moveMouseWithPrimaryButton(1300, 350)
+    fireEvent.mouseUp(document)
+
+    expect(logContainer.style.width).toBe('1024px')
+    expect(savedLayoutCalls()[1]![0].layout.width).toBe(1400)
+  })
+
   it('最小サイズを収容できないviewportではリサイズしても保存サイズを縮めない', () => {
     // 表示はviewport上限(160x60)に貼り付いていて1pxも動かせない。ここで保存値
     // だけ最小値へ落ちると、見えない縮小になってしまう。

--- a/src/components/HandLog.test.tsx
+++ b/src/components/HandLog.test.tsx
@@ -202,12 +202,14 @@ describe('HandLog', () => {
     expect(screen.getByTestId('hand-log-resize-corner')).toBeInTheDocument()
     expect(screen.queryByTestId('hand-log-header')).not.toBeInTheDocument()
     // グリップはヘッダー帯と違い本文の上に重なるので、被って掴めなくならない
-    // よう本文より前面に置く必要がある。
+    // よう本文より前面に置く必要がある。行頭は必ず文字で埋まるため右上固定。
     const moveGrip = screen.getByTestId('hand-log-move-grip')
     expect(moveGrip).toHaveStyle({
       width: '16px',
       height: '16px',
       position: 'absolute',
+      top: '0px',
+      right: '0px',
     })
     expect(Number(moveGrip.style.zIndex)).toBeGreaterThan(
       Number(screen.getByTestId('virtual-list').style.zIndex || 0)

--- a/src/components/HandLog.test.tsx
+++ b/src/components/HandLog.test.tsx
@@ -194,22 +194,32 @@ describe('HandLog', () => {
     expect(logContainer.style.height).toBe(`${DEFAULT_HAND_LOG_CONFIG.height}px`)
   })
 
-  it('HUDと重なってもヘッダーとリサイズ角を掴めるstacking順を維持する', () => {
+  it('HUDと重なっても移動グリップとリサイズ角を掴めるstacking順を維持する', () => {
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
 
     expect(Number(logContainer.style.zIndex)).toBeGreaterThan(9999)
-    expect(screen.getByTestId('hand-log-header')).toBeInTheDocument()
     expect(screen.getByTestId('hand-log-resize-corner')).toBeInTheDocument()
-    expect(screen.queryByTestId('hand-log-move-grip')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('hand-log-header')).not.toBeInTheDocument()
+    // グリップはヘッダー帯と違い本文の上に重なるので、被って掴めなくならない
+    // よう本文より前面に置く必要がある。
+    const moveGrip = screen.getByTestId('hand-log-move-grip')
+    expect(moveGrip).toHaveStyle({
+      width: '16px',
+      height: '16px',
+      position: 'absolute',
+    })
+    expect(Number(moveGrip.style.zIndex)).toBeGreaterThan(
+      Number(screen.getByTestId('virtual-list').style.zIndex || 0)
+    )
   })
 
-  it('ヘッダーをドラッグして移動し端末ローカルへ一度だけ保存する', () => {
+  it('移動グリップをドラッグして移動し端末ローカルへ一度だけ保存する', () => {
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
     updateLayout({ left: 500, top: 400, width: 400, height: 100 })
 
-    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
+    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
       button: 0,
       clientX: 600,
       clientY: 414,
@@ -248,11 +258,11 @@ describe('HandLog', () => {
     expect(savedLayoutCalls()).toHaveLength(0)
   })
 
-  it('ヘッダーとリサイズ角のdouble-clickでログを誤消去しない', async () => {
+  it('移動グリップとリサイズ角のdouble-clickでログを誤消去しない', async () => {
     const user = userEvent.setup()
     render(<HandLog entries={mockEntries} onClearLog={mockOnClearLog} />)
 
-    await user.dblClick(screen.getByTestId('hand-log-header'))
+    await user.dblClick(screen.getByTestId('hand-log-move-grip'))
     await user.dblClick(screen.getByTestId('hand-log-resize-corner'))
 
     expect(mockOnClearLog).not.toHaveBeenCalled()
@@ -271,7 +281,7 @@ describe('HandLog', () => {
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
 
-    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
+    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
       button: 0,
       clientX: 700,
       clientY: 540,
@@ -290,7 +300,7 @@ describe('HandLog', () => {
   })
 
   it.each([
-    { testId: 'hand-log-header', startX: 700, startY: 540 },
+    { testId: 'hand-log-move-grip', startX: 700, startY: 540 },
     { testId: 'hand-log-resize-corner', startX: 1014, startY: 633 },
   ])('操作の微小jitterでは遅れて届いた保存layoutを無効化しない', ({
     testId,
@@ -328,7 +338,7 @@ describe('HandLog', () => {
     expect(savedLayoutCalls()).toHaveLength(0)
   })
 
-  it('旧レイアウトの負値topを読んでもヘッダーを画面内へ復帰させる', () => {
+  it('旧レイアウトの負値topを読んでも移動グリップを画面内へ復帰させる', () => {
     mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
       if (message.action === 'getDeviceHandLogLayout') {
         callback({
@@ -343,10 +353,10 @@ describe('HandLog', () => {
     const logContainer = container.firstChild as HTMLElement
 
     expect(logContainer.style.top).toBe('0px')
-    expect(screen.getByTestId('hand-log-header')).toBeInTheDocument()
+    expect(screen.getByTestId('hand-log-move-grip')).toBeInTheDocument()
   })
 
-  it('画面高を超える保存heightを上限へ戻しリサイズ角を画面内へ復帰させる', () => {
+  it('画面高を超える保存heightは表示だけ上限へ戻しリサイズ角を画面内へ保つ', () => {
     mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
       if (message.action === 'getDeviceHandLogLayout') {
         callback({
@@ -376,7 +386,74 @@ describe('HandLog', () => {
     expect(savedLayoutCalls()).toHaveLength(1)
   })
 
-  it('mount後のviewport縮小でもヘッダーとリサイズ角を画面内へ正規化する', () => {
+  it('viewportの一時的な縮小で指定サイズを恒久的に潰さない', () => {
+    mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
+      if (message.action === 'getDeviceHandLogLayout') {
+        callback({
+          success: true,
+          layout: { left: 100, top: 100, width: 600, height: 300 },
+        })
+      } else {
+        callback?.({ success: true })
+      }
+    })
+    const { container } = render(<HandLog entries={mockEntries} />)
+    const logContainer = container.firstChild as HTMLElement
+
+    setViewport(320, 240)
+    fireEvent(window, new Event('resize'))
+
+    expect(logContainer.style.left).toBe('0px')
+    expect(logContainer.style.top).toBe('0px')
+    expect(logContainer.style.width).toBe('320px')
+    expect(logContainer.style.height).toBe('240px')
+
+    setViewport(1024, 768)
+    fireEvent(window, new Event('resize'))
+
+    expect(logContainer.style.width).toBe('600px')
+    expect(logContainer.style.height).toBe('300px')
+  })
+
+  it('viewportが0で読めてもパネルを消さず位置も動かさない', () => {
+    mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
+      if (message.action === 'getDeviceHandLogLayout') {
+        callback({
+          success: true,
+          layout: { left: 100, top: 100, width: 600, height: 300 },
+        })
+      } else {
+        callback?.({ success: true })
+      }
+    })
+    const { container } = render(<HandLog entries={mockEntries} />)
+    const logContainer = container.firstChild as HTMLElement
+
+    // 遷移直後などinnerWidth/innerHeightは一時的に0で読めることがある。
+    setViewport(0, 0)
+    fireEvent(window, new Event('resize'))
+
+    expect(logContainer.style.left).toBe('100px')
+    expect(logContainer.style.top).toBe('100px')
+    expect(logContainer.style.width).toBe('600px')
+    expect(logContainer.style.height).toBe('300px')
+    expect(savedLayoutCalls()).toHaveLength(0)
+  })
+
+  it('viewportが0でも負の既定座標は画面内へ寄せる', () => {
+    // 保存layoutがない状態で0を読むと既定layoutは大きな負値になる。
+    // 上限だけがviewport依存で、下限0は常に効かせる。
+    setViewport(0, 0)
+    const { container } = render(<HandLog entries={mockEntries} />)
+    const logContainer = container.firstChild as HTMLElement
+
+    expect(logContainer.style.left).toBe('0px')
+    expect(logContainer.style.top).toBe('0px')
+    expect(logContainer.style.width).toBe('400px')
+    expect(logContainer.style.height).toBe('100px')
+  })
+
+  it('mount後のviewport縮小でもパネル全体を画面内へ正規化する', () => {
     mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
       if (message.action === 'getDeviceHandLogLayout') {
         callback({
@@ -402,23 +479,25 @@ describe('HandLog', () => {
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
 
-    expect(logContainer.style.left).toBe('-90px')
+    expect(logContainer.style.left).toBe('0px')
     expect(logContainer.style.top).toBe('0px')
-    expect(logContainer.style.width).toBe('400px')
+    expect(logContainer.style.width).toBe('320px')
     expect(logContainer.style.height).toBe('100px')
   })
 
-  it('最小高さより狭いviewportでは表示だけ縮め保存heightを有効値に保つ', () => {
+  it('最小サイズより狭いviewportでは表示だけ縮め保存サイズを潰さない', () => {
     setViewport(320, 120)
     const { container } = render(<HandLog entries={mockEntries} scale={2} />)
     const logContainer = container.firstChild as HTMLElement
 
+    expect(logContainer.style.left).toBe('0px')
     expect(logContainer.style.top).toBe('0px')
+    expect(logContainer.style.width).toBe('160px')
     expect(logContainer.style.height).toBe('60px')
     expect(logContainer.style.transform).toContain('scale(2)')
     expect(screen.getByTestId('hand-log-resize-corner')).toBeInTheDocument()
 
-    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
+    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
       button: 0,
       clientX: 100,
       clientY: 20,
@@ -427,7 +506,14 @@ describe('HandLog', () => {
     fireEvent.mouseUp(document)
 
     expect(savedLayoutCalls()).toHaveLength(1)
-    expect(savedLayoutCalls()[0]![0].layout.height).toBe(80)
+    // 表示は160x60でも、保存されるのは指定サイズのまま。
+    expect(savedLayoutCalls()[0]![0].layout).toEqual({
+      left: 0,
+      top: 0,
+      width: 400,
+      height: 100,
+    })
+    expect(logContainer.style.width).toBe('160px')
     expect(logContainer.style.height).toBe('60px')
   })
 
@@ -523,7 +609,7 @@ describe('HandLog', () => {
         staleResizeListener(new Event('resize'))
         loadCallbacks[1]!({
           success: true,
-          layout: { left: 40, top: 30, width: 500, height: 200 },
+          layout: { left: 40, top: 30, width: 300, height: 200 },
         })
       })
 
@@ -550,7 +636,7 @@ describe('HandLog', () => {
     const logContainer = container.firstChild as HTMLElement
 
     expect(loadCallbacks).toHaveLength(1)
-    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
+    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
       button: 0,
       clientX: 700,
       clientY: 550,
@@ -565,7 +651,7 @@ describe('HandLog', () => {
     act(() => {
       loadCallbacks[1]!({
         success: true,
-        layout: { left: 40, top: 30, width: 500, height: 200 },
+        layout: { left: 40, top: 30, width: 300, height: 200 },
       })
       loadCallbacks[0]!({
         success: true,
@@ -575,7 +661,7 @@ describe('HandLog', () => {
 
     expect(logContainer.style.left).toBe('40px')
     expect(logContainer.style.top).toBe('30px')
-    expect(logContainer.style.width).toBe('500px')
+    expect(logContainer.style.width).toBe('300px')
     expect(logContainer.style.height).toBe('200px')
     expect(logContainer.style.transform).toContain('scale(2)')
   })
@@ -594,7 +680,7 @@ describe('HandLog', () => {
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
 
-    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
+    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
       button: 0,
       clientX: 200,
       clientY: 514,
@@ -637,7 +723,7 @@ describe('HandLog', () => {
     )
     const logContainer = container.firstChild as HTMLElement
 
-    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
+    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
       button: 0,
       clientX: 200,
       clientY: 514,
@@ -655,24 +741,105 @@ describe('HandLog', () => {
     expect(savedLayoutCalls()).toHaveLength(0)
   })
 
-  it('移動中もヘッダーの一部と縦方向全体を画面内へ保つ', () => {
+  it('左上へ移動してもパネル全体を画面内へ保つ', () => {
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
     updateLayout({ left: 500, top: 400, width: 400, height: 100 })
 
-    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
+    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
       button: 0,
       clientX: 600,
       clientY: 414,
     })
     moveMouseWithPrimaryButton(-2000, -2000)
 
-    expect(logContainer.style.left).toBe('-320px')
+    expect(logContainer.style.left).toBe('0px')
     expect(logContainer.style.top).toBe('0px')
     fireEvent.mouseUp(document)
   })
 
-  it('右下角で縦横をリサイズし最小値と画面高上限を適用する', () => {
+  it('右下へ移動してもパネル全体を画面内へ保つ', () => {
+    const { container } = render(<HandLog entries={mockEntries} />)
+    const logContainer = container.firstChild as HTMLElement
+    updateLayout({ left: 500, top: 400, width: 400, height: 100 })
+
+    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
+      button: 0,
+      clientX: 600,
+      clientY: 414,
+    })
+    moveMouseWithPrimaryButton(3000, 3000)
+
+    // 右下端 = viewport - パネル実寸 (1024-400, 768-100)
+    expect(logContainer.style.left).toBe('624px')
+    expect(logContainer.style.top).toBe('668px')
+    fireEvent.mouseUp(document)
+
+    expect(savedLayoutCalls()).toEqual([
+      [
+        {
+          action: 'setDeviceHandLogLayout',
+          layout: { left: 624, top: 668, width: 400, height: 100 },
+        },
+        expect.any(Function),
+      ],
+    ])
+  })
+
+  it('scale込みの実寸で画面内に収める', () => {
+    const { container } = render(<HandLog entries={mockEntries} scale={2} />)
+    const logContainer = container.firstChild as HTMLElement
+    updateLayout({ left: 100, top: 100, width: 400, height: 200 })
+
+    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
+      button: 0,
+      clientX: 200,
+      clientY: 200,
+    })
+    moveMouseWithPrimaryButton(3000, 3000)
+
+    // 実寸は 800x400。scaleを無視した400x200では画面外へはみ出す。
+    expect(logContainer.style.left).toBe('224px')
+    expect(logContainer.style.top).toBe('368px')
+    fireEvent.mouseUp(document)
+  })
+
+  it('画面幅を超える保存widthは表示だけ上限へ戻して画面内へ収める', () => {
+    mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
+      if (message.action === 'getDeviceHandLogLayout') {
+        callback({
+          success: true,
+          layout: { left: 800, top: 100, width: 1400, height: 200 },
+        })
+      } else {
+        callback?.({ success: true })
+      }
+    })
+    const { container } = render(<HandLog entries={mockEntries} />)
+    const logContainer = container.firstChild as HTMLElement
+
+    expect(logContainer.style.left).toBe('0px')
+    expect(logContainer.style.width).toBe('1024px')
+    expect(logContainer.style.top).toBe('100px')
+
+    // 表示だけの縮小であること: 移動しても保存widthは1400のまま。
+    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
+      button: 0,
+      clientX: 8,
+      clientY: 108,
+    })
+    moveMouseWithPrimaryButton(8, 158)
+    fireEvent.mouseUp(document)
+
+    expect(savedLayoutCalls()[0]![0].layout).toEqual({
+      left: 0,
+      top: 150,
+      width: 1400,
+      height: 200,
+    })
+  })
+
+  it('右下角で縦横をリサイズし最小値を適用する', () => {
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
     updateLayout({ left: 500, top: 400, width: 400, height: 100 })
@@ -683,22 +850,56 @@ describe('HandLog', () => {
       clientX: 900,
       clientY: 500,
     })
-    moveMouseWithPrimaryButton(1900, 1500)
-
-    expect(logContainer.style.width).toBe('1400px')
-    expect(logContainer.style.height).toBe('768px')
-    expect(logContainer.style.top).toBe('0px')
-    fireEvent.mouseUp(document)
-
-    fireEvent.mouseDown(resizeCorner, {
-      button: 0,
-      clientX: 1900,
-      clientY: 768,
-    })
-    moveMouseWithPrimaryButton(0, 0)
+    moveMouseWithPrimaryButton(700, 450)
 
     expect(logContainer.style.width).toBe('200px')
     expect(logContainer.style.height).toBe('80px')
+    fireEvent.mouseUp(document)
+  })
+
+  it('画面端を越える拡大はviewport実寸で頭打ちし左上を戻して収める', () => {
+    const { container } = render(<HandLog entries={mockEntries} />)
+    const logContainer = container.firstChild as HTMLElement
+    updateLayout({ left: 500, top: 400, width: 400, height: 100 })
+
+    fireEvent.mouseDown(screen.getByTestId('hand-log-resize-corner'), {
+      button: 0,
+      clientX: 900,
+      clientY: 500,
+    })
+    moveMouseWithPrimaryButton(1900, 1500)
+
+    expect(logContainer.style.width).toBe('1024px')
+    expect(logContainer.style.height).toBe('768px')
+    expect(logContainer.style.left).toBe('0px')
+    expect(logContainer.style.top).toBe('0px')
+    fireEvent.mouseUp(document)
+
+    // 保存されるのも実寸まで。画面に出ない巨大サイズは作らない。
+    expect(savedLayoutCalls()[0]![0].layout).toEqual({
+      left: 0,
+      top: 0,
+      width: 1024,
+      height: 768,
+    })
+  })
+
+  it('既定の右下寄せ位置からでも横幅を広げられる', () => {
+    const { container } = render(<HandLog entries={mockEntries} scale={2} />)
+    const logContainer = container.firstChild as HTMLElement
+
+    // 既定位置は右端から10pxしかない。端で成長を止めるとほぼ拡大できない。
+    expect(logContainer.style.left).toBe('214px')
+
+    fireEvent.mouseDown(screen.getByTestId('hand-log-resize-corner'), {
+      button: 0,
+      clientX: 1014,
+      clientY: 633,
+    })
+    moveMouseWithPrimaryButton(1214, 633)
+
+    expect(logContainer.style.width).toBe('500px')
+    expect(logContainer.style.left).toBe('24px')
     fireEvent.mouseUp(document)
   })
 
@@ -716,7 +917,7 @@ describe('HandLog', () => {
     fireEvent.mouseLeave(document)
     moveMouseWithPrimaryButton(1900, 1500)
 
-    expect(logContainer.style.width).toBe('1400px')
+    expect(logContainer.style.width).toBe('1024px')
     expect(logContainer.style.height).toBe('768px')
     expect(savedLayoutCalls()).toHaveLength(0)
 
@@ -761,7 +962,7 @@ describe('HandLog', () => {
     const logContainer = container.firstChild as HTMLElement
     updateLayout({ left: 500, top: 400, width: 400, height: 100 })
 
-    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
+    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
       button: 0,
       clientX: 600,
       clientY: 414,
@@ -780,7 +981,7 @@ describe('HandLog', () => {
     const { unmount } = render(<HandLog entries={mockEntries} />)
     updateLayout({ left: 500, top: 400, width: 400, height: 100 })
 
-    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
+    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
       button: 0,
       clientX: 600,
       clientY: 414,
@@ -840,7 +1041,7 @@ describe('HandLog', () => {
     )
     const logContainer = container.firstChild as HTMLElement
 
-    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
+    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
       button: 0,
       clientX: 700,
       clientY: 550,
@@ -863,7 +1064,7 @@ describe('HandLog', () => {
     const logContainer = container.firstChild as HTMLElement
     updateLayout({ left: 500, top: 400, width: 400, height: 100 })
 
-    fireEvent.mouseDown(screen.getByTestId('hand-log-header'), {
+    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
       button: 0,
       clientX: 600,
       clientY: 414,
@@ -878,7 +1079,7 @@ describe('HandLog', () => {
 
   it.each([
     {
-      testId: 'hand-log-header',
+      testId: 'hand-log-move-grip',
       startX: 220,
       startY: 94,
       movedX: 250,
@@ -958,7 +1159,7 @@ describe('HandLog', () => {
     expect(logContainer.style.top).toBe('483px')
   })
 
-  it('保存済みouter heightを維持してヘッダー分だけ本文を短くする', () => {
+  it('保存済みouter sizeからborderだけ引いて本文へ渡す', () => {
     mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
       if (message.action === 'getDeviceHandLogLayout') {
         callback({
@@ -974,10 +1175,12 @@ describe('HandLog', () => {
 
     expect(logContainer.style.width).toBe('520px')
     expect(logContainer.style.height).toBe('240px')
-    expect(screen.getByTestId('hand-log-header')).toHaveStyle({ height: '28px' })
+    // 画面端の判定と実寸を一致させるためborder-box。本文はそのぶん内側。
+    expect(logContainer).toHaveStyle({ boxSizing: 'border-box' })
+    // ヘッダー帯を廃したので、本文が失うのは1pxのborderだけ。
     expect(screen.getByTestId('virtual-list')).toHaveStyle({
-      width: '520px',
-      height: '212px',
+      width: '518px',
+      height: '238px',
     })
   })
 

--- a/src/components/HandLog.tsx
+++ b/src/components/HandLog.tsx
@@ -890,11 +890,12 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
     cursor: 'default'
   }
 
-  // 左上は移動専用。ヘッダー帯を廃してログ本文へ高さを明け渡す代わりに、
-  // 右下のリサイズ角と対になる最小限の掴める領域だけを重ねる。
+  // 右上は移動専用。ヘッダー帯を廃してログ本文へ高さを明け渡す代わりに、
+  // 右下のリサイズ角と対になる最小限の掴める領域だけを重ねる。行頭は必ず
+  // 文字で埋まる一方、行末は余白になりやすいので左上ではなく右上に置く。
   const moveGripStyle: CSSProperties = {
     position: 'absolute',
-    left: 0,
+    right: 0,
     top: 0,
     width: HAND_LOG_MOVE_GRIP_SIZE,
     height: HAND_LOG_MOVE_GRIP_SIZE,
@@ -904,9 +905,9 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
     cursor: interactionMode === 'move' ? 'grabbing' : 'grab',
     // ログ本文へ重なるので、地の文と混ざらない程度には輪郭を持たせる。
     backgroundColor: 'rgba(255, 255, 255, 0.16)',
-    borderRight: '1px solid rgba(255, 255, 255, 0.2)',
+    borderLeft: '1px solid rgba(255, 255, 255, 0.2)',
     borderBottom: '1px solid rgba(255, 255, 255, 0.2)',
-    borderRadius: '4px 0 4px 0',
+    borderRadius: '0 4px 0 4px',
     color: 'rgba(255, 255, 255, 0.85)',
     fontSize: 11,
     lineHeight: 1,

--- a/src/components/HandLog.tsx
+++ b/src/components/HandLog.tsx
@@ -180,10 +180,27 @@ const normalizeHandLogLayout = (
 }
 
 /**
- * リサイズは見えているサイズを起点にviewport実寸までで頭打ちにする。
- * 画面外へあふれた分を掴んで引き延ばす操作にはならず、ユーザー操作が
- * 画面に映らない巨大サイズを新たに作ることもない。
+ * リサイズ1軸ぶん。見えているサイズを起点にviewport実寸までで頭打ちにする
+ * ので、画面外へあふれた分を掴んで引き延ばす操作にはならず、画面に映らない
+ * 巨大サイズも作らない。
+ *
+ * viewportが最小サイズすら収容できない軸だけは保存値へ触れない。その状態で
+ * clampすると上下限がともに最小値になり、表示は縮んだまま1pxも変わらないの
+ * にユーザーの指定サイズだけが最小値へ落ちる（見えない縮小）ため。
  */
+const resizeHandLogAxis = (
+  startSize: number,
+  startDisplaySize: number,
+  delta: number,
+  minimum: number,
+  scale: number,
+  viewportSize: number
+): number => {
+  const limit = getHandLogViewportLimit(viewportSize, scale)
+  if (limit < minimum) return startSize
+  return clamp(startDisplaySize + delta / scale, minimum, limit)
+}
+
 const resizeHandLogLayout = (
   startLayout: HandLogLayout,
   startEnvironment: HandLogEnvironment,
@@ -195,21 +212,21 @@ const resizeHandLogLayout = (
 
   return {
     ...startLayout,
-    width: clamp(
-      startDisplaySize.width + deltaX / scale,
+    width: resizeHandLogAxis(
+      startLayout.width,
+      startDisplaySize.width,
+      deltaX,
       HAND_LOG_MIN_WIDTH,
-      Math.max(
-        HAND_LOG_MIN_WIDTH,
-        getHandLogViewportLimit(viewportWidth, scale)
-      )
+      scale,
+      viewportWidth
     ),
-    height: clamp(
-      startDisplaySize.height + deltaY / scale,
+    height: resizeHandLogAxis(
+      startLayout.height,
+      startDisplaySize.height,
+      deltaY,
       HAND_LOG_MIN_HEIGHT,
-      Math.max(
-        HAND_LOG_MIN_HEIGHT,
-        getHandLogViewportLimit(viewportHeight, scale)
-      )
+      scale,
+      viewportHeight
     ),
   }
 }

--- a/src/components/HandLog.tsx
+++ b/src/components/HandLog.tsx
@@ -29,8 +29,8 @@ interface HandLogProps {
   scrollToLatest?: boolean
 }
 
-const HAND_LOG_HEADER_HEIGHT = 28
-const HAND_LOG_HEADER_REACHABLE_WIDTH = 80
+const HAND_LOG_MOVE_GRIP_SIZE = 16
+const HAND_LOG_BORDER_WIDTH = 1
 const HAND_LOG_DRAG_THRESHOLD = 4
 const HAND_LOG_DEFAULT_RIGHT = 10
 const HAND_LOG_DEFAULT_BOTTOM = 135
@@ -106,48 +106,111 @@ const readHandLogEnvironment = (scale: number): HandLogEnvironment => ({
   viewportHeight: window.innerHeight,
 })
 
-const getHandLogDisplayHeight = (
+/**
+ * 1軸ぶんのviewport上限。0はviewport未確定として上限なしに倒す。
+ * 遷移直後などinnerWidth/innerHeightが一時的に0で読めることがあり、
+ * それをそのまま制約にするとパネルが消えて位置も左上へ吸着してしまう。
+ */
+const getHandLogViewportLimit = (
+  viewportSize: number,
+  scale: number
+): number =>
+  viewportSize > 0 ? viewportSize / scale : Number.POSITIVE_INFINITY
+
+/**
+ * viewportに収まる実サイズ。viewportより大きいlayoutは表示だけを縮め、
+ * 状態と永続化には触れない: 一時的に小さい画面（ウィンドウ縮小、別モニタ）が
+ * ユーザーの指定サイズを恒久的に潰さないようにするため。
+ */
+const getHandLogDisplaySize = (
   layout: HandLogLayout,
   environment: HandLogEnvironment
+): { width: number, height: number } => ({
+  width: Math.min(
+    layout.width,
+    getHandLogViewportLimit(environment.viewportWidth, environment.scale)
+  ),
+  height: Math.min(
+    layout.height,
+    getHandLogViewportLimit(environment.viewportHeight, environment.scale)
+  ),
+})
+
+/**
+ * 表示中のパネル全体をviewport内へ収める。端からのはみ出しは許さない。
+ * 下限0は常に効かせる: 上限だけがviewport依存で、負の座標はviewportが
+ * 未確定でも正しくない（0読み取り時の既定layoutは大きな負値になる）。
+ */
+const clampHandLogPosition = (
+  position: number,
+  renderedSize: number,
+  viewportSize: number
 ): number =>
-  Math.min(layout.height, environment.viewportHeight / environment.scale)
+  viewportSize > 0
+    ? clamp(position, 0, Math.max(0, viewportSize - renderedSize))
+    : Math.max(0, position)
 
 const normalizeHandLogLayout = (
   layout: HandLogLayout,
   environment: HandLogEnvironment
 ): HandLogLayout => {
   const { scale, viewportWidth, viewportHeight } = environment
-  const maximumHeight = viewportHeight / scale
-  // A sub-minimum viewport temporarily shrinks only the rendered panel.
-  // Keep state/persistence at HAND_LOG_MIN_HEIGHT or above; see PR #304.
-  const height = clamp(
-    layout.height,
-    HAND_LOG_MIN_HEIGHT,
-    Math.max(HAND_LOG_MIN_HEIGHT, maximumHeight)
-  )
-  const renderedWidth = layout.width * scale
-  const renderedHeight = getHandLogDisplayHeight(
-    { ...layout, height },
+  const width = Math.max(HAND_LOG_MIN_WIDTH, layout.width)
+  const height = Math.max(HAND_LOG_MIN_HEIGHT, layout.height)
+  const displaySize = getHandLogDisplaySize(
+    { ...layout, width, height },
     environment
-  ) * scale
-  const reachableWidth = Math.min(
-    HAND_LOG_HEADER_REACHABLE_WIDTH * scale,
-    viewportWidth
   )
 
   return {
     ...layout,
-    left: clamp(
+    left: clampHandLogPosition(
       layout.left,
-      reachableWidth - renderedWidth,
-      viewportWidth - reachableWidth
+      displaySize.width * scale,
+      viewportWidth
     ),
-    top: clamp(
+    top: clampHandLogPosition(
       layout.top,
-      0,
-      Math.max(0, viewportHeight - renderedHeight)
+      displaySize.height * scale,
+      viewportHeight
     ),
+    width,
     height,
+  }
+}
+
+/**
+ * リサイズは見えているサイズを起点にviewport実寸までで頭打ちにする。
+ * 画面外へあふれた分を掴んで引き延ばす操作にはならず、ユーザー操作が
+ * 画面に映らない巨大サイズを新たに作ることもない。
+ */
+const resizeHandLogLayout = (
+  startLayout: HandLogLayout,
+  startEnvironment: HandLogEnvironment,
+  deltaX: number,
+  deltaY: number
+): HandLogLayout => {
+  const { scale, viewportWidth, viewportHeight } = startEnvironment
+  const startDisplaySize = getHandLogDisplaySize(startLayout, startEnvironment)
+
+  return {
+    ...startLayout,
+    width: clamp(
+      startDisplaySize.width + deltaX / scale,
+      HAND_LOG_MIN_WIDTH,
+      Math.max(
+        HAND_LOG_MIN_WIDTH,
+        getHandLogViewportLimit(viewportWidth, scale)
+      )
+    ),
+    height: clamp(
+      startDisplaySize.height + deltaY / scale,
+      HAND_LOG_MIN_HEIGHT,
+      Math.max(
+        HAND_LOG_MIN_HEIGHT,
+        getHandLogViewportLimit(viewportHeight, scale)
+      )
+    ),
   }
 }
 
@@ -340,17 +403,12 @@ const transitionHandLogLayout = (
               left: startLayout.left + deltaX,
               top: startLayout.top + deltaY,
             }
-          : {
-              ...startLayout,
-              width: Math.max(
-                HAND_LOG_MIN_WIDTH,
-                startLayout.width + deltaX / startEnvironment.scale
-              ),
-              height: Math.max(
-                HAND_LOG_MIN_HEIGHT,
-                startLayout.height + deltaY / startEnvironment.scale
-              ),
-            }
+          : resizeHandLogLayout(
+              startLayout,
+              startEnvironment,
+              deltaX,
+              deltaY
+            )
       return {
         state: {
           ...state,
@@ -793,18 +851,22 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
   if (!config.enabled) return null
 
   const { layout, environment } = layoutMachine
-  const { width } = layout
   // Display-only shrink: the layout kept by the machine remains persistable.
-  const height = getHandLogDisplayHeight(layout, environment)
+  const { width, height } = getHandLogDisplaySize(layout, environment)
+  // border-boxなのでbody部はborderぶん内側になる。
+  const bodyWidth = Math.max(0, width - HAND_LOG_BORDER_WIDTH * 2)
+  const bodyHeight = Math.max(0, height - HAND_LOG_BORDER_WIDTH * 2)
   const interactionMode =
     layoutMachine.interaction.phase === 'interacting'
       ? layoutMachine.interaction.mode
       : null
-  const bodyHeight = Math.max(0, height - HAND_LOG_HEADER_HEIGHT)
 
   // コンテナスタイル
   const containerStyle: CSSProperties = {
     position: 'fixed',
+    // border込みでwidth/heightちょうどに収める。content-boxのままだと
+    // 実寸がborder分だけ大きく、画面端の判定と2px（scale倍）ずれる。
+    boxSizing: 'border-box',
     left: layout.left,
     top: layout.top,
     width: width,
@@ -821,35 +883,36 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
     fontFamily: 'Consolas, Monaco, "Courier New", monospace',
     fontSize: config.fontSize,
     color: '#ffffff',
-    // Keep the header and resize corner above player HUD panels (z-index
+    // Keep the move grip and resize corner above player HUD panels (z-index
     // 9999) so an overlap cannot make either interaction unreachable.
     zIndex: 10000,
     boxShadow: '0 2px 4px rgba(0, 0, 0, 0.3)',
     cursor: 'default'
   }
 
-  const headerStyle: CSSProperties = {
-    boxSizing: 'border-box',
-    width: '100%',
-    height: HAND_LOG_HEADER_HEIGHT,
-    padding: '0 8px',
-    cursor: interactionMode === 'move' ? 'grabbing' : 'grab',
-    backgroundColor: 'rgba(255, 255, 255, 0.12)',
-    borderBottom: '1px solid rgba(255, 255, 255, 0.2)',
-    color: 'rgba(255, 255, 255, 0.9)',
+  // 左上は移動専用。ヘッダー帯を廃してログ本文へ高さを明け渡す代わりに、
+  // 右下のリサイズ角と対になる最小限の掴める領域だけを重ねる。
+  const moveGripStyle: CSSProperties = {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    width: HAND_LOG_MOVE_GRIP_SIZE,
+    height: HAND_LOG_MOVE_GRIP_SIZE,
     display: 'flex',
     alignItems: 'center',
-    gap: 7,
-    fontSize: Math.max(11, config.fontSize - 1),
-    fontWeight: 600,
+    justifyContent: 'center',
+    cursor: interactionMode === 'move' ? 'grabbing' : 'grab',
+    // ログ本文へ重なるので、地の文と混ざらない程度には輪郭を持たせる。
+    backgroundColor: 'rgba(255, 255, 255, 0.16)',
+    borderRight: '1px solid rgba(255, 255, 255, 0.2)',
+    borderBottom: '1px solid rgba(255, 255, 255, 0.2)',
+    borderRadius: '4px 0 4px 0',
+    color: 'rgba(255, 255, 255, 0.85)',
+    fontSize: 11,
     lineHeight: 1,
+    letterSpacing: -1,
     userSelect: 'none',
-  }
-
-  const headerGripIconStyle: CSSProperties = {
-    color: 'rgba(255, 255, 255, 0.65)',
-    fontSize: 14,
-    letterSpacing: -2,
+    zIndex: 2,
   }
 
   const resizeCornerStyle: CSSProperties = {
@@ -876,15 +939,15 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
       style={containerStyle}
       onClick={handleContainerClick}
     >
+      {/* 左上は移動専用。右下はリサイズ専用。 */}
       <div
-        data-testid="hand-log-header"
+        data-testid="hand-log-move-grip"
         title="ドラッグしてハンドログを移動"
-        style={headerStyle}
+        style={moveGripStyle}
         onMouseDown={(event) => handleInteractionStart('move', event)}
         onClick={(event) => event.stopPropagation()}
       >
-        <span aria-hidden="true" style={headerGripIconStyle}>⠿</span>
-        <span>ハンドログ</span>
+        <span aria-hidden="true">⠿</span>
       </div>
 
       {processedItems.length > 0 ? (
@@ -894,7 +957,7 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
           rowHeight={getItemSize}
           rowComponent={EntryRow}
           rowProps={rowProps}
-          style={{ height: bodyHeight, width }}
+          style={{ height: bodyHeight, width: bodyWidth }}
         />
       ) : (
         <div style={{
@@ -911,7 +974,6 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
         </div>
       )}
 
-      {/* 右下はリサイズ専用。移動は上部ヘッダーだけが開始する。 */}
       <div
         data-testid="hand-log-resize-corner"
         title="ドラッグしてハンドログのサイズを変更"

--- a/src/components/HandLog.tsx
+++ b/src/components/HandLog.tsx
@@ -184,9 +184,10 @@ const normalizeHandLogLayout = (
  * ので、画面外へあふれた分を掴んで引き延ばす操作にはならず、画面に映らない
  * 巨大サイズも作らない。
  *
- * viewportが最小サイズすら収容できない軸だけは保存値へ触れない。その状態で
- * clampすると上下限がともに最小値になり、表示は縮んだまま1pxも変わらないの
- * にユーザーの指定サイズだけが最小値へ落ちる（見えない縮小）ため。
+ * ただし表示が1pxも変わらない操作では保存値に触れない。表示が上限へ貼り付い
+ * ている軸（保存サイズがviewportより大きい／viewportが最小値すら収容できな
+ * い）では、掴んでいない軸や外向きのドラッグまで保存値を表示上限へ落として
+ * しまい、画面を広げても戻らない「見えない縮小」になるため。
  */
 const resizeHandLogAxis = (
   startSize: number,
@@ -196,9 +197,12 @@ const resizeHandLogAxis = (
   scale: number,
   viewportSize: number
 ): number => {
-  const limit = getHandLogViewportLimit(viewportSize, scale)
-  if (limit < minimum) return startSize
-  return clamp(startDisplaySize + delta / scale, minimum, limit)
+  const resized = clamp(
+    startDisplaySize + delta / scale,
+    minimum,
+    getHandLogViewportLimit(viewportSize, scale)
+  )
+  return resized === startDisplaySize ? startSize : resized
 }
 
 const resizeHandLogLayout = (


### PR DESCRIPTION
## 概要

#304 のフォローアップです。ハンドログウィンドウについて 2 点直しました。

1. **ヘッダー領域が太すぎる** → 28px のヘッダー帯を廃止し、右下のリサイズ角と対になる **16px の移動グリップ**を右上へ重ねました。「掴める領域を提供する」という本来の目的だけを残し、空いた 28px はログ本文へ返しています。
2. **ウィンドウがブラウザ領域からはみ出す** → 表示中のパネル全体が常に viewport 内へ収まるようにしました。

## 変更内容

### 1. ヘッダー廃止 / 右上グリップ化

- `hand-log-header`（28px・全幅・「ハンドログ」ラベル付き）を削除し、`hand-log-move-grip`（16px 角・`⠿`・`cursor: grab`）を右上へ配置
- 移動 = 右上グリップ / リサイズ = 右下角、という #304 の役割分担はそのまま
- グリップは本文へ重なるため**右上**に置いています。行頭は必ず文字で埋まる一方、行末は余白になりやすいためです（当初は左上に置き、先頭行の左端 2 文字ほどに重なっていました）
- ヘッダー帯ぶんの `bodyHeight` 減算がなくなり、本文はパネル高さ（-border 1px）をそのまま使用

### 2. viewport 内への収容

- 位置 clamp を「ヘッダーの一部（80px）が見える」から「**表示中のパネル全体が画面内**」へ変更。左右上下いずれの端も越えません
- サイズ側の clamp は**表示のみ**。`normalizeHandLogLayout` は保存サイズを縮めないので、一時的にウィンドウを狭めてもユーザー指定サイズは失われず、広げ直せば元に戻ります（実装当初は保存値も clamp していましたが、mockup で一度狭い viewport を経ただけでパネルが最小サイズ 200x80 に固着したため改めました）
- 保存サイズを書き換えるのは**リサイズ操作のみ**。表示サイズを起点に viewport 実寸までで頭打ちにするため WYSIWYG になり、画面に映らない巨大サイズを新たに作ることもありません
- 画面端を越える拡大は「成長を止める」のではなく「位置 clamp で引き戻す」方式です。既定の右下寄せ位置は右端まで 10px しか余白がなく、端で止める実装では**ほぼ拡大できなくなる**ため（一度実装して差し戻し）
- `window.innerWidth/innerHeight` が **0 で読める瞬間**（ページ遷移直後に実測）は、その軸の**上限のみ**無効化し、下限 0 は維持。パネルが消えたり画面外へ固着したりしません
- container を `border-box` 化。content-box のままだと実寸が border ぶん (2 x scale px) 大きく、画面端の判定とずれるため

## スコープ

`HandLog.tsx` / 同テスト / 対応する `AGENTS.md` 記述に限定しています。イベント取り込み、統計パイプライン、background protocol、保存 schema、他コンポーネントには変更ありません。保存フォーマット（`HandLogLayout`）も不変で、既存の保存値はそのまま読めます。

## Validation

- `npm run test` — 1591 passed / 157 suites（HandLog 単体は 53 tests、+13）
- `npm run typecheck` — passed
- `npm run build` — passed
- `git diff --check` — passed
- **mockup 実ブラウザ確認**: 左上/右下への移動・端を越えるリサイズ・scale 2 のいずれでも `rect ⊆ viewport` を維持することを確認。最大化時の実寸が viewport と完全一致（border-box 化の効果）
- **mutation check**: 追加した表明が実際に効いているかを確認済み。リサイズ上限を `Infinity` 化 / normalize に破壊的 size clamp を戻す / グリップの `z-index` を 0 化 / `position: static` 化 / グリップを左上へ戻す / 位置 clamp の下限 0 を外す / `border-box` を外す、の 7 変異はいずれもテストが落ちます

## Risk / 判断が分かれうる点

- グリップは構造上ログ本文の上に重なります。右上へ置いたことで実際に文字へ被る場面はほぼありませんが、行末まで文字が伸びた行では重なります。位置・サイズは `HAND_LOG_MOVE_GRIP_SIZE`（`HandLog.tsx`）と `moveGripStyle` の調整だけで変えられます
- UI scale 0.5 ではグリップの実寸が 8x8 px になります。既存のリサイズ角（12px → 6px）と同等の縮み方です
- ヘッダーを完全に廃す代わりに「薄いヘッダー帯を残す」案も可能です。ご指示の「いっそ廃止でよいかもしれない」に沿って廃止側を採りましたが、戻すのも局所的な変更で済みます
