### PR TITLE
docs: 5.4.0のCHANGELOGに欠落した#315を追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * **ui:** ハンドログのヘッダーを右上グリップへ置換し画面内へ収める ([#305](https://github.com/solavrc/pokerchase-hud/issues/305)) ([7b4270f](https://github.com/solavrc/pokerchase-hud/commit/7b4270fa07a769a95981a8513d9477ad571e0789))
 * **ui:** ハンドログの行高を実測した折り返しから算出する ([#306](https://github.com/solavrc/pokerchase-hud/issues/306)) ([0de29dc](https://github.com/solavrc/pokerchase-hud/commit/0de29dca667ff7b65612b3749236b0e15345a204))
 * **ui:** ハンドログの行高を実測した折り返し幅から算出する ([#309](https://github.com/solavrc/pokerchase-hud/issues/309)) ([43efa79](https://github.com/solavrc/pokerchase-hud/commit/43efa798125c488b732ed0fcb093699ad87227a4))
+* **ui:** 更新情報リンクをGitHub Releases一覧に固定する ([#315](https://github.com/solavrc/pokerchase-hud/issues/315)) ([f77bba9](https://github.com/solavrc/pokerchase-hud/commit/f77bba9177c593cefa4ecb29f4d4d3b6193e9fbc))
 * **ui:** 統計の並べ替えでdefaultStatDisplayConfigsを汚染しない ([#313](https://github.com/solavrc/pokerchase-hud/issues/313)) ([5615e54](https://github.com/solavrc/pokerchase-hud/commit/5615e54faf0ad00a7bbb3355a9a0b152a4a0581d))
 * **ui:** 統計並べ替えの↑↓が1回で動かないデッドクリックを修正 ([#314](https://github.com/solavrc/pokerchase-hud/issues/314)) ([30f91f7](https://github.com/solavrc/pokerchase-hud/commit/30f91f7b0c4e66daff7be950967dfc319e6b2942))
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -387,7 +387,12 @@ Note: The system uses TypeScript enums for type safety, so new flags must be add
 2. Keep each branch and pull request focused on one change.
 3. Use Conventional Commit-style commit messages and PR titles (for example,
    `feat: add four-bet statistic` or `fix: preserve session state`). Release Please
-   uses these titles when preparing releases and the changelog.
+   uses these titles when preparing releases and the changelog. Release Please
+   parses the **whole** message, body included, so never let a parenthesis pair
+   span a line break — the parser stops at the newline waiting for `)`, fails the
+   whole commit with `commit could not be parsed`, and silently drops it from the
+   changelog and the Release body (this happened to #315 in 5.4.0). Keep each
+   `(…)` on one line, or rewrite without parentheses.
 4. Add or update tests with the implementation. Statistics tests belong beside the
    implementation in `src/stats/core/`.
 5. Before opening a ready-for-review PR, run `npm run typecheck`, `npm test`, and


### PR DESCRIPTION
## 概要

5.4.0 のリリース作業中に、[#315](https://github.com/solavrc/pokerchase-hud/pull/315) の commit が release-please に解析されず、CHANGELOG と Release 本文の両方から欠落していたことが判明した。Release 本文は公開時に手動で補ったので、恒久的な記録である `CHANGELOG.md` を修正し、再発防止をコミット規約に追加する。

## 何が起きたか

`Release Please` workflow のログ:

```
commit could not be parsed: f77bba9 fix(ui): 更新情報リンクをGitHub Releases一覧に固定する (#315)
error message: Error: unexpected token ' ' at 8:44, valid tokens [)]
```

原因は commit 本文の8行目で半角括弧の対が改行をまたいでいたこと。release-please は subject だけでなく本文全体を conventional-commits パーサにかけるため、閉じ括弧を待って改行に当たると **その commit 全体を破棄**する。バージョン判定にも changelog にも寄与せず、警告はワークフローログにしか出ないため気付きにくい。

## 変更内容

- `CHANGELOG.md`: 5.4.0 の Bug Fixes に #315 の行を追記。挿入位置は release-please 自身の並び順に合わせた
- `CONTRIBUTING.md`: commit 規約に「括弧の対を改行でまたがせない」を追加。失敗時の症状まで書いて、次に踏んだ人がログを見なくても気付けるようにした

`.release-please-manifest.json` やバージョンには触れていない。5.4.0 は公開済みで、成果物と本文は修正不要。

## 検証

Markdown のみの変更。リンク先の commit SHA と PR 番号が実在することを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)