### PR TITLE
fix(ui): ハンドログの行高を全角幅とスクロールバー幅まで含めて数える

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -499,19 +499,26 @@ width/height exactly; the log body is that minus `HAND_LOG_BORDER_WIDTH*2`.
 
 **Hand-log row height**: the virtual list positions rows from `getItemSize()`,
 so that estimate has to predict CSS wrapping or rows overlap. The whole
-calculation runs in **pixels, per character** — never in character counts.
-`canvas.measureText()` is called for each distinct character at the actual
-font/size (cached per `fontSize|char`), which is what makes mixed-width text
-correct: the monospace stack has no Japanese glyphs, so a CJK player name falls
-back to a ~1 em Japanese font while ASCII stays ~0.6 em (measured at 8px: `0` =
-4.8px, `あ` = 8px). A single ASCII-derived width under-counts such a line by up
-to ~1.7×, which is a row overlap, not a rounding error. Where canvas is
-unavailable (jsdom) the fallback is per-character too: 0.6 em narrow / 1 em
-wide, both deliberately the widest plausible value. Wrapping follows the same
-rules the CSS does — word boundaries, `break-word` only for words that cannot
-fit a line by themselves, hanging trailing spaces, and a break opportunity
-between CJK characters — plus the timestamp prefix's width charged to the first
-line.
+calculation runs in **pixels, per grapheme cluster** — never in character
+counts, and never per code point. `canvas.measureText()` is called for each
+distinct cluster at the actual font/size (cached per `fontSize|cluster`), which
+is what makes mixed-width text correct in both directions: the monospace stack
+has no Japanese glyphs, so a CJK player name falls back to a ~1 em Japanese font
+while ASCII stays ~0.6 em (measured at 8px: `0` = 4.8px, `あ` = 8px) — an
+ASCII-derived width under-counts such a line by up to ~1.7×, a row overlap; and
+a decomposed cluster (`は` + U+3099) is one rendered glyph, so measuring its
+code points separately over-counts it and leaves phantom blank rows. Where
+canvas is unavailable (jsdom) the fallback is per cluster too: 0.6 em narrow /
+1 em wide / 0 for combining-only clusters, each deliberately the widest
+plausible value. Wrapping follows the same rules the CSS does — word
+boundaries, `break-word` only for tokens that cannot fit a line by themselves,
+hanging trailing spaces, a break opportunity between CJK characters, and
+kinsoku (no break after an opening bracket, none before closing brackets or
+ideographic punctuation) — plus the timestamp prefix's width charged to the
+first line. The kinsoku sets were derived by measuring Chrome's default
+`line-break: auto`, which notably *does* allow breaking before small kana and
+`ー`; adding those would over-count instead. Re-measure against the browser
+before changing either set.
 
 The available width is the log body width, minus `getScrollbarSize()`, minus
 `EntryRow`'s horizontal padding. Both subtractions are load-bearing: `EntryRow`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -498,22 +498,34 @@ The container is `border-box` so its rendered footprint equals the clamped
 width/height exactly; the log body is that minus `HAND_LOG_BORDER_WIDTH*2`.
 
 **Hand-log row height**: the virtual list positions rows from `getItemSize()`,
-so that estimate has to predict CSS wrapping or rows overlap. It measures the
-real monospace advance width with `canvas.measureText()` at the actual
-font/size (cached per font string; falls back to a conservative 0.6 em ratio
-where canvas is unavailable, e.g. jsdom), derives chars-per-line from the row's
-real text width (the log body width above, minus `EntryRow`'s horizontal
-padding — `EntryRow` pins `boxSizing: border-box` so host-page CSS cannot move
-that boundary), adds the timestamp prefix's width to the first line when
-timestamps are on, and counts lines with the same word-boundary / `break-word`
-rules the CSS uses. Derive it from the *displayed* width, never the stored one:
-a viewport narrower than the stored width shrinks only the render, and that is
-where the wrapping actually happens. Do not reintroduce a fixed chars-per-line
-constant: the panel resizes down to `HAND_LOG_MIN_WIDTH` (200px), where the
-previous 60-chars-per-line assumption under-counted lines and rows overlapped.
-Every input to the wrap calculation must stay in `getItemSize`'s `useCallback`
-deps — react-window rebuilds its row-bounds cache only when the `rowHeight`
-identity changes.
+so that estimate has to predict CSS wrapping or rows overlap. The whole
+calculation runs in **pixels, per character** — never in character counts.
+`canvas.measureText()` is called for each distinct character at the actual
+font/size (cached per `fontSize|char`), which is what makes mixed-width text
+correct: the monospace stack has no Japanese glyphs, so a CJK player name falls
+back to a ~1 em Japanese font while ASCII stays ~0.6 em (measured at 8px: `0` =
+4.8px, `あ` = 8px). A single ASCII-derived width under-counts such a line by up
+to ~1.7×, which is a row overlap, not a rounding error. Where canvas is
+unavailable (jsdom) the fallback is per-character too: 0.6 em narrow / 1 em
+wide, both deliberately the widest plausible value. Wrapping follows the same
+rules the CSS does — word boundaries, `break-word` only for words that cannot
+fit a line by themselves, hanging trailing spaces, and a break opportunity
+between CJK characters — plus the timestamp prefix's width charged to the first
+line.
+
+The available width is the log body width, minus `getScrollbarSize()`, minus
+`EntryRow`'s horizontal padding. Both subtractions are load-bearing: `EntryRow`
+pins `boxSizing: border-box` so host-page CSS cannot move the padding boundary,
+and the `List` pins `scrollbarGutter: stable` so a non-overlay scrollbar
+(Windows/Linux) narrows the row by the same amount whether or not the log is
+currently scrolling. Derive the width from the *displayed* size, never the
+stored one: a viewport narrower than the stored width shrinks only the render,
+and that is where the wrapping actually happens. Do not reintroduce a fixed
+chars-per-line constant: the panel resizes down to `HAND_LOG_MIN_WIDTH`
+(200px), where the original 60-chars-per-line assumption under-counted lines
+and rows overlapped. Every input to the wrap calculation must stay in
+`getItemSize`'s `useCallback` deps — react-window rebuilds its row-bounds cache
+only when the `rowHeight` identity changes.
 
 **Popup theming**: `src/components/popup/theme.ts` defines two MUI themes -- `dark-felt` (default look, shares the HUD overlay's dark/gold palette) and `modern-light`. Which one renders is controlled by the `popupTheme` setting (`'auto' | 'dark' | 'light'`, default `'auto'`; テーマ control in `PopupHeader.tsx`, a 自動/ダーク/ライト 3-way `SegmentRadio`). `'auto'` resolves against the live OS `prefers-color-scheme` via `useMediaQuery` in `Popup.tsx` (`resolvePopupThemeVariant()` in `theme.ts` is the pure resolver, unit-tested independent of the DOM). Persisted to its own `chrome.storage.sync` key (`popupTheme`, see `popup-theme-storage.ts`) -- deliberately **not** a field on `UIConfig`, because `UIScaleSection`/`HudDisplaySection` broadcast every `uiConfig` write to all open game tabs (`chrome.tabs.sendMessage(..., 'updateUIConfig')`) to trigger a HUD re-render; the popup's own chrome has nothing to do with the HUD overlay, so nesting it there would fire that broadcast on every theme change for no reason. `popup.ts` pre-fetches the persisted mode before the first `render()` call so the popup never paints with the wrong theme and then swaps.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -512,13 +512,22 @@ canvas is unavailable (jsdom) the fallback is per cluster too: 0.6 em narrow /
 1 em wide / 0 for combining-only clusters, each deliberately the widest
 plausible value. Wrapping follows the same rules the CSS does — word
 boundaries, `break-word` only for tokens that cannot fit a line by themselves,
-hanging trailing spaces, a break opportunity between CJK characters, and
-kinsoku (no break after an opening bracket, none before closing brackets or
-ideographic punctuation) — plus the timestamp prefix's width charged to the
-first line. The kinsoku sets were derived by measuring Chrome's default
-`line-break: auto`, which notably *does* allow breaking before small kana and
-`ー`; adding those would over-count instead. Re-measure against the browser
-before changing either set.
+hanging trailing spaces, break opportunities between ideographic characters,
+and kinsoku (no break after an opening bracket, none before closing brackets or
+punctuation) — plus the timestamp prefix's width charged to the first line.
+
+Break opportunity is its own class, **not** "is full width": Chrome breaks
+between halfwidth kana (4px) and between emoji (10px), but not around `♠♥♦♣`,
+`★`, `→` or `①`. Emoji are matched with `\p{Emoji_Presentation}` —
+`\p{Extended_Pictographic}` also matches `♠`, which would shred every card
+line. The kinsoku sets likewise include ASCII (`:` `,` `)` `(` …), because
+`{Japanese name}: raises` — the shape of every action line — puts an ASCII
+colon straight after a wide character. All three sets (break opportunities,
+line-start kinsoku, line-end kinsoku) were derived by measuring Chrome's
+default `line-break: auto`, which notably *does* allow breaking before small
+kana and `ー`; adding those would over-count instead. Re-measure against the
+browser before changing any of them — the tests encode the measured
+expectations, not a specification.
 
 The available width is the log body width, minus `getScrollbarSize()`, minus
 `EntryRow`'s horizontal padding. Both subtractions are load-bearing: `EntryRow`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -520,7 +520,11 @@ Break opportunity is its own class, **not** "is full width": Chrome breaks
 between halfwidth kana (4px) and between emoji (10px), but not around `♠♥♦♣`,
 `★`, `→` or `①`. Emoji are matched with `\p{Emoji_Presentation}` —
 `\p{Extended_Pictographic}` also matches `♠`, which would shred every card
-line. The kinsoku sets likewise include ASCII (`:` `,` `)` `(` …), because
+line — and ideographs with `\p{Ideographic}`, so supplementary-plane kanji
+(`𠮷`, `𩸽`) are covered; a BMP-only range list silently demotes them to
+narrow non-breaking text. Whitespace is likewise its own class: `\s` is wrong
+because it matches NBSP and friends, which CSS never breaks around (`aa<NBSP>bb`
+is one word to the browser, verified). The kinsoku sets likewise include ASCII (`:` `,` `)` `(` …), because
 `{Japanese name}: raises` — the shape of every action line — puts an ASCII
 colon straight after a wide character. All three sets (break opportunities,
 line-start kinsoku, line-end kinsoku) were derived by measuring Chrome's
@@ -534,7 +538,11 @@ The available width is the log body width, minus `getScrollbarSize()`, minus
 pins `boxSizing: border-box` so host-page CSS cannot move the padding boundary,
 and the `List` pins `scrollbarGutter: stable` so a non-overlay scrollbar
 (Windows/Linux) narrows the row by the same amount whether or not the log is
-currently scrolling. Derive the width from the *displayed* size, never the
+currently scrolling. That width is re-measured with `getScrollbarSize(true)`
+whenever `devicePixelRatio` changes (page zoom, monitor move): the scrollbar's
+physical width is constant, so its CSS-pixel width — the thing being
+subtracted — moves with zoom, and both `getScrollbarSize`'s own module cache
+and a mount-time `useMemo` would otherwise pin the first value forever. Derive the width from the *displayed* size, never the
 stored one: a viewport narrower than the stored width shrinks only the render,
 and that is where the wrapping actually happens. Do not reintroduce a fixed
 chars-per-line constant: the panel resizes down to `HAND_LOG_MIN_WIDTH`

--- a/src/components/HandLog.test.tsx
+++ b/src/components/HandLog.test.tsx
@@ -1557,6 +1557,29 @@ describe('HandLogの行高推定', () => {
       expect(countWrappedLines('あいうえおかきくけこ', 100, measureToken)).toBe(2)
     })
 
+    // 以下の期待値はChromeの既定（line-break: auto）を実測して確定したもの。
+    // 1行=全角2文字ぶん(40px)で、'あいうえ'は2行が基準
+    it('行末禁則: 開き括弧の直後では改行しない', () => {
+      expect(countWrappedLines('あいうえ', 40, measureToken)).toBe(2)
+      // あ / （い / あ の3行になる
+      expect(countWrappedLines('あ（いあ', 40, measureToken)).toBe(3)
+    })
+
+    it('行頭禁則: 句読点・閉じ括弧を行頭に置かない', () => {
+      // あ / い、 / う の3行になる
+      expect(countWrappedLines('あい、う', 40, measureToken)).toBe(3)
+      expect(countWrappedLines('あい）う', 40, measureToken)).toBe(3)
+      expect(countWrappedLines('あい」う', 40, measureToken)).toBe(3)
+      expect(countWrappedLines('あい・う', 40, measureToken)).toBe(3)
+    })
+
+    it('Chrome既定で改行できる小書き仮名・長音符は禁則にしない', () => {
+      // 禁則に含めると逆に行数を過大評価して余白が空く
+      expect(countWrappedLines('あいっう', 40, measureToken)).toBe(2)
+      expect(countWrappedLines('あいーう', 40, measureToken)).toBe(2)
+      expect(countWrappedLines('あいぁう', 40, measureToken)).toBe(2)
+    })
+
     it('半角と全角が混在する行を実幅で数える', () => {
       // 'Seat 1: '(80px) + 全角3文字(60px) = 140px → 2行
       expect(countWrappedLines('Seat 1: 日本語', 100, measureToken)).toBe(2)
@@ -1599,9 +1622,41 @@ describe('HandLogの行高推定', () => {
     it('本文幅が0以下でも1文字ずつ折り返して破綻しない', () => {
       expect(estimateEntryRowHeight('abc', metrics(0))).toBeCloseTo(3 * 9.6 + 2)
     })
+
+    it('分解形の結合文字を余分な1文字として数えない', () => {
+      // 見た目が同じ合成形と分解形は同じ行高になる。コードポイント単位で
+      // 数えると分解形だけ2倍の幅になり、存在しない行ぶんの余白が空く
+      const composed = '\u3070'.repeat(30)
+      const decomposed = '\u306F\u3099'.repeat(30)
+      const rowMetrics = {
+        textWidth: 184,
+        fontSize: 8,
+        showTimestamps: false,
+      }
+      expect(estimateEntryRowHeight(decomposed, rowMetrics))
+        .toBeCloseTo(estimateEntryRowHeight(composed, rowMetrics))
+      // 全角30文字=240px → 184pxでは2行
+      expect(estimateEntryRowHeight(decomposed, rowMetrics)).toBeCloseTo(21.2)
+    })
   })
 
   describe('measureHandLogTextWidth', () => {
+    it('結合文字を含むクラスタを1グリフとして測る', () => {
+      // 合成形'ば'(U+3070)と分解形'は'+結合濁点(U+306F U+3099)は同じ1グリフ
+      expect(measureHandLogTextWidth('\u3070', 8)).toBeCloseTo(8)
+      expect(measureHandLogTextWidth('\u306F\u3099', 8)).toBeCloseTo(8)
+      // 結合文字単体は送り幅0。妥当性の下限で1emへ丸めない
+      expect(measureHandLogTextWidth('\u3099', 8)).toBe(0)
+    })
+
+    it('結合文字を含むクラスタを1グリフとして測る', () => {
+      // 合成形'ば'(U+3070)と分解形'は'+濁点(U+306F U+3099)は同じ1グリフ
+      expect(measureHandLogTextWidth('\u3070', 8)).toBeCloseTo(8)
+      expect(measureHandLogTextWidth('\u306F\u3099', 8)).toBeCloseTo(8)
+      // 結合文字単体は送り幅0（妥当性の下限で1emへ丸めない）
+      expect(measureHandLogTextWidth('\u3099', 8)).toBe(0)
+    })
+
     it('canvasが無い環境では保守的な半角/全角比へフォールバックする', () => {
       expect(measureHandLogTextWidth('00000', 8))
         .toBeCloseTo(5 * 8 * FALLBACK_NARROW_CHAR_WIDTH_RATIO)

--- a/src/components/HandLog.test.tsx
+++ b/src/components/HandLog.test.tsx
@@ -1573,6 +1573,18 @@ describe('HandLogの行高推定', () => {
       expect(countWrappedLines('あい・う', 40, measureToken)).toBe(3)
     })
 
+    it('ASCII句読点も行頭禁則として扱う', () => {
+      // '{日本語名}: raises' のように全角の直後へASCII句読点が続く行は
+      // ハンドログの主要な形。あ / い: / う の3行になる
+      expect(countWrappedLines('あい:う', 40, measureToken)).toBe(3)
+      expect(countWrappedLines('あい,う', 40, measureToken)).toBe(3)
+      expect(countWrappedLines('あい)う', 40, measureToken)).toBe(3)
+    })
+
+    it('ASCII開き括弧の直後も行末禁則として扱う', () => {
+      expect(countWrappedLines('あ(いあ', 40, measureToken)).toBe(3)
+    })
+
     it('Chrome既定で改行できる小書き仮名・長音符は禁則にしない', () => {
       // 禁則に含めると逆に行数を過大評価して余白が空く
       expect(countWrappedLines('あいっう', 40, measureToken)).toBe(2)
@@ -1583,6 +1595,29 @@ describe('HandLogの行高推定', () => {
     it('半角と全角が混在する行を実幅で数える', () => {
       // 'Seat 1: '(80px) + 全角3文字(60px) = 140px → 2行
       expect(countWrappedLines('Seat 1: 日本語', 100, measureToken)).toBe(2)
+    })
+
+    it('半角カナ・絵文字は全角幅でなくても改行機会を持つ', () => {
+      // Chrome実測: 半角カナ(4px)と絵文字(10px)は文字間で改行できるので、
+      // 前置きの残り幅を使い切ってから折り返す。1語として扱うと語ごと次行へ
+      // 送ってから割ることになり、行を1つ余計に確保してしまう
+      const width = (token: string) =>
+        [...token].reduce((total, char) => {
+          if (/\p{Emoji_Presentation}/u.test(char)) return total + 25
+          if (/[\uFF61-\uFF9F]/.test(char)) return total + 10
+          return total + (isWide(char) ? 20 : 10)
+        }, 0)
+      expect(countWrappedLines(`a ${'\uFF71'.repeat(16)}`, 60, width)).toBe(3)
+      expect(countWrappedLines(`a ${'\uD83D\uDC1F'.repeat(7)}`, 60, width)).toBe(4)
+    })
+
+    it('トランプのスートや記号は改行機会にしない', () => {
+      // Chrome実測: ♠★→①は改行機会を持たない（半角英字と同じ扱い）。
+      // 改行機会にするとカード表記の行を余計に折り返して詰めてしまう
+      expect(countWrappedLines(`a ${'\u2660'.repeat(13)}`, 60, measureToken)).toBe(4)
+      expect(countWrappedLines(`a ${'x'.repeat(13)}`, 60, measureToken)).toBe(4)
+      expect(countWrappedLines(`a ${'\u2605'.repeat(13)}`, 60, measureToken)).toBe(4)
+      expect(countWrappedLines(`a ${'\u2460'.repeat(13)}`, 60, measureToken)).toBe(4)
     })
 
     it('60文字固定の旧推定が過小評価していた幅を正しく数える', () => {

--- a/src/components/HandLog.test.tsx
+++ b/src/components/HandLog.test.tsx
@@ -17,7 +17,7 @@ jest.mock('react-window', () => {
   // 0 = macOSのオーバーレイスクロールバー、15 = Windows/Linuxの実体持ち。
   const scrollbar = { size: 0 }
   return {
-    getScrollbarSize: () => scrollbar.size,
+    getScrollbarSize: (_recalculate?: boolean) => scrollbar.size,
     __setScrollbarSize: (size: number) => { scrollbar.size = size },
     List: ({ rowComponent: RowComponent, rowCount, rowProps, rowHeight, style, listRef }: any) => {
       // Mock scrollToRow method via listRef
@@ -85,6 +85,13 @@ const savedLayoutCalls = () =>
   mockChromeRuntimeSendMessage.mock.calls.filter(
     ([message]) => message.action === 'setDeviceHandLogLayout'
   )
+const setDevicePixelRatio = (ratio: number) => {
+  Object.defineProperty(window, 'devicePixelRatio', {
+    value: ratio,
+    writable: true,
+    configurable: true,
+  })
+}
 const setScrollbarSize = (size: number) => {
   (jest.requireMock('react-window') as {
     __setScrollbarSize: (size: number) => void
@@ -129,6 +136,7 @@ describe('HandLog', () => {
     jest.clearAllMocks()
     setViewport(1024, 768)
     setScrollbarSize(0)
+    setDevicePixelRatio(1)
     mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
       if (message.action === 'getDeviceHandLogLayout') {
         callback({ success: true })
@@ -1462,6 +1470,29 @@ describe('HandLog', () => {
       expect(rowHeight(0)).toBeCloseTo(21.2)
     })
 
+    it('ズーム変更時にスクロールバー幅を測り直す', () => {
+      // ページズームでスクロールバーのCSSピクセル幅が変わる。初回計測値を
+      // 使い続けると、ズームアウト後は実際のgutterより狭くしか引かない
+      const entry: HandLogEntry[] = [
+        {
+          id: 'fit',
+          handId: 1,
+          timestamp: Date.now(),
+          text: 'x'.repeat(78),
+          type: HandLogEntryType.ACTION,
+        },
+      ]
+      render(<HandLog entries={entry} />)
+      updateLayout({ left: 100, top: 100, width: 400, height: 100 })
+      expect(rowHeight(0)).toBeCloseTo(11.6)
+
+      setScrollbarSize(15)
+      setDevicePixelRatio(0.5)
+      fireEvent(window, new Event('resize'))
+
+      expect(rowHeight(0)).toBeCloseTo(21.2)
+    })
+
     it('スクロール有無で行幅が変わらないようgutterを固定する', () => {
       render(<HandLog entries={mockEntries} />)
 
@@ -1609,6 +1640,29 @@ describe('HandLogの行高推定', () => {
         }, 0)
       expect(countWrappedLines(`a ${'\uFF71'.repeat(16)}`, 60, width)).toBe(3)
       expect(countWrappedLines(`a ${'\uD83D\uDC1F'.repeat(7)}`, 60, width)).toBe(4)
+    })
+
+    it('補助平面の漢字も改行機会として扱う', () => {
+      // CJK拡張B（`\u{20BB7}`など）はBMPの範囲指定から漏れる。半角1語として
+      // 扱うと名前ごと次行へ送ってから割るので、行を1つ余計に確保する
+      const width = (token: string) =>
+        [...token].reduce(
+          (total, char) => total + (/\p{Ideographic}/u.test(char) || isWide(char) ? 20 : 10),
+          0
+        )
+      expect(countWrappedLines(`a ${'\u{20BB7}'.repeat(8)}`, 60, width)).toBe(3)
+      expect(countWrappedLines(`a ${'\u{29E3D}'.repeat(8)}`, 60, width)).toBe(3)
+    })
+
+    it('改行禁止の空白（NBSP等）を空白として扱わない', () => {
+      // CSSはNBSPの前後で改行しない。空白扱いすると改行機会を作るうえ、
+      // 行末でぶら下げて幅も落としてしまう
+      // 同じ見た目でも、NBSPは1語として割られ通常の空白は改行機会になる
+      expect(countWrappedLines('aa\u00A0bb', 20, measureToken)).toBe(3)
+      expect(countWrappedLines('aa bb', 20, measureToken)).toBe(2)
+      // 通常の空白は行末でぶら下がるが、NBSPは幅を持ったまま次行へ送られる
+      expect(countWrappedLines('aaa\u00A0aaa', 30, measureToken)).toBe(3)
+      expect(countWrappedLines('aaa aaa', 30, measureToken)).toBe(2)
     })
 
     it('トランプのスートや記号は改行機会にしない', () => {

--- a/src/components/HandLog.test.tsx
+++ b/src/components/HandLog.test.tsx
@@ -3,8 +3,9 @@ import userEvent from '@testing-library/user-event'
 import HandLog, {
   countWrappedLines,
   estimateEntryRowHeight,
-  measureMonospaceCharWidth,
-  FALLBACK_MONOSPACE_CHAR_WIDTH_RATIO,
+  measureHandLogTextWidth,
+  FALLBACK_NARROW_CHAR_WIDTH_RATIO,
+  FALLBACK_WIDE_CHAR_WIDTH_RATIO,
 } from './HandLog'
 import { HandLogEntry, HandLogEntryType, HandLogConfig, DEFAULT_HAND_LOG_CONFIG } from '../types/hand-log'
 import { DEVICE_LAYOUT_MESSAGE_TIMEOUT_MS } from '../utils/ui-config-storage'
@@ -12,7 +13,12 @@ import { DEVICE_LAYOUT_MESSAGE_TIMEOUT_MS } from '../utils/ui-config-storage'
 // Mock react-window v2 API
 jest.mock('react-window', () => {
   const React = require('react')
+  // jsdomでは実測しようがないので、テストから明示的に切り替える。
+  // 0 = macOSのオーバーレイスクロールバー、15 = Windows/Linuxの実体持ち。
+  const scrollbar = { size: 0 }
   return {
+    getScrollbarSize: () => scrollbar.size,
+    __setScrollbarSize: (size: number) => { scrollbar.size = size },
     List: ({ rowComponent: RowComponent, rowCount, rowProps, rowHeight, style, listRef }: any) => {
       // Mock scrollToRow method via listRef
       React.useImperativeHandle(listRef, () => ({
@@ -79,6 +85,11 @@ const savedLayoutCalls = () =>
   mockChromeRuntimeSendMessage.mock.calls.filter(
     ([message]) => message.action === 'setDeviceHandLogLayout'
   )
+const setScrollbarSize = (size: number) => {
+  (jest.requireMock('react-window') as {
+    __setScrollbarSize: (size: number) => void
+  }).__setScrollbarSize(size)
+}
 
 describe('HandLog', () => {
   const mockEntries: HandLogEntry[] = [
@@ -117,6 +128,7 @@ describe('HandLog', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     setViewport(1024, 768)
+    setScrollbarSize(0)
     mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
       if (message.action === 'getDeviceHandLogLayout') {
         callback({ success: true })
@@ -1402,6 +1414,63 @@ describe('HandLog', () => {
       expect(rowHeight(0)).toBeCloseTo(59.6)
     })
 
+    it('日本語のプレイヤー名を全角幅で数える', () => {
+      // 日本語は等幅フォントに収録されず約1emの日本語フォントへフォールバック
+      // するので、ASCII基準(0.6em)で数えると行数を最大1.7倍過小評価する
+      const japaneseEntry: HandLogEntry[] = [
+        {
+          id: 'jp',
+          handId: 1,
+          timestamp: Date.now(),
+          text: '日本語'.repeat(15),
+          type: HandLogEntryType.SEAT,
+        },
+      ]
+      render(<HandLog entries={japaneseEntry} />)
+
+      // 幅400: 本文382px = 全角47文字/行 → 45文字は1行
+      updateLayout({ left: 100, top: 100, width: 400, height: 100 })
+      expect(rowHeight(0)).toBeCloseTo(11.6)
+
+      // 幅200: 本文182px = 全角22文字/行 → 45文字は3行
+      // 半角基準だと37文字/行と数えて2行になり、行が重なる
+      updateLayout({ left: 100, top: 100, width: 200, height: 100 })
+      expect(rowHeight(0)).toBeCloseTo(30.8)
+    })
+
+    it('非オーバーレイのスクロールバー幅を本文幅から差し引く', () => {
+      // Windows/Linuxの実体を持つスクロールバーは行の包含幅を狭める
+      const entry: HandLogEntry[] = [
+        {
+          id: 'fit',
+          handId: 1,
+          timestamp: Date.now(),
+          // 78文字 = 374.4px。スクロールバー無し(382px)なら1行、
+          // 15px確保する環境(367px)では2行になる長さ
+          text: 'x'.repeat(78),
+          type: HandLogEntryType.ACTION,
+        },
+      ]
+      const { unmount } = render(<HandLog entries={entry} />)
+      updateLayout({ left: 100, top: 100, width: 400, height: 100 })
+      expect(rowHeight(0)).toBeCloseTo(11.6)
+      unmount()
+
+      setScrollbarSize(15)
+      render(<HandLog entries={entry} />)
+      updateLayout({ left: 100, top: 100, width: 400, height: 100 })
+      expect(rowHeight(0)).toBeCloseTo(21.2)
+    })
+
+    it('スクロール有無で行幅が変わらないようgutterを固定する', () => {
+      render(<HandLog entries={mockEntries} />)
+
+      // 推定は常にスクロールバー幅を引くので、実描画側も常に確保させる
+      expect(screen.getByTestId('virtual-list')).toHaveStyle({
+        scrollbarGutter: 'stable',
+      })
+    })
+
     it('セパレーター行は固定高のまま', () => {
       render(<HandLog entries={mockEntries} />)
       updateLayout({ left: 100, top: 100, width: 200, height: 100 })
@@ -1422,53 +1491,80 @@ describe('HandLog', () => {
 })
 
 describe('HandLogの行高推定', () => {
-  // 等幅比を固定した決定的な計測器（実環境ではcanvas実測）
-  const monospace = (ratio: number) => (fontSize: number) => fontSize * ratio
+  // 1文字10px（全角は20px）の決定的な計測器。実環境ではcanvas実測。
+  const isWide = (char: string) => /[\u3000-\u30ff\u3400-\u9fff\uff00-\uff60]/.test(char)
+  const measureToken = (token: string) =>
+    [...token].reduce((width, char) => width + (isWide(char) ? 20 : 10), 0)
+  const measureText = (text: string, fontSize: number) =>
+    [...text].reduce(
+      (width, char) => width + fontSize * (isWide(char) ? 1 : 0.6),
+      0
+    )
 
   describe('countWrappedLines', () => {
     it('空エントリは行を占有しない', () => {
-      expect(countWrappedLines('', 40)).toBe(0)
+      expect(countWrappedLines('', 400, measureToken)).toBe(0)
     })
 
     it('1行に収まるテキストは1行', () => {
-      expect(countWrappedLines('Player1: folds', 40)).toBe(1)
+      expect(countWrappedLines('Player1: folds', 400, measureToken)).toBe(1)
     })
 
     it('単語境界で折り返す', () => {
-      expect(countWrappedLines('aaaa bbbb cccc', 10)).toBe(2)
+      expect(countWrappedLines('aaaa bbbb cccc', 100, measureToken)).toBe(2)
     })
 
-    it('単語境界で折り返すため文字数の単純除算より行数が増えうる', () => {
+    it('単語境界で折り返すため幅の単純除算より行数が増えうる', () => {
       const text = 'aaaaaa bbbbbb cccccc'
-      expect(Math.ceil(text.length / 10)).toBe(2)
-      expect(countWrappedLines(text, 10)).toBe(3)
+      expect(Math.ceil(measureToken(text) / 100)).toBe(2)
+      expect(countWrappedLines(text, 100, measureToken)).toBe(3)
     })
 
     it('1行に収まらない単語だけをbreak-wordとして分割する', () => {
-      expect(countWrappedLines('x'.repeat(25), 10)).toBe(3)
+      expect(countWrappedLines('x'.repeat(25), 100, measureToken)).toBe(3)
     })
 
     it('行頭でない長い単語は次行へ送ってから分割する', () => {
       // "ab " の後に25文字の語 → 2行目から10/10/5に割れる
-      expect(countWrappedLines(`ab ${'x'.repeat(25)}`, 10)).toBe(4)
+      expect(countWrappedLines(`ab ${'x'.repeat(25)}`, 100, measureToken)).toBe(4)
     })
 
     it('行末の空白はぶら下がり、次の単語から改行する', () => {
-      expect(countWrappedLines('aaaaaaaaaa bb', 10)).toBe(2)
+      expect(countWrappedLines('aaaaaaaaaa bb', 100, measureToken)).toBe(2)
     })
 
     it('明示的な改行を行として数える', () => {
-      expect(countWrappedLines('abc\ndef', 10)).toBe(2)
+      expect(countWrappedLines('abc\ndef', 100, measureToken)).toBe(2)
     })
 
-    it('先頭オフセット（タイムスタンプ）を消費済み文字として扱う', () => {
-      expect(countWrappedLines('cccc', 10)).toBe(1)
-      expect(countWrappedLines('cccc', 10, 8)).toBe(2)
+    it('先頭オフセット（タイムスタンプ）を消費済み幅として扱う', () => {
+      expect(countWrappedLines('cccc', 100, measureToken)).toBe(1)
+      expect(countWrappedLines('cccc', 100, measureToken, 80)).toBe(2)
+    })
+
+    it('文字数ではなく実幅で数える（全角は半角の2倍幅）', () => {
+      // 同じ5文字でも、全角は半角の2倍の幅を占める
+      expect(countWrappedLines('abcde', 100, measureToken)).toBe(1)
+      expect(countWrappedLines('あいうえお', 100, measureToken)).toBe(1)
+      expect(countWrappedLines('あいうえおか', 100, measureToken)).toBe(2)
+      // 文字数基準（10文字/行）だと1行と誤判定する長さ
+      expect(countWrappedLines('日本語のプレイヤー名', 100, measureToken)).toBe(2)
+    })
+
+    it('CJKは空白が無くても文字間で折り返す', () => {
+      // 半角の長語はbreak-wordで割られるが、CJKは通常の折り返し機会を持つ。
+      // どちらも1行100pxに5文字ずつ入る
+      expect(countWrappedLines('あいうえおかきくけこ', 100, measureToken)).toBe(2)
+    })
+
+    it('半角と全角が混在する行を実幅で数える', () => {
+      // 'Seat 1: '(80px) + 全角3文字(60px) = 140px → 2行
+      expect(countWrappedLines('Seat 1: 日本語', 100, measureToken)).toBe(2)
     })
 
     it('60文字固定の旧推定が過小評価していた幅を正しく数える', () => {
       // 幅200pxのパネル ≒ 38文字/行。旧推定は ceil(100/60)=2行だった
-      expect(countWrappedLines('x'.repeat(100), 38)).toBe(3)
+      expect(countWrappedLines('x'.repeat(100), 380, measureToken)).toBe(3)
     })
   })
 
@@ -1477,7 +1573,7 @@ describe('HandLogの行高推定', () => {
       textWidth,
       fontSize: 8,
       showTimestamps,
-      measureCharWidth: monospace(0.6),
+      measureText,
     })
 
     it('1行のエントリは1行分の高さ + 上下padding', () => {
@@ -1489,25 +1585,37 @@ describe('HandLogの行高推定', () => {
       expect(estimateEntryRowHeight('x'.repeat(100), metrics(184))).toBeCloseTo(30.8)
     })
 
+    it('日本語は全角幅で数える', () => {
+      // 30文字の全角 = 240px。半角基準(4.8px/文字=144px)だと184pxに収まって
+      // しまい1行と誤判定する
+      expect(estimateEntryRowHeight('日本語'.repeat(10), metrics(184))).toBeCloseTo(21.2)
+      expect(estimateEntryRowHeight('日本語'.repeat(10), metrics(384))).toBeCloseTo(11.6)
+    })
+
     it('タイムスタンプ表示時は先頭行の残り幅が減る', () => {
       expect(estimateEntryRowHeight('x'.repeat(100), metrics(384, true))).toBeCloseTo(30.8)
     })
 
-    it('本文幅が0以下でも1文字/行として破綻しない', () => {
+    it('本文幅が0以下でも1文字ずつ折り返して破綻しない', () => {
       expect(estimateEntryRowHeight('abc', metrics(0))).toBeCloseTo(3 * 9.6 + 2)
     })
   })
 
-  describe('measureMonospaceCharWidth', () => {
-    it('canvasが無い環境では保守的な等幅比へフォールバックする', () => {
-      expect(measureMonospaceCharWidth(8)).toBeCloseTo(8 * FALLBACK_MONOSPACE_CHAR_WIDTH_RATIO)
-      expect(measureMonospaceCharWidth(16)).toBeCloseTo(16 * FALLBACK_MONOSPACE_CHAR_WIDTH_RATIO)
+  describe('measureHandLogTextWidth', () => {
+    it('canvasが無い環境では保守的な半角/全角比へフォールバックする', () => {
+      expect(measureHandLogTextWidth('00000', 8))
+        .toBeCloseTo(5 * 8 * FALLBACK_NARROW_CHAR_WIDTH_RATIO)
+      expect(measureHandLogTextWidth('あいうえお', 8))
+        .toBeCloseTo(5 * 8 * FALLBACK_WIDE_CHAR_WIDTH_RATIO)
+      expect(measureHandLogTextWidth('', 8)).toBe(0)
     })
 
     it('フォールバック比は想定フォント中で最も広いものを採る', () => {
-      // Consolas 0.55 / Monaco・Courier New 0.6。狭い比率を既定にすると
-      // 1行あたり文字数を過大評価して行が重なる
-      expect(FALLBACK_MONOSPACE_CHAR_WIDTH_RATIO).toBeGreaterThanOrEqual(0.6)
+      // 半角: Consolas 0.55 / Monaco・Courier New 0.6
+      // 全角: 日本語フォントは1em（実測: 8pxで`あ`=8px）
+      // 狭い比率を既定にすると1行あたりの文字数を過大評価して行が重なる
+      expect(FALLBACK_NARROW_CHAR_WIDTH_RATIO).toBeGreaterThanOrEqual(0.6)
+      expect(FALLBACK_WIDE_CHAR_WIDTH_RATIO).toBeGreaterThanOrEqual(1)
     })
   })
 })

--- a/src/components/HandLog.tsx
+++ b/src/components/HandLog.tsx
@@ -526,11 +526,37 @@ const WIDE_CHAR_RANGES =
   'ᄀ-ᅟ⺀-〾ぁ-㏿㐀-䶿一-鿿' +
   'ꀀ-꓏가-힣豈-﫿︰-﹏＀-｠￠-￦'
 const WIDE_CHAR_PATTERN = new RegExp(`[${WIDE_CHAR_RANGES}]`)
-// 空白の連なり / 全角1文字 / それ以外の連なり、が折り返しの最小単位
-const TOKEN_PATTERN = new RegExp(
-  `\\s+|[${WIDE_CHAR_RANGES}]|[^\\s${WIDE_CHAR_RANGES}]+`,
-  'g'
-)
+
+/**
+ * 禁則処理。CJKは文字間で改行できるが、どこでもよいわけではない。
+ * 集合はChromeの既定（`line-break: auto`）を実測して確定したもの。
+ * 小書き仮名（ぁっゃゅょヵヶ）と長音符（ー）は既定では改行可能なので
+ * 含めない（含めると逆に行数を過大評価する）。
+ */
+/** 行頭禁則: 行の先頭に来られない文字 */
+const NO_BREAK_BEFORE_PATTERN =
+  /[\u3001\u3002\uFF0C\uFF0E\u30FB\uFF1A\uFF1B\uFF1F\uFF01\uFF09\uFF3D\uFF5D\u3009\u300B\u300D\u300F\u3011\u3015\u2026\u2025\u3005\u309D\u309E\uFF61\uFF63\uFF64\uFF65\uFF9E\uFF9F%\u00B0\u2032\u2033\u2103\u00A2]/
+/** 行末禁則: 直後で改行できない文字（開き括弧・前置記号） */
+const NO_BREAK_AFTER_PATTERN =
+  /[\uFF08\uFF3B\uFF5B\u3008\u300A\u300C\u300E\u3010\u3014\u2018\u201C\uFFE5\uFF04\u00A3]/
+
+const graphemeSegmenter =
+  typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
+    ? new Intl.Segmenter('ja', { granularity: 'grapheme' })
+    : null
+
+/**
+ * 書記素クラスタ単位に分割する。コードポイント単位で測ると、結合文字を含む
+ * 名前（分解形の`ば`など）を基底文字＋結合文字の2文字分として数えてしまい、
+ * DOMが1グリフとして描く実幅と合わない。
+ */
+const splitGraphemes = (text: string): string[] =>
+  graphemeSegmenter
+    ? Array.from(graphemeSegmenter.segment(text), segment => segment.segment)
+    : Array.from(text)
+
+/** 結合文字・ゼロ幅文字だけのクラスタ（送り幅0が正しい） */
+const ZERO_WIDTH_CLUSTER_PATTERN = /^[\p{M}\u200B-\u200D\u2060\uFEFF]+$/u
 
 const charWidthCache = new Map<string, number>()
 
@@ -549,52 +575,94 @@ const getMeasurementContext = (): CanvasRenderingContext2D | null => {
 }
 
 /**
- * 実フォント・実フォントサイズでの1文字ぶんの送り幅(px)をcanvasで実測する。
+ * 実フォント・実フォントサイズでの書記素クラスタ1つぶんの送り幅(px)を
+ * canvasで実測する。
  *
- * 文字ごとに測るのが要点。等幅フォント指定でも、日本語のように指定フォントに
- * 収録されていない文字は約1emの日本語フォントへフォールバックして描画される
- * ため、ASCII基準の一律幅で数えると行数を最大1.7倍ほど過小評価する。
- * measureTextはレイアウトと同じフォント解決を通るので、フォールバック後の
- * 実幅がそのまま得られる（実測: 8pxで`0`=4.8px / `あ`=8px）。
+ * クラスタごとに測るのが要点。等幅フォント指定でも、日本語のように指定フォント
+ * に収録されていない文字は約1emの日本語フォントへフォールバックして描画される
+ * ため、ASCII基準の一律幅で数えると行数を最大1.7倍ほど過小評価する。逆に結合
+ * 文字を基底文字と別々に測ると、DOMが1グリフに整形する名前を2文字分として
+ * 数えて過大評価する。measureTextはレイアウトと同じフォント解決・整形を通るので
+ * クラスタ単位ならどちらも実幅どおりになる（実測: 8pxで`0`=4.8px / `あ`=8px）。
  * canvasが無い環境（jsdom等）は半角/全角の保守的な比率で代替する。
  */
-const measureCharWidth = (char: string, fontSize: number): number => {
-  const key = `${fontSize}|${char}`
+const measureClusterWidth = (cluster: string, fontSize: number): number => {
+  const key = `${fontSize}|${cluster}`
   const cached = charWidthCache.get(key)
   if (cached !== undefined) return cached
 
-  const fallbackRatio = WIDE_CHAR_PATTERN.test(char)
-    ? FALLBACK_WIDE_CHAR_WIDTH_RATIO
-    : FALLBACK_NARROW_CHAR_WIDTH_RATIO
-  let charWidth = fontSize * fallbackRatio
+  // 結合文字・ゼロ幅文字だけのクラスタは送り幅0が正しい。canvasが0を返しても
+  // 「壊れた計測」とみなさず、そのまま採用する
+  const zeroWidth = ZERO_WIDTH_CLUSTER_PATTERN.test(cluster)
+  const fallbackRatio = zeroWidth
+    ? 0
+    : WIDE_CHAR_PATTERN.test(cluster)
+      ? FALLBACK_WIDE_CHAR_WIDTH_RATIO
+      : FALLBACK_NARROW_CHAR_WIDTH_RATIO
+  let clusterWidth = fontSize * fallbackRatio
   const context = getMeasurementContext()
   if (context) {
     context.font = `${fontSize}px ${HAND_LOG_FONT_FAMILY}`
-    const measured = context.measureText(char).width
+    const measured = context.measureText(cluster).width
     const ratio = measured / fontSize
+    // 妥当性の下限は、全文字0pxを返すような壊れた計測環境で1行あたりの文字数が
+    // 無限になるのを防ぐためのもの。0が正しいクラスタには適用しない
     if (
       Number.isFinite(ratio) &&
-      ratio >= MIN_PLAUSIBLE_CHAR_WIDTH_RATIO &&
-      ratio <= MAX_PLAUSIBLE_CHAR_WIDTH_RATIO
+      ratio <= MAX_PLAUSIBLE_CHAR_WIDTH_RATIO &&
+      (zeroWidth ? ratio >= 0 : ratio >= MIN_PLAUSIBLE_CHAR_WIDTH_RATIO)
     ) {
-      charWidth = measured
+      clusterWidth = measured
     }
   }
-  charWidthCache.set(key, charWidth)
-  return charWidth
+  charWidthCache.set(key, clusterWidth)
+  return clusterWidth
 }
 
 export type MeasureHandLogText = (text: string, fontSize: number) => number
 
 /**
  * 文字列の描画幅(px)。等幅フォントにもCJKフォールバックにも字詰めは無いので、
- * 文字ごとの送り幅の総和で足りる。キャッシュは文字単位なので、名前や
- * アクション語が繰り返されるログでは実質すべてキャッシュヒットする。
+ * 書記素クラスタごとの送り幅の総和で足りる。キャッシュはクラスタ単位なので、
+ * 名前やアクション語が繰り返されるログでは実質すべてキャッシュヒットする。
  */
 export const measureHandLogTextWidth: MeasureHandLogText = (text, fontSize) => {
   let width = 0
-  for (const char of text) width += measureCharWidth(char, fontSize)
+  for (const cluster of splitGraphemes(text)) {
+    width += measureClusterWidth(cluster, fontSize)
+  }
   return width
+}
+
+/**
+ * 折り返しの最小単位（トークン）へ分割する。トークン境界＝CSSが改行しうる位置。
+ * - 空白の連なりは1トークン（行末でぶら下がる）
+ * - 半角の連なりは1語
+ * - CJKは1文字ずつが改行機会。ただし禁則位置では隣とくっつけて1トークンにする
+ */
+const tokenizeForWrap = (line: string): string[] => {
+  const tokens: string[] = []
+  let previous: string | undefined
+  for (const cluster of splitGraphemes(line)) {
+    const breaks = previous === undefined
+      ? true
+      : breakAllowedBetween(previous, cluster)
+    if (breaks || tokens.length === 0) tokens.push(cluster)
+    else tokens[tokens.length - 1] += cluster
+    previous = cluster
+  }
+  return tokens
+}
+
+const breakAllowedBetween = (previous: string, next: string): boolean => {
+  const previousIsSpace = /^\s/.test(previous)
+  const nextIsSpace = /^\s/.test(next)
+  // 空白の連なりは1トークン。空白とそれ以外の境目は必ず改行機会
+  if (previousIsSpace || nextIsSpace) return previousIsSpace !== nextIsSpace
+  if (NO_BREAK_AFTER_PATTERN.test(previous)) return false
+  if (NO_BREAK_BEFORE_PATTERN.test(next)) return false
+  // CJKは空白が無くても文字間で改行できる。半角どうしは1語として繋がる
+  return WIDE_CHAR_PATTERN.test(previous) || WIDE_CHAR_PATTERN.test(next)
 }
 
 /**
@@ -605,9 +673,8 @@ export const measureHandLogTextWidth: MeasureHandLogText = (text, fontSize) => {
  * 文字幅の総和を1行の幅で割るだけでも、単語境界での折り返しを無視して行数を
  * 過小評価する（"aaaaaa bbbbbb cccccc"は幅10文字ぶんなら実際は3行）。
  * - 空白は行末でぶら下がるので、収まらない場合はその行を埋めるだけ
- * - 単語は現在行に収まらなければ次行へ送る
- * - 1行にも収まらない長い単語だけをbreak-wordとして文字単位で分割する
- * - CJKは空白が無くても文字間で改行できるので、1文字ずつが折り返し単位
+ * - トークン（tokenizeForWrap参照）は現在行に収まらなければ次行へ送る
+ * - 1行にも収まらない長いトークンだけをbreak-wordとしてクラスタ単位で分割する
  *
  * @param measureToken トークンの描画幅(px)。フォントサイズは呼び出し側で束縛する
  * @param initialUsedWidth 先頭に既に置かれている内容（タイムスタンプ）の幅(px)
@@ -629,7 +696,7 @@ export const countWrappedLines = (
       lines += 1
       used = 0
     }
-    for (const token of hardLine.match(TOKEN_PATTERN) ?? []) {
+    for (const token of tokenizeForWrap(hardLine)) {
       const width = measureToken(token)
       if (/^\s/.test(token)) {
         used = used + width <= limit ? used + width : limit
@@ -648,13 +715,13 @@ export const countWrappedLines = (
         continue
       }
       // 1行に収まらない語だけをbreak-wordとして割る
-      for (const char of token) {
-        const charWidth = measureToken(char)
-        if (used > 0 && used + charWidth > limit) {
+      for (const cluster of splitGraphemes(token)) {
+        const clusterWidth = measureToken(cluster)
+        if (used > 0 && used + clusterWidth > limit) {
           lines += 1
           used = 0
         }
-        used += charWidth
+        used += clusterWidth
       }
     }
   })

--- a/src/components/HandLog.tsx
+++ b/src/components/HandLog.tsx
@@ -511,6 +511,9 @@ const formatTimestamp = (timestamp: number): string => {
  */
 export const FALLBACK_NARROW_CHAR_WIDTH_RATIO = 0.6
 export const FALLBACK_WIDE_CHAR_WIDTH_RATIO = 1
+/** 絵文字は全角より広い（実測: 8pxで`🐟`=10px） */
+export const FALLBACK_EMOJI_CHAR_WIDTH_RATIO = 1.25
+const EMOJI_PRESENTATION_PATTERN = /\p{Emoji_Presentation}/u
 const MIN_PLAUSIBLE_CHAR_WIDTH_RATIO = 0.1
 const MAX_PLAUSIBLE_CHAR_WIDTH_RATIO = 3
 
@@ -528,17 +531,32 @@ const WIDE_CHAR_RANGES =
 const WIDE_CHAR_PATTERN = new RegExp(`[${WIDE_CHAR_RANGES}]`)
 
 /**
- * 禁則処理。CJKは文字間で改行できるが、どこでもよいわけではない。
+ * 改行機会。CJKは空白が無くても文字間で改行できるが、全角＝改行機会では
+ * ない。Chromeの実測では、半角カナ（4px）と絵文字（10px）は全角幅でなくても
+ * 改行機会を持つ一方、トランプのスート`♠♥♦♣`や`★→✓①`は持たない。
+ * 幅の判定（WIDE_CHAR_PATTERN）とは別の集合として扱う。
+ * 絵文字は`\p{Emoji_Presentation}`で判定する。`\p{Extended_Pictographic}`は
+ * `♠`まで含んでしまい、カード表記の行を余計に折り返す。
+ */
+const BREAK_OPPORTUNITY_PATTERN = new RegExp(
+  `[${WIDE_CHAR_RANGES}\\uFF61-\\uFF9F]|\\p{Emoji_Presentation}`,
+  'u'
+)
+
+/**
+ * 禁則処理。改行機会があっても、そこで改行してよいとは限らない。
  * 集合はChromeの既定（`line-break: auto`）を実測して確定したもの。
- * 小書き仮名（ぁっゃゅょヵヶ）と長音符（ー）は既定では改行可能なので
- * 含めない（含めると逆に行数を過大評価する）。
+ * - 小書き仮名（ぁっゃゅょヵヶ）と長音符（ー）は既定では改行可能なので
+ *   含めない（含めると逆に行数を過大評価する）
+ * - ASCIIの`:`や`,`も対象。`{日本語名}: raises`のように全角の直後へASCII
+ *   句読点が続く行がハンドログの主要な形なので、抜けると行が重なる
  */
 /** 行頭禁則: 行の先頭に来られない文字 */
 const NO_BREAK_BEFORE_PATTERN =
-  /[\u3001\u3002\uFF0C\uFF0E\u30FB\uFF1A\uFF1B\uFF1F\uFF01\uFF09\uFF3D\uFF5D\u3009\u300B\u300D\u300F\u3011\u3015\u2026\u2025\u3005\u309D\u309E\uFF61\uFF63\uFF64\uFF65\uFF9E\uFF9F%\u00B0\u2032\u2033\u2103\u00A2]/
+  /[\u3001\u3002\uFF0C\uFF0E\u30FB\uFF1A\uFF1B\uFF1F\uFF01\uFF09\uFF3D\uFF5D\u3009\u300B\u300D\u300F\u3011\u3015\u2026\u2025\u3005\u309D\u309E\uFF61\uFF63\uFF64\uFF65\uFF9E\uFF9F\u00B0\u2032\u2033\u2103\u00A2\u002C\u002E\u003A\u003B\u0021\u003F\u0029\u005D\u007D\u002F\u0025\u0027\u0022\u007C]/
 /** 行末禁則: 直後で改行できない文字（開き括弧・前置記号） */
 const NO_BREAK_AFTER_PATTERN =
-  /[\uFF08\uFF3B\uFF5B\u3008\u300A\u300C\u300E\u3010\u3014\u2018\u201C\uFFE5\uFF04\u00A3]/
+  /[\uFF08\uFF3B\uFF5B\u3008\u300A\u300C\u300E\u3010\u3014\u2018\u201C\uFFE5\uFF04\u00A3\uFF62\u0028\u005B\u007B\u0024\u002B]/
 
 const graphemeSegmenter =
   typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
@@ -596,9 +614,11 @@ const measureClusterWidth = (cluster: string, fontSize: number): number => {
   const zeroWidth = ZERO_WIDTH_CLUSTER_PATTERN.test(cluster)
   const fallbackRatio = zeroWidth
     ? 0
-    : WIDE_CHAR_PATTERN.test(cluster)
-      ? FALLBACK_WIDE_CHAR_WIDTH_RATIO
-      : FALLBACK_NARROW_CHAR_WIDTH_RATIO
+    : EMOJI_PRESENTATION_PATTERN.test(cluster)
+      ? FALLBACK_EMOJI_CHAR_WIDTH_RATIO
+      : WIDE_CHAR_PATTERN.test(cluster)
+        ? FALLBACK_WIDE_CHAR_WIDTH_RATIO
+        : FALLBACK_NARROW_CHAR_WIDTH_RATIO
   let clusterWidth = fontSize * fallbackRatio
   const context = getMeasurementContext()
   if (context) {
@@ -661,8 +681,12 @@ const breakAllowedBetween = (previous: string, next: string): boolean => {
   if (previousIsSpace || nextIsSpace) return previousIsSpace !== nextIsSpace
   if (NO_BREAK_AFTER_PATTERN.test(previous)) return false
   if (NO_BREAK_BEFORE_PATTERN.test(next)) return false
-  // CJKは空白が無くても文字間で改行できる。半角どうしは1語として繋がる
-  return WIDE_CHAR_PATTERN.test(previous) || WIDE_CHAR_PATTERN.test(next)
+  // CJK・半角カナ・絵文字は空白が無くても文字間で改行できる。
+  // 半角英数どうしは1語として繋がる
+  return (
+    BREAK_OPPORTUNITY_PATTERN.test(previous) ||
+    BREAK_OPPORTUNITY_PATTERN.test(next)
+  )
 }
 
 /**

--- a/src/components/HandLog.tsx
+++ b/src/components/HandLog.tsx
@@ -528,7 +528,12 @@ const MAX_PLAUSIBLE_CHAR_WIDTH_RATIO = 3
 const WIDE_CHAR_RANGES =
   'ᄀ-ᅟ⺀-〾ぁ-㏿㐀-䶿一-鿿' +
   'ꀀ-꓏가-힣豈-﫿︰-﹏＀-｠￠-￦'
-const WIDE_CHAR_PATTERN = new RegExp(`[${WIDE_CHAR_RANGES}]`)
+// `\p{Ideographic}`で補助平面（CJK拡張B以降。`\u{20BB7}`など人名に出る）も
+// 拾う。BMPの範囲指定だけでは半角扱いになり、幅も改行機会も取りこぼす。
+const WIDE_CHAR_PATTERN = new RegExp(
+  `[${WIDE_CHAR_RANGES}]|\\p{Ideographic}`,
+  'u'
+)
 
 /**
  * 改行機会。CJKは空白が無くても文字間で改行できるが、全角＝改行機会では
@@ -539,7 +544,7 @@ const WIDE_CHAR_PATTERN = new RegExp(`[${WIDE_CHAR_RANGES}]`)
  * `♠`まで含んでしまい、カード表記の行を余計に折り返す。
  */
 const BREAK_OPPORTUNITY_PATTERN = new RegExp(
-  `[${WIDE_CHAR_RANGES}\\uFF61-\\uFF9F]|\\p{Emoji_Presentation}`,
+  `[${WIDE_CHAR_RANGES}\\uFF61-\\uFF9F]|\\p{Ideographic}|\\p{Emoji_Presentation}`,
   'u'
 )
 
@@ -557,6 +562,15 @@ const NO_BREAK_BEFORE_PATTERN =
 /** 行末禁則: 直後で改行できない文字（開き括弧・前置記号） */
 const NO_BREAK_AFTER_PATTERN =
   /[\uFF08\uFF3B\uFF5B\u3008\u300A\u300C\u300E\u3010\u3014\u2018\u201C\uFFE5\uFF04\u00A3\uFF62\u0028\u005B\u007B\u0024\u002B]/
+
+/**
+ * CSSが改行機会として扱う空白。`\s`はNBSP(U+00A0)・NARROW NBSP(U+202F)・
+ * FIGURE SPACE(U+2007)まで真になるが、これらはUAX #14のGL（改行禁止）で、
+ * CSSは前後で改行しない。空白扱いすると存在しない改行機会を作るうえ、
+ * 行末でぶら下げて幅も落としてしまう。
+ */
+const BREAKABLE_SPACE_PATTERN =
+  /^[ \t\n\r\f\v\u1680\u2000-\u2006\u2008-\u200A\u2028\u2029\u205F\u3000]/
 
 const graphemeSegmenter =
   typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
@@ -675,8 +689,8 @@ const tokenizeForWrap = (line: string): string[] => {
 }
 
 const breakAllowedBetween = (previous: string, next: string): boolean => {
-  const previousIsSpace = /^\s/.test(previous)
-  const nextIsSpace = /^\s/.test(next)
+  const previousIsSpace = BREAKABLE_SPACE_PATTERN.test(previous)
+  const nextIsSpace = BREAKABLE_SPACE_PATTERN.test(next)
   // 空白の連なりは1トークン。空白とそれ以外の境目は必ず改行機会
   if (previousIsSpace || nextIsSpace) return previousIsSpace !== nextIsSpace
   if (NO_BREAK_AFTER_PATTERN.test(previous)) return false
@@ -722,7 +736,7 @@ export const countWrappedLines = (
     }
     for (const token of tokenizeForWrap(hardLine)) {
       const width = measureToken(token)
-      if (/^\s/.test(token)) {
+      if (BREAKABLE_SPACE_PATTERN.test(token)) {
         used = used + width <= limit ? used + width : limit
         continue
       }
@@ -894,6 +908,9 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
   const requestedLoadScaleRef = useRef<number | null>(null)
   const latestScaleRef = useRef(scale)
   latestScaleRef.current = scale
+  const measuredScrollbarRatioRef = useRef(
+    typeof window === 'undefined' ? 1 : window.devicePixelRatio
+  )
   const [showCopied, setShowCopied] = useState(false)
   const [showCleared, setShowCleared] = useState(false)
   const lastClickTimeRef = useRef<number>(0)
@@ -964,7 +981,7 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
   // スクロールバー環境では行の包含ブロックがその幅だけ狭くなる。
   // `scrollbarGutter: 'stable'`でスクロール有無に関わらず同じ幅を確保し、
   // 推定と実描画のどちらの状態でも一致させる（オーバーレイ環境では0）。
-  const scrollbarWidth = useMemo(() => getScrollbarSize(), [])
+  const [scrollbarWidth, setScrollbarWidth] = useState(() => getScrollbarSize())
 
   // 折り返しに使える本文幅。行はリスト幅いっぱい（width:100%）なので、
   // 行の包含ブロックはbody幅からスクロールバー幅を除いた分で、そこから
@@ -1026,6 +1043,15 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
 
   useEffect(() => {
     const handleViewportResize = () => {
+      // ページズーム（やモニタ間移動）はスクロールバーのCSSピクセル幅を変える。
+      // 物理幅は変わらないので、ズームアウトすると実際のgutterは広がる。
+      // getScrollbarSize()は初回値をモジュール内にキャッシュするため、
+      // devicePixelRatioが変わったときだけ強制的に測り直す
+      // （毎resizeでプローブを挿すと余計な強制レイアウトになる）。
+      if (window.devicePixelRatio !== measuredScrollbarRatioRef.current) {
+        measuredScrollbarRatioRef.current = window.devicePixelRatio
+        setScrollbarWidth(getScrollbarSize(true))
+      }
       // A stale passive-effect listener may fire after a new scale render.
       commitLayoutAction({
         type: 'environmentChanged',

--- a/src/components/HandLog.tsx
+++ b/src/components/HandLog.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect, useLayoutEffect, useRef, CSSProperties, useCallback, useMemo, memo } from 'react'
-import { List, useListRef } from 'react-window'
+import { List, useListRef, getScrollbarSize } from 'react-window'
 import {
   HandLogEntry,
   HandLogEntryType,
@@ -41,7 +41,7 @@ const HAND_LOG_ENTRY_PADDING_Y = 1
 const HAND_LOG_ENTRY_LINE_HEIGHT = 1.2
 const HAND_LOG_TIMESTAMP_FONT_SIZE_OFFSET = 2
 const HAND_LOG_TIMESTAMP_MARGIN_RIGHT = 8
-const HAND_LOG_TIMESTAMP_TEXT_LENGTH = '[00:00:00]'.length
+const HAND_LOG_TIMESTAMP_TEXT = '[00:00:00]'
 
 type HandLogInteractionMode = 'move' | 'resize'
 
@@ -504,114 +504,158 @@ const formatTimestamp = (timestamp: number): string => {
 
 /**
  * canvas計測が使えない環境（jsdom等）で使う1文字送り幅のem比。
- * 想定フォントはMonaco / Courier New / 汎用monospaceが約0.6、Consolasが約0.55。
- * その中で最も広い値を既定にして、行数を過小評価しない側へ倒す
- * （過大評価は行間が空くだけだが、過小評価は行の重なり＝欠落になる）。
+ * 半角: 想定フォントはMonaco / Courier New / 汎用monospaceが約0.6、
+ * Consolasが約0.55。その中で最も広い値を既定にして、行数を過小評価しない側へ
+ * 倒す（過大評価は行間が空くだけだが、過小評価は行の重なり＝欠落になる）。
+ * 全角: 日本語フォントは等幅1em。
  */
-export const FALLBACK_MONOSPACE_CHAR_WIDTH_RATIO = 0.6
-const CHAR_WIDTH_MEASUREMENT_SAMPLE = '0'.repeat(32)
-const MIN_PLAUSIBLE_CHAR_WIDTH_RATIO = 0.3
-const MAX_PLAUSIBLE_CHAR_WIDTH_RATIO = 1
-const charWidthCache = new Map<string, number>()
+export const FALLBACK_NARROW_CHAR_WIDTH_RATIO = 0.6
+export const FALLBACK_WIDE_CHAR_WIDTH_RATIO = 1
+const MIN_PLAUSIBLE_CHAR_WIDTH_RATIO = 0.1
+const MAX_PLAUSIBLE_CHAR_WIDTH_RATIO = 3
 
 /**
- * 実フォント・実フォントサイズでの1文字送り幅(px)をcanvasで実測する。
- *
- * 折り返し幅の推定はDOMと同じフォント指定で測らないと、等幅フォントでも
- * フォントごとの文字幅比の違い（Consolas 0.55 / Monaco・Courier New 0.6）が
- * そのまま行数の誤差になる。measureTextはレイアウトと同じフォント解決を通り、
- * 小さいフォントサイズ特有のラスタライズ差も込みで測れる。
- * canvasが無い環境（jsdom等）は保守的な比率へフォールバックする。
+ * 全角として扱うコードポイント（East Asian Wide / Fullwidth 相当）。
+ * 2つの用途がある:
+ * 1. canvasが無い環境での幅フォールバック（半角0.6em / 全角1em）
+ * 2. 折り返し機会の判定。CJKは空白が無くても文字間で改行できる
+ * トランプのスート（♠♥♦♣）は等幅フォント側に収録されていて半角送りなので、
+ * ここには含めない（実測でConsolas/Monaco系はASCIIと同じ送り幅）。
  */
-export const measureMonospaceCharWidth = (
-  fontSize: number,
-  fontFamily: string = HAND_LOG_FONT_FAMILY
-): number => {
-  const font = `${fontSize}px ${fontFamily}`
-  const cached = charWidthCache.get(font)
-  if (cached !== undefined) return cached
+const WIDE_CHAR_RANGES =
+  'ᄀ-ᅟ⺀-〾ぁ-㏿㐀-䶿一-鿿' +
+  'ꀀ-꓏가-힣豈-﫿︰-﹏＀-｠￠-￦'
+const WIDE_CHAR_PATTERN = new RegExp(`[${WIDE_CHAR_RANGES}]`)
+// 空白の連なり / 全角1文字 / それ以外の連なり、が折り返しの最小単位
+const TOKEN_PATTERN = new RegExp(
+  `\\s+|[${WIDE_CHAR_RANGES}]|[^\\s${WIDE_CHAR_RANGES}]+`,
+  'g'
+)
 
-  let charWidth = fontSize * FALLBACK_MONOSPACE_CHAR_WIDTH_RATIO
+const charWidthCache = new Map<string, number>()
+
+const getMeasurementContext = (): CanvasRenderingContext2D | null => {
   try {
     // jsdomはCanvasRenderingContext2D自体を定義しない。getContextを呼ぶと
     // "Not implemented"を吐くので、型の有無で先に判定して呼ばない。
     if (
-      typeof document !== 'undefined' &&
-      typeof CanvasRenderingContext2D !== 'undefined'
-    ) {
-      const context = document.createElement('canvas').getContext('2d')
-      if (context) {
-        context.font = font
-        const measured =
-          context.measureText(CHAR_WIDTH_MEASUREMENT_SAMPLE).width /
-          CHAR_WIDTH_MEASUREMENT_SAMPLE.length
-        const ratio = measured / fontSize
-        if (
-          Number.isFinite(ratio) &&
-          ratio >= MIN_PLAUSIBLE_CHAR_WIDTH_RATIO &&
-          ratio <= MAX_PLAUSIBLE_CHAR_WIDTH_RATIO
-        ) {
-          charWidth = measured
-        }
-      }
-    }
+      typeof document === 'undefined' ||
+      typeof CanvasRenderingContext2D === 'undefined'
+    ) return null
+    return document.createElement('canvas').getContext('2d')
   } catch {
-    // 計測不能ならフォールバック比率のまま
+    return null
   }
-  charWidthCache.set(font, charWidth)
+}
+
+/**
+ * 実フォント・実フォントサイズでの1文字ぶんの送り幅(px)をcanvasで実測する。
+ *
+ * 文字ごとに測るのが要点。等幅フォント指定でも、日本語のように指定フォントに
+ * 収録されていない文字は約1emの日本語フォントへフォールバックして描画される
+ * ため、ASCII基準の一律幅で数えると行数を最大1.7倍ほど過小評価する。
+ * measureTextはレイアウトと同じフォント解決を通るので、フォールバック後の
+ * 実幅がそのまま得られる（実測: 8pxで`0`=4.8px / `あ`=8px）。
+ * canvasが無い環境（jsdom等）は半角/全角の保守的な比率で代替する。
+ */
+const measureCharWidth = (char: string, fontSize: number): number => {
+  const key = `${fontSize}|${char}`
+  const cached = charWidthCache.get(key)
+  if (cached !== undefined) return cached
+
+  const fallbackRatio = WIDE_CHAR_PATTERN.test(char)
+    ? FALLBACK_WIDE_CHAR_WIDTH_RATIO
+    : FALLBACK_NARROW_CHAR_WIDTH_RATIO
+  let charWidth = fontSize * fallbackRatio
+  const context = getMeasurementContext()
+  if (context) {
+    context.font = `${fontSize}px ${HAND_LOG_FONT_FAMILY}`
+    const measured = context.measureText(char).width
+    const ratio = measured / fontSize
+    if (
+      Number.isFinite(ratio) &&
+      ratio >= MIN_PLAUSIBLE_CHAR_WIDTH_RATIO &&
+      ratio <= MAX_PLAUSIBLE_CHAR_WIDTH_RATIO
+    ) {
+      charWidth = measured
+    }
+  }
+  charWidthCache.set(key, charWidth)
   return charWidth
+}
+
+export type MeasureHandLogText = (text: string, fontSize: number) => number
+
+/**
+ * 文字列の描画幅(px)。等幅フォントにもCJKフォールバックにも字詰めは無いので、
+ * 文字ごとの送り幅の総和で足りる。キャッシュは文字単位なので、名前や
+ * アクション語が繰り返されるログでは実質すべてキャッシュヒットする。
+ */
+export const measureHandLogTextWidth: MeasureHandLogText = (text, fontSize) => {
+  let width = 0
+  for (const char of text) width += measureCharWidth(char, fontSize)
+  return width
 }
 
 /**
  * EntryRowの`white-space: pre-wrap` + `word-break: break-word`に合わせて
- * 折り返し後の行数を数える。
+ * 折り返し後の行数を数える。幅はすべてpxで扱う: 文字数で数えると半角と全角
+ * （日本語のプレイヤー名など）が混ざった行を数えられない。
  *
- * 文字数を1行あたり文字数で割るだけでは、単語境界での折り返しを無視して
- * 行数を過小評価する（"aaaaaa bbbbbb cccccc"は20文字なので幅10文字では
- * 単純除算だと2行だが、実際は3行になる）。
+ * 文字幅の総和を1行の幅で割るだけでも、単語境界での折り返しを無視して行数を
+ * 過小評価する（"aaaaaa bbbbbb cccccc"は幅10文字ぶんなら実際は3行）。
  * - 空白は行末でぶら下がるので、収まらない場合はその行を埋めるだけ
  * - 単語は現在行に収まらなければ次行へ送る
- * - 1行にも収まらない長い単語だけをbreak-wordとして分割する
+ * - 1行にも収まらない長い単語だけをbreak-wordとして文字単位で分割する
+ * - CJKは空白が無くても文字間で改行できるので、1文字ずつが折り返し単位
  *
- * @param initialUsedChars 先頭に既に置かれている内容（タイムスタンプ）の文字数換算
+ * @param measureToken トークンの描画幅(px)。フォントサイズは呼び出し側で束縛する
+ * @param initialUsedWidth 先頭に既に置かれている内容（タイムスタンプ）の幅(px)
  */
 export const countWrappedLines = (
   text: string,
-  charsPerLine: number,
-  initialUsedChars = 0
+  availableWidth: number,
+  measureToken: (token: string) => number,
+  initialUsedWidth = 0
 ): number => {
-  if (text.length === 0 && initialUsedChars === 0) return 0
+  if (text.length === 0 && initialUsedWidth === 0) return 0
 
-  const maxChars = Math.max(1, Math.floor(charsPerLine))
+  const limit = Math.max(0, availableWidth)
   let lines = 1
-  let used = Math.max(0, initialUsedChars)
+  let used = Math.max(0, initialUsedWidth)
 
   text.split('\n').forEach((hardLine, hardLineIndex) => {
     if (hardLineIndex > 0) {
       lines += 1
       used = 0
     }
-    for (const token of hardLine.match(/\s+|\S+/g) ?? []) {
-      const length = token.length
+    for (const token of hardLine.match(TOKEN_PATTERN) ?? []) {
+      const width = measureToken(token)
       if (/^\s/.test(token)) {
-        used = used + length <= maxChars ? used + length : maxChars
+        used = used + width <= limit ? used + width : limit
         continue
       }
-      if (used + length <= maxChars) {
-        used += length
+      if (used + width <= limit) {
+        used += width
         continue
       }
       if (used > 0) {
         lines += 1
         used = 0
       }
-      if (length <= maxChars) {
-        used = length
+      if (width <= limit) {
+        used = width
         continue
       }
-      const chunks = Math.ceil(length / maxChars)
-      lines += chunks - 1
-      used = length - (chunks - 1) * maxChars
+      // 1行に収まらない語だけをbreak-wordとして割る
+      for (const char of token) {
+        const charWidth = measureToken(char)
+        if (used > 0 && used + charWidth > limit) {
+          lines += 1
+          used = 0
+        }
+        used += charWidth
+      }
     }
   })
 
@@ -619,12 +663,15 @@ export const countWrappedLines = (
 }
 
 export interface HandLogRowMetrics {
-  /** 折り返しに使える本文幅(px)。= 行の幅 - 左右padding */
+  /**
+   * 折り返しに使える本文幅(px)。
+   * = リスト幅 - スクロールバー幅 - EntryRowの左右padding
+   */
   textWidth: number
   fontSize: number
   showTimestamps: boolean
-  /** フォントサイズ→1文字幅(px)。既定はcanvas実測（テストからの差し替え口） */
-  measureCharWidth?: (fontSize: number) => number
+  /** 文字列→描画幅(px)。既定はcanvas実測（テストからの差し替え口） */
+  measureText?: MeasureHandLogText
 }
 
 /**
@@ -637,23 +684,22 @@ export const estimateEntryRowHeight = (
     textWidth,
     fontSize,
     showTimestamps,
-    measureCharWidth = measureMonospaceCharWidth
+    measureText = measureHandLogTextWidth
   }: HandLogRowMetrics
 ): number => {
-  const charWidth = Math.max(measureCharWidth(fontSize), Number.EPSILON)
-  const charsPerLine = Math.max(1, Math.floor(textWidth / charWidth))
-  // タイムスタンプは本文より小さいフォントの別spanなので、幅を本文の文字数へ換算する
-  const timestampChars = showTimestamps
-    ? Math.ceil(
-      (
-        measureCharWidth(
-          Math.max(fontSize - HAND_LOG_TIMESTAMP_FONT_SIZE_OFFSET, 1)
-        ) * HAND_LOG_TIMESTAMP_TEXT_LENGTH +
-        HAND_LOG_TIMESTAMP_MARGIN_RIGHT
-      ) / charWidth
-    )
+  // タイムスタンプは本文より小さいフォントの別spanなので、そのフォントで測る
+  const timestampWidth = showTimestamps
+    ? measureText(
+      HAND_LOG_TIMESTAMP_TEXT,
+      Math.max(fontSize - HAND_LOG_TIMESTAMP_FONT_SIZE_OFFSET, 1)
+    ) + HAND_LOG_TIMESTAMP_MARGIN_RIGHT
     : 0
-  const lines = countWrappedLines(text, charsPerLine, timestampChars)
+  const lines = countWrappedLines(
+    text,
+    textWidth,
+    token => measureText(token, fontSize),
+    timestampWidth
+  )
   return lines * fontSize * HAND_LOG_ENTRY_LINE_HEIGHT + HAND_LOG_ENTRY_PADDING_Y * 2
 }
 
@@ -823,13 +869,20 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
     displaySize.height - HAND_LOG_BORDER_WIDTH * 2
   )
 
+  // Listは`overflow: auto`なので、Windows/Linuxのような非オーバーレイ
+  // スクロールバー環境では行の包含ブロックがその幅だけ狭くなる。
+  // `scrollbarGutter: 'stable'`でスクロール有無に関わらず同じ幅を確保し、
+  // 推定と実描画のどちらの状態でも一致させる（オーバーレイ環境では0）。
+  const scrollbarWidth = useMemo(() => getScrollbarSize(), [])
+
   // 折り返しに使える本文幅。行はリスト幅いっぱい（width:100%）なので、
-  // 行の包含ブロックはbody幅そのもので、そこからEntryRow自身の左右padding
-  // だけがテキスト幅を狭める。保存幅ではなく表示幅から引くのが要点:
-  // viewportが保存幅より狭いときは表示だけが縮み、折り返しは縮んだ側で起きる。
+  // 行の包含ブロックはbody幅からスクロールバー幅を除いた分で、そこから
+  // EntryRow自身の左右paddingだけがテキスト幅を狭める。保存幅ではなく
+  // 表示幅から引くのが要点: viewportが保存幅より狭いときは表示だけが縮み、
+  // 折り返しは縮んだ側で起きる。
   const entryTextWidth = Math.max(
     0,
-    bodyWidth - HAND_LOG_ENTRY_PADDING_X * 2
+    bodyWidth - scrollbarWidth - HAND_LOG_ENTRY_PADDING_X * 2
   )
 
   // アイテムの高さを計算
@@ -1173,7 +1226,13 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
           rowHeight={getItemSize}
           rowComponent={EntryRow}
           rowProps={rowProps}
-          style={{ height: bodyHeight, width: bodyWidth }}
+          style={{
+            height: bodyHeight,
+            width: bodyWidth,
+            // 行高の推定がスクロールバー幅を常に差し引くので、実際の行幅も
+            // スクロール有無で変わらないよう固定する（entryTextWidth参照）。
+            scrollbarGutter: 'stable',
+          }}
         />
       ) : (
         <div style={{


### PR DESCRIPTION
#306 のレビューで chatgpt-codex-connector[bot] が指摘した P1 2件への対応（#306 はマージ済みのため別PR）。どちらも「推定幅が実描画幅より広い → 行数を過小評価 → 行が重なる」という同じ失敗の別経路。

- https://github.com/solavrc/pokerchase-hud/pull/306#discussion_r3688832868
- https://github.com/solavrc/pokerchase-hud/pull/306#discussion_r3688832871

## 1. 日本語グリフの実幅（P1）

文字幅を ASCII の `0` 1文字だけで代表させていたため、等幅フォントに収録されていない日本語（プレイヤー名・卓名）が描画時に約1emの日本語フォントへフォールバックしても、推定は約0.6emのままだった。PokerChase では日本語名が主流なのでエッジケースではない。

実ブラウザでの計測（8px、`Consolas, Monaco, "Courier New", monospace`）:

| 文字 | 実幅 |
|---|---|
| `0` | 4.801px (0.60em) |
| `あ` / `語` | 8.0px (1.00em) |
| `♠` `♦` | 4.801px（等幅側に収録。全角ではない） |

18文字の日本語名 `日本語のプレイヤー名テスト用アカウント` は実幅152px に対し推定91px（**1.67倍の過小評価**）。mockup に日本語名を入れて幅を掃引すると、幅232〜290px で Seat 行が実際21.19px（2行）必要なのに11.59px（1行）しか割り当てられず、次の行が重なることを再現した。

**修正**: 計測を文字単位（`fontSize|char` でキャッシュ）に変え、折り返し計算を文字数から px へ移行。`measureText` はレイアウトと同じフォント解決を通るので、フォールバック後の実幅がそのまま得られる。CJK は空白が無くても文字間で改行できるため、折り返し単位としても1文字ずつ扱う。canvas が無い環境（jsdom）は半角0.6em / 全角1em でフォールバック（どちらも想定フォント中で最も広い値）。

## 2. 非オーバーレイ・スクロールバー（P1）

`List` は `overflow: auto` なので、Windows/Linux の実体を持つスクロールバー環境では行の包含幅がその分だけ狭くなる。実測（15px スクロールバーを再現）: リスト `offsetWidth` 398px に対し行の幅は383px。推定は398基準だったため約15px ぶん広く見積もっていた。

**修正**: `getScrollbarSize()`（react-window が提供）を本文幅から差し引き、`List` に `scrollbarGutter: 'stable'` を指定。これでスクロール有無に関わらず行幅が一定になり、推定と実描画が両状態で一致する（オーバーレイ環境=macOS では 0px なので実質無変更）。

## 検証

- `npm run test`（1622件）/ `npm run typecheck` パス。テストは `src/components/HandLog.test.tsx` に追加（+7件、計84件）。フォールバックを ASCII 一律に戻す／スクロールバー減算を外す変異でそれぞれ落ちることを確認済み。
- 実ブラウザ計測（各行の割り当て高 vs `height:auto` クローンの自然高）:
  - 日本語名入り mockup・幅200〜480px … **修正前は不足15件 → 修正後は288行でゼロ**
  - 15px スクロールバーを再現した環境・幅200〜480px × スクロール有無 … 306行（うち38行が折り返し）で**不足ゼロ**、1行分以上の過大評価もゼロ
- `AGENTS.md` の「Hand-log row height」を px 単位・文字単位計測・スクロールバー確保の説明へ更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)