### PR TITLE
feat(observability): 作業ビルドからも診断情報を送れるようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Build extension
         env:
-          SENTRY_ENABLED: 'true'
+          SENTRY_ENVIRONMENT: production
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: npm run build
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -125,12 +125,44 @@ the traversal cost. Do not attach the exact raw event, player names,
 account IDs, chat text, Firebase document paths, auth objects, or tokens
 directly to Sentry.
 
-## Builds and source maps
+## Build identity
 
-Normal local/CI/E2E builds keep telemetry disabled. The release workflow sets
-`SENTRY_ENABLED=true`, but the runtime still requires the user's per-profile
-opt-in and optional host grant. Its `SENTRY_AUTH_TOKEN` repository secret
-enables the esbuild plugin to:
+Telemetry is compiled into every build except E2E. Diagnostics are opt-in, so
+the maintainer's own play sessions are a primary source of signal — especially
+schema-validation failures, which is how a PokerChase payload change becomes
+visible at all (see "Incident Diagnosis Practices" in AGENTS.md). Those events
+are `captureMessage` plus structured context and need no source maps, so a
+build without an upload token is still worth reporting from. Excluding working
+builds would silence the configuration most likely to opt in and act on the
+result.
+
+What differs between a release and a working build is only its **identity**, so
+a working build can never be symbolicated against, or counted toward, the
+published release:
+
+| Build | `SENTRY_ENVIRONMENT` | Environment | Release |
+|---|---|---|---|
+| Release workflow | `production` | `production` | `pokerchase-hud@<manifest version>` |
+| Working build | unset | `development` | `pokerchase-hud@<manifest version>+dev.<short sha>` |
+| E2E | n/a | — | telemetry compiled out |
+
+`scripts/build-extension.ts` resolves the short commit and appends `-dirty`
+when the tree has uncommitted changes — the marker is the point: it says the
+commit alone does not identify what is running. Outside a git checkout the
+revision resolves to `unknown`. The runtime falls back to `development` and the
+plain versioned release when nothing was injected (jest, where esbuild's define
+does not apply); it never falls back to `production`, because an un-injected
+build is by definition not the release whose source maps are on file.
+
+Set `SENTRY_DISABLED=true` to compile telemetry out of a build entirely. Note
+that this is not required for privacy: the runtime per-profile opt-in and
+optional host grant gate every build, so a contributor who never enables
+**診断情報を送信** reports nothing regardless.
+
+## Source maps
+
+The release workflow's `SENTRY_AUTH_TOKEN` repository secret enables the
+esbuild plugin to:
 
 1. build release `pokerchase-hud@<manifest version>`;
 2. upload minified JavaScript and source maps;
@@ -140,14 +172,10 @@ enables the esbuild plugin to:
 The authentication token is a build secret and must never be committed. The
 public DSN is intentionally bundled into the extension.
 
-To test a telemetry-enabled local build without uploading source maps:
-
-```sh
-SENTRY_ENABLED=true npm run build
-```
-
-To exercise the complete upload path, set a Sentry organization token with
-project release permissions in `SENTRY_AUTH_TOKEN`.
+Setting `SENTRY_AUTH_TOKEN` locally uploads source maps for the `+dev.<sha>`
+release too, so a working build's stack traces resolve as well. Without it,
+schema-validation diagnostics still arrive intact — only stack traces stay
+minified.
 
 ## Operational limits
 

--- a/scripts/build-extension.ts
+++ b/scripts/build-extension.ts
@@ -1,5 +1,6 @@
 import { build, BuildOptions, Plugin } from 'esbuild'
 import { sentryEsbuildPlugin } from '@sentry/esbuild-plugin'
+import { execFileSync } from 'child_process'
 import { copyFileSync, mkdirSync } from 'fs'
 import { parse } from 'path'
 import { resolve } from 'path'
@@ -23,17 +24,63 @@ const {
 //                  to the e2e fixture origin in the e2e build only.
 const outdir = process.env.E2E_OUTDIR || 'dist'
 const e2eManifestOverride = process.env.E2E_MANIFEST
+
+// --- Sentry telemetry build identity --------------------------------------
+// Diagnostics are opt-in, so the maintainer's own play sessions are a primary
+// source of signal -- especially schema-validation failures, which is how a
+// PokerChase payload change becomes visible at all (see "Incident Diagnosis
+// Practices" in AGENTS.md). Those events are captureMessage + structured
+// context and need no source maps, so a build without an upload token is still
+// worth reporting from. Telemetry is therefore compiled into every build except
+// E2E; what changes between a release and a working build is only its identity.
+//
+//   SENTRY_ENVIRONMENT=production  - release workflow marker. Claims the plain
+//                                    `pokerchase-hud@<version>` release name,
+//                                    which the uploaded source maps belong to.
+//   (unset)                        - a working build. Reports under
+//                                    environment=development and a distinct
+//                                    `+dev.<sha>` release, so it can never be
+//                                    symbolicated against, or counted toward,
+//                                    the published release.
+//   SENTRY_DISABLED=true           - compile telemetry out entirely.
+//
+// The runtime per-profile opt-in and optional host grant still gate every
+// build: a contributor who never enables 診断情報を送信 reports nothing.
+const isProductionRelease = process.env.SENTRY_ENVIRONMENT === 'production'
 const sentryEnabled =
-  !e2eManifestOverride && process.env.SENTRY_ENABLED === 'true'
+  !e2eManifestOverride && process.env.SENTRY_DISABLED !== 'true'
 const sentryUploadEnabled =
   sentryEnabled && Boolean(process.env.SENTRY_AUTH_TOKEN)
-const sentryRelease = `pokerchase-hud@${manifest.version}`
+const sentryEnvironment = isProductionRelease ? 'production' : 'development'
 
-if (sentryEnabled && !sentryUploadEnabled) {
+/**
+ * Short commit of the working build, with a `-dirty` marker when the tree has
+ * uncommitted changes -- the marker is the point: it says the commit alone does
+ * not identify what is running. Falls back to `unknown` outside a git checkout.
+ */
+const resolveBuildRevision = (): string => {
+  const git = (...args: string[]): string =>
+    execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim()
+  try {
+    const revision = git('rev-parse', '--short', 'HEAD')
+    return git('status', '--porcelain') ? `${revision}-dirty` : revision
+  } catch {
+    return 'unknown'
+  }
+}
+
+const sentryRelease = isProductionRelease
+  ? `pokerchase-hud@${manifest.version}`
+  : `pokerchase-hud@${manifest.version}+dev.${resolveBuildRevision()}`
+
+if (isProductionRelease && !sentryUploadEnabled) {
   console.warn(
-    '[Sentry] Telemetry is enabled, but SENTRY_AUTH_TOKEN is missing; ' +
-    'building without source-map upload.'
+    '[Sentry] Building a production release without SENTRY_AUTH_TOKEN; ' +
+    'no source maps will be uploaded.'
   )
+}
+if (sentryEnabled) {
+  console.log(`[Sentry] ${sentryEnvironment} build, release ${sentryRelease}`)
 }
 const e2eManifestPlugin: Plugin | undefined = e2eManifestOverride ? {
   name: 'e2e-manifest-override',
@@ -72,6 +119,8 @@ const options: BuildOptions = {
     'process.env.SENTRY_ENABLED': JSON.stringify(
       sentryEnabled ? 'true' : 'false'
     ),
+    'process.env.SENTRY_ENVIRONMENT': JSON.stringify(sentryEnvironment),
+    'process.env.SENTRY_RELEASE': JSON.stringify(sentryRelease),
     // ReadEntityStreamのキャッシュ無効化フラグ。ブラウザ（Service Worker）実行時には
     // 環境変数を設定する手段がそもそも無いため、ビルド時にfalseへ畳み込むことで
     // `process`オブジェクトへのランタイム依存を無くす（Node上のjestではテスト変換経由の

--- a/src/observability/sentry-build-identity.test.ts
+++ b/src/observability/sentry-build-identity.test.ts
@@ -1,0 +1,101 @@
+/**
+ * A working build must never claim the published release's identity: its stack
+ * traces would be resolved against source maps uploaded for different code, and
+ * its events would be counted toward the release users actually run.
+ * scripts/build-extension.ts injects both values; jest exercises the same
+ * process.env reads directly.
+ */
+import * as Sentry from '@sentry/browser'
+import manifest from '../../manifest.json'
+
+jest.mock('@sentry/browser', () => ({
+  init: jest.fn(),
+  close: jest.fn().mockResolvedValue(true),
+  globalHandlersIntegration: jest.fn(() => ({ name: 'GlobalHandlers' })),
+  linkedErrorsIntegration: jest.fn(() => ({ name: 'LinkedErrors' })),
+  dedupeIntegration: jest.fn(() => ({ name: 'Dedupe' })),
+  withScope: jest.fn(),
+  captureException: jest.fn(),
+  captureMessage: jest.fn()
+}))
+
+const startBackgroundSentry = async (
+  build: { release?: string, environment?: string }
+) => {
+  process.env.SENTRY_ENABLED = 'true'
+  if (build.release) process.env.SENTRY_RELEASE = build.release
+  else delete process.env.SENTRY_RELEASE
+  if (build.environment) process.env.SENTRY_ENVIRONMENT = build.environment
+  else delete process.env.SENTRY_ENVIRONMENT
+
+  await chrome.storage.local.set({ sentryTelemetryConsent: true })
+  ;(chrome.permissions.contains as jest.Mock).mockResolvedValue(true)
+
+  let init: jest.Mock | undefined
+  await jest.isolateModulesAsync(async () => {
+    init = require('@sentry/browser').init
+    const { initSentry } = require('./sentry')
+    await initSentry('background')
+  })
+  return init as jest.Mock
+}
+
+describe('Sentry build identity', () => {
+  // Only clears call records; test-setup.ts owns the chrome mock behaviours.
+  beforeEach(() => { jest.clearAllMocks() })
+
+  afterEach(() => {
+    delete process.env.SENTRY_ENABLED
+    delete process.env.SENTRY_RELEASE
+    delete process.env.SENTRY_ENVIRONMENT
+  })
+
+  it('reports a release build under the plain versioned release', async () => {
+    const init = await startBackgroundSentry({
+      release: `pokerchase-hud@${manifest.version}`,
+      environment: 'production'
+    })
+
+    expect(init).toHaveBeenCalledWith(expect.objectContaining({
+      release: `pokerchase-hud@${manifest.version}`,
+      environment: 'production'
+    }))
+  })
+
+  it('keeps a working build off the published release identity', async () => {
+    const init = await startBackgroundSentry({
+      release: `pokerchase-hud@${manifest.version}+dev.abc1234-dirty`,
+      environment: 'development'
+    })
+
+    expect(init).toHaveBeenCalledWith(expect.objectContaining({
+      release: `pokerchase-hud@${manifest.version}+dev.abc1234-dirty`,
+      environment: 'development'
+    }))
+    const [{ release }] = init.mock.calls.at(-1) as [{ release: string }]
+    expect(release).not.toBe(`pokerchase-hud@${manifest.version}`)
+  })
+
+  it('defaults to development when the build injected nothing', async () => {
+    const init = await startBackgroundSentry({})
+
+    // Never fall back to `production`: an un-injected build is, by definition,
+    // not the release whose source maps are on file.
+    expect(init).toHaveBeenCalledWith(expect.objectContaining({
+      release: `pokerchase-hud@${manifest.version}`,
+      environment: 'development'
+    }))
+  })
+
+  it('keeps Sentry unused when telemetry is compiled out', async () => {
+    delete process.env.SENTRY_ENABLED
+    await chrome.storage.local.set({ sentryTelemetryConsent: true })
+
+    await jest.isolateModulesAsync(async () => {
+      const { initSentry } = require('./sentry')
+      await initSentry('background')
+    })
+
+    expect(Sentry.init).not.toHaveBeenCalled()
+  })
+})

--- a/src/observability/sentry.ts
+++ b/src/observability/sentry.ts
@@ -25,7 +25,13 @@ export interface CaptureErrorOptions {
 
 const SENTRY_DSN =
   'https://7a6e9be8cb1bdaab2ec2b9ba0565ad93@o4507260715794432.ingest.us.sentry.io/4511816450637824'
-const SENTRY_RELEASE = `pokerchase-hud@${manifest.version}`
+// Injected by scripts/build-extension.ts. A working build reports under
+// environment=development and a `+dev.<sha>` release so it can never be
+// symbolicated against, or counted toward, the published release. The
+// fallbacks cover jest, where esbuild's define does not apply.
+const SENTRY_RELEASE =
+  process.env.SENTRY_RELEASE || `pokerchase-hud@${manifest.version}`
+const SENTRY_ENVIRONMENT = process.env.SENTRY_ENVIRONMENT || 'development'
 const SAFE_TAGS = new Set([
   'api_type_id',
   'error_type',
@@ -286,7 +292,7 @@ const startSentry = async (
   Sentry.init({
     dsn: SENTRY_DSN,
     release: SENTRY_RELEASE,
-    environment: 'production',
+    environment: SENTRY_ENVIRONMENT,
     skipBrowserExtensionCheck: true,
     defaultIntegrations: false,
     integrations: [


### PR DESCRIPTION
## 動機

診断情報はオプトインです。つまり、実際に有効化して結果に対処できる人物 — メンテナ自身 — のプレイが主要な信号源になります。とりわけ**スキーマ検証失敗**は、PokerChase のペイロード変更が可視化される唯一の経路です（AGENTS.md "Incident Diagnosis Practices"、season-3 で ~2ヶ月気づかれなかったあの系統）。毎日プレイしている環境は API 変更の最速の検知点になります。

にもかかわらず、その環境 — dev build — だけが構造的にゼロ件しか報告しない構成でした。手元には popup の undecoded-event カウンタがありますが、これは自分で見に行くプル型の信号です。

## dev build の何が問題だったのか

「dev build だから」ではなく、**公開リリースと区別がつかなかったから**です:

- [sentry.ts](../blob/main/src/observability/sentry.ts) の `release` は manifest のバージョンのみから決まる → 作業ビルドが公開リリースそのものを名乗る
- `environment: 'production'` がハードコード

つまり**命名の問題**であって原理的な制約ではありません。さらに、最も価値の高いスキーマ検証イベントは `captureMessage` + 構造化コンテキストで、**ソースマップを一切必要としません**。アップロードトークンの無いビルドからでも報告する価値があります。

## 変更

E2E 以外の全ビルドに telemetry を組み込み、リリースと作業ビルドの違いを **identity だけ**に閉じます。作業ビルドが公開リリースのソースマップで解決されることも、そのメトリクスに混入することも構造的に起こりません。

| ビルド | `SENTRY_ENVIRONMENT` | environment | release |
|---|---|---|---|
| リリースワークフロー | `production` | `production` | `pokerchase-hud@<version>` |
| 作業ビルド | 未設定 | `development` | `pokerchase-hud@<version>+dev.<short sha>` |
| E2E | — | — | telemetry 除去 |

- short sha には作業ツリーが dirty なとき `-dirty` を付けます。**このマーカー自体が目的**で、「コミットだけでは動いているコードを特定できない」ことを示します。git チェックアウト外では `unknown`。
- ランタイムは未注入時（jest など、esbuild の define が効かない環境）に `development` と素のリリースへフォールバックし、**`production` へは決して倒れません** — 未注入ビルドは定義上、ソースマップのあるリリースではないからです。
- `SENTRY_DISABLED=true` で完全除去も可能。ただしプライバシー目的では不要です: プロファイル単位のオプトインとホスト権限が全ビルドで従来どおり効くため、トグルを触らないコントリビュータからは何も送られません。
- `SENTRY_AUTH_TOKEN` をローカルに置けば `+dev.<sha>` リリース側にもソースマップが上がります（既存の `sentryUploadEnabled` 経路がそのまま効く）。

## 検証

4つのビルドモードすべてについて、実際の出力を検査しました:

| モード | 結果 |
|---|---|
| `npm run build` | `[Sentry] development build, release pokerchase-hud@5.3.1+dev.323c9a1-dirty` / バンドル内 `="development"` |
| `SENTRY_ENVIRONMENT=production npm run build` | `release pokerchase-hud@5.3.1` / `="production"` |
| `SENTRY_DISABLED=true npm run build` | `telemetryEnabled` が `()=>!1` に畳み込み |
| `npm run build:e2e` | 同上（従来どおり強制OFF） |

`src/observability/sentry-build-identity.test.ts` を追加（4件）。リリース/作業ビルドそれぞれの identity、未注入時に `production` へ倒れないこと、除去ビルドで `Sentry.init` が呼ばれないことを固定しています。

`npm run typecheck` / `npm run test`（159 suites・1623 tests）green。

## 関連

[#308](https://github.com/solavrc/pokerchase-hud/pull/308) は独立した bugfix（診断情報トグルの誤ロールバック）で、コンフリクトはありません。あちらを先にマージしても順序は問いません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
