### PR TITLE
docs: ファイル構成ツリーのインデントずれを修正する

### DIFF
--- a/docs/file-organization.md
+++ b/docs/file-organization.md
@@ -75,7 +75,7 @@
     ├── background/            # Service worker modules
     │   ├── auto-sync-boot.ts        # Auth-ready auto-sync initialization (init race guard)
     │   ├── AGENTS.md                # Nested review rules (SW concurrency invariants)
-│   ├── event-ingestion.ts       # Raw Event Lake ingestion: serialized queue, durability
+    │   ├── event-ingestion.ts       # Raw Event Lake ingestion: serialized queue, durability
     │   │                            #   barrier, content dedup + sequence assignment,
     │   │                            #   session-activity transitions (201/303/308 → 309/203)
     │   ├── hud-config-sync.ts       # UIConfig broadcast to game tabs


### PR DESCRIPTION
## 概要

`docs/file-organization.md` の ASCII ツリーで、`src/background/event-ingestion.ts` の行だけが行頭の4スペースを欠いており、前後の行（`auto-sync-boot.ts` / `AGENTS.md` / `hud-config-sync.ts` など）と縦線がずれていたため補って整列させました。

## 変更内容

- 78行目に行頭4スペースを追加（1行のみ、`1 insertion(+), 1 deletion(-)`）
- continuation 行（79-80行目）は元から正しいため未変更

## 修正後

```
    ├── background/            # Service worker modules
    │   ├── auto-sync-boot.ts        # Auth-ready auto-sync initialization (init race guard)
    │   ├── AGENTS.md                # Nested review rules (SW concurrency invariants)
    │   ├── event-ingestion.ts       # Raw Event Lake ingestion: serialized queue, durability
    │   │                            #   barrier, content dedup + sequence assignment,
    │   │                            #   session-activity transitions (201/303/308 → 309/203)
    │   ├── hud-config-sync.ts       # UIConfig broadcast to game tabs
```

ドキュメントのみの変更でコードへの影響はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)