### PR TITLE
feat(ui): Chromeウェブストアのレビュー依頼バナーを追加する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -857,7 +857,10 @@ Every live raw `EVT_HAND_RESULTS` row MUST atomically create a pending-derivatio
   is routed through the trusted background via `getDeviceUILayout`,
   `setDeviceUIScale`, `setDeviceHudPosition`, `getDeviceHandLogLayout`,
   `setDeviceHandLogLayout`, and `resetDeviceUILayout`; content scripts do
-  not access the restricted local area directly.
+  not access the restricted local area directly. Popup-facing banner state
+  lives here too and is read directly by the popup: `rebuildAdvisory`,
+  `pendingUpdate`, `minVersionGateState`, `whatsNewUnseenVersion`, and
+  `reviewPrompt` (see "Chrome Web Store review prompt" below).
 - **Layout reset is one operation over every device-local appearance key**:
   the popup's 「位置とサイズをリセット」 (`UIScaleSection.tsx`) sends a single
   `resetDeviceUILayout`, and the background removes `handLogLayout` and every
@@ -969,3 +972,15 @@ sola-approved: GitHub Releases are the single source of truth for user-facing up
 - **Badge logic** (`src/background/whats-new-badge.ts`): `chrome.runtime.onInstalled` (`reason === 'update'` only — fresh installs do not get an update badge) records every running version in the legacy-compatible `whatsNewUnseenVersion` storage key, independent of whether a Release can be fetched. `PopupHeader` sends the idempotent `acknowledgeWhatsNew` message after the version and the Releases link are visible.
 - **Badge precedence (3-way): rebuild-advisory > update-manager > whats-new.** `resolveActiveBadge()` remains the single source of truth and is covered by all eight boolean combinations. The informational badge sets `N` only when neither higher-priority badge is active, and it never clears a higher-priority badge.
 - **Service Worker startup reassertion**: `reassertWhatsNewBadgeOnStartup()` runs after `initUpdateManager()` finishes its startup cleanup. A still-unseen informational badge suppressed by rebuild/update state can therefore be promoted on a later startup without extra session/operation hooks.
+
+### Chrome Web Store review prompt
+
+sola-approved request to rate the extension on the Chrome Web Store. Popup-only by design: **no badge, no `chrome.notifications`, no HUD surface** — it must never interrupt play, and it is the one banner that always fails quiet (any uncertainty resolves to "don't ask").
+
+- **Eligibility** (`src/background/review-prompt.ts`): evaluated *only* when the popup mounts (`getReviewPrompt` message). No `event-ingestion.ts` hook and no per-hand counter exist for this — `db.hands.count()` is a native IndexedDB count, cheap enough to run on popup open. It must reach `REVIEW_PROMPT_MIN_HANDS` (500, `src/constants/review-prompt.ts`); the first crossing latches `eligibleSince` into `chrome.storage.local`'s `reviewPrompt` and the count never runs again (a later 全データ削除 does not un-latch it). A resolved prompt short-circuits before the count.
+- **State machine** (pure `isReviewPromptVisible()`, unit-tested independent of storage): 「評価する」/「今後表示しない」 (`rated`/`dismissed`) are terminal — never shown again, and a later `later` cannot revive them. 「後で」 snoozes for `REVIEW_PROMPT_SNOOZE_MS` (30 days). A `snoozedAt` in the future (clock skew / hand-edited storage) keeps the banner hidden rather than showing it early. `parseReviewPromptState()` normalizes corrupted values instead of throwing or silently dropping a recorded resolution.
+- **Precedence**: `ReviewPromptSection.tsx` hides itself whenever rebuild-advisory (`pendingVersion`), a pending update, or the min-version gate (`supported === false`) is active — the same rebuild > update > informational ordering as the badge precedence above. Asking for a 5-star review next to 「サポートが終了しました」 is exactly what this prevents. The suppression keys are read once at mount (no `onChanged` subscription): a banner appearing while the popup is already open is cosmetic, and the popup is short-lived.
+- **Link**: `https://chromewebstore.google.com/detail/${chrome.runtime.id}/reviews`, built at runtime (`buildChromeWebStoreReviewUrl()`). The slug-less form 301-redirects to `/detail/pokerchase-hud/<id>/reviews` (measured 2026-07-31), so the store listing name can change without breaking the link, and a fork (different manifest `key` → different ID) links to its own listing. Same rationale as `GITHUB_RELEASES_URL` above: do not hard-code what the runtime already knows.
+- **Ordering guarantee**: 「評価する」 awaits the `resolveReviewPrompt` round-trip *before* `chrome.tabs.create()`, because opening a tab tears the popup down and a fire-and-forget write could be lost — the user would then be asked again after already reviewing. On timeout it still opens the store page (user intent wins; the cost is one extra ask later).
+- **Store imagery is unaffected**: `e2e/tools/capture-store-imagery.ts` captures a fixture of 11 hands, far below the threshold, so the banner can never leak into Web Store screenshots.
+- Ownership: eligibility, snooze, and resolution all live in the background module; the popup component only renders the boolean it is handed and reports which button was pressed. Keep the `reviewPrompt` key single-writer (background) if this is extended.

--- a/docs/file-organization.md
+++ b/docs/file-organization.md
@@ -88,6 +88,7 @@
     │   ├── operation-state.ts       # Long-operation exclusivity + idle-transition listeners
     │   ├── ports.ts                 # Port lifecycle, ACTIVE-only stats delivery, hand-completion epoch
     │   ├── rebuild-advisory.ts      # データ再構築 advisory (REBUILD_ADVISORY_VERSION, badge)
+    │   ├── review-prompt.ts         # Chrome Web Store review prompt (hand-count gate, snooze)
     │   ├── undecoded-event-tracker.ts # Dropped/undecoded event counters (popup alert)
     │   ├── update-manager.ts        # Forced update: safe-window, drain barrier,
     │   │                            #   commitReloadIfStillSafe(), pending-update persistence
@@ -120,8 +121,8 @@
     │       ├── HudDisplaySection.tsx    # Display mode toggle (簡易/詳細)
     │       ├── ImportExportSection.tsx
     │       ├── PopupHeader.tsx          # Theme icon toggle (自動→ライト→ダーク)
+    │       ├── ReviewPromptSection.tsx  # Chrome Web Store review request banner
     │       ├── SectionCard.tsx / SectionHeading.tsx / ToggleChip.tsx
-    │       ├── toggleGroupStyles.ts     # Shared width for the two top toggles
     │       ├── StatisticsConfigSection.tsx
     │       ├── SyncStatusSection.tsx
     │       ├── TableSizeFilterSection.tsx # テーブル人数 filter (full/4p/3p/hu)
@@ -129,13 +130,15 @@
     │       ├── UndecodedEventSection.tsx  # Dropped-event alert
     │       ├── UpdateSection.tsx          # Forced-update / min-version banners
     │       ├── popup-boot-theme.ts / popup-theme-storage.ts / theme.ts  # Dark/light theming
-    │       └── send-message.ts
+    │       ├── send-message.ts
+    │       └── toggleGroupStyles.ts     # Shared width for the two top toggles
     │
     ├── constants/
     │   ├── database.ts        # DATABASE_CONSTANTS, REBUILD_ADVISORY_VERSION
     │   ├── runtime.ts         # Runtime constants
     │   ├── update.ts          # Forced-update constants (side-effect-free)
-    │   └── release-info.ts    # Fixed GitHub Releases URL + unread storage key
+    │   ├── release-info.ts    # Fixed GitHub Releases URL + unread storage key
+    │   └── review-prompt.ts   # Review-prompt state/thresholds + visibility rule (pure)
     │
     ├── db/
     │   └── poker-chase-db.ts  # Dexie database definition (v7 schema: sequence-key Lake + replayDetails)

--- a/src/background/message-router.review-prompt.test.ts
+++ b/src/background/message-router.review-prompt.test.ts
@@ -1,0 +1,111 @@
+/**
+ * message-router.ts - getReviewPrompt / resolveReviewPrompt plumbing
+ *
+ * Verifies the Chrome Web Store review-prompt messages are wired end-to-end:
+ * `getReviewPrompt` answers from the `hands` table of the DB the router was
+ * registered with (not some other instance), `resolveReviewPrompt` persists
+ * the pressed button, and a failing DB surfaces as an error response rather
+ * than a fabricated `visible` value.
+ */
+import { IDBKeyRange, indexedDB } from 'fake-indexeddb'
+import PokerChaseService, { PokerChaseDB } from '../app'
+import { registerMessageRouter } from './message-router'
+import {
+  REVIEW_PROMPT_MIN_HANDS,
+  REVIEW_PROMPT_STORAGE_KEY,
+  type ReviewPromptState,
+} from '../constants/review-prompt'
+import type { ChromeMessage, MessageResponse } from '../types/messages'
+
+const settle = () => new Promise(resolve => setTimeout(resolve, 50))
+
+const readState = async (): Promise<ReviewPromptState> =>
+  (await chrome.storage.local.get(REVIEW_PROMPT_STORAGE_KEY))?.[REVIEW_PROMPT_STORAGE_KEY] ?? {}
+
+describe('message-router review prompt', () => {
+  let db: PokerChaseDB
+  let service: PokerChaseService
+  let listener: (request: ChromeMessage, sender: chrome.runtime.MessageSender, sendResponse: (response: MessageResponse) => void) => boolean | void
+
+  const send = async (message: ChromeMessage) => {
+    const sendResponse = jest.fn()
+    const handled = listener(message, {}, sendResponse)
+    expect(handled).toBe(true)
+    await settle()
+    expect(sendResponse).toHaveBeenCalledTimes(1)
+    return sendResponse.mock.calls[0]![0] as any
+  }
+
+  /** Minimal rows: only the row count matters to the eligibility gate. */
+  const seedHands = (count: number) =>
+    db.hands.bulkAdd(Array.from({ length: count }, (_unused, index) => ({
+      // `hands` uses an explicit (non auto-increment) `id` primary key
+      id: index + 1,
+      approxTimestamp: index,
+      seatUserIds: [],
+      winningPlayerIds: [],
+      smallBlind: 0,
+      bigBlind: 0,
+      session: { id: 'test', battleType: undefined, name: undefined },
+      results: [],
+    }) as any))
+
+  beforeEach(async () => {
+    db = new PokerChaseDB(indexedDB, IDBKeyRange)
+    await db.open()
+    service = new PokerChaseService({ db })
+    await service.ready
+
+    ;(chrome.runtime.onMessage.addListener as jest.Mock).mockClear()
+    registerMessageRouter(service, db, 'https://example.com/*')
+    listener = (chrome.runtime.onMessage.addListener as jest.Mock).mock.calls[0][0]
+  })
+
+  afterEach(async () => {
+    db.close()
+    await db.delete()
+  })
+
+  test('getReviewPrompt responds visible:false while the hands table is below the threshold', async () => {
+    await seedHands(REVIEW_PROMPT_MIN_HANDS - 1)
+
+    expect(await send({ action: 'getReviewPrompt' } as ChromeMessage)).toEqual({
+      success: true,
+      visible: false,
+    })
+    expect(await readState()).toEqual({})
+  })
+
+  test('getReviewPrompt responds visible:true from the registered db once the threshold is reached', async () => {
+    await seedHands(REVIEW_PROMPT_MIN_HANDS)
+
+    expect(await send({ action: 'getReviewPrompt' } as ChromeMessage)).toEqual({
+      success: true,
+      visible: true,
+    })
+    expect((await readState()).eligibleSince).toEqual(expect.any(Number))
+  })
+
+  test('resolveReviewPrompt persists the pressed button and later prompts stay hidden', async () => {
+    await chrome.storage.local.set({ [REVIEW_PROMPT_STORAGE_KEY]: { eligibleSince: 1 } })
+
+    expect(await send({ action: 'resolveReviewPrompt', choice: 'dismissed' } as ChromeMessage))
+      .toEqual({ success: true })
+
+    const state = await readState()
+    expect(state.resolution).toBe('dismissed')
+    expect(await send({ action: 'getReviewPrompt' } as ChromeMessage)).toEqual({
+      success: true,
+      visible: false,
+    })
+  })
+
+  test('getReviewPrompt reports an error instead of a fabricated answer when the db is unavailable', async () => {
+    db.close()
+
+    const response = await send({ action: 'getReviewPrompt' } as ChromeMessage)
+    expect(response.success).toBe(false)
+    expect(response.error).toEqual(expect.any(String))
+    expect(response.visible).toBeUndefined()
+  })
+})

--- a/src/background/message-router.review-prompt.test.ts
+++ b/src/background/message-router.review-prompt.test.ts
@@ -16,6 +16,7 @@ import {
   type ReviewPromptState,
 } from '../constants/review-prompt'
 import type { ChromeMessage, MessageResponse } from '../types/messages'
+import { trackServiceForTeardown } from '../utils/test-service-teardown'
 
 const settle = () => new Promise(resolve => setTimeout(resolve, 50))
 
@@ -53,7 +54,7 @@ describe('message-router review prompt', () => {
   beforeEach(async () => {
     db = new PokerChaseDB(indexedDB, IDBKeyRange)
     await db.open()
-    service = new PokerChaseService({ db })
+    service = trackServiceForTeardown(new PokerChaseService({ db }))
     await service.ready
 
     ;(chrome.runtime.onMessage.addListener as jest.Mock).mockClear()

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -17,6 +17,7 @@ import { resolveAdvisory } from './rebuild-advisory'
 import { getUndecodedEventStats, resetUndecodedEventStats } from './undecoded-event-tracker'
 import { applyUpdateNow } from './update-manager'
 import { acknowledgeWhatsNew } from './whats-new-badge'
+import { evaluateReviewPromptVisibility, resolveReviewPrompt } from './review-prompt'
 import {
   HAND_LOG_LAYOUT_STORAGE_KEY,
   HUD_POSITION_STORAGE_KEYS,
@@ -954,6 +955,24 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
         .then(() => sendResponse({ success: true }))
         .catch(error => {
           console.error('[acknowledgeWhatsNew] Error:', error)
+          sendResponse({ success: false, error: error.message })
+        })
+      return true
+    } else if (request.action === 'getReviewPrompt') {
+      // Popup起動時: 累計ハンド数・スヌーズ・決着からレビュー依頼の表示可否を判定
+      evaluateReviewPromptVisibility(db)
+        .then(visible => sendResponse({ success: true, visible }))
+        .catch(error => {
+          console.error('[getReviewPrompt] Error:', error)
+          sendResponse({ success: false, error: error.message })
+        })
+      return true
+    } else if (request.action === 'resolveReviewPrompt') {
+      // Popupの「評価する」「後で」「今後表示しない」操作を記録
+      resolveReviewPrompt(request.choice)
+        .then(() => sendResponse({ success: true }))
+        .catch(error => {
+          console.error('[resolveReviewPrompt] Error:', error)
           sendResponse({ success: false, error: error.message })
         })
       return true

--- a/src/background/review-prompt.test.ts
+++ b/src/background/review-prompt.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for the review-prompt background logic
+ * (src/background/review-prompt.ts).
+ *
+ * Covers: the hand-count gate and its one-way latch, the snooze/resolution
+ * bookkeeping, and the two properties that keep this from becoming a nag —
+ * a resolved prompt never queries the DB again and never comes back.
+ */
+import {
+  evaluateReviewPromptVisibility,
+  getReviewPromptState,
+  resolveReviewPrompt,
+} from './review-prompt'
+import {
+  REVIEW_PROMPT_MIN_HANDS,
+  REVIEW_PROMPT_SNOOZE_MS,
+  REVIEW_PROMPT_STORAGE_KEY,
+} from '../constants/review-prompt'
+import type { PokerChaseDB } from '../db/poker-chase-db'
+
+const NOW = 1_800_000_000_000
+
+describe('review-prompt (background)', () => {
+  let mockDb: jest.Mocked<PokerChaseDB>
+  let handCount: jest.Mock
+
+  beforeEach(async () => {
+    await chrome.storage.local.set({ [REVIEW_PROMPT_STORAGE_KEY]: undefined })
+    jest.clearAllMocks()
+
+    handCount = jest.fn()
+    mockDb = { hands: { count: handCount } } as any
+  })
+
+  describe('evaluateReviewPromptVisibility', () => {
+    it('累計ハンド数が閾値未満なら表示せず、状態も記録しない', async () => {
+      handCount.mockResolvedValue(REVIEW_PROMPT_MIN_HANDS - 1)
+
+      expect(await evaluateReviewPromptVisibility(mockDb, NOW)).toBe(false)
+      expect(await getReviewPromptState()).toEqual({})
+    })
+
+    it('閾値に到達したら表示し、eligibleSinceを記録する', async () => {
+      handCount.mockResolvedValue(REVIEW_PROMPT_MIN_HANDS)
+
+      expect(await evaluateReviewPromptVisibility(mockDb, NOW)).toBe(true)
+      expect(await getReviewPromptState()).toEqual({ eligibleSince: NOW })
+    })
+
+    it('一度eligibleになったら以降はハンド数を数え直さない（全データ削除後も降りない）', async () => {
+      handCount.mockResolvedValue(REVIEW_PROMPT_MIN_HANDS)
+      await evaluateReviewPromptVisibility(mockDb, NOW)
+      handCount.mockClear()
+      handCount.mockResolvedValue(0)
+
+      expect(await evaluateReviewPromptVisibility(mockDb, NOW + 1)).toBe(true)
+      expect(handCount).not.toHaveBeenCalled()
+    })
+
+    it('決着済みなら表示せず、DBへの問い合わせも行わない', async () => {
+      await chrome.storage.local.set({
+        [REVIEW_PROMPT_STORAGE_KEY]: { eligibleSince: NOW, resolution: 'rated', resolvedAt: NOW },
+      })
+
+      expect(await evaluateReviewPromptVisibility(mockDb, NOW + 1)).toBe(false)
+      expect(handCount).not.toHaveBeenCalled()
+    })
+
+    it('スヌーズ中は表示せず、期間が明けたら再表示する', async () => {
+      await chrome.storage.local.set({
+        [REVIEW_PROMPT_STORAGE_KEY]: { eligibleSince: NOW, snoozedAt: NOW },
+      })
+
+      expect(await evaluateReviewPromptVisibility(mockDb, NOW + REVIEW_PROMPT_SNOOZE_MS - 1)).toBe(false)
+      expect(await evaluateReviewPromptVisibility(mockDb, NOW + REVIEW_PROMPT_SNOOZE_MS)).toBe(true)
+    })
+  })
+
+  describe('resolveReviewPrompt', () => {
+    beforeEach(async () => {
+      await chrome.storage.local.set({ [REVIEW_PROMPT_STORAGE_KEY]: { eligibleSince: NOW } })
+    })
+
+    it('「後で」はスヌーズ時刻だけを記録する（決着にしない）', async () => {
+      await resolveReviewPrompt('later', NOW + 10)
+
+      expect(await getReviewPromptState()).toEqual({ eligibleSince: NOW, snoozedAt: NOW + 10 })
+    })
+
+    it.each(['rated', 'dismissed'] as const)('「%s」は決着として記録する', async (choice) => {
+      await resolveReviewPrompt(choice, NOW + 10)
+
+      expect(await getReviewPromptState()).toEqual({
+        eligibleSince: NOW,
+        resolution: choice,
+        resolvedAt: NOW + 10,
+      })
+      expect(await evaluateReviewPromptVisibility(mockDb, NOW + 20)).toBe(false)
+    })
+
+    it('決着済みの状態は上書きしない（「後で」で復活もしない）', async () => {
+      await resolveReviewPrompt('rated', NOW + 10)
+      await resolveReviewPrompt('later', NOW + 20)
+      await resolveReviewPrompt('dismissed', NOW + 30)
+
+      expect(await getReviewPromptState()).toEqual({
+        eligibleSince: NOW,
+        resolution: 'rated',
+        resolvedAt: NOW + 10,
+      })
+    })
+  })
+})

--- a/src/background/review-prompt.ts
+++ b/src/background/review-prompt.ts
@@ -1,0 +1,97 @@
+/** !!! CONTENT_SCRIPTS、WEB_ACCESSIBLE_RESOURCESからインポートしないこと !!! */
+/**
+ * Chrome ウェブストアのレビュー依頼（sola承認）のbackground側。
+ *
+ * 「表示してよいか」の判定と決着の記録だけを持つ。判定材料のうち
+ * 累計ハンド数（`hands`テーブル件数）はIndexedDB由来でPopupからは
+ * 触れないため（PopupバンドルにDexieを引き込まない方針、
+ * `constants/update.ts`冒頭のコメント参照）、ここで数えてPopupには
+ * boolean だけを返す。
+ *
+ * 評価タイミングはPopupを開いた瞬間のみ（`getReviewPrompt`メッセージ）。
+ * イベント取り込み経路（`event-ingestion.ts`）には一切フックしない:
+ * この機能のためにセッション終了フックやカウンタ書き込みを増やす価値は
+ * 無く、`db.hands.count()`はIndexedDBネイティブのcountで十分速い。
+ * しかも決着済み（`resolution`あり）ならcount自体を実行しない。
+ *
+ * 表示条件の判定と決着の記録がどちらもここに集約されているのが肝心で、
+ * Popup側は「表示する/しない」と「押されたボタンを送る」だけを担う
+ * （storage keyの書き込み主体をbackgroundに一本化する）。
+ */
+import type { PokerChaseDB } from '../db/poker-chase-db'
+import {
+  isReviewPromptVisible,
+  parseReviewPromptState,
+  REVIEW_PROMPT_MIN_HANDS,
+  REVIEW_PROMPT_STORAGE_KEY,
+  type ReviewPromptChoice,
+  type ReviewPromptState,
+} from '../constants/review-prompt'
+
+/** `chrome.storage.local`から現在の依頼状態を取得する（未設定なら空オブジェクト） */
+export const getReviewPromptState = async (): Promise<ReviewPromptState> => {
+  const result = await chrome.storage.local.get(REVIEW_PROMPT_STORAGE_KEY)
+  return parseReviewPromptState(result?.[REVIEW_PROMPT_STORAGE_KEY])
+}
+
+const setReviewPromptState = async (state: ReviewPromptState): Promise<void> => {
+  await chrome.storage.local.set({ [REVIEW_PROMPT_STORAGE_KEY]: state })
+}
+
+/**
+ * Popupを開いたときに呼ぶ（`getReviewPrompt`メッセージ）。
+ *
+ * まだ表示条件を満たしていない状態でのみ`hands`件数を数え、閾値に
+ * 到達していれば`eligibleSince`を記録する（一度立てば以降countしない）。
+ * 戻り値は「このPopupで依頼バナーを出してよいか」。
+ */
+export const evaluateReviewPromptVisibility = async (
+  db: PokerChaseDB,
+  now: number = Date.now()
+): Promise<boolean> => {
+  const state = await getReviewPromptState()
+  // 決着済みなら以後は何も問い合わせない（countも走らせない）
+  if (state.resolution) return false
+
+  if (state.eligibleSince === undefined) {
+    const handCount = await db.hands.count()
+    if (handCount < REVIEW_PROMPT_MIN_HANDS) return false
+    const eligible: ReviewPromptState = { ...state, eligibleSince: now }
+    await setReviewPromptState(eligible)
+    return isReviewPromptVisible(eligible, now)
+  }
+
+  return isReviewPromptVisible(state, now)
+}
+
+/**
+ * Popupのボタン操作を記録する（`resolveReviewPrompt`メッセージ）。
+ *
+ * - `rated` / `dismissed`: 決着として記録し、以後二度と表示しない。
+ *   「評価する」を実際に投稿したかは検知できないが、ストアページまで
+ *   送り出した相手に再度お願いする方が体験として悪い。
+ * - `later`: スヌーズ時刻だけ更新する（`REVIEW_PROMPT_SNOOZE_MS`後に再表示）。
+ *
+ * 決着済みの状態に対しては何もしない（後から`later`で復活させない、
+ * 最初の決着を上書きしない）。
+ */
+export const resolveReviewPrompt = async (
+  choice: ReviewPromptChoice,
+  now: number = Date.now()
+): Promise<void> => {
+  const state = await getReviewPromptState()
+  if (state.resolution) return
+
+  if (choice === 'later') {
+    await setReviewPromptState({ ...state, snoozedAt: now })
+    return
+  }
+
+  await setReviewPromptState({
+    ...state,
+    // 表示せずに決着させる経路は無いが、記録の一貫性のため補完しておく
+    eligibleSince: state.eligibleSince ?? now,
+    resolution: choice,
+    resolvedAt: now,
+  })
+}

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -44,6 +44,7 @@ import { StatisticsConfigSection } from './popup/StatisticsConfigSection'
 import { moveStatInDisplayOrder } from './popup/stat-display-order'
 import { UndecodedEventSection } from './popup/UndecodedEventSection'
 import { UpdateSection } from './popup/UpdateSection'
+import { ReviewPromptSection } from './popup/ReviewPromptSection'
 import { PopupHeader } from './popup/PopupHeader'
 import { SectionCard } from './popup/SectionCard'
 import { TelemetrySection } from './popup/TelemetrySection'
@@ -602,6 +603,11 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
         (どちらも該当時のみ描画。他セクションより先に表示し、ユーザーの
         目に触れやすくする) */}
       <UpdateSection />
+
+      {/* Chrome ウェブストアのレビュー依頼（表示条件を満たし、かつ
+        再構築/更新系バナーが出ていないときのみ描画。優先順位の判定は
+        ReviewPromptSection自身が持つ） */}
+      <ReviewPromptSection />
 
       {/* UI Display Controls */}
       <SectionCard>

--- a/src/components/popup/ReviewPromptSection.test.tsx
+++ b/src/components/popup/ReviewPromptSection.test.tsx
@@ -111,6 +111,39 @@ describe('ReviewPromptSection', () => {
     // 記録の送信がタブを開くより先（Popupは新規タブで破棄されるため）
     const resolveCallOrder = mockSendMessage.mock.invocationCallOrder.at(-1)!
     expect(resolveCallOrder).toBeLessThan((chrome.tabs.create as jest.Mock).mock.invocationCallOrder[0]!)
+    await waitFor(() => {
+      expect(screen.queryByText(PROMPT_TEXT)).not.toBeInTheDocument()
+    })
+  })
+
+  it('記録の応答待ちの間はバナーを残してボタンを無効化する（無反応の窓を作らない）', async () => {
+    const user = userEvent.setup()
+    let releaseResolve: (() => void) | undefined
+    mockSendMessage.mockImplementation((message: any, callback?: (response: any) => void) => {
+      if (message?.action === 'getReviewPrompt') {
+        callback?.({ success: true, visible: true })
+        return
+      }
+      // SWのコールドスタートで往復が延びた状態を再現する
+      releaseResolve = () => callback?.({ success: true })
+    })
+    render(<ReviewPromptSection />)
+    await findPrompt()
+
+    await user.click(screen.getByText('評価する'))
+
+    // 応答が返るまではバナーもボタンも残っている（消えたまま無反応にしない）
+    expect(screen.getByText(PROMPT_TEXT)).toBeInTheDocument()
+    expect(screen.getByText('開いています...').closest('button')).toBeDisabled()
+    expect(screen.getByText('後で').closest('button')).toBeDisabled()
+    expect(screen.getByText('今後表示しない').closest('button')).toBeDisabled()
+    expect(chrome.tabs.create).not.toHaveBeenCalled()
+
+    releaseResolve!()
+
+    await waitFor(() => {
+      expect(chrome.tabs.create).toHaveBeenCalled()
+    })
     expect(screen.queryByText(PROMPT_TEXT)).not.toBeInTheDocument()
   })
 

--- a/src/components/popup/ReviewPromptSection.test.tsx
+++ b/src/components/popup/ReviewPromptSection.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ReviewPromptSection } from './ReviewPromptSection'
+import { PENDING_UPDATE_STORAGE_KEY } from '../../constants/update'
+import { MIN_VERSION_GATE_STORAGE_KEY } from '../../services/min-version-gate'
+import { REBUILD_ADVISORY_STORAGE_KEY } from '../../background/rebuild-advisory'
+
+const PROMPT_TEXT = 'PokerChase HUD は役に立っていますか？'
+
+describe('ReviewPromptSection', () => {
+  let mockSendMessage: jest.Mock
+  let visible: boolean
+
+  const findPrompt = () => waitFor(() => screen.getByText(PROMPT_TEXT))
+
+  beforeEach(() => {
+    visible = true
+    mockSendMessage = jest.fn((message: any, callback?: (response: any) => void) => {
+      if (message?.action === 'getReviewPrompt') {
+        callback?.({ success: true, visible })
+        return
+      }
+      callback?.({ success: true })
+    })
+    global.chrome = {
+      ...global.chrome,
+      runtime: {
+        ...global.chrome.runtime,
+        id: 'ffkgffhokobiegbodhhbfannffpgakhi',
+        sendMessage: mockSendMessage,
+      },
+    } as any
+  })
+
+  it('backgroundがvisible=trueを返したら依頼バナーを表示する', async () => {
+    render(<ReviewPromptSection />)
+
+    await findPrompt()
+    expect(screen.getByText('評価する')).toBeInTheDocument()
+    expect(screen.getByText('後で')).toBeInTheDocument()
+    expect(screen.getByText('今後表示しない')).toBeInTheDocument()
+  })
+
+  it('visible=falseなら何も表示しない', async () => {
+    visible = false
+
+    const { container } = render(<ReviewPromptSection />)
+
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalled()
+    })
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('backgroundが応答しない場合は表示しない（フェイルオープンで非表示側）', async () => {
+    mockSendMessage.mockImplementation((_message: any, callback?: (response: any) => void) => {
+      callback?.(undefined)
+    })
+
+    const { container } = render(<ReviewPromptSection />)
+
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalled()
+    })
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it.each([
+    ['データ再構築アドバイザリ', REBUILD_ADVISORY_STORAGE_KEY, { pendingVersion: 2 }],
+    ['保留中アップデート', PENDING_UPDATE_STORAGE_KEY, { pending: true, version: '5.5.0' }],
+    ['サポート終了ゲート', MIN_VERSION_GATE_STORAGE_KEY, { supported: false, checkedAt: 1 }],
+  ])('%sが出ている間は表示しない（優先順位）', async (_label, key, value) => {
+    await chrome.storage.local.set({ [key]: value })
+
+    const { container } = render(<ReviewPromptSection />)
+
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalled()
+    })
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('優先度の高いバナーが解消済みなら表示する', async () => {
+    await chrome.storage.local.set({
+      [REBUILD_ADVISORY_STORAGE_KEY]: { acknowledgedVersion: 2 },
+      [PENDING_UPDATE_STORAGE_KEY]: { pending: false },
+      [MIN_VERSION_GATE_STORAGE_KEY]: { supported: true, checkedAt: 1 },
+    })
+
+    render(<ReviewPromptSection />)
+
+    await findPrompt()
+  })
+
+  it('「評価する」でresolveReviewPromptを記録してからストアのレビューページを開く', async () => {
+    const user = userEvent.setup()
+    render(<ReviewPromptSection />)
+    await findPrompt()
+
+    await user.click(screen.getByText('評価する'))
+
+    await waitFor(() => {
+      expect(chrome.tabs.create).toHaveBeenCalledWith({
+        url: 'https://chromewebstore.google.com/detail/ffkgffhokobiegbodhhbfannffpgakhi/reviews',
+      })
+    })
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      { action: 'resolveReviewPrompt', choice: 'rated' },
+      expect.any(Function)
+    )
+    // 記録の送信がタブを開くより先（Popupは新規タブで破棄されるため）
+    const resolveCallOrder = mockSendMessage.mock.invocationCallOrder.at(-1)!
+    expect(resolveCallOrder).toBeLessThan((chrome.tabs.create as jest.Mock).mock.invocationCallOrder[0]!)
+    expect(screen.queryByText(PROMPT_TEXT)).not.toBeInTheDocument()
+  })
+
+  it.each([
+    ['後で', 'later'],
+    ['今後表示しない', 'dismissed'],
+  ])('「%s」は選択を記録してバナーを閉じる（タブは開かない）', async (label, choice) => {
+    const user = userEvent.setup()
+    render(<ReviewPromptSection />)
+    await findPrompt()
+
+    await user.click(screen.getByText(label))
+
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      { action: 'resolveReviewPrompt', choice },
+      expect.any(Function)
+    )
+    expect(chrome.tabs.create).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(screen.queryByText(PROMPT_TEXT)).not.toBeInTheDocument()
+    })
+  })
+
+  it('chrome.runtime.idが取得できない異常系では表示しない', async () => {
+    global.chrome = {
+      ...global.chrome,
+      runtime: { ...global.chrome.runtime, id: undefined, sendMessage: mockSendMessage },
+    } as any
+
+    const { container } = render(<ReviewPromptSection />)
+
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalled()
+    })
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/components/popup/ReviewPromptSection.tsx
+++ b/src/components/popup/ReviewPromptSection.tsx
@@ -1,0 +1,140 @@
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Typography from '@mui/material/Typography'
+import { StarRounded } from '@mui/icons-material'
+import { useCallback, useEffect, useState } from 'react'
+import { buildChromeWebStoreReviewUrl } from '../../constants/review-prompt'
+import { PENDING_UPDATE_STORAGE_KEY, type PendingUpdateState } from '../../constants/update'
+import { MIN_VERSION_GATE_STORAGE_KEY, type MinVersionGateState } from '../../services/min-version-gate'
+import { REBUILD_ADVISORY_STORAGE_KEY, type RebuildAdvisoryState } from '../../background/rebuild-advisory'
+import type {
+  GetReviewPromptMessage,
+  ResolveReviewPromptMessage,
+  ReviewPromptResponse,
+} from '../../types/messages'
+import type { ReviewPromptChoice } from '../../constants/review-prompt'
+import { sendMessageWithTimeout } from './send-message'
+
+const REVIEW_PROMPT_MESSAGE_TIMEOUT_MS = 5000
+
+/**
+ * Chrome ウェブストアのレビュー依頼バナー（sola承認）。
+ *
+ * 表示可否の判定材料（累計ハンド数・スヌーズ・決着）はすべてbackgroundの
+ * `review-prompt.ts`が持っており、ここはその boolean を受け取って描画し、
+ * 押されたボタンを送り返すだけ（storage keyの書き込み主体をbackgroundに
+ * 一本化している）。
+ *
+ * **他バナーとの優先順位**: バッジの優先順位（rebuild > update > 情報系,
+ * AGENTS.md「Badge precedence」）と同じ考え方で、データ再構築アドバイザリ・
+ * 保留中アップデート・サポート終了ゲートのいずれかが出ている間は自分を
+ * 引っ込める。「サポートが終了しました」の隣で「評価してください」と
+ * 出るのは体験として悪い。
+ *
+ * 抑制キーの購読はマウント時の一度きり（`chrome.storage.onChanged`は
+ * 購読しない）。Popupを開いたまま更新が降ってきた場合にバナーが2枚
+ * 並ぶだけで実害が無く、短命なPopupのためにもう1つ購読を増やす価値が
+ * 無いため。
+ */
+export const ReviewPromptSection = () => {
+  const [visible, setVisible] = useState(false)
+  const [suppressed, setSuppressed] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+
+    // フェイルオープン: 応答なし/エラー時は非表示のまま（依頼バナーは
+    // 出ない方に倒す）
+    sendMessageWithTimeout<ReviewPromptResponse>(
+      { action: 'getReviewPrompt' } as GetReviewPromptMessage,
+      REVIEW_PROMPT_MESSAGE_TIMEOUT_MS
+    ).then((response) => {
+      if (!cancelled && response?.success && response.visible) {
+        setVisible(true)
+      }
+    })
+
+    chrome.storage.local.get(
+      [REBUILD_ADVISORY_STORAGE_KEY, PENDING_UPDATE_STORAGE_KEY, MIN_VERSION_GATE_STORAGE_KEY],
+      (result: Record<string, any>) => {
+        if (cancelled) return
+        // 読めなかった場合は抑制したまま（優先度の高いバナーを隠すより、
+        // 依頼を出さない方が安全側）
+        if (chrome.runtime.lastError) return
+        const advisory = result?.[REBUILD_ADVISORY_STORAGE_KEY] as RebuildAdvisoryState | undefined
+        const pendingUpdate = result?.[PENDING_UPDATE_STORAGE_KEY] as PendingUpdateState | undefined
+        const gate = result?.[MIN_VERSION_GATE_STORAGE_KEY] as MinVersionGateState | undefined
+        setSuppressed(
+          !!advisory?.pendingVersion || !!pendingUpdate?.pending || gate?.supported === false
+        )
+      }
+    )
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const resolve = useCallback((choice: ReviewPromptChoice) =>
+    sendMessageWithTimeout(
+      { action: 'resolveReviewPrompt', choice } as ResolveReviewPromptMessage,
+      REVIEW_PROMPT_MESSAGE_TIMEOUT_MS
+    ), [])
+
+  // `chrome.runtime.id`はmanifestの`key`から決まる固定値。取得できない
+  // 異常系ではレビューページを組み立てられないため、バナー自体を出さない
+  const reviewUrl = chrome.runtime.id ? buildChromeWebStoreReviewUrl(chrome.runtime.id) : undefined
+
+  const handleRate = useCallback(async () => {
+    setVisible(false)
+    // 記録の完了を待ってからタブを開く: 新規タブへ切り替わるとPopupは
+    // 破棄されるため、送信しっぱなしだと決着が失われうる。タイムアウト時
+    // （応答なし）はストアページを開く方を優先する -- ユーザーの意図を
+    // 妨げないのが優先で、記録漏れは「後日もう一度聞かれる」だけで済む
+    await resolve('rated')
+    if (reviewUrl) chrome.tabs.create({ url: reviewUrl })
+  }, [resolve, reviewUrl])
+
+  const handleLater = useCallback(() => {
+    setVisible(false)
+    void resolve('later')
+  }, [resolve])
+
+  const handleDismiss = useCallback(() => {
+    setVisible(false)
+    void resolve('dismissed')
+  }, [resolve])
+
+  if (!visible || suppressed || !reviewUrl) return null
+
+  return (
+    <Box sx={{ mt: 1 }}>
+      {/* severity="info"（お知らせ扱い）のまま、アイコンだけ★=評価の語彙に
+        差し替える。色はテーマの`warning`（ダーク=ゴールド#d9a842 /
+        ライト=ブロンズ#b9812c）で、既定のinfo青より両テーマのパレットに馴染む */}
+      <Alert
+        severity="info"
+        icon={<StarRounded fontSize="inherit" sx={{ color: 'warning.main' }} />}
+      >
+        <Typography variant="body2">
+          PokerChase HUD は役に立っていますか？
+        </Typography>
+        <Typography variant="caption" sx={{ display: 'block', mt: 0.25 }}>
+          Chrome ウェブストアでの評価・レビューが今後の開発の励みになります。
+        </Typography>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}>
+          <Button size="small" color="inherit" onClick={handleRate}>
+            評価する
+          </Button>
+          <Button size="small" color="inherit" onClick={handleLater}>
+            後で
+          </Button>
+          <Button size="small" color="inherit" onClick={handleDismiss}>
+            今後表示しない
+          </Button>
+        </Box>
+      </Alert>
+    </Box>
+  )
+}

--- a/src/components/popup/ReviewPromptSection.tsx
+++ b/src/components/popup/ReviewPromptSection.tsx
@@ -40,6 +40,7 @@ const REVIEW_PROMPT_MESSAGE_TIMEOUT_MS = 5000
 export const ReviewPromptSection = () => {
   const [visible, setVisible] = useState(false)
   const [suppressed, setSuppressed] = useState(true)
+  const [rating, setRating] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -87,12 +88,19 @@ export const ReviewPromptSection = () => {
   const reviewUrl = chrome.runtime.id ? buildChromeWebStoreReviewUrl(chrome.runtime.id) : undefined
 
   const handleRate = useCallback(async () => {
-    setVisible(false)
     // 記録の完了を待ってからタブを開く: 新規タブへ切り替わるとPopupは
     // 破棄されるため、送信しっぱなしだと決着が失われうる。タイムアウト時
     // （応答なし）はストアページを開く方を優先する -- ユーザーの意図を
-    // 妨げないのが優先で、記録漏れは「後日もう一度聞かれる」だけで済む
+    // 妨げないのが優先で、記録漏れは「後日もう一度聞かれる」だけで済む。
+    //
+    // 待っている間はバナーを消さずボタンをdisabledにする（UpdateSectionの
+    // applyingと同じ形）。先に消してしまうと、SWのコールドスタートで
+    // 往復が延びたときに「押したのに何も起きない」無反応の窓ができ、
+    // そこでPopupを閉じられると`rated`だけ記録されてストアは開かれない
+    // -- 二度と聞かない状態になってしまう
+    setRating(true)
     await resolve('rated')
+    setVisible(false)
     if (reviewUrl) chrome.tabs.create({ url: reviewUrl })
   }, [resolve, reviewUrl])
 
@@ -124,13 +132,13 @@ export const ReviewPromptSection = () => {
           Chrome ウェブストアでの評価・レビューが今後の開発の励みになります。
         </Typography>
         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}>
-          <Button size="small" color="inherit" onClick={handleRate}>
-            評価する
+          <Button size="small" color="inherit" onClick={handleRate} disabled={rating}>
+            {rating ? '開いています...' : '評価する'}
           </Button>
-          <Button size="small" color="inherit" onClick={handleLater}>
+          <Button size="small" color="inherit" onClick={handleLater} disabled={rating}>
             後で
           </Button>
-          <Button size="small" color="inherit" onClick={handleDismiss}>
+          <Button size="small" color="inherit" onClick={handleDismiss} disabled={rating}>
             今後表示しない
           </Button>
         </Box>

--- a/src/constants/review-prompt.test.ts
+++ b/src/constants/review-prompt.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for the review-prompt pure logic (src/constants/review-prompt.ts).
+ *
+ * Covers: URL construction, storage-value normalization (corrupted values must
+ * neither throw nor silently drop a recorded resolution), and the
+ * visibility state machine including the snooze window and clock-skew edges.
+ */
+import {
+  buildChromeWebStoreReviewUrl,
+  isReviewPromptVisible,
+  parseReviewPromptState,
+  REVIEW_PROMPT_SNOOZE_MS,
+  type ReviewPromptState,
+} from './review-prompt'
+
+const NOW = 1_800_000_000_000
+
+describe('buildChromeWebStoreReviewUrl', () => {
+  it('拡張機能IDからレビュータブのURLを組み立てる（slugは含めない）', () => {
+    expect(buildChromeWebStoreReviewUrl('ffkgffhokobiegbodhhbfannffpgakhi'))
+      .toBe('https://chromewebstore.google.com/detail/ffkgffhokobiegbodhhbfannffpgakhi/reviews')
+  })
+})
+
+describe('parseReviewPromptState', () => {
+  it('未設定/非オブジェクトは空の状態として扱う', () => {
+    expect(parseReviewPromptState(undefined)).toEqual({})
+    expect(parseReviewPromptState(null)).toEqual({})
+    expect(parseReviewPromptState('rated')).toEqual({})
+    expect(parseReviewPromptState(42)).toEqual({})
+  })
+
+  it('既知のフィールドだけを型チェックして拾う', () => {
+    expect(parseReviewPromptState({
+      eligibleSince: NOW,
+      snoozedAt: NOW + 1,
+      resolution: 'rated',
+      resolvedAt: NOW + 2,
+      somethingElse: 'ignored',
+    })).toEqual({
+      eligibleSince: NOW,
+      snoozedAt: NOW + 1,
+      resolution: 'rated',
+      resolvedAt: NOW + 2,
+    })
+  })
+
+  it('壊れた値は捨てる（例外を投げない）', () => {
+    expect(parseReviewPromptState({
+      eligibleSince: 'yesterday',
+      snoozedAt: Number.NaN,
+      resolution: 'maybe',
+      resolvedAt: NOW,
+    })).toEqual({})
+  })
+
+  it('resolutionが不正ならresolvedAtも拾わない（決着扱いにしない）', () => {
+    const parsed = parseReviewPromptState({ resolution: null, resolvedAt: NOW })
+    expect(parsed.resolution).toBeUndefined()
+    expect(parsed.resolvedAt).toBeUndefined()
+  })
+})
+
+describe('isReviewPromptVisible', () => {
+  const eligible: ReviewPromptState = { eligibleSince: NOW - 1000 }
+
+  it('表示条件未達（eligibleSince未設定）なら表示しない', () => {
+    expect(isReviewPromptVisible({}, NOW)).toBe(false)
+  })
+
+  it('表示条件を満たし、スヌーズも決着も無ければ表示する', () => {
+    expect(isReviewPromptVisible(eligible, NOW)).toBe(true)
+  })
+
+  it.each(['rated', 'dismissed'] as const)('決着済み(%s)なら二度と表示しない', (resolution) => {
+    expect(isReviewPromptVisible({ ...eligible, resolution, resolvedAt: NOW - 1 }, NOW)).toBe(false)
+    // スヌーズ期間が明けていても決着が優先される
+    expect(isReviewPromptVisible(
+      { ...eligible, resolution, snoozedAt: NOW - REVIEW_PROMPT_SNOOZE_MS * 2 },
+      NOW
+    )).toBe(false)
+  })
+
+  it('スヌーズ期間中は表示しない', () => {
+    expect(isReviewPromptVisible({ ...eligible, snoozedAt: NOW }, NOW)).toBe(false)
+    expect(isReviewPromptVisible(
+      { ...eligible, snoozedAt: NOW - REVIEW_PROMPT_SNOOZE_MS + 1 },
+      NOW
+    )).toBe(false)
+  })
+
+  it('スヌーズ期間が明けたら再表示する（境界値は表示側）', () => {
+    expect(isReviewPromptVisible(
+      { ...eligible, snoozedAt: NOW - REVIEW_PROMPT_SNOOZE_MS },
+      NOW
+    )).toBe(true)
+  })
+
+  it('未来のsnoozedAt（時計の巻き戻し等）は非表示側に倒す', () => {
+    expect(isReviewPromptVisible({ ...eligible, snoozedAt: NOW + 60_000 }, NOW)).toBe(false)
+  })
+})

--- a/src/constants/review-prompt.ts
+++ b/src/constants/review-prompt.ts
@@ -1,0 +1,103 @@
+/**
+ * Chrome ウェブストアのレビュー依頼（sola承認）のstorage key・型・純粋関数。
+ *
+ * `constants/update.ts`と同じ理由で副作用フリーの独立モジュールとして
+ * 切り出している: Popupがこれを`background/review-prompt.ts`から直接
+ * importすると、そのimport連鎖（PokerChaseDB / Dexie）ごとPopupバンドルで
+ * 実行されてしまうため。
+ *
+ * 状態は`chrome.storage.local`に置く（`pendingUpdate` /
+ * `rebuildAdvisory` / `whatsNewUnseenVersion`と同じ area）。判断材料の
+ * 累計ハンド数がそもそも端末のIndexedDB由来で端末ごとに異なるため、
+ * `storage.sync`に置いても「デバイスAで条件を満たした」状態を
+ * デバイスBへ持ち込むだけで嬉しくない。複数デバイスで最大1回ずつ
+ * 聞かれうるのは許容する（依頼は生涯1回、スヌーズ1回分の差でしかない）。
+ */
+
+export const REVIEW_PROMPT_STORAGE_KEY = 'reviewPrompt'
+
+/** 依頼を終了させる決着（どちらも二度と表示しない） */
+export type ReviewPromptResolution = 'rated' | 'dismissed'
+
+/** Popupのボタンに対応するユーザーの選択（`later`はスヌーズのみ） */
+export type ReviewPromptChoice = ReviewPromptResolution | 'later'
+
+export interface ReviewPromptState {
+  /**
+   * 表示条件（累計ハンド数）を最初に満たした時刻(ms)。
+   * 一度立ったら降りない: 全データ削除でハンド数が0に戻っても、
+   * 「十分に使った」という事実は変わらないため。
+   */
+  eligibleSince?: number
+  /** 「後で」を押した時刻(ms)。`REVIEW_PROMPT_SNOOZE_MS`経過するまで再表示しない */
+  snoozedAt?: number
+  /** 「評価する」「今後表示しない」で決着した理由。設定済みなら二度と表示しない */
+  resolution?: ReviewPromptResolution
+  /** `resolution`を記録した時刻(ms) */
+  resolvedAt?: number
+}
+
+/**
+ * 依頼を出し始める累計ハンド数（`hands`テーブルの件数）。
+ *
+ * 数セッション使い込んで価値を実感した頃合いを狙う閾値（sola選択）。
+ * インストール直後の押し付けを避けつつ、母数を極端に絞らない妥協点。
+ */
+export const REVIEW_PROMPT_MIN_HANDS = 500
+
+/** 「後で」を押されてから再表示するまでの期間（30日） */
+export const REVIEW_PROMPT_SNOOZE_MS = 30 * 24 * 60 * 60 * 1000
+
+/**
+ * レビュー投稿ページのURLを拡張機能ID（`chrome.runtime.id`）から組み立てる。
+ *
+ * slug（`/detail/pokerchase-hud/<id>/reviews`）を含めない形にしているのは、
+ * slugがストア掲載名に追従して変わりうる一方、ID単独の形は
+ * `https://chromewebstore.google.com/detail/<id>/reviews` → slug付きURLへ
+ * 301リダイレクトされるため（2026-07-31実測）。IDをビルド時に埋め込まず
+ * 実行時に取得するのも同じ理由で、manifestの`key`から決まる値なので
+ * fork（別のkey）ではそのforkのストアページを指す。
+ */
+export const buildChromeWebStoreReviewUrl = (extensionId: string): string =>
+  `https://chromewebstore.google.com/detail/${extensionId}/reviews`
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value)
+
+/**
+ * `chrome.storage.local`から読んだ生の値を`ReviewPromptState`に正規化する。
+ *
+ * 壊れた値（手動編集・将来の形式変更）で例外を投げたり、意図せず
+ * 「決着済み」を失って再度依頼したりしないよう、既知のフィールドだけを
+ * 型チェックして拾う。
+ */
+export const parseReviewPromptState = (value: unknown): ReviewPromptState => {
+  if (!value || typeof value !== 'object') return {}
+  const raw = value as Record<string, unknown>
+  const state: ReviewPromptState = {}
+  if (isFiniteNumber(raw.eligibleSince)) state.eligibleSince = raw.eligibleSince
+  if (isFiniteNumber(raw.snoozedAt)) state.snoozedAt = raw.snoozedAt
+  if (raw.resolution === 'rated' || raw.resolution === 'dismissed') {
+    state.resolution = raw.resolution
+    if (isFiniteNumber(raw.resolvedAt)) state.resolvedAt = raw.resolvedAt
+  }
+  return state
+}
+
+/**
+ * 永続化された状態だけから「いま表示してよいか」を判定する純粋関数
+ * （累計ハンド数の判定は`eligibleSince`として既に畳み込まれている前提）。
+ *
+ * スヌーズ中の判定は「経過時間が負」（端末時計が巻き戻った、未来の
+ * タイムスタンプが書かれている）でも非表示側に倒す。しつこく出るより
+ * 出ない方に倒すのが、この種の依頼バナーの安全側。
+ */
+export const isReviewPromptVisible = (state: ReviewPromptState, now: number): boolean => {
+  if (state.resolution) return false
+  if (state.eligibleSince === undefined) return false
+  if (state.snoozedAt !== undefined) {
+    const elapsed = now - state.snoozedAt
+    if (elapsed < REVIEW_PROMPT_SNOOZE_MS) return false
+  }
+  return true
+}

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -43,6 +43,9 @@ const fireStorageChange = (
 
 global.chrome = {
   runtime: {
+    // 実拡張機能では常に存在する固定値（manifestの`key`から決まる）。
+    // getURL()のモックが使っているホスト名と揃えている
+    id: 'mock-extension-id',
     sendMessage: jest.fn(),
     onMessage: {
       addListener: jest.fn(),

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -7,6 +7,7 @@ import type { FilterOptions, PlayerStats, PositionalStatsResult, RecentHandsResu
 import { HandLogConfig, HandLogEvent, HandLogLayout, UIConfig } from './hand-log'
 import type { SyncState } from '../services/auto-sync-service'
 import type { UndecodedEventStats } from '../background/undecoded-event-tracker'
+import type { ReviewPromptChoice } from '../constants/review-prompt'
 
 // Message action constants
 export const MESSAGE_ACTIONS = {
@@ -76,6 +77,9 @@ export const MESSAGE_ACTIONS = {
   APPLY_PENDING_UPDATE: 'applyPendingUpdate',
   // What's New (per-version release notes)
   ACKNOWLEDGE_WHATS_NEW: 'acknowledgeWhatsNew',
+  // Chrome Web Store review prompt
+  GET_REVIEW_PROMPT: 'getReviewPrompt',
+  RESOLVE_REVIEW_PROMPT: 'resolveReviewPrompt',
 } as const
 
 // Import/Export related messages
@@ -392,6 +396,16 @@ export interface AcknowledgeWhatsNewMessage {
   action: 'acknowledgeWhatsNew'
 }
 
+// Chrome Web Store review prompt messages
+export interface GetReviewPromptMessage {
+  action: 'getReviewPrompt'
+}
+
+export interface ResolveReviewPromptMessage {
+  action: 'resolveReviewPrompt'
+  choice: ReviewPromptChoice
+}
+
 export interface FirebaseBackupProgressMessage {
   action: 'firebaseBackupProgress'
   progress: number
@@ -476,6 +490,11 @@ export interface ApplyUpdateResponse extends SuccessResponse {
   reason?: string
 }
 
+export interface ReviewPromptResponse extends SuccessResponse {
+  /** レビュー依頼バナーを表示してよいか（表示条件・スヌーズ・決着を畳み込んだ結果） */
+  visible: boolean
+}
+
 export interface DeviceUILayoutResponse extends SuccessResponse {
   scale: number
   position?: HudPosition
@@ -485,7 +504,7 @@ export interface DeviceHandLogLayoutResponse extends SuccessResponse {
   layout?: HandLogLayout
 }
 
-export type MessageResponse = SuccessResponse | ErrorResponse | BackupListResponse | BackupDownloadResponse | AuthStatusResponse | SyncStateResponse | UnsyncedCountResponse | SyncInfoResponse | OperationStateResponse | PositionalStatsResponse | RecentHandsResponse | UndecodedEventStatsResponse | ApplyUpdateResponse | DeviceUILayoutResponse | DeviceHandLogLayoutResponse
+export type MessageResponse = SuccessResponse | ErrorResponse | BackupListResponse | BackupDownloadResponse | AuthStatusResponse | SyncStateResponse | UnsyncedCountResponse | SyncInfoResponse | OperationStateResponse | PositionalStatsResponse | RecentHandsResponse | UndecodedEventStatsResponse | ApplyUpdateResponse | ReviewPromptResponse | DeviceUILayoutResponse | DeviceHandLogLayoutResponse
 
 // Union type of all possible messages
 export type ChromeMessage =
@@ -542,6 +561,8 @@ export type ChromeMessage =
   | AcknowledgeUndecodedEventStatsMessage
   | ApplyPendingUpdateMessage
   | AcknowledgeWhatsNewMessage
+  | GetReviewPromptMessage
+  | ResolveReviewPromptMessage
 
 // Helper function for type guard implementation
 const isMessageWithAction = (msg: unknown, action: string): msg is { action: string } =>
@@ -649,3 +670,9 @@ export const isApplyPendingUpdateMessage = (msg: unknown): msg is ApplyPendingUp
 
 export const isAcknowledgeWhatsNewMessage = (msg: unknown): msg is AcknowledgeWhatsNewMessage =>
   isMessageWithAction(msg, 'acknowledgeWhatsNew')
+
+export const isGetReviewPromptMessage = (msg: unknown): msg is GetReviewPromptMessage =>
+  isMessageWithAction(msg, 'getReviewPrompt')
+
+export const isResolveReviewPromptMessage = (msg: unknown): msg is ResolveReviewPromptMessage =>
+  isMessageWithAction(msg, 'resolveReviewPrompt')


### PR DESCRIPTION
## 概要

累計500ハンド以上プレイしたユーザーに対し、ポップアップ上部で Chrome ウェブストアのレビュー投稿を依頼するバナーを追加する。バッジ・通知・HUD 表示は一切追加せず、ポップアップを開いたときにだけ判定する。

## 背景

ウェブストアの掲載順位・信頼性はレビュー数に依存する一方、拡張機能からユーザーに依頼する導線が存在しなかった。ただしこの種のバナーは「出しすぎ」の害が大きいため、以下を設計上の制約とした。

- **プレイを妨げない**: HUD オーバーレイやバッジ・通知には一切出さない（ポップアップ限定）
- **価値を実感した後に聞く**: インストール直後には出さない
- **迷ったら出さない**: 判定材料が欠けている・時計が狂っている・backgroundが応答しない、いずれの場合も非表示に倒す
- **一度断られたら終わり**: 「今後表示しない」「評価する」は終端状態

## 変更内容

**判定ロジック（background）**
- `src/constants/review-prompt.ts`: storage key・状態型・閾値と、永続化状態のみから表示可否を決める純粋関数 `isReviewPromptVisible()`。`constants/update.ts` と同じ理由で副作用フリー（Popup バンドルに Dexie を引き込まない）
- `src/background/review-prompt.ts`: ハンド数ゲートと決着の記録。評価はポップアップ起動時のみ（`getReviewPrompt` メッセージ）で、`event-ingestion.ts` へのフックもハンドごとのカウンタ書き込みも追加していない。`db.hands.count()` は IndexedDB ネイティブの count で、決着済みなら count 自体を実行しない
- 閾値 `REVIEW_PROMPT_MIN_HANDS = 500` に到達した時点で `eligibleSince` をラッチし、以降は数え直さない（全データ削除でハンド数が0に戻っても降りない）
- 「評価する」/「今後表示しない」は終端、「後で」は30日スヌーズ。決着済みの状態は `later` でも上書きしない。未来の `snoozedAt`（時計の巻き戻し・手編集）は非表示側に倒す。壊れた storage 値は `parseReviewPromptState()` で正規化する

**UI（popup）**
- `src/components/popup/ReviewPromptSection.tsx`: `UpdateSection` の直下に表示。データ再構築アドバイザリ・保留中アップデート・サポート終了ゲートのいずれかが有効な間は自分を引っ込める（バッジ優先順位と同じ rebuild > update > 情報系。「サポートが終了しました」の隣で評価を求めないため）
- 「評価する」は `resolveReviewPrompt` の往復を待ってから `chrome.tabs.create()` する。タブを開くとポップアップが破棄されるため、送信しっぱなしだと決着が失われ、レビュー済みのユーザーに再度聞いてしまう。タイムアウト時はストアページを開く方を優先する（記録漏れは「後日もう一度聞かれる」だけで済む）
- レビューURLは `chrome.runtime.id` から実行時に組み立てる。slug 無し形式が slug 付き URL へ 301 リダイレクトされることを実測で確認済み（2026-07-31）なので、掲載名の変更で壊れず、fork（別 `key` → 別ID）は自身のストアページを指す。`GITHUB_RELEASES_URL` と同じ方針

**その他**
- `src/types/messages.ts` / `src/background/message-router.ts`: `getReviewPrompt` / `resolveReviewPrompt` の追加
- `src/test-setup.ts`: `chrome.runtime.id` のモック追加
- `AGENTS.md` / `docs/file-organization.md`: 仕様と新規ファイルを追記

ストア用スクリーンショット（`e2e/tools/capture-store-imagery.ts`、11ハンドのフィクスチャ）は閾値を大きく下回るため、バナーが写り込むことはない。文言も特定の評価点を要求しない形にしている（ウェブストアのポリシー）。

## 検証

- `npm run typecheck` パス
- `npm run test` パス（165 suites / 1711 tests、うち新規37件）
- `npm run build` パス
- 実コンポーネント/実テーマを単体バンドルして dark-felt / modern-light 両テーマの表示を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

