### PR TITLE
fix(stats): mergeStatDisplayConfigsが既定構成の要素を参照ごと返さないようにする

### DIFF
--- a/src/components/Popup.test.tsx
+++ b/src/components/Popup.test.tsx
@@ -1462,11 +1462,32 @@ describe('Popup', () => {
       )
     })
 
-    it('既定構成（module-levelのdefaultStatDisplayConfigs）を汚染しない', async () => {
-      // mergeStatDisplayConfigsは「保存済み設定に無い新規統計」について
-      // defaultStatDisplayConfigsの要素をそのまま返す（コピーしない）。
-      // ここではpfrを保存済み設定から抜いて、その共有参照が
-      // pendingStatDisplayConfigsに入る状態を作る。
+    it('既定構成（module-levelのdefaultStatDisplayConfigs）を汚染しない（保存済みoptionsが無い初回表示）', async () => {
+      // pendingStatDisplayConfigsにdefaultStatDisplayConfigsの要素が
+      // そのまま入る現存唯一の経路: 保存済みoptionsが無いとstateの初期値が
+      // module-levelの定数そのものになる。その場書き換え実装では、
+      // 「適用」していない並べ替えが定数に残り、同一JSコンテキスト内で
+      // 以降に呼ばれるmergeStatDisplayConfigs等が汚れた既定値でマージする。
+      syncData = { uiConfig: DEFAULT_UI_CONFIG }
+      const before = defaultStatDisplayConfigs.map(config => ({ ...config }))
+
+      render(<Popup />)
+      await waitForAsyncOperations()
+
+      // 往復させるとその場書き換え実装でもorderが元に戻ってしまうため片道で検証する
+      await userEvent.click(orderButtonsFor('HAND').down)
+
+      // 並べ替えは保留中のstateにのみ反映される
+      expect(displayedStatNames().slice(0, 3)).toEqual(['VPIP', 'HAND', 'VPIP·F'])
+      expect(screen.getByText('(未適用の変更があります)')).toBeInTheDocument()
+      expect(defaultStatDisplayConfigs).toEqual(before)
+    })
+
+    it('既定構成（module-levelのdefaultStatDisplayConfigs）を汚染しない（保存済み設定に欠けがある場合）', async () => {
+      // 保存済み設定に無い項目（pfr）をmergeStatDisplayConfigsが補う経路。
+      // mergeStatDisplayConfigs自体も複製を返すようになったため現在この経路で
+      // 共有参照は入らないが、二重の防御（マージ側の複製・並べ替え側の複製）の
+      // どちらか一方が外れても定数が汚れないことをUI側から独立に保証する。
       syncData.options.filterOptions.statDisplayConfigs =
         defaultStatDisplayConfigs.filter(config => config.id !== 'pfr')
       const before = defaultStatDisplayConfigs.map(config => ({ ...config }))
@@ -1474,8 +1495,6 @@ describe('Popup', () => {
       render(<Popup />)
       await waitForAsyncOperations()
 
-      // 共有参照であるpfrを巻き込む並べ替え（往復させると
-      // その場書き換え実装でもorderが元に戻ってしまうため片道で検証する）
       await userEvent.click(orderButtonsFor('PFR').up)
 
       expect(defaultStatDisplayConfigs).toEqual(before)

--- a/src/stats/index.test.ts
+++ b/src/stats/index.test.ts
@@ -79,6 +79,23 @@ describe('mergeStatDisplayConfigs', () => {
     expect(merged.every(c => c.enabled === false)).toBe(true)
     expect(merged).toHaveLength(defaults.length)
   })
+
+  it('戻り値はdefaultConfigsの要素と同一オブジェクトを含まない（呼び出し側の変更がデフォルトへ漏れない）', () => {
+    // 新規統計（保存済み設定に無い項目）についてデフォルト設定のオブジェクトを
+    // 参照ごと返していると、呼び出し側がマージ結果を書き換えた際に
+    // `defaultStatDisplayConfigs`（モジュールレベル定数）まで汚染される。
+    // 実際にPopupの並べ替えハンドラで発生した（PR #312で発覚）。
+    const saved: StatDisplayConfig[] = [{ id: 'hands', enabled: true, order: 0 }]
+    const snapshot = defaults.map(c => ({ ...c }))
+
+    const merged = mergeStatDisplayConfigs(saved, defaults)
+
+    expect(merged.every(config => !defaults.includes(config))).toBe(true)
+
+    // マージ結果を書き換えてもdefaultsは不変
+    merged.forEach(config => { config.order = -1; config.enabled = false })
+    expect(defaults).toEqual(snapshot)
+  })
 })
 
 /**

--- a/src/stats/index.ts
+++ b/src/stats/index.ts
@@ -116,8 +116,12 @@ export function mergeStatDisplayConfigs(
         order: existingConfig.order
       }
     }
-    // 新規統計 - デフォルト設定をそのまま使用
-    return defaultConfig
+    // 新規統計 - デフォルト設定をそのまま使用（ただし複製する）。
+    // `defaultConfig`を参照ごと返すと、戻り値の配列に
+    // `defaultStatDisplayConfigs`（モジュールレベル定数）と同一の
+    // オブジェクトが混ざり、呼び出し側がマージ結果を書き換えた際に
+    // 定数まで汚染される。
+    return { ...defaultConfig }
   })
 
   // orderでソートして表示順を安定させる


### PR DESCRIPTION
## 問題

`src/stats/index.ts` の `mergeStatDisplayConfigs()` は、保存済み設定に無い新規統計について `defaultConfig` を**参照ごと**返していた。

```ts
// 新規統計 - デフォルト設定をそのまま使用
return defaultConfig
```

このため戻り値の配列に module-level 定数 `defaultStatDisplayConfigs` と同一のオブジェクトが混ざる（新規統計が追加された後の既存ユーザーが該当）。呼び出し側がマージ結果をその場で書き換えると、エクスポートされた既定構成まで汚染される。

実際に `Popup.tsx` の `handleStatOrderChange()` で発生していた。PR #312（モックアップ）でポップアップと HUD を同一ページに同居させたところ、適用していない並べ替えが HUD へ漏れて発覚。

## #314 との関係

Popup 側の変異は #314 が `moveStatInDisplayOrder()` へ切り出す際に複製するよう修正済み（`reordered.map((config, order) => ({ ...config, order }))`）。本 PR は当初 Popup 側も直していたが、#314 のほうがデッドクリック修正と統合された上位互換なので、**Popup.tsx への変更は破棄して #314 のものを採用**した。

残したのはマージ側の防御と、それに対応するテスト。

## 修正

- `mergeStatDisplayConfigs()` が新規統計についても複製（`{ ...defaultConfig }`）を返す

これでアリアシング源は「保存済み options が無い初回表示で state の初期値が定数そのもの」（`Popup.tsx:87-88`）の 1 本のみになり、そこは #314 の複製で守られる。二重の防御になるので、将来変異箇所が増えても再発しない。

## テスト

- `src/stats/index.test.ts` — 戻り値が `defaultConfigs` の要素と同一オブジェクトを含まないこと、マージ結果を書き換えても `defaults` が不変であることを検証
- `src/components/Popup.test.tsx` — #314 が追加した汚染テストを 2 ケースに分割
  - **保存済み options が無い初回表示** — 現存唯一の共有参照経路。#314 の実装で `moveStatInDisplayOrder()` をその場書き換えに戻すと**落ちる**ことを確認済み
  - **保存済み設定に欠けがある場合** — #314 のテストを引き継ぎ。マージ側が複製するようになった旨にコメントを更新した上で、マージ側・並べ替え側どちらか一方の複製を外しても定数が汚れないことを両方向で実測確認

- `npm run test`: 161 suites / 1674 tests 全pass
- `npm run typecheck`: pass

エンティティ導出・統計計算には触れていないため `npm run verify-stats` および `REBUILD_ADVISORY_VERSION` の bump は不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
