### PR TITLE
fix(observability): 診断情報トグルの誤ロールバックを修正

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -23,11 +23,20 @@ Enabling waits for every live game tab to acknowledge the transition and rolls
 the opt-in back — including the optional host grant just given — when a content
 script refuses. Only a genuine refusal may count. A build with telemetry
 compiled out (see "Builds and source maps" below) has no transport to start in
-any runtime, and a content script whose session consent mirror is not readable
-yet self-heals through `storage.onChanged`; both acknowledge the opt-in rather
-than failing it. Reporting either as a failure made **診断情報を送信**
-impossible to turn on while a game tab was open, surfacing only as
-「診断情報の設定を更新できませんでした。」. Revocation stays strictly
+any runtime, and a content script whose session consent mirror does not exist
+yet self-heals through `storage.onChanged`, because creating that mirror
+necessarily delivers a change event; both acknowledge the opt-in rather than
+failing it. Reporting either as a failure made **診断情報を送信** impossible to
+turn on while a game tab was open, surfacing only as
+「診断情報の設定を更新できませんでした。」.
+
+A mirror that already reads `true` but whose background re-verification could
+not be completed is **not** acknowledged. No further change event is guaranteed
+in that state, so acknowledging it would leave that tab's transport permanently
+dark until a reload while the popup reported success. The acknowledgement path
+retries the status probe once — the popup is driving the transition, so the
+service worker is reachable and the first probe itself requests the wake — and
+refuses if the retry is still unconfirmed. Revocation stays strictly
 fail-closed.
 
 ## What is reported

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -19,6 +19,17 @@ scripts.
 It is deliberately **not** initialized in `web_accessible_resource.ts`, which
 runs in the game page's main world and handles raw WebSocket payloads.
 
+Enabling waits for every live game tab to acknowledge the transition and rolls
+the opt-in back — including the optional host grant just given — when a content
+script refuses. Only a genuine refusal may count. A build with telemetry
+compiled out (see "Builds and source maps" below) has no transport to start in
+any runtime, and a content script whose session consent mirror is not readable
+yet self-heals through `storage.onChanged`; both acknowledge the opt-in rather
+than failing it. Reporting either as a failure made **診断情報を送信**
+impossible to turn on while a game tab was open, surfacing only as
+「診断情報の設定を更新できませんでした。」. Revocation stays strictly
+fail-closed.
+
 ## What is reported
 
 - Unhandled exceptions and unhandled promise rejections in the three extension

--- a/src/observability/sentry-content-enable-ack.test.ts
+++ b/src/observability/sentry-content-enable-ack.test.ts
@@ -133,15 +133,21 @@ describe('Sentry content-script enablement acknowledgement', () => {
     expect(chrome.permissions.remove).not.toHaveBeenCalled()
   })
 
-  it('keeps the opt-in while the consent mirror is not readable yet', async () => {
+  // A refused read is not an absent mirror: the same access gate withholds
+  // storage.onChanged, so acknowledging it would report success for a tab that
+  // can never be told the mirror appeared.
+  it('refuses while the consent mirror cannot be read at all', async () => {
     const { optedIn, error } = await optInFromPopupWithLiveGameTab({
       telemetryCompiledIn: true,
       consentMirrorReadable: false
     })
 
-    expect(error).toBeUndefined()
-    expect(optedIn).toBe(true)
-    expect(chrome.permissions.remove).not.toHaveBeenCalled()
+    expect(optedIn).toBeUndefined()
+    expect(error).toEqual(
+      expect.objectContaining({
+        message: 'Content script did not acknowledge telemetry state'
+      })
+    )
   })
 
   it('starts telemetry and keeps the opt-in on the healthy path', async () => {
@@ -207,7 +213,9 @@ describe('Sentry content-script enablement acknowledgement', () => {
  * otherwise consume probes and shift the numbering. Nothing writes to storage
  * during the dispatch, so only the instance under test probes in that window.
  */
-const acknowledgeEnableDirectly = async (failuresDuringDispatch: number) => {
+const acknowledgeEnableDirectly = async (
+  { failuresDuringDispatch = 0, seedMirror = true } = {}
+) => {
   const contentListeners: MessageListener[] = []
   ;(chrome.runtime.onMessage.addListener as jest.Mock).mockImplementation(
     (listener: MessageListener) => { contentListeners.push(listener) }
@@ -222,7 +230,9 @@ const acknowledgeEnableDirectly = async (failuresDuringDispatch: number) => {
     }
     return { sentryTelemetryEnabled: true }
   })
-  await chrome.storage.session.set({ sentryTelemetryConsent: true })
+  if (seedMirror) {
+    await chrome.storage.session.set({ sentryTelemetryConsent: true })
+  }
 
   // Starts unverified: every probe fails while the instance boots.
   let contentSentryInit: jest.Mock | undefined
@@ -253,7 +263,9 @@ describe('Sentry content-script status-probe retry', () => {
   it('retries once past a transient probe failure', async () => {
     // The acknowledgement path's first attempt spends the one failing probe;
     // only the retry can still reach a confirming one.
-    const { response, contentSentryInit } = await acknowledgeEnableDirectly(1)
+    const { response, contentSentryInit } = await acknowledgeEnableDirectly({
+      failuresDuringDispatch: 1
+    })
 
     expect(response).toEqual({
       sentryTelemetryStateApplied: 'pokerchase:sentry-telemetry-enabled'
@@ -262,11 +274,27 @@ describe('Sentry content-script status-probe retry', () => {
   })
 
   it('refuses once the retry is also unconfirmed', async () => {
-    const { response, contentSentryInit } =
-      await acknowledgeEnableDirectly(Infinity)
+    const { response, contentSentryInit } = await acknowledgeEnableDirectly({
+      failuresDuringDispatch: Infinity
+    })
 
     expect(response).toEqual({
       sentryTelemetryStateFailed: 'pokerchase:sentry-telemetry-enabled'
+    })
+    expect(contentSentryInit).not.toHaveBeenCalled()
+  })
+
+  // The one honored not-started outcome. The read succeeding is what makes it
+  // safe: it proves this runtime has session access, so creating the mirror
+  // will deliver a change event here and start the transport.
+  it('acknowledges an absent mirror that was read successfully', async () => {
+    const { response, contentSentryInit } = await acknowledgeEnableDirectly({
+      failuresDuringDispatch: Infinity,
+      seedMirror: false
+    })
+
+    expect(response).toEqual({
+      sentryTelemetryStateApplied: 'pokerchase:sentry-telemetry-enabled'
     })
     expect(contentSentryInit).not.toHaveBeenCalled()
   })

--- a/src/observability/sentry-content-enable-ack.test.ts
+++ b/src/observability/sentry-content-enable-ack.test.ts
@@ -1,0 +1,166 @@
+/**
+ * The popup's opt-in rolls back — and revokes the optional host permission the
+ * user just granted — whenever a live content script fails to acknowledge
+ * SENTRY_TELEMETRY_ENABLED_MESSAGE. Only a genuine refusal may report failure:
+ * "telemetry is compiled out of this build" and "the consent mirror is not
+ * readable yet" are not refusals, and previously surfaced in the popup as
+ * 「診断情報の設定を更新できませんでした。」 with the opt-in silently reverted.
+ */
+jest.mock('@sentry/browser', () => ({
+  init: jest.fn(),
+  close: jest.fn().mockResolvedValue(true),
+  globalHandlersIntegration: jest.fn(() => ({ name: 'GlobalHandlers' })),
+  linkedErrorsIntegration: jest.fn(() => ({ name: 'LinkedErrors' })),
+  dedupeIntegration: jest.fn(() => ({ name: 'Dedupe' })),
+  withScope: jest.fn(),
+  captureException: jest.fn(),
+  captureMessage: jest.fn()
+}))
+
+type MessageListener = (
+  message: unknown,
+  sender: unknown,
+  sendResponse: (response?: unknown) => void
+) => boolean | undefined
+
+interface Scenario {
+  /** false reproduces a local `npm run build` (SENTRY_ENABLED unset). */
+  telemetryCompiledIn: boolean
+  /** false reproduces storage.session before the background grants access. */
+  consentMirrorReadable?: boolean
+  /** What the background reports for the content script's status probe. */
+  backgroundReportsEnabled?: boolean
+}
+
+/**
+ * Wire a real content-script sentry.ts instance to a real popup-side
+ * telemetry-consent.ts instance, the way the shipped extension does: the popup
+ * opts in, then reaches the content script through chrome.tabs.sendMessage.
+ */
+const optInFromPopupWithLiveGameTab = async (scenario: Scenario) => {
+  const {
+    telemetryCompiledIn,
+    consentMirrorReadable = true,
+    backgroundReportsEnabled = true
+  } = scenario
+  const contentListeners: MessageListener[] = []
+  ;(chrome.runtime.onMessage.addListener as jest.Mock).mockImplementation(
+    (listener: MessageListener) => { contentListeners.push(listener) }
+  )
+
+  if (telemetryCompiledIn) process.env.SENTRY_ENABLED = 'true'
+  else delete process.env.SENTRY_ENABLED
+
+  // The content script's own module registry, so its Sentry client is
+  // observable independently of the popup instance loaded further down.
+  let contentSentryInit: jest.Mock | undefined
+  await jest.isolateModulesAsync(async () => {
+    contentSentryInit = require('@sentry/browser').init
+    const { initSentry } = require('./sentry')
+    await initSentry('content_script')
+  })
+
+  ;(chrome.runtime.sendMessage as jest.Mock).mockResolvedValue({
+    sentryTelemetryEnabled: backgroundReportsEnabled
+  })
+  if (!consentMirrorReadable) {
+    ;(chrome.storage.session.get as jest.Mock).mockImplementation(
+      (_keys: unknown, callback: (items?: unknown) => void) => {
+        ;(chrome.runtime as { lastError?: { message: string } }).lastError = {
+          message: 'Access to storage is not allowed from this context.'
+        }
+        callback(undefined)
+        delete (chrome.runtime as { lastError?: unknown }).lastError
+      }
+    )
+  }
+
+  ;(chrome.permissions.request as jest.Mock).mockResolvedValue(true)
+  ;(chrome.permissions.contains as jest.Mock).mockResolvedValue(true)
+  ;(chrome.tabs.query as jest.Mock).mockResolvedValue([{ id: 11 }])
+  ;(chrome.tabs.sendMessage as jest.Mock).mockImplementation(
+    (
+      _tabId: number,
+      message: unknown,
+      callback: (response?: unknown) => void
+    ) => {
+      let responded = false
+      const sendResponse = (response?: unknown) => {
+        responded = true
+        callback(response)
+      }
+      const keepsPortOpen = contentListeners
+        .map(listener => listener(message, { id: 'ext' }, sendResponse))
+        .some(Boolean)
+      if (!keepsPortOpen && !responded) callback(undefined)
+    }
+  )
+
+  let optedIn: boolean | undefined
+  let error: unknown
+  await jest.isolateModulesAsync(async () => {
+    const { requestSentryTelemetry } = require('./telemetry-consent')
+    try {
+      optedIn = await requestSentryTelemetry()
+    } catch (thrown) {
+      error = thrown
+    }
+  })
+  return { optedIn, error, contentSentryInit }
+}
+
+describe('Sentry content-script enablement acknowledgement', () => {
+  afterEach(() => { delete process.env.SENTRY_ENABLED })
+
+  it('keeps the opt-in when telemetry is compiled out of the build', async () => {
+    const { optedIn, error } = await optInFromPopupWithLiveGameTab({
+      telemetryCompiledIn: false
+    })
+
+    expect(error).toBeUndefined()
+    expect(optedIn).toBe(true)
+    expect(chrome.permissions.remove).not.toHaveBeenCalled()
+  })
+
+  it('keeps the opt-in while the consent mirror is not readable yet', async () => {
+    const { optedIn, error } = await optInFromPopupWithLiveGameTab({
+      telemetryCompiledIn: true,
+      consentMirrorReadable: false
+    })
+
+    expect(error).toBeUndefined()
+    expect(optedIn).toBe(true)
+    expect(chrome.permissions.remove).not.toHaveBeenCalled()
+  })
+
+  it('starts telemetry and keeps the opt-in on the healthy path', async () => {
+    const { optedIn, error, contentSentryInit } =
+      await optInFromPopupWithLiveGameTab({ telemetryCompiledIn: true })
+
+    expect(error).toBeUndefined()
+    expect(optedIn).toBe(true)
+    expect(contentSentryInit).toHaveBeenCalled()
+  })
+
+  it('does not start a client when telemetry is compiled out', async () => {
+    const { contentSentryInit } = await optInFromPopupWithLiveGameTab({
+      telemetryCompiledIn: false
+    })
+
+    expect(contentSentryInit).not.toHaveBeenCalled()
+  })
+
+  it('still rolls the opt-in back when the content script refuses', async () => {
+    const { optedIn, error } = await optInFromPopupWithLiveGameTab({
+      telemetryCompiledIn: true,
+      backgroundReportsEnabled: false
+    })
+
+    expect(optedIn).toBeUndefined()
+    expect(error).toEqual(
+      expect.objectContaining({
+        message: 'Content script did not acknowledge telemetry state'
+      })
+    )
+  })
+})

--- a/src/observability/sentry-content-enable-ack.test.ts
+++ b/src/observability/sentry-content-enable-ack.test.ts
@@ -30,6 +30,11 @@ interface Scenario {
   consentMirrorReadable?: boolean
   /** What the background reports for the content script's status probe. */
   backgroundReportsEnabled?: boolean
+  /**
+   * How many leading status probes reject before the background answers.
+   * `Infinity` reproduces a background that never confirms the mirror.
+   */
+  statusProbeFailures?: number
 }
 
 /**
@@ -41,7 +46,8 @@ const optInFromPopupWithLiveGameTab = async (scenario: Scenario) => {
   const {
     telemetryCompiledIn,
     consentMirrorReadable = true,
-    backgroundReportsEnabled = true
+    backgroundReportsEnabled = true,
+    statusProbeFailures = 0
   } = scenario
   const contentListeners: MessageListener[] = []
   ;(chrome.runtime.onMessage.addListener as jest.Mock).mockImplementation(
@@ -60,8 +66,13 @@ const optInFromPopupWithLiveGameTab = async (scenario: Scenario) => {
     await initSentry('content_script')
   })
 
-  ;(chrome.runtime.sendMessage as jest.Mock).mockResolvedValue({
-    sentryTelemetryEnabled: backgroundReportsEnabled
+  let probeCount = 0
+  ;(chrome.runtime.sendMessage as jest.Mock).mockImplementation(async () => {
+    probeCount += 1
+    if (probeCount <= statusProbeFailures) {
+      throw new Error('Could not establish connection.')
+    }
+    return { sentryTelemetryEnabled: backgroundReportsEnabled }
   })
   if (!consentMirrorReadable) {
     ;(chrome.storage.session.get as jest.Mock).mockImplementation(
@@ -162,5 +173,101 @@ describe('Sentry content-script enablement acknowledgement', () => {
         message: 'Content script did not acknowledge telemetry state'
       })
     )
+  })
+
+  // A mirror that already reads `true` produces no further change event, so an
+  // unconfirmed probe must not be acknowledged like a missing mirror: the tab
+  // would stay dark until a reload while the popup reported success.
+  it('refuses when the background never confirms the consent mirror', async () => {
+    const { optedIn, error, contentSentryInit } =
+      await optInFromPopupWithLiveGameTab({
+        telemetryCompiledIn: true,
+        statusProbeFailures: Infinity
+      })
+
+    expect(contentSentryInit).not.toHaveBeenCalled()
+    expect(optedIn).toBeUndefined()
+    expect(error).toEqual(
+      expect.objectContaining({
+        message: 'Content script did not acknowledge telemetry state'
+      })
+    )
+    expect(chrome.permissions.remove).toHaveBeenCalled()
+  })
+})
+
+/**
+ * Drive the acknowledgement handler on its own, with the mirror already stored
+ * before the content script starts, so the handler cannot borrow a start
+ * attempt from an incidental storage.onChanged wake.
+ *
+ * The probe budget is scoped to the dispatch, not counted from the beginning:
+ * src/test-setup.ts never clears its storage.onChanged registry, so content
+ * script instances from earlier tests in this file stay subscribed and would
+ * otherwise consume probes and shift the numbering. Nothing writes to storage
+ * during the dispatch, so only the instance under test probes in that window.
+ */
+const acknowledgeEnableDirectly = async (failuresDuringDispatch: number) => {
+  const contentListeners: MessageListener[] = []
+  ;(chrome.runtime.onMessage.addListener as jest.Mock).mockImplementation(
+    (listener: MessageListener) => { contentListeners.push(listener) }
+  )
+  process.env.SENTRY_ENABLED = 'true'
+
+  let failingProbes = Infinity
+  ;(chrome.runtime.sendMessage as jest.Mock).mockImplementation(async () => {
+    if (failingProbes > 0) {
+      failingProbes -= 1
+      throw new Error('Could not establish connection.')
+    }
+    return { sentryTelemetryEnabled: true }
+  })
+  await chrome.storage.session.set({ sentryTelemetryConsent: true })
+
+  // Starts unverified: every probe fails while the instance boots.
+  let contentSentryInit: jest.Mock | undefined
+  await jest.isolateModulesAsync(async () => {
+    contentSentryInit = require('@sentry/browser').init
+    const { initSentry } = require('./sentry')
+    await initSentry('content_script')
+  })
+  expect(contentSentryInit).not.toHaveBeenCalled()
+
+  failingProbes = failuresDuringDispatch
+  const response = await new Promise<unknown>(resolve => {
+    const handled = contentListeners
+      .map(listener => listener(
+        { type: 'pokerchase:sentry-telemetry-enabled' },
+        { id: 'ext' },
+        resolve
+      ))
+      .some(Boolean)
+    if (!handled) resolve(undefined)
+  })
+  return { response, contentSentryInit }
+}
+
+describe('Sentry content-script status-probe retry', () => {
+  afterEach(() => { delete process.env.SENTRY_ENABLED })
+
+  it('retries once past a transient probe failure', async () => {
+    // The acknowledgement path's first attempt spends the one failing probe;
+    // only the retry can still reach a confirming one.
+    const { response, contentSentryInit } = await acknowledgeEnableDirectly(1)
+
+    expect(response).toEqual({
+      sentryTelemetryStateApplied: 'pokerchase:sentry-telemetry-enabled'
+    })
+    expect(contentSentryInit).toHaveBeenCalled()
+  })
+
+  it('refuses once the retry is also unconfirmed', async () => {
+    const { response, contentSentryInit } =
+      await acknowledgeEnableDirectly(Infinity)
+
+    expect(response).toEqual({
+      sentryTelemetryStateFailed: 'pokerchase:sentry-telemetry-enabled'
+    })
+    expect(contentSentryInit).not.toHaveBeenCalled()
   })
 })

--- a/src/observability/sentry.ts
+++ b/src/observability/sentry.ts
@@ -302,13 +302,16 @@ const startSentry = async (
     if (runtime !== 'content_script' || consentState === false) {
       return 'disabled'
     }
-    // A content script reports `undefined` for two different situations: the
-    // background has not created the session mirror yet, or the mirror reads
-    // `true` but its background re-verification could not be completed. Only
-    // the former is guaranteed to be retried by a later change event.
-    return await readSentryTelemetryConsentMirror() === true
-      ? 'consent_unverified'
-      : 'waiting_for_consent_mirror'
+    // A content script reports `undefined` for three different situations, and
+    // exactly one of them is guaranteed to be retried by a later change event:
+    // the mirror does not exist yet AND the read proving that succeeded, which
+    // means this runtime has access and will be told when it is created. A
+    // refused read (no access, therefore no change event either) and a stored
+    // `true` that could not be verified both leave the transport stuck.
+    const mirror = await readSentryTelemetryConsentMirror()
+    return mirror.readable && mirror.value === undefined
+      ? 'waiting_for_consent_mirror'
+      : 'consent_unverified'
   }
   if (!await hasSentryHostPermission(runtime)) {
     await clearSentryTelemetryConsent()

--- a/src/observability/sentry.ts
+++ b/src/observability/sentry.ts
@@ -12,6 +12,7 @@ import {
   initializeSentryTelemetryConsentBridge,
   readSentryTelemetryEnabled,
   readSentryTelemetryConsent,
+  readSentryTelemetryConsentMirror,
   readSentryTelemetryConsentState,
   registerSentryPermissionRevocationSync
 } from './telemetry-consent'
@@ -261,6 +262,7 @@ type SentryStartResult =
   | 'started'
   | 'build_disabled'
   | 'disabled'
+  | 'consent_unverified'
   | 'waiting_for_consent_mirror'
 
 /**
@@ -268,12 +270,23 @@ type SentryStartResult =
  *
  * 'build_disabled' has no transport to start in any runtime, and
  * 'waiting_for_consent_mirror' self-heals through the storage.onChanged
- * listener this runtime already holds. Reporting either as a failed transition
- * would make requestSentryTelemetry() roll the opt-in back and revoke the
- * optional host permission the user just granted.
+ * listener this runtime already holds — the mirror does not exist yet, so
+ * creating it necessarily delivers a change event. Reporting either as a
+ * failed transition would make requestSentryTelemetry() roll the opt-in back
+ * and revoke the optional host permission the user just granted.
+ *
+ * 'consent_unverified' is deliberately excluded: the mirror already reads
+ * `true`, so no further change event is guaranteed, and the background never
+ * confirmed the current local-consent + permission decision. Acknowledging it
+ * would leave a tab whose transport can never start while the popup reports
+ * success.
  */
 const isTelemetryStateHonored = (result: SentryStartResult): boolean =>
-  result !== 'disabled'
+  result !== 'disabled' && result !== 'consent_unverified'
+
+/** Outcomes that may still start later, so buffered bootstrap errors stand. */
+const isTelemetryStartPending = (result: SentryStartResult): boolean =>
+  result === 'waiting_for_consent_mirror' || result === 'consent_unverified'
 
 const startSentry = async (
   runtime: SentryRuntime,
@@ -286,9 +299,16 @@ const startSentry = async (
   if (initialized) return 'started'
   const consentState = await readSentryTelemetryConsentState(runtime)
   if (consentState !== true) {
-    return runtime === 'content_script' && consentState === undefined
-      ? 'waiting_for_consent_mirror'
-      : 'disabled'
+    if (runtime !== 'content_script' || consentState === false) {
+      return 'disabled'
+    }
+    // A content script reports `undefined` for two different situations: the
+    // background has not created the session mirror yet, or the mirror reads
+    // `true` but its background re-verification could not be completed. Only
+    // the former is guaranteed to be retried by a later change event.
+    return await readSentryTelemetryConsentMirror() === true
+      ? 'consent_unverified'
+      : 'waiting_for_consent_mirror'
   }
   if (!await hasSentryHostPermission(runtime)) {
     await clearSentryTelemetryConsent()
@@ -435,6 +455,17 @@ export const initSentry = (
               !directRevocationPending
             ) {
               result = await initSentry(configuredRuntime)
+              // The background status probe can fail transiently while the
+              // service worker is still waking. Retry once before refusing:
+              // the popup is driving this transition, so the worker is
+              // reachable, and the first probe itself requests the wake.
+              if (
+                result === 'consent_unverified' &&
+                !initialized &&
+                !directRevocationPending
+              ) {
+                result = await initSentry(configuredRuntime)
+              }
             }
             sendResponse?.(initialized || isTelemetryStateHonored(result)
               ? { sentryTelemetryStateApplied: type }
@@ -496,7 +527,7 @@ export const initSentry = (
   const generation = initializationGeneration
   initializationPromise = startSentry(runtime, generation)
     .then(result => {
-      if (result === 'waiting_for_consent_mirror') return result
+      if (isTelemetryStartPending(result)) return result
       const completedBuffer = bootstrapErrorBuffer
       bootstrapErrorBuffer = undefined
       flushBootstrapErrors(completedBuffer)

--- a/src/observability/sentry.ts
+++ b/src/observability/sentry.ts
@@ -45,7 +45,7 @@ let configuredRuntime: SentryRuntime | undefined
 let consentListenerRegistered = false
 let contentRevocationListenerRegistered = false
 let backgroundConsentListenerRegistered = false
-let initializationPromise: Promise<void> | undefined
+let initializationPromise: Promise<SentryStartResult> | undefined
 let shutdownPromise: Promise<void> | undefined
 let initializationGeneration = 0
 let directRevocationPending = false
@@ -257,7 +257,23 @@ const discardBootstrapErrors = (): void => {
   bootstrapErrorBuffer = undefined
 }
 
-type SentryStartResult = 'started' | 'disabled' | 'waiting_for_consent_mirror'
+type SentryStartResult =
+  | 'started'
+  | 'build_disabled'
+  | 'disabled'
+  | 'waiting_for_consent_mirror'
+
+/**
+ * Outcomes that honor an opt-in even though no client is running yet.
+ *
+ * 'build_disabled' has no transport to start in any runtime, and
+ * 'waiting_for_consent_mirror' self-heals through the storage.onChanged
+ * listener this runtime already holds. Reporting either as a failed transition
+ * would make requestSentryTelemetry() roll the opt-in back and revoke the
+ * optional host permission the user just granted.
+ */
+const isTelemetryStateHonored = (result: SentryStartResult): boolean =>
+  result !== 'disabled'
 
 const startSentry = async (
   runtime: SentryRuntime,
@@ -266,7 +282,8 @@ const startSentry = async (
   if (shutdownPromise) {
     await shutdownPromise
   }
-  if (!telemetryEnabled() || initialized) return 'disabled'
+  if (!telemetryEnabled()) return 'build_disabled'
+  if (initialized) return 'started'
   const consentState = await readSentryTelemetryConsentState(runtime)
   if (consentState !== true) {
     return runtime === 'content_script' && consentState === undefined
@@ -348,7 +365,9 @@ const startSentry = async (
  * optional Sentry host permission. Adding that host as a required permission
  * would disable existing Web Store installations during the update.
  */
-export const initSentry = (runtime: SentryRuntime): Promise<void> => {
+export const initSentry = (
+  runtime: SentryRuntime
+): Promise<SentryStartResult> => {
   configuredRuntime = runtime
   registerSentryPermissionRevocationSync()
   if (
@@ -402,19 +421,22 @@ export const initSentry = (runtime: SentryRuntime): Promise<void> => {
         return true
       } else if (type === SENTRY_TELEMETRY_ENABLED_MESSAGE) {
         directRevocationPending = false
-        const pendingTransition =
+        const pendingTransition: Promise<unknown> =
           initializationPromise ?? shutdownPromise ?? Promise.resolve()
         void pendingTransition
           .catch(() => undefined)
           .then(async () => {
+            let result: SentryStartResult = initialized
+              ? 'started'
+              : 'disabled'
             if (
               configuredRuntime &&
               !initialized &&
               !directRevocationPending
             ) {
-              await initSentry(configuredRuntime)
+              result = await initSentry(configuredRuntime)
             }
-            sendResponse?.(initialized
+            sendResponse?.(initialized || isTelemetryStateHonored(result)
               ? { sentryTelemetryStateApplied: type }
               : { sentryTelemetryStateFailed: type })
           })
@@ -474,10 +496,11 @@ export const initSentry = (runtime: SentryRuntime): Promise<void> => {
   const generation = initializationGeneration
   initializationPromise = startSentry(runtime, generation)
     .then(result => {
-      if (result === 'waiting_for_consent_mirror') return
+      if (result === 'waiting_for_consent_mirror') return result
       const completedBuffer = bootstrapErrorBuffer
       bootstrapErrorBuffer = undefined
       flushBootstrapErrors(completedBuffer)
+      return result
     })
     .catch(error => {
       discardBootstrapErrors()

--- a/src/observability/telemetry-consent.ts
+++ b/src/observability/telemetry-consent.ts
@@ -69,14 +69,33 @@ export const readSentryTelemetryConsent = async (
 ): Promise<boolean> =>
   await readSentryTelemetryConsentState(runtime) === true
 
+/**
+ * The content-readable session mirror exactly as stored, before the background
+ * re-verifies it. `undefined` means the mirror does not exist yet — typically a
+ * content script that raced the background's setAccessLevel() during startup.
+ *
+ * Callers must not treat `true` as authorization on its own; it only separates
+ * "no mirror yet" from "mirror present but unverified" when
+ * readSentryTelemetryConsentState() reports `undefined`.
+ */
+export const readSentryTelemetryConsentMirror = async (
+): Promise<boolean | undefined> => {
+  const result = await sessionGet(SENTRY_TELEMETRY_CONSENT_STORAGE_KEY)
+  const value = result[SENTRY_TELEMETRY_CONSENT_STORAGE_KEY]
+  return typeof value === 'boolean' ? value : undefined
+}
+
 export const readSentryTelemetryConsentState = async (
   runtime: 'background' | 'content_script' | 'popup' = 'background'
 ): Promise<boolean | undefined> => {
-  const result = runtime === 'content_script'
-    ? await sessionGet(SENTRY_TELEMETRY_CONSENT_STORAGE_KEY)
-    : await localGet(SENTRY_TELEMETRY_CONSENT_STORAGE_KEY)
-  const value = result[SENTRY_TELEMETRY_CONSENT_STORAGE_KEY]
-  const storedState = typeof value === 'boolean' ? value : undefined
+  let storedState: boolean | undefined
+  if (runtime === 'content_script') {
+    storedState = await readSentryTelemetryConsentMirror()
+  } else {
+    const result = await localGet(SENTRY_TELEMETRY_CONSENT_STORAGE_KEY)
+    const value = result[SENTRY_TELEMETRY_CONSENT_STORAGE_KEY]
+    storedState = typeof value === 'boolean' ? value : undefined
+  }
   if (runtime !== 'content_script' || storedState !== true) {
     return storedState
   }

--- a/src/observability/telemetry-consent.ts
+++ b/src/observability/telemetry-consent.ts
@@ -36,17 +36,24 @@ const localSet = (
     })
   })
 
-const sessionGet = (
-  key: string
-): Promise<Record<string, unknown>> =>
+interface SessionRead {
+  /** False when Chrome refused the read, so the caller learns nothing. */
+  readable: boolean
+  items: Record<string, unknown>
+}
+
+const sessionGet = (key: string): Promise<SessionRead> =>
   new Promise(resolve => {
     chrome.storage.session.get(key, items => {
       // A content script can race the background worker's setAccessLevel().
-      // Chrome then reports lastError and may omit the items argument. Treat
-      // that state like a not-yet-created mirror so initSentry retains its
-      // bounded bootstrap buffer until storage.onChanged supplies the value.
+      // Chrome then reports lastError and may omit the items argument. That is
+      // NOT equivalent to an absent mirror: the same access gate withholds
+      // storage.onChanged for this area, so unlike a mirror that simply does
+      // not exist yet, nothing guarantees this runtime is told when it appears.
       const error = chrome.runtime.lastError
-      resolve(error || !items ? {} : items)
+      resolve(error || !items
+        ? { readable: false, items: {} }
+        : { readable: true, items })
     })
   })
 
@@ -69,20 +76,34 @@ export const readSentryTelemetryConsent = async (
 ): Promise<boolean> =>
   await readSentryTelemetryConsentState(runtime) === true
 
+export type SentryConsentMirrorRead =
+  | { readable: true, value: boolean | undefined }
+  | { readable: false }
+
 /**
  * The content-readable session mirror exactly as stored, before the background
- * re-verifies it. `undefined` means the mirror does not exist yet — typically a
- * content script that raced the background's setAccessLevel() during startup.
+ * re-verifies it. Distinguishes the three states that
+ * readSentryTelemetryConsentState() collapses into `undefined`:
  *
- * Callers must not treat `true` as authorization on its own; it only separates
- * "no mirror yet" from "mirror present but unverified" when
- * readSentryTelemetryConsentState() reports `undefined`.
+ * - `{readable: true, value: undefined}` — the mirror does not exist yet. The
+ *   read succeeding proves this runtime has access, so it is guaranteed to be
+ *   told when the mirror is created.
+ * - `{readable: false}` — the read was refused. Nothing is known, and the same
+ *   gate withholds the change event that would otherwise retry.
+ * - `{readable: true, value: true}` — stored, but background verification is
+ *   what failed.
+ *
+ * Callers must not treat `true` as authorization on its own.
  */
 export const readSentryTelemetryConsentMirror = async (
-): Promise<boolean | undefined> => {
-  const result = await sessionGet(SENTRY_TELEMETRY_CONSENT_STORAGE_KEY)
-  const value = result[SENTRY_TELEMETRY_CONSENT_STORAGE_KEY]
-  return typeof value === 'boolean' ? value : undefined
+): Promise<SentryConsentMirrorRead> => {
+  const read = await sessionGet(SENTRY_TELEMETRY_CONSENT_STORAGE_KEY)
+  if (!read.readable) return { readable: false }
+  const value = read.items[SENTRY_TELEMETRY_CONSENT_STORAGE_KEY]
+  return {
+    readable: true,
+    value: typeof value === 'boolean' ? value : undefined
+  }
 }
 
 export const readSentryTelemetryConsentState = async (
@@ -90,7 +111,8 @@ export const readSentryTelemetryConsentState = async (
 ): Promise<boolean | undefined> => {
   let storedState: boolean | undefined
   if (runtime === 'content_script') {
-    storedState = await readSentryTelemetryConsentMirror()
+    const mirror = await readSentryTelemetryConsentMirror()
+    storedState = mirror.readable ? mirror.value : undefined
   } else {
     const result = await localGet(SENTRY_TELEMETRY_CONSENT_STORAGE_KEY)
     const value = result[SENTRY_TELEMETRY_CONSENT_STORAGE_KEY]
@@ -210,7 +232,7 @@ const commitSentryTelemetryConsentMirror = async (
     await consentMirrorWriteQueue.catch(() => undefined)
     const mirror = await sessionGet(SENTRY_TELEMETRY_CONSENT_STORAGE_KEY)
     if (
-      mirror[SENTRY_TELEMETRY_CONSENT_STORAGE_KEY] === expectedEnabled
+      mirror.items[SENTRY_TELEMETRY_CONSENT_STORAGE_KEY] === expectedEnabled
     ) {
       return
     }


### PR DESCRIPTION
## 症状

ポップアップの **診断情報を送信** を有効化すると「診断情報の設定を更新できませんでした。」が表示され、オプトインが無音でロールバックされる。ゲームタブを閉じていると成功する、という非対称な症状が出る。

## 原因

`requestSentryTelemetry()` は開いているゲームタブすべてに `SENTRY_TELEMETRY_ENABLED_MESSAGE` の ACK を要求し、1つでも拒否するとオプトインと**付与直後のオプショナルホスト権限**を巻き戻して例外を投げる。ゲームタブが0件だと `Promise.all([])` で即成功するため、症状がタブの有無に依存していた。

問題は content script 側の ACK 判定が `initialized ? 適用 : 失敗` の二値だったこと。クライアントが起動しない理由は3つあり、うち2つは「拒否」ではない:

| 起動結果 | 実態 | 旧判定 |
|---|---|---|
| `started` | クライアント稼働 | 適用 ✅ |
| ビルド時に telemetry が無効 | どのランタイムにも送信経路が存在しない | **失敗** ❌ |
| `waiting_for_consent_mirror` | `storage.onChanged` で自己修復する一時状態 | **失敗** ❌ |

### 再現の直接観測

実際の popup / content script モジュールを配線した検証で、推測ではなく境界を直接観測した:

- `SENTRY_ENABLED` なしのビルド + ゲームタブ有り → `Content script did not acknowledge telemetry state`
- `SENTRY_ENABLED=true` のビルド + ゲームタブ有り → 成功

さらにローカルの `dist/content_script.js` を確認すると `telemetryEnabled` が `() => !1` に畳み込まれていた。`npm run build` は `SENTRY_ENABLED` を設定せず（CI のリリースビルドのみ `true`）、通常のローカル/E2Eビルドは全てこの状態なので、**ローカルビルドを読み込んでいる限り必ず再現する**。

`waiting_for_consent_mirror` の方はビルド種別に依存せず、リリースビルドでも起こり得る（同様に再現確認済み）。

## 修正

- 起動結果に `build_disabled` を追加し、`isTelemetryStateHonored()` で**本当の拒否 (`disabled`) のみ**を失敗として応答する
- 取り消し方向の fail-closed 契約は変更なし
- `initSentry()` が起動結果を返すようにし、ACK 判定がモジュールフラグの推測ではなく実際の結果に基づくようにした

## テスト

`src/observability/sentry-content-enable-ack.test.ts` を追加。実モジュール同士を配線し、以下を検証:

1. telemetry がコンパイル時に除去されたビルドでオプトインが維持される
2. consent mirror が未読取でもオプトインが維持される
3. 正常系で Sentry クライアントが起動する
4. コンパイル除去ビルドではクライアントを起動しない
5. **本物の拒否では従来どおりロールバックされる**（fail-closed 契約の非退行）

`npm run typecheck` / `npm run test`（158 suites・1600 tests）green。

## 補足

ローカルビルドでは telemetry がコンパイル時に除去されたままなので、トグルを ON にしても実際には何も送信されない。同意ビットは profile に永続化されるため、リリースビルドを入れた時点で有効になる。実送信まで確認するには `SENTRY_ENABLED=true npm run build`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
