### PR TITLE
feat(ui): 配置リセットをHUDパネル・倍率へ広げ、リセット後にログが消えるのを直す

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -751,19 +751,25 @@ v3 added composite indexes for player-specific queries. v6 changes the Raw Lake 
   `setDeviceUIScale`, `setDeviceHudPosition`, `getDeviceHandLogLayout`,
   `setDeviceHandLogLayout`, and `resetDeviceUILayout`; content scripts do
   not access the restricted local area directly.
-- **Layout reset is one operation over both surfaces**: the popup's
-  「位置とサイズをリセット」 (`UIScaleSection.tsx`) sends a single
-  `resetDeviceUILayout`, and the background removes `handLogLayout` *and*
-  every `hudPosition_*` key in one `chrome.storage.local.remove` call so the
-  two cannot diverge. Keys come from `HUD_POSITION_STORAGE_KEYS`
+- **Layout reset is one operation over every device-local appearance key**:
+  the popup's 「位置とサイズをリセット」 (`UIScaleSection.tsx`) sends a single
+  `resetDeviceUILayout`, and the background removes `handLogLayout`, every
+  `hudPosition_*` key, *and* `uiScale` in one `chrome.storage.local.remove`
+  call so they cannot diverge. Scale is in scope because the button means
+  "back to the default look" (sola): leaving a large scale behind returns the
+  panels to default positions computed for a size they no longer are, so the
+  hand log's default slot above the seat plate stops fitting. Keys come from `HUD_POSITION_STORAGE_KEYS`
   (`ui-config-storage.ts`), built from the valid position ids rather than by
   prefix-scanning `storage.local`, which also holds unrelated keys. Clearing
   storage alone does not move anything on an open tab — neither `HandLog` nor
   `useDraggable` watches storage — so the background also broadcasts one
   `resetUILayout` message that `content_script.ts` fans out into the
   `resetHandLogLayout` and `resetHudPositions` window events those two
-  subscribe to. Device-local *scale* (`uiScale`) is deliberately not cleared:
-  it is a readability preference, not a placement.
+  subscribe to. Scale rides its own existing channel
+  (`updateDeviceUIScale`) rather than being folded into `resetUILayout`:
+  `App.tsx` already owns scale as `uiConfig.scale` and that broadcast is its
+  only update path. The popup does not subscribe to either broadcast, so
+  `UIScaleSection` resets its own displayed scale from the success response.
 
 #### Config Interfaces
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,27 +487,18 @@ freshly read `readHandLogEnvironment()` and adopts it. Reset exists to rescue a
 panel the user cannot find, and a stale cached viewport is one of the ways a
 panel gets lost — computing the default *and* the in-viewport clamp from the
 same stale value cannot detect the mismatch, so the rescue silently reproduces
-it. For the same reason the default position moved to the top-left area from
-the former right/bottom-anchored `viewportWidth - margin - width*scale`: that
-formula is only ever as correct as the viewport reading behind it, and a
-too-large reading put the panel outside the window (real report: window at half
-the display, reset made the log vanish, maximizing revealed it). It also landed
-on the *outermost* point of the coordinate box — the first place to fall out of
-view if the reference frame is off at all — wedged between the bottom seat HUD
-panels and the action-button strip. `left` is now a fixed 10px; `top` stacks the
-panel *upward* from the top-left seat plate
-(`viewportHeight * HAND_LOG_SEAT_PLATE_TOP_ROW_TOP_RATIO`, measured percentages
-in `src/mockup/table-layout.ts`'s `SEATS[].plate`), clamped to
-`[0, HAND_LOG_DEFAULT_TOP_MAX]`. Two constraints fix that placement (sola):
-**never cover a name plate** — they carry the chip stacks, so even a partial
-overlap hides how much a player has left — and never take the apparently-free
-band *below* that plate, which is where `Hud.tsx`'s `SEAT_POSITIONS[2]`
-(top 35%) puts player B's own HUD panel. Overlapping the menu is fine.
-Anchoring the panel's bottom to the plate rather than its top to a fixed offset
-is what fixes the concession order as the panel grows with `scale`:
-plate > SB·BB/ante > menu. The `[0, MAX]` clamp is the safety property, not a
-detail: it caps how far a wrong viewport reading can displace the default.
-There is no header bar: the
+it. For the same reason the default position moved to a fixed top-left offset
+(`HAND_LOG_DEFAULT_LEFT`/`TOP`) from the former right/bottom-anchored
+`viewportWidth - margin - width*scale`: that formula is only ever as correct as
+the viewport reading behind it, and a too-large reading put the panel outside
+the window (real report: window at half the display, reset made the log vanish,
+maximizing revealed it). A constant has no such failure mode at all. It also
+landed on the *outermost* point of the coordinate box — the first place to fall
+out of view if the reference frame is off — wedged between the bottom seat HUD
+panels and the action-button strip. The top-left default does overlap the
+game's own menu / SB·BB / ante chrome; that is accepted (sola: the user can
+just move it), and at the default scale it still stops short of the seat name
+plates, which carry the chip stacks. There is no header bar: the
 upper-right grip (16px, `hand-log-move-grip`) is the move handle and the
 lower-right corner is resize-only, so the whole panel height belongs to the log
 body. The grip is deliberately upper-*right*: it overlays the log body, and a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -481,7 +481,33 @@ persistence in one component-local state machine. The machine's concrete
 active pointer interaction, rejects layout-load callbacks bound to an older
 request or scale, and emits at most one persistence effect from the common
 interaction exit. Do not add another effect/ref that mutates or saves hand-log
-coordinates outside that transition outlet. There is no header bar: the
+coordinates outside that transition outlet. **The `reset` action is the one
+input that must not trust the machine's own `environment`**: it carries a
+freshly read `readHandLogEnvironment()` and adopts it. Reset exists to rescue a
+panel the user cannot find, and a stale cached viewport is one of the ways a
+panel gets lost — computing the default *and* the in-viewport clamp from the
+same stale value cannot detect the mismatch, so the rescue silently reproduces
+it. For the same reason the default position moved to the top-left area from
+the former right/bottom-anchored `viewportWidth - margin - width*scale`: that
+formula is only ever as correct as the viewport reading behind it, and a
+too-large reading put the panel outside the window (real report: window at half
+the display, reset made the log vanish, maximizing revealed it). It also landed
+on the *outermost* point of the coordinate box — the first place to fall out of
+view if the reference frame is off at all — wedged between the bottom seat HUD
+panels and the action-button strip. `left` is now a fixed 10px; `top` stacks the
+panel *upward* from the top-left seat plate
+(`viewportHeight * HAND_LOG_SEAT_PLATE_TOP_ROW_TOP_RATIO`, measured percentages
+in `src/mockup/table-layout.ts`'s `SEATS[].plate`), clamped to
+`[0, HAND_LOG_DEFAULT_TOP_MAX]`. Two constraints fix that placement (sola):
+**never cover a name plate** — they carry the chip stacks, so even a partial
+overlap hides how much a player has left — and never take the apparently-free
+band *below* that plate, which is where `Hud.tsx`'s `SEAT_POSITIONS[2]`
+(top 35%) puts player B's own HUD panel. Overlapping the menu is fine.
+Anchoring the panel's bottom to the plate rather than its top to a fixed offset
+is what fixes the concession order as the panel grows with `scale`:
+plate > SB·BB/ante > menu. The `[0, MAX]` clamp is the safety property, not a
+detail: it caps how far a wrong viewport reading can displace the default.
+There is no header bar: the
 upper-right grip (16px, `hand-log-move-grip`) is the move handle and the
 lower-right corner is resize-only, so the whole panel height belongs to the log
 body. The grip is deliberately upper-*right*: it overlays the log body, and a
@@ -723,8 +749,21 @@ v3 added composite indexes for player-specific queries. v6 changes the Raw Lake 
   (`pokerChaseServiceState` — playerId, latestEvtDeal, session). Layout access
   is routed through the trusted background via `getDeviceUILayout`,
   `setDeviceUIScale`, `setDeviceHudPosition`, `getDeviceHandLogLayout`,
-  `setDeviceHandLogLayout`, and `resetDeviceHandLogLayout`; content scripts do
+  `setDeviceHandLogLayout`, and `resetDeviceUILayout`; content scripts do
   not access the restricted local area directly.
+- **Layout reset is one operation over both surfaces**: the popup's
+  「位置とサイズをリセット」 (`UIScaleSection.tsx`) sends a single
+  `resetDeviceUILayout`, and the background removes `handLogLayout` *and*
+  every `hudPosition_*` key in one `chrome.storage.local.remove` call so the
+  two cannot diverge. Keys come from `HUD_POSITION_STORAGE_KEYS`
+  (`ui-config-storage.ts`), built from the valid position ids rather than by
+  prefix-scanning `storage.local`, which also holds unrelated keys. Clearing
+  storage alone does not move anything on an open tab — neither `HandLog` nor
+  `useDraggable` watches storage — so the background also broadcasts one
+  `resetUILayout` message that `content_script.ts` fans out into the
+  `resetHandLogLayout` and `resetHudPositions` window events those two
+  subscribe to. Device-local *scale* (`uiScale`) is deliberately not cleared:
+  it is a readability preference, not a placement.
 
 #### Config Interfaces
 

--- a/src/background/message-router.device-layout.test.ts
+++ b/src/background/message-router.device-layout.test.ts
@@ -311,8 +311,10 @@ describe('message-router device-local UI layout', () => {
     await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(resetResponse).toHaveBeenCalledWith({ success: true })
+    // removeではなく既定値を明示的に書く。キー欠落は「端末ローカルへ未移行」を
+    // 意味するので、消すと次の読み込みでsyncの旧倍率から復活してしまう。
     expect(await chrome.storage.local.get(UI_SCALE_STORAGE_KEY)).toEqual({
-      [UI_SCALE_STORAGE_KEY]: undefined,
+      [UI_SCALE_STORAGE_KEY]: DEFAULT_UI_CONFIG.scale,
     })
     // ストレージを消すだけでは開いているタブのHUDは縮まない。倍率の配信経路は
     // 既存のupdateDeviceUIScaleを使う（resetUILayoutへ相乗りさせない）。
@@ -322,6 +324,37 @@ describe('message-router device-local UI layout', () => {
     expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
       action: 'updateDeviceUIScale',
       scale: DEFAULT_UI_CONFIG.scale,
+    })
+  })
+
+  it.each<[string, Record<string, unknown>]>([
+    ['uiConfig.scale', { uiConfig: { ...DEFAULT_UI_CONFIG, scale: 1.6 } }],
+    ['legacyUIScale', { [LEGACY_SYNC_UI_SCALE_KEY]: 1.8 }],
+  ])('リセットした倍率がsyncの旧倍率(%s)で復活しない', async (_label, syncSeed) => {
+    // 5.4.0(#290)より前から使っている端末はsyncに互換用の旧倍率を持ち続ける
+    // （persistSyncedUIConfigが毎回書き戻すので消えない）。localのuiScaleを
+    // removeすると、次のgetDeviceUILayoutが「未移行」と判定してその旧倍率を
+    // 書き戻し、倍率だけリセット前へ戻ってしまう。
+    await chrome.storage.sync.set(syncSeed)
+    await chrome.storage.local.set({ [UI_SCALE_STORAGE_KEY]: 1.6 })
+    const resetResponse = jest.fn()
+    const layoutResponse = jest.fn()
+
+    listener({ action: 'resetDeviceUILayout' }, {}, resetResponse)
+    await getPendingStorageWriteTail()
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(resetResponse).toHaveBeenCalledWith({ success: true })
+
+    // リセット後にポップアップを開き直す/ゲームタブを再読み込みする経路
+    listener({ action: 'getDeviceUILayout' }, {}, layoutResponse)
+    await getPendingStorageWriteTail()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(layoutResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true, scale: DEFAULT_UI_CONFIG.scale })
+    )
+    expect(await chrome.storage.local.get(UI_SCALE_STORAGE_KEY)).toEqual({
+      [UI_SCALE_STORAGE_KEY]: DEFAULT_UI_CONFIG.scale,
     })
   })
 
@@ -467,13 +500,19 @@ describe('message-router device-local UI layout', () => {
         finishDelayedReset = () => defaultRemove(key, callback)
       }
     )
-    ;(chrome.storage.local.set as jest.Mock).mockImplementationOnce(
-      (_items, callback) => {
+    // resetも倍率の既定値をsetで書くので、失敗させたいのはlayout保存側だけ。
+    // itemsの中身で見分ける（呼び出し順に依存させない）。
+    const storageSet = chrome.storage.local.set as jest.Mock
+    const defaultSet = storageSet.getMockImplementation()!
+    storageSet.mockImplementation((items, callback) => {
+      if (HAND_LOG_LAYOUT_STORAGE_KEY in items) {
         ;(chrome.runtime as any).lastError = { message: 'quota' }
         callback()
         delete (chrome.runtime as any).lastError
+        return
       }
-    )
+      defaultSet(items, callback)
+    })
     const resetResponse = jest.fn()
     const saveResponse = jest.fn()
 

--- a/src/background/message-router.device-layout.test.ts
+++ b/src/background/message-router.device-layout.test.ts
@@ -4,7 +4,10 @@ import type { ChromeMessage, MessageResponse } from '../types/messages'
 import { DEFAULT_UI_CONFIG } from '../types/hand-log'
 import {
   HAND_LOG_LAYOUT_STORAGE_KEY,
+  HUD_POSITION_STORAGE_KEYS,
   hudPositionStorageKey,
+  isValidHudPositionId,
+  REAL_TIME_HUD_POSITION_OFFSET,
   LEGACY_SYNC_UI_SCALE_KEY,
   UI_SCALE_STORAGE_KEY,
 } from '../utils/ui-config-storage'
@@ -227,7 +230,40 @@ describe('message-router device-local UI layout', () => {
     })
   })
 
-  it('ハンドログの端末ローカルlayoutだけを削除する', async () => {
+  // 実装が削除に使う定数から期待値を組み立てると、定数が狭まったとき期待値も
+  // 同時に狭まって「全席」という性質が検出できなくなる（自己参照）。
+  // 席IDの集合はここにリテラルで固定し、実装側の定数と突き合わせる。
+  const ALL_HUD_POSITION_KEYS = [
+    'hudPosition_0',
+    'hudPosition_1',
+    'hudPosition_2',
+    'hudPosition_3',
+    'hudPosition_4',
+    'hudPosition_5',
+    // リアルタイムHUD（100番台）も同じ操作で戻る対象
+    'hudPosition_100',
+    'hudPosition_101',
+    'hudPosition_102',
+    'hudPosition_103',
+    'hudPosition_104',
+    'hudPosition_105',
+  ]
+
+  it('削除対象キーがisValidHudPositionIdの受理範囲と一致する', () => {
+    // ここがずれると、setDeviceHudPositionは書けるのにresetでは消えない
+    // 「消し残るキー」が生まれる。
+    expect([...HUD_POSITION_STORAGE_KEYS].sort()).toEqual(
+      [...ALL_HUD_POSITION_KEYS].sort()
+    )
+    for (const key of ALL_HUD_POSITION_KEYS) {
+      const seatIndex = Number(key.replace('hudPosition_', ''))
+      expect(isValidHudPositionId(seatIndex)).toBe(true)
+    }
+    expect(isValidHudPositionId(6)).toBe(false)
+    expect(isValidHudPositionId(REAL_TIME_HUD_POSITION_OFFSET + 6)).toBe(false)
+  })
+
+  it('ハンドログlayoutと全席のHUD位置をまとめて削除する', async () => {
     const position = { top: '12%', left: '20%' }
     await chrome.storage.local.set({
       [HAND_LOG_LAYOUT_STORAGE_KEY]: {
@@ -236,21 +272,41 @@ describe('message-router device-local UI layout', () => {
         width: 400,
         height: 100,
       },
-      [hudPositionStorageKey(0)]: position,
+      ...Object.fromEntries(ALL_HUD_POSITION_KEYS.map(key => [key, position])),
+      [UI_SCALE_STORAGE_KEY]: 1.4,
     })
     const resetResponse = jest.fn()
 
-    listener({ action: 'resetDeviceHandLogLayout' }, {}, resetResponse)
+    listener({ action: 'resetDeviceUILayout' }, {}, resetResponse)
     await getPendingStorageWriteTail()
     await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(resetResponse).toHaveBeenCalledWith({ success: true })
     expect(await chrome.storage.local.get([
       HAND_LOG_LAYOUT_STORAGE_KEY,
-      hudPositionStorageKey(0),
+      ...ALL_HUD_POSITION_KEYS,
     ])).toEqual({
       [HAND_LOG_LAYOUT_STORAGE_KEY]: undefined,
-      [hudPositionStorageKey(0)]: position,
+      ...Object.fromEntries(
+        ALL_HUD_POSITION_KEYS.map(key => [key, undefined])
+      ),
+    })
+  })
+
+  it('倍率など配置以外の端末ローカル設定は消さない', async () => {
+    await chrome.storage.local.set({
+      [UI_SCALE_STORAGE_KEY]: 1.4,
+      [hudPositionStorageKey(0)]: { top: '12%', left: '20%' },
+    })
+    const resetResponse = jest.fn()
+
+    listener({ action: 'resetDeviceUILayout' }, {}, resetResponse)
+    await getPendingStorageWriteTail()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(resetResponse).toHaveBeenCalledWith({ success: true })
+    expect(await chrome.storage.local.get(UI_SCALE_STORAGE_KEY)).toEqual({
+      [UI_SCALE_STORAGE_KEY]: 1.4,
     })
   })
 
@@ -270,11 +326,11 @@ describe('message-router device-local UI layout', () => {
     )
     const resetResponse = jest.fn()
 
-    listener({ action: 'resetDeviceHandLogLayout' }, {}, resetResponse)
+    listener({ action: 'resetDeviceUILayout' }, {}, resetResponse)
     await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
-      action: 'resetHandLogLayout',
+      action: 'resetUILayout',
     })
     expect(resetResponse).not.toHaveBeenCalled()
     expect(await chrome.storage.local.get(HAND_LOG_LAYOUT_STORAGE_KEY)).toEqual({
@@ -304,7 +360,7 @@ describe('message-router device-local UI layout', () => {
     const saveResponse = jest.fn()
     ;(chrome.tabs.query as jest.Mock).mockClear()
 
-    listener({ action: 'resetDeviceHandLogLayout' }, {}, resetResponse)
+    listener({ action: 'resetDeviceUILayout' }, {}, resetResponse)
     listener({
       action: 'setDeviceHandLogLayout',
       layout: newLayout,
@@ -347,10 +403,10 @@ describe('message-router device-local UI layout', () => {
     const resetResponse = jest.fn()
     const saveResponse = jest.fn()
 
-    listener({ action: 'resetDeviceHandLogLayout' }, {}, resetResponse)
+    listener({ action: 'resetDeviceUILayout' }, {}, resetResponse)
     await new Promise(resolve => setTimeout(resolve, 0))
     expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
-      action: 'resetHandLogLayout',
+      action: 'resetUILayout',
     })
 
     listener({
@@ -405,7 +461,7 @@ describe('message-router device-local UI layout', () => {
     const resetResponse = jest.fn()
     const saveResponse = jest.fn()
 
-    listener({ action: 'resetDeviceHandLogLayout' }, {}, resetResponse)
+    listener({ action: 'resetDeviceUILayout' }, {}, resetResponse)
     listener({
       action: 'setDeviceHandLogLayout',
       layout: newLayout,
@@ -417,7 +473,7 @@ describe('message-router device-local UI layout', () => {
     await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
-      action: 'resetHandLogLayout',
+      action: 'resetUILayout',
     })
     expect(chrome.tabs.sendMessage).not.toHaveBeenCalledWith(
       42,

--- a/src/background/message-router.device-layout.test.ts
+++ b/src/background/message-router.device-layout.test.ts
@@ -293,7 +293,13 @@ describe('message-router device-local UI layout', () => {
     })
   })
 
-  it('倍率など配置以外の端末ローカル設定は消さない', async () => {
+  it('端末ローカルの倍率も消して既定倍率を全ゲームタブへ配信する', async () => {
+    // 「既定の見た目へ戻す」操作なので倍率も対象（sola指定）。倍率を残すと
+    // 大きい倍率のままパネルが既定位置へ戻り、既定位置が前提とする余白に
+    // 収まらない状態が残る。
+    ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => {
+      callback([{ id: 42 }])
+    })
     await chrome.storage.local.set({
       [UI_SCALE_STORAGE_KEY]: 1.4,
       [hudPositionStorageKey(0)]: { top: '12%', left: '20%' },
@@ -306,7 +312,16 @@ describe('message-router device-local UI layout', () => {
 
     expect(resetResponse).toHaveBeenCalledWith({ success: true })
     expect(await chrome.storage.local.get(UI_SCALE_STORAGE_KEY)).toEqual({
-      [UI_SCALE_STORAGE_KEY]: 1.4,
+      [UI_SCALE_STORAGE_KEY]: undefined,
+    })
+    // ストレージを消すだけでは開いているタブのHUDは縮まない。倍率の配信経路は
+    // 既存のupdateDeviceUIScaleを使う（resetUILayoutへ相乗りさせない）。
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+      action: 'resetUILayout',
+    })
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+      action: 'updateDeviceUIScale',
+      scale: DEFAULT_UI_CONFIG.scale,
     })
   })
 
@@ -378,7 +393,8 @@ describe('message-router device-local UI layout', () => {
       success: false,
       error: 'Superseded by newer hand log layout',
     })
-    expect(chrome.tabs.query).toHaveBeenCalledTimes(2)
+    // reset は resetUILayout と updateDeviceUIScale の2配信、layout保存が1配信
+    expect(chrome.tabs.query).toHaveBeenCalledTimes(3)
     expect(saveResponse).toHaveBeenCalledWith({ success: true })
     expect(await chrome.storage.local.get(HAND_LOG_LAYOUT_STORAGE_KEY)).toEqual({
       [HAND_LOG_LAYOUT_STORAGE_KEY]: newLayout,

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -18,6 +18,7 @@ import { applyUpdateNow } from './update-manager'
 import { acknowledgeWhatsNew } from './whats-new-badge'
 import {
   HAND_LOG_LAYOUT_STORAGE_KEY,
+  HUD_POSITION_STORAGE_KEYS,
   hudPositionStorageKey,
   isValidHandLogLayout,
   isValidHudPosition,
@@ -464,16 +465,20 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
         )
       )
       return true
-    } else if (request.action === 'resetDeviceHandLogLayout') {
+    } else if (request.action === 'resetDeviceUILayout') {
+      // HUDパネル位置とハンドログを1回のremoveでまとめて消す。片方だけ成功して
+      // 片方が残る中間状態を作らないため、キーを分けて2回呼ばない。
+      // ハンドログ用のキューに載せるのは、同時に走りうる
+      // set/getDeviceHandLogLayoutと順序を保つため。
       enqueueHandLogLayoutWrite(
         callback => chrome.storage.local.remove(
-          HAND_LOG_LAYOUT_STORAGE_KEY,
+          [HAND_LOG_LAYOUT_STORAGE_KEY, ...HUD_POSITION_STORAGE_KEYS],
           callback
         ),
         sendResponse,
-        'Failed to reset hand log layout',
+        'Failed to reset UI layout',
         complete => broadcastToGameTabs(
-          { action: 'resetHandLogLayout' },
+          { action: 'resetUILayout' },
           complete
         )
       )

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -474,14 +474,29 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
       // する余白（ネームプレートの上など）に収まらない状態が残ってしまう。
       // ハンドログ用のキューに載せるのは、同時に走りうる
       // set/getDeviceHandLogLayoutと順序を保つため。
+      // 倍率だけは remove ではなく既定値を明示的に書く。localのuiScale欠落は
+      // 「端末ローカルへ未移行」を意味していて（getDeviceUILayoutの
+      // needsScaleMigration）、消すと次の読み込みがsyncに残る互換用の旧倍率
+      // から移行し直し、倍率だけリセット前へ復活してしまう。sync側の旧倍率は
+      // 版が混在する端末のために残す必要があり、消して解決はできない。
+      // 世代を上げるのは、この時点で読み込み中の移行（古い世代を掴んでいる）に
+      // 書き戻させないため。
+      deviceScaleWriteGeneration += 1
       enqueueHandLogLayoutWrite(
         callback => chrome.storage.local.remove(
-          [
-            HAND_LOG_LAYOUT_STORAGE_KEY,
-            ...HUD_POSITION_STORAGE_KEYS,
-            UI_SCALE_STORAGE_KEY,
-          ],
-          callback
+          [HAND_LOG_LAYOUT_STORAGE_KEY, ...HUD_POSITION_STORAGE_KEYS],
+          () => {
+            // removeが失敗したらlastErrorが立っている間に抜ける。
+            // 続けてsetを呼ぶとlastErrorが上書きされ、失敗が成功に見える。
+            if (chrome.runtime.lastError) {
+              callback()
+              return
+            }
+            chrome.storage.local.set(
+              { [UI_SCALE_STORAGE_KEY]: DEFAULT_UI_CONFIG.scale },
+              callback
+            )
+          }
         ),
         sendResponse,
         'Failed to reset UI layout',

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -1,5 +1,6 @@
 /** !!! CONTENT_SCRIPTS、WEB_ACCESSIBLE_RESOURCESからインポートしないこと !!! */
 import PokerChaseService, { PokerChaseDB } from '../app'
+import { DEFAULT_UI_CONFIG } from '../types/hand-log'
 import type {
   ChromeMessage,
   ImportStatusMessage,
@@ -466,21 +467,37 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
       )
       return true
     } else if (request.action === 'resetDeviceUILayout') {
-      // HUDパネル位置とハンドログを1回のremoveでまとめて消す。片方だけ成功して
-      // 片方が残る中間状態を作らないため、キーを分けて2回呼ばない。
+      // ハンドログ・HUDパネル位置・倍率を1回のremoveでまとめて消す。片方だけ
+      // 成功して片方が残る中間状態を作らないため、キーを分けて複数回呼ばない。
+      // 倍率も対象なのは、このボタンが「既定の見た目へ戻す」操作だから（sola）。
+      // 倍率を残すと、大きい倍率のままパネルが既定位置へ戻り、既定位置が前提と
+      // する余白（ネームプレートの上など）に収まらない状態が残ってしまう。
       // ハンドログ用のキューに載せるのは、同時に走りうる
       // set/getDeviceHandLogLayoutと順序を保つため。
       enqueueHandLogLayoutWrite(
         callback => chrome.storage.local.remove(
-          [HAND_LOG_LAYOUT_STORAGE_KEY, ...HUD_POSITION_STORAGE_KEYS],
+          [
+            HAND_LOG_LAYOUT_STORAGE_KEY,
+            ...HUD_POSITION_STORAGE_KEYS,
+            UI_SCALE_STORAGE_KEY,
+          ],
           callback
         ),
         sendResponse,
         'Failed to reset UI layout',
-        complete => broadcastToGameTabs(
-          { action: 'resetUILayout' },
-          complete
-        )
+        complete => {
+          // 倍率はresetUILayoutとは別経路で反映する。ゲームタブ側の倍率は
+          // App.tsxがuiConfig.scaleとして持っており、既存のscale配信
+          // （updateDeviceUIScale）がその唯一の更新経路だから。
+          // resetUILayoutにscaleを相乗りさせると、HandLog/useDraggableの
+          // リセットとscale更新が1つのメッセージに同居して責務が混ざる。
+          broadcastToGameTabs({ action: 'resetUILayout' }, () => {
+            broadcastToGameTabs({
+              action: 'updateDeviceUIScale',
+              scale: DEFAULT_UI_CONFIG.scale,
+            }, complete)
+          })
+        }
       )
       return true
     } else if (request.action === 'exportData') {

--- a/src/components/HandLog.test.tsx
+++ b/src/components/HandLog.test.tsx
@@ -291,7 +291,7 @@ describe('HandLog', () => {
     fireEvent.mouseUp(document)
 
     expect(logContainer.style.left).toBe('10px')
-    expect(logContainer.style.top).toBe('75px')
+    expect(logContainer.style.top).toBe('10px')
     expect(savedLayoutCalls()).toHaveLength(0)
   })
 
@@ -334,7 +334,7 @@ describe('HandLog', () => {
     })
 
     expect(logContainer.style.left).toBe('60px')
-    expect(logContainer.style.top).toBe('105px')
+    expect(logContainer.style.top).toBe('40px')
     fireEvent.mouseUp(document)
   })
 
@@ -479,50 +479,20 @@ describe('HandLog', () => {
     expect(savedLayoutCalls()).toHaveLength(0)
   })
 
-  it('既定位置は0で頭打ちなのでviewportを0で読んでも画面内に残る', () => {
-    // 上端はネームプレートを避けるためviewport比で決まるが、必ず[0, 400]で
-    // 頭打ちにする。右下寄せ（viewportWidth - 余白 - 幅）だった頃はこの天井が
-    // 無く、viewportが実ウィンドウより大きい値で読めた瞬間に既定座標が画面外へ
-    // 落ちた（実機: ウィンドウを画面半分にした状態でリセットするとログが消え、
-    // 最大化すると現れた）。
+  it('既定位置はviewportに依存しないので0で読んでも画面内に残る', () => {
+    // 既定位置は左上からの固定オフセット。右下寄せ
+    // （viewportWidth - 余白 - 幅）だった頃はviewportの読み値がそのまま座標に
+    // なり、実ウィンドウより大きい値で読めた瞬間に画面外へ落ちた（実機:
+    // ウィンドウを画面半分にした状態でリセットするとログが消え、最大化すると
+    // 現れた）。定数ならその経路自体が存在しない。
     setViewport(0, 0)
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
 
     expect(logContainer.style.left).toBe('10px')
-    expect(logContainer.style.top).toBe('0px')
+    expect(logContainer.style.top).toBe('10px')
     expect(logContainer.style.width).toBe('400px')
     expect(logContainer.style.height).toBe('100px')
-  })
-
-  it('既定位置は左上のネームプレートより上に収まる', () => {
-    // プレートにはチップスタックが出るので、一部でも覆うと残りスタックが
-    // 読めなくなる（sola指定、最優先の制約）。幅400pxのパネルは左端に置くと
-    // 左列のプレートと横方向で必ず重なるため、縦で外すしかない。
-    // 実測値は src/mockup/table-layout.ts の SEATS[].plate（viewport比）:
-    // 上段プレイヤーB = 上端23.6%。
-    const TOP_ROW_PLATE_TOP = 0.236
-
-    for (const viewportHeight of [640, 720, 860, 900, 1080, 1440]) {
-      setViewport(1280, viewportHeight)
-      const { container, unmount } = render(<HandLog entries={mockEntries} />)
-      const style = (container.firstChild as HTMLElement).style
-      const bottom = parseFloat(style.top) + parseFloat(style.height)
-
-      expect(bottom).toBeLessThanOrEqual(viewportHeight * TOP_ROW_PLATE_TOP)
-      unmount()
-    }
-  })
-
-  it('既定の上端は天井で頭打ちになりviewport高に比例し続けない', () => {
-    // 天井が今回の修正の安全性質そのもの。これが無いと既定の上端は
-    // viewportの読み値にそのまま比例し、実ウィンドウより大きい値を掴んだ
-    // 瞬間に既定座標が画面外へ落ちる（＝直した不具合の入力が復活する）。
-    setViewport(1280, 3000)
-    const { container } = render(<HandLog entries={mockEntries} />)
-
-    // 天井が無ければ 3000*0.236 - 100 - 6 = 602px になる
-    expect((container.firstChild as HTMLElement).style.top).toBe('400px')
   })
 
   it('viewportが0のときは負へ動かしたドラッグ結果を画面内へ寄せる', () => {
@@ -544,23 +514,6 @@ describe('HandLog', () => {
     fireEvent.mouseUp(document)
   })
 
-  it('既定位置はプレイヤーBのHUDパネルの帯へ入らない', () => {
-    // BとAのプレートの間（32%〜57.8%）は一見あいているが、そこには
-    // Hud.tsx の SEAT_POSITIONS[2] = top 35% がある。ログを差し込むと
-    // HUDパネルそのものを潰す。
-    const B_HUD_TOP_RATIO = 0.35
-
-    for (const viewportHeight of [640, 860, 1080, 1440]) {
-      setViewport(1280, viewportHeight)
-      const { container, unmount } = render(<HandLog entries={mockEntries} />)
-      const style = (container.firstChild as HTMLElement).style
-      const bottom = parseFloat(style.top) + parseFloat(style.height)
-
-      expect(bottom).toBeLessThanOrEqual(viewportHeight * B_HUD_TOP_RATIO)
-      unmount()
-    }
-  })
-
   it('実ウィンドウより大きいviewportを保持していてもリセットは画面内へ戻す', () => {
     // 最大化時のviewportで環境をつかんだまま、ウィンドウが画面半分になり
     // resizeを取りこぼした状況。リセットはenvironmentを読み直すので、
@@ -574,8 +527,7 @@ describe('HandLog', () => {
     fireEvent(window, new CustomEvent('resetHandLogLayout'))
 
     expect(logContainer.style.left).toBe('10px')
-    // 400高ではプレート上端(94px)の上に100pxを積む余地が無く0へ張り付く
-    expect(logContainer.style.top).toBe('0px')
+    expect(logContainer.style.top).toBe('10px')
     // 幅400は500幅のviewportに収まるので表示は縮まない
     expect(logContainer.style.width).toBe('400px')
     expect(logContainer.style.height).toBe('100px')
@@ -608,9 +560,9 @@ describe('HandLog', () => {
     const logContainer = container.firstChild as HTMLElement
 
     // 幅は表示上限（viewport実寸）まで縮み、左端の既定オフセット10pxは
-    // 収まる余地が無いので0へ寄る。
+    // 収まる余地が無いので0へ寄る。高さ側にはまだ余地があるので10pxのまま。
     expect(logContainer.style.left).toBe('0px')
-    expect(logContainer.style.top).toBe('0px')
+    expect(logContainer.style.top).toBe('10px')
     expect(logContainer.style.width).toBe('320px')
     expect(logContainer.style.height).toBe('100px')
   })
@@ -1221,7 +1173,7 @@ describe('HandLog', () => {
     fireEvent(window, new CustomEvent('resetHandLogLayout'))
 
     expect(logContainer.style.left).toBe('10px')
-    expect(logContainer.style.top).toBe('75px')
+    expect(logContainer.style.top).toBe('10px')
     expect(logContainer.style.width).toBe(`${DEFAULT_HAND_LOG_CONFIG.width}px`)
     expect(logContainer.style.height).toBe(`${DEFAULT_HAND_LOG_CONFIG.height}px`)
   })
@@ -1256,9 +1208,7 @@ describe('HandLog', () => {
     fireEvent(window, new CustomEvent('resetHandLogLayout'))
 
     expect(logContainer.style.left).toBe('10px')
-    // scale2では実寸200pxがプレート上端(181px)の上に収まらず0へ張り付く。
-    // プレートを守る側に倒し、上のクライアントUIへ食い込ませる。
-    expect(logContainer.style.top).toBe('0px')
+    expect(logContainer.style.top).toBe('10px')
     expect(logContainer.style.width).toBe(`${DEFAULT_HAND_LOG_CONFIG.width}px`)
     expect(logContainer.style.height).toBe(`${DEFAULT_HAND_LOG_CONFIG.height}px`)
     // 操作中に届いた新しいscaleは、resetの時点で確定して表示にも反映される
@@ -1328,7 +1278,7 @@ describe('HandLog', () => {
     fireEvent(window, new CustomEvent('resetHandLogLayout'))
 
     expect(logContainer.style.left).toBe('10px')
-    expect(logContainer.style.top).toBe('75px')
+    expect(logContainer.style.top).toBe('10px')
     expect(logContainer.style.width).toBe(`${DEFAULT_HAND_LOG_CONFIG.width}px`)
     expect(logContainer.style.height).toBe(`${DEFAULT_HAND_LOG_CONFIG.height}px`)
     expect(document.body.style.cursor).toBe('')
@@ -1352,7 +1302,7 @@ describe('HandLog', () => {
     const logContainer = container.firstChild as HTMLElement
 
     expect(logContainer.style.left).toBe('10px')
-    expect(logContainer.style.top).toBe('75px')
+    expect(logContainer.style.top).toBe('10px')
     expect(logContainer.style.width).toBe(`${DEFAULT_HAND_LOG_CONFIG.width}px`)
     expect(logContainer.style.height).toBe(`${DEFAULT_HAND_LOG_CONFIG.height}px`)
   })

--- a/src/components/HandLog.test.tsx
+++ b/src/components/HandLog.test.tsx
@@ -290,8 +290,8 @@ describe('HandLog', () => {
     moveMouseWithPrimaryButton(650, 550)
     fireEvent.mouseUp(document)
 
-    expect(logContainer.style.left).toBe('614px')
-    expect(logContainer.style.top).toBe('533px')
+    expect(logContainer.style.left).toBe('10px')
+    expect(logContainer.style.top).toBe('75px')
     expect(savedLayoutCalls()).toHaveLength(0)
   })
 
@@ -323,7 +323,9 @@ describe('HandLog', () => {
       clientX: 700,
       clientY: 540,
     })
-    moveMouseWithPrimaryButton(650, 510)
+    // 既定位置は左上なので、左上方向へ動かすとclampで0に張り付いて
+    // 「巻き戻していない」ことが観測できない。右下方向へ動かす。
+    moveMouseWithPrimaryButton(750, 570)
     act(() => {
       resolveInitialLoad({
         success: true,
@@ -331,8 +333,8 @@ describe('HandLog', () => {
       })
     })
 
-    expect(logContainer.style.left).toBe('564px')
-    expect(logContainer.style.top).toBe('503px')
+    expect(logContainer.style.left).toBe('60px')
+    expect(logContainer.style.top).toBe('105px')
     fireEvent.mouseUp(document)
   })
 
@@ -477,15 +479,104 @@ describe('HandLog', () => {
     expect(savedLayoutCalls()).toHaveLength(0)
   })
 
-  it('viewportが0でも負の既定座標は画面内へ寄せる', () => {
-    // 保存layoutがない状態で0を読むと既定layoutは大きな負値になる。
-    // 上限だけがviewport依存で、下限0は常に効かせる。
+  it('既定位置は0で頭打ちなのでviewportを0で読んでも画面内に残る', () => {
+    // 上端はネームプレートを避けるためviewport比で決まるが、必ず[0, 400]で
+    // 頭打ちにする。右下寄せ（viewportWidth - 余白 - 幅）だった頃はこの天井が
+    // 無く、viewportが実ウィンドウより大きい値で読めた瞬間に既定座標が画面外へ
+    // 落ちた（実機: ウィンドウを画面半分にした状態でリセットするとログが消え、
+    // 最大化すると現れた）。
     setViewport(0, 0)
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
 
+    expect(logContainer.style.left).toBe('10px')
+    expect(logContainer.style.top).toBe('0px')
+    expect(logContainer.style.width).toBe('400px')
+    expect(logContainer.style.height).toBe('100px')
+  })
+
+  it('既定位置は左上のネームプレートより上に収まる', () => {
+    // プレートにはチップスタックが出るので、一部でも覆うと残りスタックが
+    // 読めなくなる（sola指定、最優先の制約）。幅400pxのパネルは左端に置くと
+    // 左列のプレートと横方向で必ず重なるため、縦で外すしかない。
+    // 実測値は src/mockup/table-layout.ts の SEATS[].plate（viewport比）:
+    // 上段プレイヤーB = 上端23.6%。
+    const TOP_ROW_PLATE_TOP = 0.236
+
+    for (const viewportHeight of [640, 720, 860, 900, 1080, 1440]) {
+      setViewport(1280, viewportHeight)
+      const { container, unmount } = render(<HandLog entries={mockEntries} />)
+      const style = (container.firstChild as HTMLElement).style
+      const bottom = parseFloat(style.top) + parseFloat(style.height)
+
+      expect(bottom).toBeLessThanOrEqual(viewportHeight * TOP_ROW_PLATE_TOP)
+      unmount()
+    }
+  })
+
+  it('既定の上端は天井で頭打ちになりviewport高に比例し続けない', () => {
+    // 天井が今回の修正の安全性質そのもの。これが無いと既定の上端は
+    // viewportの読み値にそのまま比例し、実ウィンドウより大きい値を掴んだ
+    // 瞬間に既定座標が画面外へ落ちる（＝直した不具合の入力が復活する）。
+    setViewport(1280, 3000)
+    const { container } = render(<HandLog entries={mockEntries} />)
+
+    // 天井が無ければ 3000*0.236 - 100 - 6 = 602px になる
+    expect((container.firstChild as HTMLElement).style.top).toBe('400px')
+  })
+
+  it('viewportが0のときは負へ動かしたドラッグ結果を画面内へ寄せる', () => {
+    // viewport=0は「未確定」扱いで上限クランプを外す一方、下限0は常に効かせる。
+    // 既定位置自体は非負なので、この分岐へ負値を通せるのはドラッグだけ。
+    setViewport(0, 0)
+    const { container } = render(<HandLog entries={mockEntries} />)
+    const logContainer = container.firstChild as HTMLElement
+
+    fireEvent.mouseDown(screen.getByTestId('hand-log-move-grip'), {
+      button: 0,
+      clientX: 300,
+      clientY: 300,
+    })
+    moveMouseWithPrimaryButton(150, 150)
+
     expect(logContainer.style.left).toBe('0px')
     expect(logContainer.style.top).toBe('0px')
+    fireEvent.mouseUp(document)
+  })
+
+  it('既定位置はプレイヤーBのHUDパネルの帯へ入らない', () => {
+    // BとAのプレートの間（32%〜57.8%）は一見あいているが、そこには
+    // Hud.tsx の SEAT_POSITIONS[2] = top 35% がある。ログを差し込むと
+    // HUDパネルそのものを潰す。
+    const B_HUD_TOP_RATIO = 0.35
+
+    for (const viewportHeight of [640, 860, 1080, 1440]) {
+      setViewport(1280, viewportHeight)
+      const { container, unmount } = render(<HandLog entries={mockEntries} />)
+      const style = (container.firstChild as HTMLElement).style
+      const bottom = parseFloat(style.top) + parseFloat(style.height)
+
+      expect(bottom).toBeLessThanOrEqual(viewportHeight * B_HUD_TOP_RATIO)
+      unmount()
+    }
+  })
+
+  it('実ウィンドウより大きいviewportを保持していてもリセットは画面内へ戻す', () => {
+    // 最大化時のviewportで環境をつかんだまま、ウィンドウが画面半分になり
+    // resizeを取りこぼした状況。リセットはenvironmentを読み直すので、
+    // 既定位置も画面内クランプも「今の」ウィンドウで決まる。
+    const { container } = render(<HandLog entries={mockEntries} />)
+    const logContainer = container.firstChild as HTMLElement
+    updateLayout({ left: 900, top: 700, width: 400, height: 100 })
+
+    // resizeを発火させずにviewportだけ縮める＝environmentは1024x768のまま
+    setViewport(500, 400)
+    fireEvent(window, new CustomEvent('resetHandLogLayout'))
+
+    expect(logContainer.style.left).toBe('10px')
+    // 400高ではプレート上端(94px)の上に100pxを積む余地が無く0へ張り付く
+    expect(logContainer.style.top).toBe('0px')
+    // 幅400は500幅のviewportに収まるので表示は縮まない
     expect(logContainer.style.width).toBe('400px')
     expect(logContainer.style.height).toBe('100px')
   })
@@ -516,6 +607,8 @@ describe('HandLog', () => {
     const { container } = render(<HandLog entries={mockEntries} />)
     const logContainer = container.firstChild as HTMLElement
 
+    // 幅は表示上限（viewport実寸）まで縮み、左端の既定オフセット10pxは
+    // 収まる余地が無いので0へ寄る。
     expect(logContainer.style.left).toBe('0px')
     expect(logContainer.style.top).toBe('0px')
     expect(logContainer.style.width).toBe('320px')
@@ -642,7 +735,7 @@ describe('HandLog', () => {
     act(() => {
       jest.advanceTimersByTime(DEVICE_LAYOUT_MESSAGE_TIMEOUT_MS)
     })
-    expect(logContainer.style.left).toBe('614px')
+    expect(logContainer.style.left).toBe('10px')
 
     act(() => {
       loadCallbacks[0]!({
@@ -993,11 +1086,13 @@ describe('HandLog', () => {
     })
   })
 
-  it('既定の右下寄せ位置からでも横幅を広げられる', () => {
+  it('右端に寄せた位置からでも横幅を広げられる', () => {
     const { container } = render(<HandLog entries={mockEntries} scale={2} />)
     const logContainer = container.firstChild as HTMLElement
+    // 右端から10pxまで寄せた状態。端で成長を止めるとほぼ拡大できないので、
+    // はみ出しは位置clampがパネルを引き戻して解決する。
+    updateLayout({ left: 214, top: 433, width: 400, height: 100 })
 
-    // 既定位置は右端から10pxしかない。端で成長を止めるとほぼ拡大できない。
     expect(logContainer.style.left).toBe('214px')
 
     fireEvent.mouseDown(screen.getByTestId('hand-log-resize-corner'), {
@@ -1125,8 +1220,8 @@ describe('HandLog', () => {
 
     fireEvent(window, new CustomEvent('resetHandLogLayout'))
 
-    expect(logContainer.style.left).toBe('614px')
-    expect(logContainer.style.top).toBe('533px')
+    expect(logContainer.style.left).toBe('10px')
+    expect(logContainer.style.top).toBe('75px')
     expect(logContainer.style.width).toBe(`${DEFAULT_HAND_LOG_CONFIG.width}px`)
     expect(logContainer.style.height).toBe(`${DEFAULT_HAND_LOG_CONFIG.height}px`)
   })
@@ -1144,7 +1239,7 @@ describe('HandLog', () => {
     expect(logContainer.style.height).toBe('240px')
   })
 
-  it('操作中のresetはpending scaleを採用して既定layoutを正規化する', () => {
+  it('操作中のresetは最新のscaleを採用して既定layoutを正規化する', () => {
     const { container, rerender } = render(
       <HandLog entries={mockEntries} scale={1} />
     )
@@ -1160,10 +1255,13 @@ describe('HandLog', () => {
 
     fireEvent(window, new CustomEvent('resetHandLogLayout'))
 
-    expect(logContainer.style.left).toBe('214px')
-    expect(logContainer.style.top).toBe('433px')
+    expect(logContainer.style.left).toBe('10px')
+    // scale2では実寸200pxがプレート上端(181px)の上に収まらず0へ張り付く。
+    // プレートを守る側に倒し、上のクライアントUIへ食い込ませる。
+    expect(logContainer.style.top).toBe('0px')
     expect(logContainer.style.width).toBe(`${DEFAULT_HAND_LOG_CONFIG.width}px`)
     expect(logContainer.style.height).toBe(`${DEFAULT_HAND_LOG_CONFIG.height}px`)
+    // 操作中に届いた新しいscaleは、resetの時点で確定して表示にも反映される
     expect(logContainer.style.transform).toContain('scale(2)')
     expect(savedLayoutCalls()).toHaveLength(0)
   })
@@ -1229,8 +1327,8 @@ describe('HandLog', () => {
     moveMouseWithPrimaryButton(movedX, movedY)
     fireEvent(window, new CustomEvent('resetHandLogLayout'))
 
-    expect(logContainer.style.left).toBe('614px')
-    expect(logContainer.style.top).toBe('533px')
+    expect(logContainer.style.left).toBe('10px')
+    expect(logContainer.style.top).toBe('75px')
     expect(logContainer.style.width).toBe(`${DEFAULT_HAND_LOG_CONFIG.width}px`)
     expect(logContainer.style.height).toBe(`${DEFAULT_HAND_LOG_CONFIG.height}px`)
     expect(document.body.style.cursor).toBe('')
@@ -1253,8 +1351,8 @@ describe('HandLog', () => {
     )
     const logContainer = container.firstChild as HTMLElement
 
-    expect(logContainer.style.left).toBe('614px')
-    expect(logContainer.style.top).toBe('533px')
+    expect(logContainer.style.left).toBe('10px')
+    expect(logContainer.style.top).toBe('75px')
     expect(logContainer.style.width).toBe(`${DEFAULT_HAND_LOG_CONFIG.width}px`)
     expect(logContainer.style.height).toBe(`${DEFAULT_HAND_LOG_CONFIG.height}px`)
   })
@@ -1262,10 +1360,14 @@ describe('HandLog', () => {
   it('スケールが表示と正規化の共通environmentに適用される', () => {
     const { container } = render(<HandLog entries={mockEntries} scale={1.5} />)
     const logContainer = container.firstChild as HTMLElement
+    // 既定位置は左上固定でscaleに依存しないため、scaleが正規化にも効いて
+    // いることは画面端へ寄せた保存layoutでしか観測できない。
+    // 幅400はscale1.5で実寸600、viewport1024なので左端上限は424になる。
+    updateLayout({ left: 900, top: 700, width: 400, height: 100 })
 
     expect(logContainer.style.transform).toContain('scale(1.5)')
-    expect(logContainer.style.left).toBe('414px')
-    expect(logContainer.style.top).toBe('483px')
+    expect(logContainer.style.left).toBe('424px')
+    expect(logContainer.style.top).toBe('618px')
   })
 
   it('保存済みouter sizeからborderだけ引いて本文へ渡す', () => {

--- a/src/components/HandLog.tsx
+++ b/src/components/HandLog.tsx
@@ -33,42 +33,25 @@ const HAND_LOG_MOVE_GRIP_SIZE = 16
 const HAND_LOG_BORDER_WIDTH = 1
 const HAND_LOG_DRAG_THRESHOLD = 4
 /**
- * 既定位置は画面左上側。右下基準（viewportWidth - 余白 - 幅*scale）を
- * やめた理由は2つある:
+ * 既定位置は画面左上からの固定オフセット。右下基準
+ * （viewportWidth - 余白 - 幅*scale）をやめた理由は2つある:
+ *
  * 1. 右下基準は「viewportを正しく読めている」ことがそのまま位置の正しさに
  *    なる。environmentが実ウィンドウより大きいと左端が実ウィンドウの外へ
  *    落ちる ―― 実機で「ウィンドウを画面半分にした状態でリセットしたら
- *    ログが消え、最大化したら現れた」として観測された。
+ *    ログが消え、最大化したら現れた」として観測された。左上固定なら
+ *    viewportに一切依存しないので、この経路自体が存在しない。
  * 2. 右下隅は座標系の最も外側の点でもある。ユーザーが自分でドラッグして
- *    置く内側の位置と違い、参照フレームが少しでもずれると真っ先に
- *    画面外へ出る。加えて席のHUDパネル（Hud.tsxのSEAT_POSITIONS、
- *    下段70%）とアクションボタン帯に挟まれ、400x100が必ず何かに重なる。
+ *    置く内側の位置と違い、参照フレームが少しでもずれると真っ先に画面外へ
+ *    出る。加えて席のHUDパネル（Hud.tsxのSEAT_POSITIONS、下段70%）と
+ *    アクションボタン帯に挟まれ、既定サイズ400x100が必ず何かに重なる。
+ *
+ * 左上ではゲーム側のメニュー/SB・BB/アンティと重なるが、そこは許容する
+ * （sola指定: 「どのみちユーザーが動かせる」）。既定倍率ならネームプレート
+ * には届かない。
  */
 const HAND_LOG_DEFAULT_LEFT = 10
-/**
- * 既定位置は画面上部のクライアントUIと左上のネームプレートの間へ差し込む
- * （sola指定）。プレートにはチップスタックが出るので、一部でも覆うと残り
- * スタックが読めなくなる ―― これが最優先の制約。メニューへの重なりは許容。
- *
- * 幅400pxのパネルを左端に置くと、左列のプレート（上段プレイヤーB / 下段
- * プレイヤーA）とは横方向で必ず重なるので、縦で外すしかない。上段プレートの
- * 上端に下端を合わせて上へ積むことで、パネルが高いほど（scaleが大きいほど）
- * 上のクライアントUI側へ食い込む ―― 譲る順序を「プレート > SB/BB・アンティ >
- * メニュー」に固定している。
- *
- * 実測値は src/mockup/table-layout.ts の SEATS[].plate（実機スクリーンショット
- * 由来、viewport比）: 上段プレイヤーB = 上端23.6%。プレートもviewport比で動くので、
- * こちらも比率で追う。
- */
-const HAND_LOG_SEAT_PLATE_TOP_ROW_TOP_RATIO = 0.236
-/** プレート上端との間に残す余白。実機のプレートは装飾枠込みで個体差がある。 */
-const HAND_LOG_SEAT_PLATE_MARGIN = 6
-/**
- * 比率が正しいのは「viewportを正しく読めている」前提の上だけなので、上限で
- * 頭打ちにする。右下基準だった頃はこの天井が無く、大きすぎる読み取りが
- * そのまま画面外の座標になっていた。
- */
-const HAND_LOG_DEFAULT_TOP_MAX = 400
+const HAND_LOG_DEFAULT_TOP = 10
 const HAND_LOG_FONT_FAMILY = 'Consolas, Monaco, "Courier New", monospace'
 const HAND_LOG_SEPARATOR_HEIGHT = 10
 const HAND_LOG_ENTRY_PADDING_X = 8
@@ -278,31 +261,12 @@ const resizeHandLogLayout = (
   }
 }
 
-/**
- * 上段プレートの上端へ下端を合わせ、そこから上へ積む。
- *
- * 上段プレートの「下」（Bのプレートと Aのプレートの間）へ入れる案は採らない:
- * その帯にはプレイヤーBのHUDパネルそのものが載っている
- * （`Hud.tsx` の SEAT_POSITIONS[2] = top 35%）ので、ログでHUDを潰してしまう。
- */
-const createDefaultHandLogTop = (environment: HandLogEnvironment): number => {
-  const plateTop =
-    environment.viewportHeight * HAND_LOG_SEAT_PLATE_TOP_ROW_TOP_RATIO
-  const renderedHeight = DEFAULT_HAND_LOG_CONFIG.height * environment.scale
-
-  return clamp(
-    plateTop - renderedHeight - HAND_LOG_SEAT_PLATE_MARGIN,
-    0,
-    HAND_LOG_DEFAULT_TOP_MAX
-  )
-}
-
 const createDefaultHandLogLayout = (
   environment: HandLogEnvironment
 ): HandLogLayout =>
   normalizeHandLogLayout({
     left: HAND_LOG_DEFAULT_LEFT,
-    top: Math.round(createDefaultHandLogTop(environment)),
+    top: HAND_LOG_DEFAULT_TOP,
     width: DEFAULT_HAND_LOG_CONFIG.width,
     height: DEFAULT_HAND_LOG_CONFIG.height,
   }, environment)

--- a/src/components/HandLog.tsx
+++ b/src/components/HandLog.tsx
@@ -32,8 +32,43 @@ interface HandLogProps {
 const HAND_LOG_MOVE_GRIP_SIZE = 16
 const HAND_LOG_BORDER_WIDTH = 1
 const HAND_LOG_DRAG_THRESHOLD = 4
-const HAND_LOG_DEFAULT_RIGHT = 10
-const HAND_LOG_DEFAULT_BOTTOM = 135
+/**
+ * 既定位置は画面左上側。右下基準（viewportWidth - 余白 - 幅*scale）を
+ * やめた理由は2つある:
+ * 1. 右下基準は「viewportを正しく読めている」ことがそのまま位置の正しさに
+ *    なる。environmentが実ウィンドウより大きいと左端が実ウィンドウの外へ
+ *    落ちる ―― 実機で「ウィンドウを画面半分にした状態でリセットしたら
+ *    ログが消え、最大化したら現れた」として観測された。
+ * 2. 右下隅は座標系の最も外側の点でもある。ユーザーが自分でドラッグして
+ *    置く内側の位置と違い、参照フレームが少しでもずれると真っ先に
+ *    画面外へ出る。加えて席のHUDパネル（Hud.tsxのSEAT_POSITIONS、
+ *    下段70%）とアクションボタン帯に挟まれ、400x100が必ず何かに重なる。
+ */
+const HAND_LOG_DEFAULT_LEFT = 10
+/**
+ * 既定位置は画面上部のクライアントUIと左上のネームプレートの間へ差し込む
+ * （sola指定）。プレートにはチップスタックが出るので、一部でも覆うと残り
+ * スタックが読めなくなる ―― これが最優先の制約。メニューへの重なりは許容。
+ *
+ * 幅400pxのパネルを左端に置くと、左列のプレート（上段プレイヤーB / 下段
+ * プレイヤーA）とは横方向で必ず重なるので、縦で外すしかない。上段プレートの
+ * 上端に下端を合わせて上へ積むことで、パネルが高いほど（scaleが大きいほど）
+ * 上のクライアントUI側へ食い込む ―― 譲る順序を「プレート > SB/BB・アンティ >
+ * メニュー」に固定している。
+ *
+ * 実測値は src/mockup/table-layout.ts の SEATS[].plate（実機スクリーンショット
+ * 由来、viewport比）: 上段プレイヤーB = 上端23.6%。プレートもviewport比で動くので、
+ * こちらも比率で追う。
+ */
+const HAND_LOG_SEAT_PLATE_TOP_ROW_TOP_RATIO = 0.236
+/** プレート上端との間に残す余白。実機のプレートは装飾枠込みで個体差がある。 */
+const HAND_LOG_SEAT_PLATE_MARGIN = 6
+/**
+ * 比率が正しいのは「viewportを正しく読めている」前提の上だけなので、上限で
+ * 頭打ちにする。右下基準だった頃はこの天井が無く、大きすぎる読み取りが
+ * そのまま画面外の座標になっていた。
+ */
+const HAND_LOG_DEFAULT_TOP_MAX = 400
 const HAND_LOG_FONT_FAMILY = 'Consolas, Monaco, "Courier New", monospace'
 const HAND_LOG_SEPARATOR_HEIGHT = 10
 const HAND_LOG_ENTRY_PADDING_X = 8
@@ -87,7 +122,7 @@ type HandLogMachineAction =
   | { type: 'loadStarted', load: HandLogLoad }
   | { type: 'loadResolved', load: HandLogLoad, layout: HandLogLayout | undefined }
   | { type: 'externalLayout', layout: HandLogLayout }
-  | { type: 'reset' }
+  | { type: 'reset', environment: HandLogEnvironment }
   | { type: 'interactionStarted', mode: HandLogInteractionMode, x: number, y: number }
   | { type: 'pointerMoved', x: number, y: number }
   | { type: 'interactionFinished', deferPersistenceForLoad?: boolean }
@@ -243,18 +278,31 @@ const resizeHandLogLayout = (
   }
 }
 
+/**
+ * 上段プレートの上端へ下端を合わせ、そこから上へ積む。
+ *
+ * 上段プレートの「下」（Bのプレートと Aのプレートの間）へ入れる案は採らない:
+ * その帯にはプレイヤーBのHUDパネルそのものが載っている
+ * （`Hud.tsx` の SEAT_POSITIONS[2] = top 35%）ので、ログでHUDを潰してしまう。
+ */
+const createDefaultHandLogTop = (environment: HandLogEnvironment): number => {
+  const plateTop =
+    environment.viewportHeight * HAND_LOG_SEAT_PLATE_TOP_ROW_TOP_RATIO
+  const renderedHeight = DEFAULT_HAND_LOG_CONFIG.height * environment.scale
+
+  return clamp(
+    plateTop - renderedHeight - HAND_LOG_SEAT_PLATE_MARGIN,
+    0,
+    HAND_LOG_DEFAULT_TOP_MAX
+  )
+}
+
 const createDefaultHandLogLayout = (
   environment: HandLogEnvironment
 ): HandLogLayout =>
   normalizeHandLogLayout({
-    left:
-      environment.viewportWidth -
-      HAND_LOG_DEFAULT_RIGHT -
-      DEFAULT_HAND_LOG_CONFIG.width * environment.scale,
-    top:
-      environment.viewportHeight -
-      HAND_LOG_DEFAULT_BOTTOM -
-      DEFAULT_HAND_LOG_CONFIG.height * environment.scale,
+    left: HAND_LOG_DEFAULT_LEFT,
+    top: Math.round(createDefaultHandLogTop(environment)),
     width: DEFAULT_HAND_LOG_CONFIG.width,
     height: DEFAULT_HAND_LOG_CONFIG.height,
   }, environment)
@@ -384,7 +432,13 @@ const transitionHandLogLayout = (
     }
 
     case 'reset': {
-      const environment = state.pendingEnvironment ?? state.environment
+      // 保持している environment ではなく、呼び出し側が読み直した実寸を採用する。
+      // resizeイベントの取りこぼしなどで environment が実ウィンドウとずれていると、
+      // 既定位置の算出も画面内クランプも同じ古い値を使うためズレを検出できず、
+      // パネルが画面外に置かれても誰も気付けない（実機で発生した）。
+      // リセットはユーザーが「今の画面で見える状態へ戻す」操作なので、
+      // ここで環境を確定させ直すのが正しい。
+      const environment = action.environment
       return {
         state: {
           ...state,
@@ -1059,7 +1113,10 @@ const HandLog = memo<HandLogProps>(({ entries, config: userConfig, onClearLog, s
       })
     }
     const handleReset = () => {
-      commitLayoutAction({ type: 'reset' })
+      commitLayoutAction({
+        type: 'reset',
+        environment: readHandLogEnvironment(latestScaleRef.current),
+      })
     }
     const handleUpdate = (event: Event) => {
       const nextLayout = (event as CustomEvent<unknown>).detail

--- a/src/components/hud/hooks/useDraggable.test.ts
+++ b/src/components/hud/hooks/useDraggable.test.ts
@@ -197,6 +197,119 @@ describe('useDraggable', () => {
     )
   })
 
+  describe('ポップアップからの配置リセット', () => {
+    const startDrag = (result: { current: ReturnType<typeof useDraggable> }) => {
+      const mockContainer = document.createElement('div')
+      mockContainer.getBoundingClientRect = jest.fn(() => ({
+        top: 0, left: 0, width: 100, height: 100,
+        right: 100, bottom: 100, x: 0, y: 0, toJSON: () => {},
+      }))
+      Object.defineProperty(result.current.containerRef, 'current', {
+        value: mockContainer,
+        writable: true,
+      })
+      act(() => {
+        result.current.handleMouseDown({
+          preventDefault: jest.fn(),
+          stopPropagation: jest.fn(),
+          clientX: 100,
+          clientY: 100,
+        } as unknown as React.MouseEvent)
+      })
+    }
+
+    it('保存済み位置を捨ててdefaultPositionの描画へ戻す', () => {
+      const savedPosition = { top: '30%', left: '70%' }
+      mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
+        callback({
+          success: true,
+          scale: 1,
+          ...(message.action === 'getDeviceUILayout' ? { position: savedPosition } : {}),
+        })
+      })
+      const { result } = renderHook(() => useDraggable(0, defaultPosition))
+      expect(result.current.position).toEqual(savedPosition)
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('resetHudPositions'))
+      })
+
+      // positionがnull＝Hud.tsxがdefaultPosition（SEAT_POSITIONS）を描く状態。
+      expect(result.current.position).toBeNull()
+      // storageはbackground側で既に空。ここから書き戻してはならない。
+      expect(mockChromeRuntimeSendMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'setDeviceHudPosition' }),
+        expect.any(Function)
+      )
+    })
+
+    it('リセット後に届いた古い保存位置で復活させない', () => {
+      let resolveInitialLoad!: (response: unknown) => void
+      mockChromeRuntimeSendMessage.mockImplementation((message, callback) => {
+        if (message.action === 'getDeviceUILayout') {
+          resolveInitialLoad = callback
+        } else {
+          callback({ success: true })
+        }
+      })
+      const { result } = renderHook(() => useDraggable(0, defaultPosition))
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('resetHudPositions'))
+      })
+      act(() => {
+        resolveInitialLoad({
+          success: true,
+          scale: 1,
+          position: { top: '30%', left: '70%' },
+        })
+      })
+
+      expect(result.current.position).toBeNull()
+    })
+
+    it('進行中のドラッグを破棄して消した位置を書き戻させない', () => {
+      const { result } = renderHook(() => useDraggable(0, defaultPosition))
+      startDrag(result)
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mousemove', {
+          clientX: 150, clientY: 120, bubbles: true,
+        }))
+      })
+      expect(result.current.position).not.toBeNull()
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent('resetHudPositions'))
+      })
+
+      expect(result.current.isDragging).toBe(false)
+      expect(result.current.position).toBeNull()
+
+      // 掴んだままのmousemove/mouseupが残っていても再保存されない
+      act(() => {
+        document.dispatchEvent(new MouseEvent('mousemove', {
+          clientX: 300, clientY: 300, bubbles: true,
+        }))
+        document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+      })
+
+      expect(result.current.position).toBeNull()
+      expect(mockChromeRuntimeSendMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'setDeviceHudPosition' }),
+        expect.any(Function)
+      )
+    })
+
+    it('アンマウント後のリセット通知でstate更新しない', () => {
+      const { unmount } = renderHook(() => useDraggable(0, defaultPosition))
+      unmount()
+
+      expect(() => {
+        window.dispatchEvent(new CustomEvent('resetHudPositions'))
+      }).not.toThrow()
+    })
+  })
+
   it('別の席番号では異なるストレージキーを使用', () => {
     renderHook(() => useDraggable(3, defaultPosition))
 

--- a/src/components/hud/hooks/useDraggable.ts
+++ b/src/components/hud/hooks/useDraggable.ts
@@ -42,6 +42,29 @@ export const useDraggable = (seatIndex: number, defaultPosition: CSSProperties) 
     }
   }, [position, seatIndex, isDragging])
 
+  // ポップアップの「位置とサイズをリセット」。バックグラウンドが
+  // storage.local から hudPosition_* を消し、ゲームタブへ配信してくる。
+  // 保存済みの位置を捨てて defaultPosition の描画へ戻すだけで、
+  // ここからは書き戻さない（storageは背景側で既に空になっている）。
+  useEffect(() => {
+    const handleReset = () => {
+      // A reset is newer than any in-flight startup read. Without this bump a
+      // loadHudPosition callback still in flight would restore the position
+      // that was just cleared.
+      positionEditGenerationRef.current += 1
+      // 進行中のドラッグは破棄する。残すとmousemoveが掴んだ時点の
+      // startLeft/startTopから再開し、消したはずの位置を書き戻してしまう。
+      dragRef.current = null
+      shouldPersistPositionRef.current = false
+      setIsDragging(false)
+      setPosition(null)
+    }
+    window.addEventListener('resetHudPositions', handleReset)
+    return () => {
+      window.removeEventListener('resetHudPositions', handleReset)
+    }
+  }, [])
+
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()

--- a/src/components/popup/UIScaleSection.test.tsx
+++ b/src/components/popup/UIScaleSection.test.tsx
@@ -51,21 +51,21 @@ describe('UIScaleSection', () => {
       .toHaveValue('Shift + H')
   })
 
-  it('ハンドログの位置とサイズのリセットを永続backgroundへ委譲する', async () => {
+  it('HUDとハンドログの位置とサイズのリセットを永続backgroundへ委譲する', async () => {
     const user = userEvent.setup()
     render(<UIScaleSection {...defaultProps} />)
 
     await user.click(screen.getByRole('button', { name: '位置とサイズをリセット' }))
 
     expect(mockChromeRuntimeSendMessage).toHaveBeenCalledWith(
-      { action: 'resetDeviceHandLogLayout' },
+      { action: 'resetDeviceUILayout' },
       expect.any(Function)
     )
     expect(mockTabsQuery).not.toHaveBeenCalled()
     expect(mockTabsSendMessage).not.toHaveBeenCalled()
   })
 
-  it('ハンドログlayoutの永続削除に失敗した場合は表示だけをリセットしない', async () => {
+  it('UI配置の永続削除に失敗した場合は表示だけをリセットしない', async () => {
     const user = userEvent.setup()
     mockChromeRuntimeSendMessage.mockImplementation((_message, callback) => {
       callback({ success: false, error: 'remove failed' })
@@ -75,7 +75,7 @@ describe('UIScaleSection', () => {
     await user.click(screen.getByRole('button', { name: '位置とサイズをリセット' }))
 
     expect(mockChromeRuntimeSendMessage).toHaveBeenCalledWith(
-      { action: 'resetDeviceHandLogLayout' },
+      { action: 'resetDeviceUILayout' },
       expect.any(Function)
     )
     expect(mockTabsSendMessage).not.toHaveBeenCalled()

--- a/src/components/popup/UIScaleSection.test.tsx
+++ b/src/components/popup/UIScaleSection.test.tsx
@@ -65,6 +65,43 @@ describe('UIScaleSection', () => {
     expect(mockTabsSendMessage).not.toHaveBeenCalled()
   })
 
+  it('リセット成功後は倍率表示も既定へ戻す', async () => {
+    // 倍率のstorage削除とゲームタブへの配信はbackgroundが行うが、ポップアップ
+    // 自身は配信を購読していないので、成功応答を受けて自前で戻す必要がある。
+    const user = userEvent.setup()
+    render(
+      <UIScaleSection
+        {...defaultProps}
+        uiConfig={{ ...DEFAULT_UI_CONFIG, scale: 1.6 }}
+      />
+    )
+    expect(screen.getByText('160%')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: '位置とサイズをリセット' }))
+
+    expect(mockSetUIConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ scale: DEFAULT_UI_CONFIG.scale })
+    )
+  })
+
+  it('リセットが失敗した場合は倍率表示を戻さない', async () => {
+    const user = userEvent.setup()
+    mockChromeRuntimeSendMessage.mockImplementation((_message, callback) => {
+      callback({ success: false, error: 'remove failed' })
+    })
+    render(
+      <UIScaleSection
+        {...defaultProps}
+        uiConfig={{ ...DEFAULT_UI_CONFIG, scale: 1.6 }}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: '位置とサイズをリセット' }))
+
+    expect(mockSetUIConfig).not.toHaveBeenCalled()
+    expect(screen.getByText('160%')).toBeInTheDocument()
+  })
+
   it('UI配置の永続削除に失敗した場合は表示だけをリセットしない', async () => {
     const user = userEvent.setup()
     mockChromeRuntimeSendMessage.mockImplementation((_message, callback) => {

--- a/src/components/popup/UIScaleSection.tsx
+++ b/src/components/popup/UIScaleSection.tsx
@@ -10,7 +10,7 @@ import { DEFAULT_UI_CONFIG, type UIConfig } from '../../types/hand-log'
 import { formatShortcut, shortcutFromKeyboardEvent } from '../../utils/keyboard-shortcut'
 import {
   saveLocalUIScale,
-  resetHandLogLayout,
+  resetUILayout,
   saveSyncedUIConfig,
   saveSyncedUIConfigPatch,
 } from '../../utils/ui-config-storage'
@@ -178,11 +178,11 @@ export const UIScaleSection = ({
         <Button
           size="small"
           variant="text"
-          title="ハンドログの位置とサイズをリセット"
+          title="HUDパネルとハンドログの位置とサイズを既定へ戻す"
           onClick={() => {
             // Persistence and live-tab delivery both run in the background so
             // closing the action popup cannot interrupt the reset.
-            resetHandLogLayout()
+            resetUILayout()
           }}
           sx={{
             ml: 'auto',

--- a/src/components/popup/UIScaleSection.tsx
+++ b/src/components/popup/UIScaleSection.tsx
@@ -178,11 +178,23 @@ export const UIScaleSection = ({
         <Button
           size="small"
           variant="text"
-          title="HUDパネルとハンドログの位置とサイズを既定へ戻す"
+          title="HUDパネルとハンドログの位置・サイズ・倍率を既定へ戻す"
           onClick={() => {
             // Persistence and live-tab delivery both run in the background so
             // closing the action popup cannot interrupt the reset.
-            resetUILayout()
+            resetUILayout(() => {
+              // 倍率はbackgroundがstorageから消し、ゲームタブへは
+              // updateDeviceUIScaleで配信される。ポップアップ自身は購読して
+              // いないので、成功応答を受けてここで既定へ戻す。
+              // 進行中のscale書き込みがあれば、その基準もここへ寄せる。
+              latestAppliedScaleRequestIdRef.current = ++nextScaleRequestIdRef.current
+              latestAppliedScaleRef.current = DEFAULT_UI_CONFIG.scale
+              pendingScaleRef.current = DEFAULT_UI_CONFIG.scale
+              setUIConfig({
+                ...latestUIConfigRef.current,
+                scale: DEFAULT_UI_CONFIG.scale,
+              })
+            })
           }}
           sx={{
             ml: 'auto',

--- a/src/content_script.download-ack.test.ts
+++ b/src/content_script.download-ack.test.ts
@@ -124,17 +124,23 @@ describe('content_script.ts download message handlers send an explicit ack', () 
     expect(sendResponse).toHaveBeenCalledWith({ success: false, error: 'createObjectURL boom' })
   })
 
-  test('resetHandLogLayout forwards the popup reset into the page', () => {
+  test('resetUILayout fans the popup reset out to both the hand log and the HUD panels', () => {
     const dispatchEvent = jest.spyOn(window, 'dispatchEvent')
 
     listener(
-      { action: 'resetHandLogLayout' },
+      { action: 'resetUILayout' },
       {},
       jest.fn()
     )
 
+    // Two independent subscribers: HandLog.tsx's layout machine and
+    // useDraggable.ts. A single delivery that only reached one of them would
+    // leave half the panels where the user dragged them.
     expect(dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'resetHandLogLayout' })
+    )
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'resetHudPositions' })
     )
   })
 

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -320,8 +320,12 @@ const messageHandlers: Record<string, (message: ChromeMessage) => void> = {
       }))
     }
   },
-  resetHandLogLayout: () => {
+  // 配信は1メッセージ、購読は2コンポーネント。HandLogとuseDraggableは
+  // 互いに独立した状態機械なので、片方だけを再マウントさせずに
+  // それぞれのイベントで既定へ戻させる。
+  resetUILayout: () => {
     window.dispatchEvent(new CustomEvent(EVENTS.RESET_HAND_LOG_LAYOUT))
+    window.dispatchEvent(new CustomEvent(EVENTS.RESET_HUD_POSITIONS))
   },
   updateHandLogLayout: (message) => {
     if ('layout' in message) {

--- a/src/mockup/mock-chrome.ts
+++ b/src/mockup/mock-chrome.ts
@@ -6,6 +6,7 @@ import {
 } from '../components/popup/popup-theme-storage'
 import {
   HAND_LOG_LAYOUT_STORAGE_KEY,
+  HUD_POSITION_STORAGE_KEYS,
   hudPositionStorageKey,
   persistSyncedUIConfig,
   persistSyncedUIConfigPatch,
@@ -206,16 +207,21 @@ export const installChromeMock = (): MockChromeController => {
           return
         }
 
-        if (message.action === 'resetDeviceHandLogLayout') {
-          localStorage.remove(HAND_LOG_LAYOUT_STORAGE_KEY, () => {
-            // Clearing storage is not enough: `HandLog` does not watch
-            // storage, it resets on this window event. The real background
-            // sends it to the game tab, where `content_script.ts` re-dispatches
-            // it -- without this the popup's 位置とサイズをリセット button would
-            // do nothing visible.
-            window.dispatchEvent(new CustomEvent(MESSAGE_ACTIONS.RESET_HAND_LOG_LAYOUT))
-            callback?.({ success: true })
-          })
+        if (message.action === 'resetDeviceUILayout') {
+          localStorage.remove(
+            [HAND_LOG_LAYOUT_STORAGE_KEY, ...HUD_POSITION_STORAGE_KEYS],
+            () => {
+              // Clearing storage is not enough: neither `HandLog` nor
+              // `useDraggable` watches storage -- they reset on these window
+              // events. The real background sends one `resetUILayout` message
+              // to the game tab, where `content_script.ts` fans it out into
+              // exactly these two -- without them the popup's
+              // 位置とサイズをリセット button would do nothing visible.
+              window.dispatchEvent(new CustomEvent(MESSAGE_ACTIONS.RESET_HAND_LOG_LAYOUT))
+              window.dispatchEvent(new CustomEvent(MESSAGE_ACTIONS.RESET_HUD_POSITIONS))
+              callback?.({ success: true })
+            }
+          )
           return
         }
 

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -55,9 +55,11 @@ export const MESSAGE_ACTIONS = {
   SET_DEVICE_HUD_POSITION: 'setDeviceHudPosition',
   GET_DEVICE_HAND_LOG_LAYOUT: 'getDeviceHandLogLayout',
   SET_DEVICE_HAND_LOG_LAYOUT: 'setDeviceHandLogLayout',
-  RESET_DEVICE_HAND_LOG_LAYOUT: 'resetDeviceHandLogLayout',
+  RESET_DEVICE_UI_LAYOUT: 'resetDeviceUILayout',
   UPDATE_HAND_LOG_LAYOUT: 'updateHandLogLayout',
+  RESET_UI_LAYOUT: 'resetUILayout',
   RESET_HAND_LOG_LAYOUT: 'resetHandLogLayout',
+  RESET_HUD_POSITIONS: 'resetHudPositions',
   SET_SYNCED_UI_CONFIG: 'setSyncedUIConfig',
   // Operation state
   GET_OPERATION_STATE: 'getOperationState',
@@ -228,8 +230,14 @@ export interface SetDeviceHandLogLayoutMessage {
   layout: HandLogLayout
 }
 
-export interface ResetDeviceHandLogLayoutMessage {
-  action: 'resetDeviceHandLogLayout'
+/**
+ * ポップアップ→バックグラウンド。端末内に保存されたHUDパネル位置と
+ * ハンドログのレイアウトを、まとめて既定へ戻す。
+ * 個別リセットに分けていないのは、ユーザーから見て「配置を元に戻す」は
+ * ひとつの操作であり、片方だけ消えて片方が残る中間状態を作らないため。
+ */
+export interface ResetDeviceUILayoutMessage {
+  action: 'resetDeviceUILayout'
 }
 
 export interface UpdateHandLogLayoutMessage {
@@ -237,8 +245,14 @@ export interface UpdateHandLogLayoutMessage {
   layout: HandLogLayout
 }
 
-export interface ResetHandLogLayoutMessage {
-  action: 'resetHandLogLayout'
+/**
+ * バックグラウンド→ゲームタブ。`content_script.ts`が
+ * `resetHandLogLayout`と`resetHudPositions`のwindowイベントへ展開する。
+ * ストレージを消すだけでは開いているタブの表示は戻らない
+ * （`useDraggable`はマウント時にしか読まない）ため、この配信が必要。
+ */
+export interface ResetUILayoutMessage {
+  action: 'resetUILayout'
 }
 
 export interface SetSyncedUIConfigMessage {
@@ -488,9 +502,9 @@ export type ChromeMessage =
   | SetDeviceHudPositionMessage
   | GetDeviceHandLogLayoutMessage
   | SetDeviceHandLogLayoutMessage
-  | ResetDeviceHandLogLayoutMessage
+  | ResetDeviceUILayoutMessage
   | UpdateHandLogLayoutMessage
-  | ResetHandLogLayoutMessage
+  | ResetUILayoutMessage
   | SetSyncedUIConfigMessage
   | PatchSyncedUIConfigMessage
   | FirebaseAuthStatusMessage

--- a/src/utils/ui-config-storage.test.ts
+++ b/src/utils/ui-config-storage.test.ts
@@ -9,7 +9,7 @@ import {
   LEGACY_SYNC_UI_SCALE_KEY,
   persistSyncedUIConfig,
   resolveLocalUIScale,
-  resetHandLogLayout,
+  resetUILayout,
   saveHandLogLayout,
   saveLocalUIScale,
   saveHudPosition,
@@ -318,7 +318,7 @@ describe('ui-config-storage', () => {
 
     loadHandLogLayout(loadCallback)
     saveHandLogLayout(layout)
-    resetHandLogLayout(resetCallback)
+    resetUILayout(resetCallback)
 
     expect(loadCallback).toHaveBeenCalledWith(layout)
     expect(chrome.runtime.sendMessage).toHaveBeenNthCalledWith(
@@ -333,13 +333,13 @@ describe('ui-config-storage', () => {
     )
     expect(chrome.runtime.sendMessage).toHaveBeenNthCalledWith(
       3,
-      { action: 'resetDeviceHandLogLayout' },
+      { action: 'resetDeviceUILayout' },
       expect.any(Function)
     )
     expect(resetCallback).toHaveBeenCalled()
   })
 
-  it('ハンドログlayoutのreset失敗時は成功callbackを呼ばない', () => {
+  it('UI配置resetの失敗時は成功callbackを呼ばない', () => {
     ;(chrome.runtime.sendMessage as jest.Mock).mockImplementationOnce(
       (_message, callback) => {
         callback({ success: false, error: 'remove failed' })
@@ -347,7 +347,7 @@ describe('ui-config-storage', () => {
     )
     const callback = jest.fn()
 
-    resetHandLogLayout(callback)
+    resetUILayout(callback)
 
     expect(callback).not.toHaveBeenCalled()
   })
@@ -363,7 +363,7 @@ describe('ui-config-storage', () => {
       )
       const callback = jest.fn()
 
-      resetHandLogLayout(callback)
+      resetUILayout(callback)
       jest.advanceTimersByTime(DEVICE_LAYOUT_MESSAGE_TIMEOUT_MS)
       expect(callback).not.toHaveBeenCalled()
 

--- a/src/utils/ui-config-storage.ts
+++ b/src/utils/ui-config-storage.ts
@@ -20,6 +20,24 @@ export const HAND_LOG_MIN_HEIGHT = 80
 export const hudPositionStorageKey = (seatIndex: number): string =>
   `hudPosition_${seatIndex}`
 
+/** 通常HUD(0-5)とリアルタイムHUD(100-105)の全席。`isValidHudPositionId`と同じ範囲。 */
+export const HUD_POSITION_IDS: readonly number[] = [
+  ...Array.from({ length: 6 }, (_, seatIndex) => seatIndex),
+  ...Array.from(
+    { length: 6 },
+    (_, seatIndex) => REAL_TIME_HUD_POSITION_OFFSET + seatIndex
+  ),
+]
+
+/**
+ * 消すキーは前方一致で走査せず、有効な席IDから組み立てる。
+ * `storage.local`にはサービス状態など無関係のキーも同居しており、
+ * `get(null)`で全件読んで前方一致で消す実装は、将来別用途の
+ * `hudPosition_`付きキーが増えたときに巻き込む。
+ */
+export const HUD_POSITION_STORAGE_KEYS: readonly string[] =
+  HUD_POSITION_IDS.map(hudPositionStorageKey)
+
 type SyncedUIConfig = Omit<UIConfig, 'scale'>
 type PendingSyncedUIConfigWrite = {
   callback?: (success: boolean) => void
@@ -336,9 +354,14 @@ export const saveHandLogLayout = (layout: HandLogLayout): void => {
   )
 }
 
-export const resetHandLogLayout = (callback?: () => void): void => {
+/**
+ * HUDパネル位置とハンドログのレイアウトをまとめて既定へ戻す。
+ * 永続化も開いているタブへの配信もバックグラウンドが行うので、
+ * 呼び出し直後にポップアップが閉じてもリセットは中断されない。
+ */
+export const resetUILayout = (callback?: () => void): void => {
   sendDeviceLayoutWriteMessage(
-    { action: 'resetDeviceHandLogLayout' },
+    { action: 'resetDeviceUILayout' },
     status => {
       if (status === 'success') callback?.()
     }


### PR DESCRIPTION
## 概要

ポップアップの「位置とサイズをリセット」について、報告された2点に対応します。

1. HUDパネルの位置がリセットされない（ハンドログのみが対象だった）
2. リセットするとハンドログが画面から消える

## 1. リセットの対象をHUD＋ハンドログの両方に

これまではハンドログのレイアウトだけを戻していました。ボタンはHUD倍率の行にあり表示ラベルも「位置とサイズをリセット」なので、HUDパネルを動かしたユーザーが押しても何も起きず、効いていないように見えます。

HUDパネルのドラッグ位置は `useDraggable.ts` が `hudPosition_0`–`5`（通常HUD）と `hudPosition_100`–`105`（リアルタイムHUD）へ保存していますが、**製品コードにこれを削除する経路が存在しませんでした**（同等物はモックアップ専用の `clearHudPositions` にしかない）。

```
ポップアップ  resetDeviceUILayout（1メッセージ）
      ↓
background   handLogLayout + hudPosition_* を1回の remove でまとめて削除
      ↓       resetUILayout を1回配信
content_script  resetHandLogLayout / resetHudPositions の2イベントへ展開
      ↓
HandLog / useDraggable  それぞれ既定へ復帰
```

- 削除を1回にまとめたのは、片方だけ消えて片方が残る中間状態を作らないためです
- 消すキーは `storage.local` の前方一致走査ではなく有効な席IDから組み立てます（無関係のキーも同居しているため）
- ストレージを消すだけでは開いているタブの表示は戻りません（`HandLog` も `useDraggable` も storage を監視していない）ので、配信が必要です
- 端末ローカルの倍率 `uiScale` は配置ではなく可読性の設定なので消しません

## 2. リセットしたハンドログが画面外へ飛ぶ不具合

既定位置の算出式が右下基準でした。

```
left = viewportWidth - 10 - width * scale
```

この式は「viewportを正しく読めていること」がそのまま位置の正しさになります。状態機械が保持する `environment` が実ウィンドウより大きいと、最大化時の幅で計算した左端が半分幅のウィンドウの外へ落ちます。**既定位置の算出も画面内へのクランプも同じ古い値を使う**ため、ズレを検出できず素通りします。

対策は2段構えです。

1. **既定位置を左上側へ移し、上端に天井 `[0, 400]` を設けた** — どれだけ読み違えても既定座標が画面外へ運ばれません。右下隅は座標系の最も外側の点でもあり、参照フレームが少しでもずれると真っ先に画面外へ出ます
2. **reset遷移が `environment` を引数で受け取る** — 呼び出し側が `readHandLogEnvironment()` の実測値を渡します。リセットは見失ったパネルを救出する操作なのに、パネルを見失った原因である同じ古い状態を信じて計算していました

### 既定位置の決め方

左上のネームプレートの上端に**下端を合わせて上へ積みます**。

- プレートにはチップスタックが出るので、一部でも覆うと残りスタックが読めなくなります（最優先の制約）
- プレートの下（BとAのプレートの間）は空いて見えますが、そこには `Hud.tsx` の `SEAT_POSITIONS[2] = top 35%` があり、ログでHUDパネルを潰します
- 下端をプレートに合わせることで、`scale` でパネルが高くなったときに譲る順序が **プレート > SB/BB・アンティ > メニュー** に固定されます

1512x860 実測: ログ `(10, 97)–(410, 197)`、ネームプレート／HUDパネル／SB/BB／アンティの重なりはいずれも 0、メニューのみ重なり。

**既知の制限**: 倍率2.0では実寸200pxがプレート上端より上に収まらず上端0に張り付き、上部UIへ食い込みます（画面高768pxならプレート上端が181px）。プレートは守られます。

## 検証

- `npm run typecheck` クリーン、`npm run test` 1685件全通過
- 統合リセットをモックアップで実測確認（HUD `10%,35%`→`37.5%,54.7%`、ログ `(10,10)`→`(422,615)` から1クリックで両方復帰）
- 4観点の敵対的レビューを実施。プロダクションコードへの指摘はゼロ、テストの検出力不足が3件指摘されたため修正し、**指摘者が使ったのと同じ変異（`HUD_POSITION_IDS` から100番台を削る／`clampHandLogPosition` の0分岐から `Math.max` を外す／天井を無限大にする）で検出されることを実測確認**

## 未解決

`environment` が実ウィンドウとずれる根本原因は特定できていません。診断では、陳腐化した environment を再現した実コンポーネント検証で `left=2150px/top=1205px` という完全に画面外の結果を確認しており症状とは一致しますが、コード上の到達経路は塞がっているという分析もあります。ドラッグ時の画面内クランプは同じ `environment` を使うため、同じズレが起きればクランプも効きません。リセットは救出手段として確実に効くようになりましたが、再発するようなら追跡します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)