### PR TITLE
fix(ui): ハンドログの行高を実測した折り返しから算出する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -497,6 +497,24 @@ rather than by refusing to grow: the default bottom-right position leaves only
 The container is `border-box` so its rendered footprint equals the clamped
 width/height exactly; the log body is that minus `HAND_LOG_BORDER_WIDTH*2`.
 
+**Hand-log row height**: the virtual list positions rows from `getItemSize()`,
+so that estimate has to predict CSS wrapping or rows overlap. It measures the
+real monospace advance width with `canvas.measureText()` at the actual
+font/size (cached per font string; falls back to a conservative 0.6 em ratio
+where canvas is unavailable, e.g. jsdom), derives chars-per-line from the row's
+real text width (the log body width above, minus `EntryRow`'s horizontal
+padding — `EntryRow` pins `boxSizing: border-box` so host-page CSS cannot move
+that boundary), adds the timestamp prefix's width to the first line when
+timestamps are on, and counts lines with the same word-boundary / `break-word`
+rules the CSS uses. Derive it from the *displayed* width, never the stored one:
+a viewport narrower than the stored width shrinks only the render, and that is
+where the wrapping actually happens. Do not reintroduce a fixed chars-per-line
+constant: the panel resizes down to `HAND_LOG_MIN_WIDTH` (200px), where the
+previous 60-chars-per-line assumption under-counted lines and rows overlapped.
+Every input to the wrap calculation must stay in `getItemSize`'s `useCallback`
+deps — react-window rebuilds its row-bounds cache only when the `rowHeight`
+identity changes.
+
 **Popup theming**: `src/components/popup/theme.ts` defines two MUI themes -- `dark-felt` (default look, shares the HUD overlay's dark/gold palette) and `modern-light`. Which one renders is controlled by the `popupTheme` setting (`'auto' | 'dark' | 'light'`, default `'auto'`; テーマ control in `PopupHeader.tsx`, a 自動/ダーク/ライト 3-way `SegmentRadio`). `'auto'` resolves against the live OS `prefers-color-scheme` via `useMediaQuery` in `Popup.tsx` (`resolvePopupThemeVariant()` in `theme.ts` is the pure resolver, unit-tested independent of the DOM). Persisted to its own `chrome.storage.sync` key (`popupTheme`, see `popup-theme-storage.ts`) -- deliberately **not** a field on `UIConfig`, because `UIScaleSection`/`HudDisplaySection` broadcast every `uiConfig` write to all open game tabs (`chrome.tabs.sendMessage(..., 'updateUIConfig')`) to trigger a HUD re-render; the popup's own chrome has nothing to do with the HUD overlay, so nesting it there would fire that broadcast on every theme change for no reason. `popup.ts` pre-fetches the persisted mode before the first `render()` call so the popup never paints with the wrong theme and then swaps.
 
 ## Statistics System

--- a/src/components/HandLog.test.tsx
+++ b/src/components/HandLog.test.tsx
@@ -1,6 +1,11 @@
 import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import HandLog from './HandLog'
+import HandLog, {
+  countWrappedLines,
+  estimateEntryRowHeight,
+  measureMonospaceCharWidth,
+  FALLBACK_MONOSPACE_CHAR_WIDTH_RATIO,
+} from './HandLog'
 import { HandLogEntry, HandLogEntryType, HandLogConfig, DEFAULT_HAND_LOG_CONFIG } from '../types/hand-log'
 import { DEVICE_LAYOUT_MESSAGE_TIMEOUT_MS } from '../utils/ui-config-storage'
 
@@ -8,17 +13,27 @@ import { DEVICE_LAYOUT_MESSAGE_TIMEOUT_MS } from '../utils/ui-config-storage'
 jest.mock('react-window', () => {
   const React = require('react')
   return {
-    List: ({ rowComponent: RowComponent, rowCount, rowProps, style, listRef }: any) => {
+    List: ({ rowComponent: RowComponent, rowCount, rowProps, rowHeight, style, listRef }: any) => {
       // Mock scrollToRow method via listRef
       React.useImperativeHandle(listRef, () => ({
         scrollToRow: jest.fn(),
         get element() { return null },
       }))
 
+      // 本物のListと同じく、行ラッパーへrowHeightの戻り値をそのまま適用する。
+      // 行高の推定はこのラッパーのstyle.heightから検証する。
       return (
         <div data-testid="virtual-list" style={style}>
           {Array.from({ length: rowCount }).map((_, index) => (
-            <div key={index}>
+            <div
+              key={index}
+              data-testid={`virtual-row-${index}`}
+              style={{
+                height: typeof rowHeight === 'function'
+                  ? rowHeight(index, rowProps)
+                  : rowHeight,
+              }}
+            >
               <RowComponent
                 index={index}
                 style={{}}
@@ -1320,9 +1335,179 @@ describe('HandLog', () => {
 
   it('ハンド間にセパレーターが表示される', () => {
     render(<HandLog entries={mockEntries} />)
-    
+
     // Virtual listの中にセパレーターが含まれている
     const virtualList = screen.getByTestId('virtual-list')
     expect(virtualList.children.length).toBeGreaterThan(mockEntries.length) // セパレーターが追加されている
+  })
+
+  describe('仮想リストの行高', () => {
+    // 既定fontSize=8・等幅比0.6（jsdomにcanvasが無いためフォールバック）で
+    // 1文字4.8px。折り返し幅は「表示幅 - border 1px×2 - EntryRowの左右
+    // padding 8px×2」。
+    const longEntry: HandLogEntry[] = [
+      {
+        id: 'long',
+        handId: 1,
+        timestamp: Date.now(),
+        text: 'x'.repeat(100),
+        type: HandLogEntryType.ACTION,
+      },
+    ]
+    const rowHeight = (index: number) =>
+      parseFloat(screen.getByTestId(`virtual-row-${index}`).style.height)
+
+    it('パネル幅が狭いほど実際の折り返し行数だけ行高が伸びる', () => {
+      render(<HandLog entries={longEntry} />)
+
+      // 幅400: 本文382px ≒ 79文字/行 → 100文字は2行
+      updateLayout({ left: 100, top: 100, width: 400, height: 100 })
+      expect(rowHeight(0)).toBeCloseTo(21.2)
+
+      // 幅200(最小): 本文182px ≒ 37文字/行 → 100文字は3行
+      // 60文字固定の旧推定では幅によらず2行のままで、行が重なっていた
+      updateLayout({ left: 100, top: 100, width: 200, height: 100 })
+      expect(rowHeight(0)).toBeCloseTo(30.8)
+    })
+
+    it('viewportが保存幅より狭いときは表示幅で折り返しを数える', () => {
+      render(<HandLog entries={longEntry} />)
+      updateLayout({ left: 0, top: 0, width: 600, height: 300 })
+
+      // 幅600: 本文582px ≒ 121文字/行 → 100文字は1行
+      expect(rowHeight(0)).toBeCloseTo(11.6)
+
+      setViewport(200, 768)
+      fireEvent(window, new Event('resize'))
+
+      // 保存幅は600pxのまま表示だけ200pxへ縮む。折り返しは縮んだ側で起きる
+      // ので、保存幅で数えると1行のままになり行が重なる
+      expect(rowHeight(0)).toBeCloseTo(30.8)
+    })
+
+    it('タイムスタンプ接頭辞の分だけ先頭行の残り幅を減らす', () => {
+      render(<HandLog entries={longEntry} config={{ showTimestamps: true }} />)
+      updateLayout({ left: 100, top: 100, width: 400, height: 100 })
+
+      // [00:00:00]は6px等幅10文字+margin 8px = 44px ≒ 10文字分。
+      // 先頭行には本文が入らず、80文字+20文字と合わせて3行になる
+      expect(rowHeight(0)).toBeCloseTo(30.8)
+    })
+
+    it('フォントサイズを上げると1行あたり文字数が減り行高が伸びる', () => {
+      render(<HandLog entries={longEntry} config={{ fontSize: 16 }} />)
+      updateLayout({ left: 100, top: 100, width: 400, height: 100 })
+
+      // 1文字9.6px ≒ 39文字/行 → 100文字は3行、1行の高さも倍
+      expect(rowHeight(0)).toBeCloseTo(59.6)
+    })
+
+    it('セパレーター行は固定高のまま', () => {
+      render(<HandLog entries={mockEntries} />)
+      updateLayout({ left: 100, top: 100, width: 200, height: 100 })
+
+      // mockEntriesはhandId=1が3件、その後にhandId=2との区切りが入る
+      expect(rowHeight(3)).toBe(10)
+    })
+
+    it('EntryRowはborder-boxでpadding込みの高さに一致させる', () => {
+      render(<HandLog entries={longEntry} />)
+
+      expect(screen.getByText('x'.repeat(100))).toHaveStyle({
+        boxSizing: 'border-box',
+        padding: '1px 8px',
+      })
+    })
+  })
+})
+
+describe('HandLogの行高推定', () => {
+  // 等幅比を固定した決定的な計測器（実環境ではcanvas実測）
+  const monospace = (ratio: number) => (fontSize: number) => fontSize * ratio
+
+  describe('countWrappedLines', () => {
+    it('空エントリは行を占有しない', () => {
+      expect(countWrappedLines('', 40)).toBe(0)
+    })
+
+    it('1行に収まるテキストは1行', () => {
+      expect(countWrappedLines('Player1: folds', 40)).toBe(1)
+    })
+
+    it('単語境界で折り返す', () => {
+      expect(countWrappedLines('aaaa bbbb cccc', 10)).toBe(2)
+    })
+
+    it('単語境界で折り返すため文字数の単純除算より行数が増えうる', () => {
+      const text = 'aaaaaa bbbbbb cccccc'
+      expect(Math.ceil(text.length / 10)).toBe(2)
+      expect(countWrappedLines(text, 10)).toBe(3)
+    })
+
+    it('1行に収まらない単語だけをbreak-wordとして分割する', () => {
+      expect(countWrappedLines('x'.repeat(25), 10)).toBe(3)
+    })
+
+    it('行頭でない長い単語は次行へ送ってから分割する', () => {
+      // "ab " の後に25文字の語 → 2行目から10/10/5に割れる
+      expect(countWrappedLines(`ab ${'x'.repeat(25)}`, 10)).toBe(4)
+    })
+
+    it('行末の空白はぶら下がり、次の単語から改行する', () => {
+      expect(countWrappedLines('aaaaaaaaaa bb', 10)).toBe(2)
+    })
+
+    it('明示的な改行を行として数える', () => {
+      expect(countWrappedLines('abc\ndef', 10)).toBe(2)
+    })
+
+    it('先頭オフセット（タイムスタンプ）を消費済み文字として扱う', () => {
+      expect(countWrappedLines('cccc', 10)).toBe(1)
+      expect(countWrappedLines('cccc', 10, 8)).toBe(2)
+    })
+
+    it('60文字固定の旧推定が過小評価していた幅を正しく数える', () => {
+      // 幅200pxのパネル ≒ 38文字/行。旧推定は ceil(100/60)=2行だった
+      expect(countWrappedLines('x'.repeat(100), 38)).toBe(3)
+    })
+  })
+
+  describe('estimateEntryRowHeight', () => {
+    const metrics = (textWidth: number, showTimestamps = false) => ({
+      textWidth,
+      fontSize: 8,
+      showTimestamps,
+      measureCharWidth: monospace(0.6),
+    })
+
+    it('1行のエントリは1行分の高さ + 上下padding', () => {
+      expect(estimateEntryRowHeight('Player1: folds', metrics(384))).toBeCloseTo(11.6)
+    })
+
+    it('本文幅が狭いと行数が増える', () => {
+      expect(estimateEntryRowHeight('x'.repeat(100), metrics(384))).toBeCloseTo(21.2)
+      expect(estimateEntryRowHeight('x'.repeat(100), metrics(184))).toBeCloseTo(30.8)
+    })
+
+    it('タイムスタンプ表示時は先頭行の残り幅が減る', () => {
+      expect(estimateEntryRowHeight('x'.repeat(100), metrics(384, true))).toBeCloseTo(30.8)
+    })
+
+    it('本文幅が0以下でも1文字/行として破綻しない', () => {
+      expect(estimateEntryRowHeight('abc', metrics(0))).toBeCloseTo(3 * 9.6 + 2)
+    })
+  })
+
+  describe('measureMonospaceCharWidth', () => {
+    it('canvasが無い環境では保守的な等幅比へフォールバックする', () => {
+      expect(measureMonospaceCharWidth(8)).toBeCloseTo(8 * FALLBACK_MONOSPACE_CHAR_WIDTH_RATIO)
+      expect(measureMonospaceCharWidth(16)).toBeCloseTo(16 * FALLBACK_MONOSPACE_CHAR_WIDTH_RATIO)
+    })
+
+    it('フォールバック比は想定フォント中で最も広いものを採る', () => {
+      // Consolas 0.55 / Monaco・Courier New 0.6。狭い比率を既定にすると
+      // 1行あたり文字数を過大評価して行が重なる
+      expect(FALLBACK_MONOSPACE_CHAR_WIDTH_RATIO).toBeGreaterThanOrEqual(0.6)
+    })
   })
 })

--- a/src/components/HandLog.tsx
+++ b/src/components/HandLog.tsx
@@ -34,6 +34,14 @@ const HAND_LOG_BORDER_WIDTH = 1
 const HAND_LOG_DRAG_THRESHOLD = 4
 const HAND_LOG_DEFAULT_RIGHT = 10
 const HAND_LOG_DEFAULT_BOTTOM = 135
+const HAND_LOG_FONT_FAMILY = 'Consolas, Monaco, "Courier New", monospace'
+const HAND_LOG_SEPARATOR_HEIGHT = 10
+const HAND_LOG_ENTRY_PADDING_X = 8
+const HAND_LOG_ENTRY_PADDING_Y = 1
+const HAND_LOG_ENTRY_LINE_HEIGHT = 1.2
+const HAND_LOG_TIMESTAMP_FONT_SIZE_OFFSET = 2
+const HAND_LOG_TIMESTAMP_MARGIN_RIGHT = 8
+const HAND_LOG_TIMESTAMP_TEXT_LENGTH = '[00:00:00]'.length
 
 type HandLogInteractionMode = 'move' | 'resize'
 
@@ -494,6 +502,161 @@ const formatTimestamp = (timestamp: number): string => {
   })
 }
 
+/**
+ * canvas計測が使えない環境（jsdom等）で使う1文字送り幅のem比。
+ * 想定フォントはMonaco / Courier New / 汎用monospaceが約0.6、Consolasが約0.55。
+ * その中で最も広い値を既定にして、行数を過小評価しない側へ倒す
+ * （過大評価は行間が空くだけだが、過小評価は行の重なり＝欠落になる）。
+ */
+export const FALLBACK_MONOSPACE_CHAR_WIDTH_RATIO = 0.6
+const CHAR_WIDTH_MEASUREMENT_SAMPLE = '0'.repeat(32)
+const MIN_PLAUSIBLE_CHAR_WIDTH_RATIO = 0.3
+const MAX_PLAUSIBLE_CHAR_WIDTH_RATIO = 1
+const charWidthCache = new Map<string, number>()
+
+/**
+ * 実フォント・実フォントサイズでの1文字送り幅(px)をcanvasで実測する。
+ *
+ * 折り返し幅の推定はDOMと同じフォント指定で測らないと、等幅フォントでも
+ * フォントごとの文字幅比の違い（Consolas 0.55 / Monaco・Courier New 0.6）が
+ * そのまま行数の誤差になる。measureTextはレイアウトと同じフォント解決を通り、
+ * 小さいフォントサイズ特有のラスタライズ差も込みで測れる。
+ * canvasが無い環境（jsdom等）は保守的な比率へフォールバックする。
+ */
+export const measureMonospaceCharWidth = (
+  fontSize: number,
+  fontFamily: string = HAND_LOG_FONT_FAMILY
+): number => {
+  const font = `${fontSize}px ${fontFamily}`
+  const cached = charWidthCache.get(font)
+  if (cached !== undefined) return cached
+
+  let charWidth = fontSize * FALLBACK_MONOSPACE_CHAR_WIDTH_RATIO
+  try {
+    // jsdomはCanvasRenderingContext2D自体を定義しない。getContextを呼ぶと
+    // "Not implemented"を吐くので、型の有無で先に判定して呼ばない。
+    if (
+      typeof document !== 'undefined' &&
+      typeof CanvasRenderingContext2D !== 'undefined'
+    ) {
+      const context = document.createElement('canvas').getContext('2d')
+      if (context) {
+        context.font = font
+        const measured =
+          context.measureText(CHAR_WIDTH_MEASUREMENT_SAMPLE).width /
+          CHAR_WIDTH_MEASUREMENT_SAMPLE.length
+        const ratio = measured / fontSize
+        if (
+          Number.isFinite(ratio) &&
+          ratio >= MIN_PLAUSIBLE_CHAR_WIDTH_RATIO &&
+          ratio <= MAX_PLAUSIBLE_CHAR_WIDTH_RATIO
+        ) {
+          charWidth = measured
+        }
+      }
+    }
+  } catch {
+    // 計測不能ならフォールバック比率のまま
+  }
+  charWidthCache.set(font, charWidth)
+  return charWidth
+}
+
+/**
+ * EntryRowの`white-space: pre-wrap` + `word-break: break-word`に合わせて
+ * 折り返し後の行数を数える。
+ *
+ * 文字数を1行あたり文字数で割るだけでは、単語境界での折り返しを無視して
+ * 行数を過小評価する（"aaaaaa bbbbbb cccccc"は20文字なので幅10文字では
+ * 単純除算だと2行だが、実際は3行になる）。
+ * - 空白は行末でぶら下がるので、収まらない場合はその行を埋めるだけ
+ * - 単語は現在行に収まらなければ次行へ送る
+ * - 1行にも収まらない長い単語だけをbreak-wordとして分割する
+ *
+ * @param initialUsedChars 先頭に既に置かれている内容（タイムスタンプ）の文字数換算
+ */
+export const countWrappedLines = (
+  text: string,
+  charsPerLine: number,
+  initialUsedChars = 0
+): number => {
+  if (text.length === 0 && initialUsedChars === 0) return 0
+
+  const maxChars = Math.max(1, Math.floor(charsPerLine))
+  let lines = 1
+  let used = Math.max(0, initialUsedChars)
+
+  text.split('\n').forEach((hardLine, hardLineIndex) => {
+    if (hardLineIndex > 0) {
+      lines += 1
+      used = 0
+    }
+    for (const token of hardLine.match(/\s+|\S+/g) ?? []) {
+      const length = token.length
+      if (/^\s/.test(token)) {
+        used = used + length <= maxChars ? used + length : maxChars
+        continue
+      }
+      if (used + length <= maxChars) {
+        used += length
+        continue
+      }
+      if (used > 0) {
+        lines += 1
+        used = 0
+      }
+      if (length <= maxChars) {
+        used = length
+        continue
+      }
+      const chunks = Math.ceil(length / maxChars)
+      lines += chunks - 1
+      used = length - (chunks - 1) * maxChars
+    }
+  })
+
+  return lines
+}
+
+export interface HandLogRowMetrics {
+  /** 折り返しに使える本文幅(px)。= 行の幅 - 左右padding */
+  textWidth: number
+  fontSize: number
+  showTimestamps: boolean
+  /** フォントサイズ→1文字幅(px)。既定はcanvas実測（テストからの差し替え口） */
+  measureCharWidth?: (fontSize: number) => number
+}
+
+/**
+ * 仮想リストの行高を、実際の本文幅で折り返した行数から求める。
+ * `boxSizing: border-box`のEntryRowに与える高さなので、上下paddingを含む。
+ */
+export const estimateEntryRowHeight = (
+  text: string,
+  {
+    textWidth,
+    fontSize,
+    showTimestamps,
+    measureCharWidth = measureMonospaceCharWidth
+  }: HandLogRowMetrics
+): number => {
+  const charWidth = Math.max(measureCharWidth(fontSize), Number.EPSILON)
+  const charsPerLine = Math.max(1, Math.floor(textWidth / charWidth))
+  // タイムスタンプは本文より小さいフォントの別spanなので、幅を本文の文字数へ換算する
+  const timestampChars = showTimestamps
+    ? Math.ceil(
+      (
+        measureCharWidth(
+          Math.max(fontSize - HAND_LOG_TIMESTAMP_FONT_SIZE_OFFSET, 1)
+        ) * HAND_LOG_TIMESTAMP_TEXT_LENGTH +
+        HAND_LOG_TIMESTAMP_MARGIN_RIGHT
+      ) / charWidth
+    )
+    : 0
+  const lines = countWrappedLines(text, charsPerLine, timestampChars)
+  return lines * fontSize * HAND_LOG_ENTRY_LINE_HEIGHT + HAND_LOG_ENTRY_PADDING_Y * 2
+}
+
 interface EntryRowData {
   items: Array<{ entry: HandLogEntry, isSeparator: boolean }>
   showTimestamps: boolean
@@ -519,9 +682,10 @@ const EntryRow = ({ index, style, items, showTimestamps, copiedHandId, onEntryCl
     return (
       <div style={{
         ...style,
+        boxSizing: 'border-box',
         display: 'flex',
         alignItems: 'center',
-        padding: '0 8px'
+        padding: `0 ${HAND_LOG_ENTRY_PADDING_X}px`
       }}>
         <div style={{
           borderTop: '1px solid rgba(255, 255, 255, 0.2)',
@@ -536,8 +700,13 @@ const EntryRow = ({ index, style, items, showTimestamps, copiedHandId, onEntryCl
   const [isHovered, setIsHovered] = useState(false)
 
   const entryStyle: CSSProperties = {
+    // 行高の推定（estimateEntryRowHeight）はテキスト幅を
+    // 「行幅 - 左右padding」として計算する。ホスト側CSSのbox-sizingに
+    // 左右されないよう、ここで明示する。react-windowが与えるheightにも
+    // 上下paddingが含まれるようになるため、垂直方向の勘定とも一致する。
+    boxSizing: 'border-box',
     color: entryTypeColors[entry.type],
-    lineHeight: 1.2,
+    lineHeight: HAND_LOG_ENTRY_LINE_HEIGHT,
     whiteSpace: 'pre-wrap',
     wordBreak: 'break-word',
     opacity: entry.type === HandLogEntryType.SEAT ? 0.8 : 1,
@@ -548,14 +717,14 @@ const EntryRow = ({ index, style, items, showTimestamps, copiedHandId, onEntryCl
       : copiedHandId === entry.handId
         ? 'rgba(0, 200, 0, 0.2)'
         : 'transparent',
-    padding: '1px 8px',
+    padding: `${HAND_LOG_ENTRY_PADDING_Y}px ${HAND_LOG_ENTRY_PADDING_X}px`,
     fontSize
   }
 
   const timestampStyle: CSSProperties = {
     color: '#666666',
-    fontSize: fontSize - 2,
-    marginRight: '8px'
+    fontSize: fontSize - HAND_LOG_TIMESTAMP_FONT_SIZE_OFFSET,
+    marginRight: `${HAND_LOG_TIMESTAMP_MARGIN_RIGHT}px`
   }
 
   return (
@@ -639,16 +808,45 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
     return items
   }, [entries])
 
+  // Display-only shrink: the layout kept by the machine remains persistable.
+  const displaySize = getHandLogDisplaySize(
+    layoutMachine.layout,
+    layoutMachine.environment
+  )
+  // border-boxなのでbody部はborderぶん内側になる。
+  const bodyWidth = Math.max(
+    0,
+    displaySize.width - HAND_LOG_BORDER_WIDTH * 2
+  )
+  const bodyHeight = Math.max(
+    0,
+    displaySize.height - HAND_LOG_BORDER_WIDTH * 2
+  )
+
+  // 折り返しに使える本文幅。行はリスト幅いっぱい（width:100%）なので、
+  // 行の包含ブロックはbody幅そのもので、そこからEntryRow自身の左右padding
+  // だけがテキスト幅を狭める。保存幅ではなく表示幅から引くのが要点:
+  // viewportが保存幅より狭いときは表示だけが縮み、折り返しは縮んだ側で起きる。
+  const entryTextWidth = Math.max(
+    0,
+    bodyWidth - HAND_LOG_ENTRY_PADDING_X * 2
+  )
+
   // アイテムの高さを計算
+  // 本文幅・フォントサイズ・タイムスタンプ有無が変わるとこのコールバックの
+  // identityも変わり、react-window側の行境界キャッシュ（rowHeightに対する
+  // useMemo）が破棄されて再計算される。
   const getItemSize = useCallback((index: number) => {
     const item = processedItems[index]
     if (!item) return 0
-    if (item.isSeparator) return 10
+    if (item.isSeparator) return HAND_LOG_SEPARATOR_HEIGHT
 
-    // テキストの長さとフォントサイズに基づいて高さを推定
-    const lines = Math.ceil(item.entry.text.length / 60)
-    return lines * (config.fontSize * 1.2) + 2
-  }, [processedItems, config.fontSize])
+    return estimateEntryRowHeight(item.entry.text, {
+      textWidth: entryTextWidth,
+      fontSize: config.fontSize,
+      showTimestamps: config.showTimestamps
+    })
+  }, [processedItems, entryTextWidth, config.fontSize, config.showTimestamps])
 
   // Prop scale and viewport dimensions are inputs to the same layout machine
   // as pointer interaction. useLayoutEffect updates scale before paint while
@@ -872,11 +1070,7 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
   if (!config.enabled) return null
 
   const { layout, environment } = layoutMachine
-  // Display-only shrink: the layout kept by the machine remains persistable.
-  const { width, height } = getHandLogDisplaySize(layout, environment)
-  // border-boxなのでbody部はborderぶん内側になる。
-  const bodyWidth = Math.max(0, width - HAND_LOG_BORDER_WIDTH * 2)
-  const bodyHeight = Math.max(0, height - HAND_LOG_BORDER_WIDTH * 2)
+  const { width, height } = displaySize
   const interactionMode =
     layoutMachine.interaction.phase === 'interacting'
       ? layoutMachine.interaction.mode
@@ -901,7 +1095,7 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
     transformOrigin: 'top left',
     overflowY: 'hidden',
     overflowX: 'hidden',
-    fontFamily: 'Consolas, Monaco, "Courier New", monospace',
+    fontFamily: HAND_LOG_FONT_FAMILY,
     fontSize: config.fontSize,
     color: '#ffffff',
     // Keep the move grip and resize corner above player HUD panels (z-index


### PR DESCRIPTION
## 背景

`HandLog.tsx` の `getItemSize()` が行高を `Math.ceil(text.length / 60) * (fontSize * 1.2) + 2` と1行60文字固定で推定していたため、本文幅が狭いと実際の折り返し行数が推定を上回り、react-window が次行を早く配置してログ行が重なる（＝欠ける）。

再現条件: `EntryRow` は `white-space: pre-wrap` + `word-break: break-word`。既定 fontSize 8 の等幅フォントは1文字約4.8pxなので、本文幅が約288pxを下回ると実際は60文字未満で折り返す。パネルは `HAND_LOG_MIN_WIDTH = 200` までリサイズできるため、幅200pxにするだけで再現する。#305 以前から存在する問題で、#305 の viewport 追従（保存幅より狭い viewport では表示幅だけ縮む）が発生経路をもう1つ追加している。

#305 のレビューで chatgpt-codex-connector[bot] が指摘した件（https://github.com/solavrc/pokerchase-hud/pull/305#discussion_r3688610672 ）。

## 変更内容

- **文字幅の実測**: `measureMonospaceCharWidth()` が `canvas.measureText()` で実フォント（`Consolas, Monaco, "Courier New", monospace`）・実フォントサイズの1文字送り幅を測り、フォント文字列でキャッシュ。等幅でも Consolas 0.55 / Monaco・Courier New 0.6 と比率が違うため決め打ちでは行数がずれる。canvas が無い環境（jsdom）は想定フォント中で最も広い 0.6em へフォールバック（過大評価＝行間が空くだけ／過小評価＝重なり、なので広い側）。
- **折り返し行数**: `countWrappedLines()` が `pre-wrap` + `break-word` と同じ規則で数える。単純除算は単語境界での折り返しを無視して過小評価する（`"aaaaaa bbbbbb cccccc"` は20文字・幅10文字で実際は3行）。空白のぶら下がり／単語の送り／1行に収まらない語だけの分割を再現。
- **タイムスタンプ**: `showTimestamps` 時は `[HH:MM:SS]`（本文より2px小さいフォント）＋ margin 8px を本文の文字数へ換算し、先頭行の消費分に加算。
- **折り返し幅**: 保存幅ではなく**表示幅**（body幅 = 表示幅 - border×2、から `EntryRow` の左右padding×2を引いた値）から算出。viewport が保存幅より狭いときの折り返しは縮んだ表示側で起きるため。
- **box-sizing**: `EntryRow` に `boxSizing: 'border-box'` を明示。ホストページの CSS に関わらず「行幅 - 左右padding」がテキスト幅になり、react-window が渡す `height` にも上下paddingが含まれて垂直方向の勘定も一致する。
- **再計算**: 本文幅・フォントサイズ・タイムスタンプ有無を `getItemSize` の `useCallback` 依存に追加。react-window v2 は `rowHeight` の identity に対する `useMemo` で行境界キャッシュを持つので、identity が変われば破棄・再計算される（List 側の追加リセットは不要）。

レイアウト状態機械には触れていない（`transitionHandLogLayout()` の単一出口・永続化出口はそのまま）。

## 検証

- `npm run test`（1615件）/ `npm run typecheck` パス。テストは `src/components/HandLog.test.tsx` に co-locate（+22件）。旧実装へ戻すと行高テストが落ちることを確認済み。
- `npm run mockup` を実ブラウザで計測（各行の割り当て高 vs `height:auto` クローンの自然高）:
  - 既定 fontSize 8 / 幅200〜600px … 297行、不足ゼロ
  - fontSize 14 + タイムスタンプ / 幅200〜600px … 378行（うち135行が実際に折り返し）、**不足ゼロ**、1行分以上の過大評価は3行のみ
- 幅200px・fontSize 14 で2〜3行に折り返す表示を目視確認（重なりなし）。既定設定の見た目は従来と同一。
- `AGENTS.md` の Hand-log セクションに「Hand-log row height」を追記（固定文字数へ戻さないこと、表示幅から求めること、deps を落とさないこと）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)