### PR TITLE
fix(ui): 統計並べ替えの↑↓が1回で動かないデッドクリックを修正

### DIFF
--- a/src/components/Popup.test.tsx
+++ b/src/components/Popup.test.tsx
@@ -1389,4 +1389,96 @@ describe('Popup', () => {
       jest.useRealTimers()
     }, 15000)
   })
+
+  describe('統計の並べ替え（未適用の変更）', () => {
+    // 一覧に出ている統計名のみ（playerNameはHUDヘッダー常時表示のため非表示）
+    const displayedStatNames = () =>
+      screen.getAllByRole('listitem')
+        .map(item => item.querySelector('.MuiListItemText-primary')?.textContent)
+
+    const orderButtonsFor = (statName: string) => {
+      const listItem = screen.getByText(statName).closest('li')!
+      const [up, down] = Array.from(listItem.querySelectorAll('button'))
+      return { up: up!, down: down! }
+    }
+
+    it('一覧はplayerNameを除外して表示する', async () => {
+      render(<Popup />)
+      await waitForAsyncOperations()
+
+      expect(displayedStatNames().slice(0, 3)).toEqual(['HAND', 'VPIP', 'VPIP·F'])
+      expect(screen.queryByText('Name')).not.toBeInTheDocument()
+    })
+
+    it('↑1回で表示順が1つ動く（非表示のplayerNameを跨ぐケース）', async () => {
+      // 回帰テスト: 生配列インデックスでorderを交換していた頃は、
+      // VPIP（表示2番目）の↑1回目が非表示のplayerName（order 1）と
+      // 入れ替わるだけで、表示順が全く変化しないデッドクリックだった。
+      render(<Popup />)
+      await waitForAsyncOperations()
+
+      await userEvent.click(orderButtonsFor('VPIP').up)
+
+      expect(displayedStatNames().slice(0, 3)).toEqual(['VPIP', 'HAND', 'VPIP·F'])
+      expect(screen.getByText('(未適用の変更があります)')).toBeInTheDocument()
+    })
+
+    it('↓1回でも表示順が1つ動く（非表示のplayerNameを跨ぐケース）', async () => {
+      render(<Popup />)
+      await waitForAsyncOperations()
+
+      await userEvent.click(orderButtonsFor('HAND').down)
+
+      expect(displayedStatNames().slice(0, 3)).toEqual(['VPIP', 'HAND', 'VPIP·F'])
+    })
+
+    it('適用すると並べ替え後のstatDisplayConfigsが保存・配信される', async () => {
+      render(<Popup />)
+      await waitForAsyncOperations()
+
+      await userEvent.click(orderButtonsFor('VPIP').up)
+      await userEvent.click(screen.getByRole('button', { name: '適用' }))
+
+      await waitFor(() => {
+        expect(syncData.options.filterOptions.statDisplayConfigs[0]).toEqual(
+          expect.objectContaining({ id: 'vpip', order: 0 })
+        )
+      })
+      // playerNameは自身のスロット（order 1）に据え置かれ、HANDが後ろへ
+      const savedOrder = (syncData.options.filterOptions.statDisplayConfigs as { id: string }[])
+        .slice(0, 3)
+        .map(config => config.id)
+      expect(savedOrder).toEqual(['vpip', 'playerName', 'hands'])
+
+      expect(mockChromeRuntimeSendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'updateBattleTypeFilter',
+          filterOptions: expect.objectContaining({
+            statDisplayConfigs: expect.arrayContaining([
+              expect.objectContaining({ id: 'vpip', order: 0 })
+            ])
+          })
+        })
+      )
+    })
+
+    it('既定構成（module-levelのdefaultStatDisplayConfigs）を汚染しない', async () => {
+      // mergeStatDisplayConfigsは「保存済み設定に無い新規統計」について
+      // defaultStatDisplayConfigsの要素をそのまま返す（コピーしない）。
+      // ここではpfrを保存済み設定から抜いて、その共有参照が
+      // pendingStatDisplayConfigsに入る状態を作る。
+      syncData.options.filterOptions.statDisplayConfigs =
+        defaultStatDisplayConfigs.filter(config => config.id !== 'pfr')
+      const before = defaultStatDisplayConfigs.map(config => ({ ...config }))
+
+      render(<Popup />)
+      await waitForAsyncOperations()
+
+      // 共有参照であるpfrを巻き込む並べ替え（往復させると
+      // その場書き換え実装でもorderが元に戻ってしまうため片道で検証する）
+      await userEvent.click(orderButtonsFor('PFR').up)
+
+      expect(defaultStatDisplayConfigs).toEqual(before)
+    })
+  })
 })

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -39,6 +39,7 @@ import { GameTypeFilterSection } from './popup/GameTypeFilterSection'
 import { TableSizeFilterSection } from './popup/TableSizeFilterSection'
 import { HandLimitSection } from './popup/HandLimitSection'
 import { StatisticsConfigSection } from './popup/StatisticsConfigSection'
+import { moveStatInDisplayOrder } from './popup/stat-display-order'
 import { UndecodedEventSection } from './popup/UndecodedEventSection'
 import { UpdateSection } from './popup/UpdateSection'
 import { PopupHeader } from './popup/PopupHeader'
@@ -441,24 +442,12 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
   }
 
   const handleStatOrderChange = (statId: string, direction: 'up' | 'down') => {
-    const newConfigs = [...pendingStatDisplayConfigs]
-    const index = newConfigs.findIndex(config => config.id === statId)
-    
-    if (index === -1) return
-
-    const targetIndex = direction === 'up' ? index - 1 : index + 1
-    
-    // Swap order values
-    const currentConfig = newConfigs[index]
-    const targetConfig = newConfigs[targetIndex]
-    if (currentConfig && targetConfig) {
-      const tempOrder = currentConfig.order
-      currentConfig.order = targetConfig.order
-      targetConfig.order = tempOrder
-    }
-
-    // Sort by order
-    newConfigs.sort((a, b) => a.order - b.order)
+    // 移動単位はStatisticsConfigSectionの「表示リスト」基準
+    // （playerNameを除外しorderでソートしたもの）。
+    // 生配列インデックスで隣接要素とorderを交換すると、表示されていない
+    // playerNameと入れ替わるだけのデッドクリックが発生する。
+    const newConfigs = moveStatInDisplayOrder(pendingStatDisplayConfigs, statId, direction)
+    if (!newConfigs) return
 
     // Stat order changed (pending)
     setPendingStatDisplayConfigs(newConfigs)

--- a/src/components/popup/StatisticsConfigSection.tsx
+++ b/src/components/popup/StatisticsConfigSection.tsx
@@ -10,6 +10,7 @@ import Typography from '@mui/material/Typography'
 import { defaultRegistry } from '../../stats'
 import type { StatDisplayConfig } from '../../types/filters'
 import { SectionHeading } from './SectionHeading'
+import { getStatConfigsInDisplayOrder } from './stat-display-order'
 
 interface StatisticsConfigSectionProps {
   pendingStatDisplayConfigs: StatDisplayConfig[]
@@ -39,10 +40,11 @@ export const StatisticsConfigSection = ({
         )}
       </SectionHeading>
       <List dense style={{ maxHeight: 200, overflow: 'auto' }}>
-        {pendingStatDisplayConfigs
-          .filter(config => config.id !== 'playerName') // playerNameはヘッダーに常に表示されるため除外
-          .sort((a, b) => a.order - b.order)
-          .map((config, index) => {
+        {/* 一覧・↑↓のdisabled判定・handleStatOrderChangeの移動単位は、
+            すべてこの同じ表示リスト基準（playerNameを除外しorderでソート）で
+            なければならない。ズレるとデッドクリックになる。 */}
+        {getStatConfigsInDisplayOrder(pendingStatDisplayConfigs)
+          .map((config, index, displayedConfigs) => {
             const statDef = defaultRegistry.get(config.id)
             return (
               <ListItem key={config.id} style={{ paddingLeft: 0, paddingRight: 0 }}>
@@ -55,7 +57,7 @@ export const StatisticsConfigSection = ({
                 </IconButton>
                 <IconButton
                   size="small"
-                  disabled={index === pendingStatDisplayConfigs.filter(c => c.id !== 'playerName').length - 1}
+                  disabled={index === displayedConfigs.length - 1}
                   onClick={() => handleStatOrderChange(config.id, 'down')}
                 >
                   ↓

--- a/src/components/popup/stat-display-order.test.ts
+++ b/src/components/popup/stat-display-order.test.ts
@@ -1,0 +1,118 @@
+import type { StatDisplayConfig } from '../../types/filters'
+import { defaultStatDisplayConfigs } from '../../stats'
+import { getStatConfigsInDisplayOrder, moveStatInDisplayOrder } from './stat-display-order'
+
+/**
+ * ポップアップの統計並べ替えロジックのユニットテスト。
+ *
+ * 中核の不変条件: 1クリック = 表示リスト上で1段移動。
+ * 表示されない`playerName`のスロットを跨ぐ移動でも「見た目が変わらない
+ * デッドクリック」を発生させない。
+ */
+describe('getStatConfigsInDisplayOrder', () => {
+  it('playerNameを除外しorderの昇順で返す', () => {
+    const configs: StatDisplayConfig[] = [
+      { id: 'vpip', enabled: true, order: 2 },
+      { id: 'playerName', enabled: true, order: 1 },
+      { id: 'hands', enabled: true, order: 0 },
+    ]
+
+    expect(getStatConfigsInDisplayOrder(configs).map(config => config.id)).toEqual(['hands', 'vpip'])
+  })
+
+  it('入力配列を破壊しない（sortのin-place副作用を漏らさない）', () => {
+    const configs: StatDisplayConfig[] = [
+      { id: 'vpip', enabled: true, order: 2 },
+      { id: 'playerName', enabled: true, order: 1 },
+      { id: 'hands', enabled: true, order: 0 },
+    ]
+
+    getStatConfigsInDisplayOrder(configs)
+
+    expect(configs.map(config => config.id)).toEqual(['vpip', 'playerName', 'hands'])
+  })
+})
+
+describe('moveStatInDisplayOrder', () => {
+  const displayOrderOf = (configs: StatDisplayConfig[]) =>
+    getStatConfigsInDisplayOrder(configs).map(config => config.id)
+
+  // 表示されないplayerNameがhandsとvpipの間（order 1）に挟まる既定構成。
+  // 生配列インデックスで隣接要素とorderを交換する実装は、ここでデッドクリック
+  // （↑を押しても表示順が変わらない）になっていた。
+  const configs: StatDisplayConfig[] = [
+    { id: 'hands', enabled: true, order: 0 },
+    { id: 'playerName', enabled: true, order: 1 },
+    { id: 'vpip', enabled: true, order: 2 },
+    { id: 'vpipF', enabled: false, order: 3 },
+  ]
+
+  it('1回の↑で表示リスト上を必ず1段だけ移動する（playerNameを跨ぐケース）', () => {
+    const moved = moveStatInDisplayOrder(configs, 'vpip', 'up')
+
+    expect(displayOrderOf(moved!)).toEqual(['vpip', 'hands', 'vpipF'])
+  })
+
+  it('1回の↓で表示リスト上を必ず1段だけ移動する（playerNameを跨ぐケース）', () => {
+    const moved = moveStatInDisplayOrder(configs, 'hands', 'down')
+
+    expect(displayOrderOf(moved!)).toEqual(['vpip', 'hands', 'vpipF'])
+  })
+
+  it('非表示のplayerNameは表示リストの並べ替えに巻き込まれない（自身のスロットに据え置き）', () => {
+    const moved = moveStatInDisplayOrder(configs, 'vpip', 'up')!
+
+    // playerNameは元のスロット（前後1件ずつの間）に残ったまま、
+    // 全体のorderが0..n-1に振り直される
+    expect(moved.map(config => ({ id: config.id, order: config.order }))).toEqual([
+      { id: 'vpip', order: 0 },
+      { id: 'playerName', order: 1 },
+      { id: 'hands', order: 2 },
+      { id: 'vpipF', order: 3 },
+    ])
+  })
+
+  it('表示リストの端を越える移動はnullを返す（未適用フラグを立てさせない）', () => {
+    expect(moveStatInDisplayOrder(configs, 'hands', 'up')).toBeNull()
+    expect(moveStatInDisplayOrder(configs, 'vpipF', 'down')).toBeNull()
+  })
+
+  it('未知のIDはnullを返す', () => {
+    expect(moveStatInDisplayOrder(configs, 'unknownStat', 'up')).toBeNull()
+  })
+
+  it('order重複があっても1クリックで1段だけ動く（order交換ではなく振り直し）', () => {
+    // mergeStatDisplayConfigsは新規統計にデフォルトorderを、既存統計には
+    // ユーザー保存orderを与えるため、両者が衝突した設定が実在しうる。
+    // order値の交換だと衝突時に見た目が変わらないデッドクリックになる。
+    const duplicated: StatDisplayConfig[] = [
+      { id: 'hands', enabled: true, order: 0 },
+      { id: 'vpip', enabled: true, order: 1 },
+      { id: 'pfr', enabled: true, order: 1 },
+    ]
+
+    const moved = moveStatInDisplayOrder(duplicated, 'pfr', 'up')!
+
+    expect(displayOrderOf(moved)).toEqual(['hands', 'pfr', 'vpip'])
+    expect(moved.map(config => config.order)).toEqual([0, 1, 2])
+  })
+
+  it('enabledなど他のフィールドを保持する', () => {
+    const moved = moveStatInDisplayOrder(configs, 'vpipF', 'up')!
+
+    expect(moved.find(config => config.id === 'vpipF')).toEqual({ id: 'vpipF', enabled: false, order: 2 })
+  })
+
+  it('入力の要素をコピーして返す（defaultStatDisplayConfigsを汚染しない）', () => {
+    const before = defaultStatDisplayConfigs.map(config => ({ ...config }))
+
+    // Popupの初期stateはdefaultStatDisplayConfigsそのもの。
+    // 要素をその場で書き換える実装だとモジュールレベルの既定構成が壊れる。
+    const moved = moveStatInDisplayOrder(defaultStatDisplayConfigs, 'vpip', 'up')!
+
+    expect(defaultStatDisplayConfigs).toEqual(before)
+    moved.forEach(config => {
+      expect(defaultStatDisplayConfigs).not.toContain(config)
+    })
+  })
+})

--- a/src/components/popup/stat-display-order.ts
+++ b/src/components/popup/stat-display-order.ts
@@ -1,0 +1,73 @@
+import type { StatDisplayConfig } from '../../types/filters'
+
+/**
+ * ポップアップの並べ替えリストに載らない統計。
+ *
+ * `playerName`はHUDヘッダーに常時表示されるため、ユーザーが順序を操作できる
+ * 対象ではない（StatisticsConfigSectionの一覧から除外される）。
+ */
+const HIDDEN_STAT_IDS: readonly string[] = ['playerName']
+
+export const isStatListedInPopup = (config: StatDisplayConfig): boolean =>
+  !HIDDEN_STAT_IDS.includes(config.id)
+
+/**
+ * ポップアップの並べ替えリストに表示される統計を、表示順（orderの昇順）で返す。
+ *
+ * これがユーザーに見えている唯一の順序であり、↑↓の移動単位・
+ * disabled判定（先頭/末尾）はすべてこのリスト基準でなければならない。
+ */
+export const getStatConfigsInDisplayOrder = (
+  configs: StatDisplayConfig[]
+): StatDisplayConfig[] =>
+  configs.filter(isStatListedInPopup).sort((a, b) => a.order - b.order)
+
+/**
+ * 表示リスト上で統計を1つ上/下に移動した新しい設定配列を返す。
+ * 移動できない場合（未知のID・すでに端）はnullを返す。
+ *
+ * 基準は必ず「表示リスト」であって、statDisplayConfigsの生の配列インデックス
+ * ではない。生配列の隣接要素とorderを交換する実装では、表示上は隣り合って
+ * いない`playerName`と入れ替わるケース（VPIPの↑1回目、HANDの↓1回目）で
+ * 表示順が全く変化しないデッドクリックになる。
+ *
+ * 非表示項目は元のスロット位置に据え置き、表示項目だけを入れ替えたうえで
+ * order全体を0..n-1に振り直す。order値の交換ではなく振り直しにしているのは、
+ * order重複があっても1クリック=1段の移動を保証するため（mergeStatDisplayConfigs
+ * は新規統計にデフォルトorderを、既存統計にユーザー保存orderを与えるので、
+ * 両者が衝突した設定が実在しうる）。
+ *
+ * 要素は必ずコピーしてから書き換える: 呼び出し側のconfigsは
+ * `defaultStatDisplayConfigs`の要素をそのまま参照しうる（Popupの初期state、
+ * および`mergeStatDisplayConfigs`の新規統計パス）ため、その場でorderを
+ * 書き換えるとモジュールレベルのデフォルト構成を汚染する。
+ */
+export const moveStatInDisplayOrder = (
+  configs: StatDisplayConfig[],
+  statId: string,
+  direction: 'up' | 'down'
+): StatDisplayConfig[] | null => {
+  // 表示リストと同じ順序で全項目を並べる（Array.prototype.sortは安定ソート）
+  const sortedConfigs = [...configs].sort((a, b) => a.order - b.order)
+
+  // 表示項目が入っているスロット位置（非表示項目のスロットは含まない）
+  const listedSlots = sortedConfigs.reduce<number[]>((slots, config, slot) => {
+    if (isStatListedInPopup(config)) slots.push(slot)
+    return slots
+  }, [])
+
+  const listedIndex = listedSlots.findIndex(slot => sortedConfigs[slot]!.id === statId)
+  if (listedIndex === -1) return null
+
+  const targetIndex = direction === 'up' ? listedIndex - 1 : listedIndex + 1
+  if (targetIndex < 0 || targetIndex >= listedSlots.length) return null
+
+  // 表示リスト上で隣接する2項目を入れ替える（非表示項目のスロットは据え置き）
+  const fromSlot = listedSlots[listedIndex]!
+  const toSlot = listedSlots[targetIndex]!
+  const reordered = [...sortedConfigs]
+  reordered[fromSlot] = sortedConfigs[toSlot]!
+  reordered[toSlot] = sortedConfigs[fromSlot]!
+
+  return reordered.map((config, order) => ({ ...config, order }))
+}


### PR DESCRIPTION
## 概要

ポップアップの「HUD表示設定」で統計の並べ替え ↑↓ を押しても、表示順が全く変化しないケース（デッドクリック）を修正します。

`Popup.tsx` の `handleStatOrderChange()` は `pendingStatDisplayConfigs`（全19件）の**生配列インデックス**で隣接要素と `order` を交換していましたが、`StatisticsConfigSection.tsx` の表示リストは `playerName`（HUDヘッダーに常時表示されるため）を `filter` で除外しています。

結果、表示上は隣り合っていない `playerName`（order 1）と入れ替わるケースで、ボタンを押しても見た目が変わらないデッドクリックになっていました。

- 表示リスト先頭は `[HAND, VPIP, VPIP·F, ...]`（playerNameは非表示）
- **VPIP（表示2番目）の ↑ を1回押す → 表示順は変化なし**。ただし「(未適用の変更があります)」バナーは出る
- もう1回 ↑ を押すとようやく `[VPIP, HAND, VPIP·F]` に動く
- 同様に **HAND（表示1番目）の ↓ 1回目**も playerName と入れ替わるだけで見た目が変わらない

## 変更内容

表示リストの構築ロジックを `src/components/popup/stat-display-order.ts` に純関数として切り出し、**一覧表示・↑↓の disabled 判定・並べ替えの3箇所すべてが同じ基準を共有する**ようにしました。

- `Popup.tsx` — `moveStatInDisplayOrder()` に委譲。移動不可（未知ID／すでに端）なら `null` を返し、state も未適用フラグも更新しない
- `StatisticsConfigSection.tsx` — 同じ `getStatConfigsInDisplayOrder()` を使用。↓の disabled 判定にあった行ごとの再 filter も解消

### `moveStatInDisplayOrder()` の設計

- 非表示項目（`playerName`）は元のスロット位置に据え置き、表示項目だけを入れ替えてから `order` 全体を 0..n-1 に振り直す
- **order 値の交換ではなく振り直し**にしたのは、order の重複が実在しうるため。`mergeStatDisplayConfigs` は新規統計にデフォルト order を、既存統計にユーザー保存 order を与えるので、両者が衝突した設定では order 交換だと再びデッドクリックになります
- 要素は必ず `{...config, order}` でコピー。**修正前は配列のシャローコピーのみ**で `currentConfig.order = ...` が共有要素をその場で書き換えており、Popup の初期 state と `mergeStatDisplayConfigs` の新規統計パス（`return defaultConfig`）経由で module-level の `defaultStatDisplayConfigs` を汚染していました。今回併せて解消しています

## テスト

`Popup.test.tsx` に `describe('統計の並べ替え（未適用の変更）')` を新設、`stat-display-order.test.ts` に純関数のユニットテスト10件を追加しました。

修正前の実装に対して意図どおり落ちることを確認済みです（`git stash` で `Popup.tsx` のみ旧実装に戻して実測、4件 fail）:

- ↑1回で表示順が1つ動く（VPIP ↑ → `[VPIP, HAND, VPIP·F]`）
- ↓1回でも動く（HAND ↓）
- 適用後の永続化・配信内容（`playerName` は order 1 のまま据え置き）
- `defaultStatDisplayConfigs` を汚染しない

`npm run test`（161スイート / 1672テスト）と `npm run typecheck` はいずれも green です。エンティティ導出・統計計算には触れていないため `verify-stats` / `REBUILD_ADVISORY_VERSION` の対象外です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
