### PR TITLE
refactor(hud): Hud.tsxの死んだPlayerTypeIcons呼び出しを削除

### DIFF
--- a/src/components/Hud.tsx
+++ b/src/components/Hud.tsx
@@ -9,7 +9,6 @@ import { DragHandle } from './hud/DragHandle'
 import { HudHeader } from './hud/HudHeader'
 import { StatDisplay } from './hud/StatDisplay'
 import { CompactStatDisplay } from './hud/CompactStatDisplay'
-import { PlayerTypeIcons } from './hud/PlayerTypeIcons'
 import { RealTimeStatsDisplay } from './hud/RealTimeStatsDisplay'
 import { PositionalStatsPanel } from './hud/PositionalStatsPanel'
 import { PositionalPanelTrigger } from './hud/PositionalPanelTrigger'
@@ -343,7 +342,6 @@ const Hud = memo((props: HudProps) => {
             <span style={{ ...styles.playerName, color: HUD_MUTED_TEXT_COLOR, fontStyle: 'italic' }}>
               Waiting for Hand...
             </span>
-            <PlayerTypeIcons />
           </div>
           <div style={{ padding: '4px 6px', minHeight: '20px' }} />
         </div>
@@ -384,7 +382,6 @@ const Hud = memo((props: HudProps) => {
                   onToggle={props.onToggleRecentHandsPanel}
                 />
               )}
-              <PlayerTypeIcons />
             </div>
           </div>
           <div style={{


### PR DESCRIPTION
## 概要

`src/components/Hud.tsx` に残っていた props 無しの `<PlayerTypeIcons />` 2箇所を削除しました。いずれも常に何も描画しない死にコードです。

- 342行目付近: `EMPTY_SEAT_ID` の「Waiting for Hand...」分岐
- 382行目付近: プレイヤーは居るが stats が無い「No Data」分岐

## 死にコードである根拠

`PlayerTypeIcons` は `classifyPlayerType(statResults)` が `null` を返すと何も描画しません。props を渡さない呼び出しでは `statResults === undefined` となり、`findFraction` が `undefined` を返して `vpipDenom = 0` になります。これは baseline n-gate (`PLAYER_TYPE_THRESHOLDS.minVpipN = 30`) を満たさないため、`classifyPlayerType` は他の判定に到達する前に即 `null` を返します（`src/components/hud/playerTypeRules.ts:92-94`）。

これらは `PlayerTypeIcons` が置き換えた、旧・装飾用 🐟/🦈 プレースホルダペアの名残です。

## 影響範囲

実際の分類アイコン表示は `src/components/hud/HudHeader.tsx:134` が `statResults` を渡して行っており、そちらは無変更です。テストコードから `PlayerTypeIcons` / `data-player-type` を参照している箇所もありません。

## 検証

- `npm run typecheck` — エラーなし
- `npm run test` — 157 suites / 1593 tests すべて成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)