### PR TITLE
feat(ui): テーブル人数フィルタをレンジスライダーへ

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -769,7 +769,7 @@ v3 added composite indexes for player-specific queries. v6 changes the Raw Lake 
 | `UIConfig` | `src/types/hand-log.ts` | `displayEnabled`; `scale` (0.5–2.0) is runtime state persisted separately as device-local `uiScale` |
 | `HandLogConfig` | `src/types/hand-log.ts` | `enabled`, `maxHands`, `position`, `width`, `height`, `fontSize`, `opacity` |
 | `HandLogLayout` | `src/types/hand-log.ts` | Device-local pixel `left`, `top`, `width`, and `height`, persisted as `handLogLayout` |
-| `FilterOptions` | `src/types/filters.ts` | `gameTypes` (sng/mtt/ring), `tableSize` (full/4p/3p/hu players-dealt layer, `src/utils/table-size.ts`, opt-out multiselect, missing key = all layers/no filter; popup label "テーブル人数"), `handLimit`, `statDisplayConfigs` |
+| `FilterOptions` | `src/types/filters.ts` | `gameTypes` (sng/mtt/ring), `tableSize` (full/4p/3p/hu players-dealt layer, `src/utils/table-size.ts`, missing key = all layers/no filter; popup label "テーブル人数", edited as a **contiguous range** on a two-thumb slider — the layers are ordered by player count and a gap in the middle has no meaning, so per-layer checkboxes could express states no user wants; `src/utils/table-size-range.ts` converts between the range and the stored per-layer booleans and folds a legacy non-contiguous selection into the smallest span covering it), `handLimit`, `statDisplayConfigs` |
 | `PopupThemeMode` | `src/components/popup/theme.ts` | `'auto' \| 'dark' \| 'light'` (default `'auto'`), persisted standalone as `popupTheme` (`popup-theme-storage.ts`) — popup-only, not part of `UIConfig`/its all-tabs broadcast |
 | `HudPosition` | `src/components/Hud.tsx` | `top`, `left` (percentage) |
 

--- a/src/components/Popup.test.tsx
+++ b/src/components/Popup.test.tsx
@@ -770,6 +770,89 @@ describe('Popup', () => {
     )
   })
 
+  it('旧UIで作れた連続しないtableSizeは起動時に丸めて保存・配信する', async () => {
+    // 旧チェックボックスUIでのみ作れた状態（フルとHUだけ）。表示だけを丸めると
+    // 「ポップアップは全層選択に見えるのに、実際のフィルタは3人/4人を除外した
+    // まま」という不一致が、ユーザーがスライダーを触るまで残ってしまう。
+    syncData = {
+      options: {
+        sendUserData: true,
+        filterOptions: {
+          gameTypes: { sng: true, mtt: true, ring: true },
+          tableSize: { full: true, '4p': false, '3p': false, hu: true },
+          handLimit: 500,
+          statDisplayConfigs: defaultStatDisplayConfigs,
+        },
+      },
+      uiConfig: DEFAULT_UI_CONFIG,
+    }
+
+    render(<Popup />)
+
+    await waitForAsyncOperations()
+
+    const [lower, upper] = screen.getAllByRole('slider').slice(0, 2) as HTMLInputElement[]
+    expect(lower).toHaveValue('1')
+    expect(upper).toHaveValue('4')
+
+    // storageも同じ全層へ揃う（表示だけが広がることはない）
+    await waitFor(() => {
+      expect(syncData.options.filterOptions.tableSize).toEqual({
+        full: true, '4p': true, '3p': true, hu: true,
+      })
+    })
+    // 対象範囲が実際に変わるので、開いているゲームタブへも伝える
+    expect(mockChromeRuntimeSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'updateBattleTypeFilter',
+        filterOptions: expect.objectContaining({
+          tableSize: { full: true, '4p': true, '3p': true, hu: true },
+        }),
+      })
+    )
+
+    // 丸めた値がstateにも入っていること。表示だけ丸めてstateに古い値を残すと、
+    // 次に別のフィルタを変えた瞬間に連続しない値がstorageへ書き戻り、
+    // 起動時の移行が取り消される。
+    await userEvent.click(screen.getByRole('checkbox', { name: 'MTT' }))
+
+    await waitFor(() => {
+      expect(syncData.options.filterOptions.gameTypes.mtt).toBe(false)
+    })
+    expect(syncData.options.filterOptions.tableSize).toEqual({
+      full: true, '4p': true, '3p': true, hu: true,
+    })
+  })
+
+  it('連続したtableSizeは起動時に書き換えない', async () => {
+    syncData = {
+      options: {
+        sendUserData: true,
+        filterOptions: {
+          gameTypes: { sng: true, mtt: true, ring: true },
+          tableSize: { full: true, '4p': true, '3p': false, hu: false },
+          handLimit: 500,
+          statDisplayConfigs: defaultStatDisplayConfigs,
+        },
+      },
+      uiConfig: DEFAULT_UI_CONFIG,
+    }
+
+    render(<Popup />)
+
+    await waitForAsyncOperations()
+
+    const [lower, upper] = screen.getAllByRole('slider').slice(0, 2) as HTMLInputElement[]
+    expect(lower).toHaveValue('3')
+    expect(upper).toHaveValue('4')
+    expect(syncData.options.filterOptions.tableSize).toEqual({
+      full: true, '4p': true, '3p': false, hu: false,
+    })
+    expect(mockChromeRuntimeSendMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'updateBattleTypeFilter' })
+    )
+  })
+
   it('旧storageにtableSizeキーが無いユーザーはデフォルト（全層選択）で復元される（グレースフルなマイグレーション）', async () => {
     syncData = {
       options: {

--- a/src/components/Popup.test.tsx
+++ b/src/components/Popup.test.tsx
@@ -732,16 +732,17 @@ describe('Popup', () => {
     // 明示する（ホバーtitleだけに頼らない。codex review, PR #145）
     expect(screen.getByText('「フル」は6maxで5〜6人、4maxで4人(満席)を対象とします')).toBeInTheDocument()
 
-    const fullCheckbox = screen.getByRole('checkbox', { name: 'フル' }) as HTMLInputElement
-    const fourPCheckbox = screen.getByRole('checkbox', { name: '4人 (ショート)' }) as HTMLInputElement
-    const threePCheckbox = screen.getByRole('checkbox', { name: '3人' }) as HTMLInputElement
-    const huCheckbox = screen.getByRole('checkbox', { name: 'HU (2人)' }) as HTMLInputElement
+    // デフォルト（新規ユーザー/tableSizeキー欠落時）は全層 = フィルタなし。
+    // レンジスライダーなので「両端が最小と最大」で表現される。
+    const [lower, upper] = screen.getAllByRole('slider').slice(0, 2) as HTMLInputElement[]
+    expect(lower).toHaveAttribute('aria-label', 'テーブル人数の下限')
+    expect(upper).toHaveAttribute('aria-label', 'テーブル人数の上限')
+    expect(lower).toHaveValue('1')
+    expect(upper).toHaveValue('4')
 
-    // デフォルト（新規ユーザー/tableSizeキー欠落時）は全層選択 = フィルタなし
-    expect(fullCheckbox.checked).toBe(true)
-    expect(fourPCheckbox.checked).toBe(true)
-    expect(threePCheckbox.checked).toBe(true)
-    expect(huCheckbox.checked).toBe(true)
+    // 層ごとのチェックボックスは廃止（連続しない選択を作れてしまうため）
+    expect(screen.queryByRole('checkbox', { name: 'フル' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('checkbox', { name: 'HU (2人)' })).not.toBeInTheDocument()
   })
 
   it('テーブル人数フィルター変更時はフラットなoptionsキーへ保存しupdateBattleTypeFilterメッセージを送る', async () => {
@@ -749,7 +750,9 @@ describe('Popup', () => {
 
     await waitForAsyncOperations()
 
-    await userEvent.click(screen.getByRole('checkbox', { name: 'HU (2人)' }))
+    // 下限つまみを HU(1) から 3人(2) へ動かす = HUだけ対象外
+    const lower = screen.getAllByRole('slider')[0]!
+    fireEvent.change(lower, { target: { value: '2' } })
 
     await waitFor(() => {
       expect(syncData.options).toEqual(
@@ -785,10 +788,9 @@ describe('Popup', () => {
 
     await waitForAsyncOperations()
 
-    const fullCheckbox = screen.getByRole('checkbox', { name: 'フル' }) as HTMLInputElement
-    const huCheckbox = screen.getByRole('checkbox', { name: 'HU (2人)' }) as HTMLInputElement
-    expect(fullCheckbox.checked).toBe(true)
-    expect(huCheckbox.checked).toBe(true)
+    const [lower, upper] = screen.getAllByRole('slider').slice(0, 2) as HTMLInputElement[]
+    expect(lower).toHaveValue('1')
+    expect(upper).toHaveValue('4')
   })
 
   it('旧@extend-chrome/storage bucketキーのみのユーザーはフラットキーへ移行される', async () => {

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -3,8 +3,8 @@ import { ThemeProvider } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import { ChangeEvent, useEffect, useRef, useState } from 'react'
 import type { FilterOptions, GameTypeFilter, TableSizeFilter } from '../types'
-import { DEFAULT_TABLE_SIZE_FILTER } from '../types'
-import { rangeToTableSizeFilter } from '../utils/table-size-range'
+import { ALL_TABLE_SIZE_LAYERS, DEFAULT_TABLE_SIZE_FILTER } from '../types'
+import { rangeToTableSizeFilter, tableSizeFilterToRange } from '../utils/table-size-range'
 import { loadOptions, saveOptions, type Options } from '../utils/options-storage'
 import { defaultStatDisplayConfigs, mergeStatDisplayConfigs } from '../stats'
 import type { StatDisplayConfig } from '../types/filters'
@@ -260,19 +260,47 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
           setStatDisplayConfigs(mergedConfigs)
           setPendingStatDisplayConfigs(mergedConfigs)
 
+          // 旧チェックボックスUIでのみ作れた「連続していない」テーブル人数の
+          // 選択（例: フルとHUだけ）は、スライダーでは表現できないので最小区間へ
+          // 丸める。表示だけを丸めると、ポップアップは全層選択に見えるのに実際の
+          // フィルタは3人/4人を除外したまま、という不一致が編集するまで残る。
+          // ここで状態・storage・ゲームタブの3者を揃えてしまう。
+          const storedTableSize = savedOptions.filterOptions.tableSize || DEFAULT_TABLE_SIZE_FILTER
+          const normalizedTableSize = rangeToTableSizeFilter(
+            tableSizeFilterToRange(storedTableSize)
+          )
+          const tableSizeNeedsNormalizing = ALL_TABLE_SIZE_LAYERS.some(
+            layer => storedTableSize[layer] !== normalizedTableSize[layer]
+          )
+          const statConfigsGrew = Boolean(
+            savedOptions.filterOptions.statDisplayConfigs &&
+            mergedConfigs.length > savedOptions.filterOptions.statDisplayConfigs.length
+          )
+
           // Save merged configurations back to storage if new stats were added
-          if (savedOptions.filterOptions.statDisplayConfigs && mergedConfigs.length > savedOptions.filterOptions.statDisplayConfigs.length) {
-            saveOptions({
+          if (statConfigsGrew || tableSizeNeedsNormalizing) {
+            const migratedOptions = {
               ...savedOptions,
               filterOptions: {
                 ...savedOptions.filterOptions,
-                statDisplayConfigs: mergedConfigs
+                ...(statConfigsGrew ? { statDisplayConfigs: mergedConfigs } : {}),
+                ...(tableSizeNeedsNormalizing ? { tableSize: normalizedTableSize } : {}),
               }
-            })
+            }
+            saveOptions(migratedOptions)
+            // 丸めはフィルタの対象範囲を実際に変えるので、開いているゲームタブへも
+            // 伝える必要がある（statDisplayConfigsだけの移行は表示順の話なので
+            // 従来どおり保存だけでよい）。
+            if (tableSizeNeedsNormalizing) {
+              chrome.runtime.sendMessage<UpdateBattleTypeFilterMessage>({
+                action: 'updateBattleTypeFilter',
+                filterOptions: migratedOptions.filterOptions,
+              })
+            }
           }
 
           setGameTypeFilter(savedOptions.filterOptions.gameTypes || { sng: true, mtt: true, ring: true })
-          setTableSizeFilter(savedOptions.filterOptions.tableSize || DEFAULT_TABLE_SIZE_FILTER)
+          setTableSizeFilter(normalizedTableSize)
           setHandLimit(savedOptions.filterOptions.handLimit)
         }
       }

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -4,6 +4,7 @@ import useMediaQuery from '@mui/material/useMediaQuery'
 import { ChangeEvent, useEffect, useRef, useState } from 'react'
 import type { FilterOptions, GameTypeFilter, TableSizeFilter } from '../types'
 import { DEFAULT_TABLE_SIZE_FILTER } from '../types'
+import { rangeToTableSizeFilter } from '../utils/table-size-range'
 import { loadOptions, saveOptions, type Options } from '../utils/options-storage'
 import { defaultStatDisplayConfigs, mergeStatDisplayConfigs } from '../stats'
 import type { StatDisplayConfig } from '../types/filters'
@@ -395,11 +396,11 @@ const Popup = ({ initialPopupThemeMode }: PopupProps = {}) => {
     saveAndBroadcastOptions(updatedOptions)
   }
 
-  const handleTableSizeFilterChange = (layer: keyof TableSizeFilter) => (event: ChangeEvent<HTMLInputElement>) => {
-    const newFilter = {
-      ...tableSizeFilter,
-      [layer]: event.target.checked
-    }
+  const handleTableSizeFilterChange = (_event: Event, value: number | number[]) => {
+    // レンジスライダーなので常に [下限, 上限]。単一値で来ることはないが、
+    // MUIの型は number | number[] なので念のため弾く。
+    if (!Array.isArray(value) || value.length !== 2) return
+    const newFilter = rangeToTableSizeFilter([value[0]!, value[1]!])
 
     // Table-size filter changed (C案)
     setTableSizeFilter(newFilter)

--- a/src/components/popup/TableSizeFilterSection.test.tsx
+++ b/src/components/popup/TableSizeFilterSection.test.tsx
@@ -1,0 +1,131 @@
+import { act, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import type { TableSizeFilter } from '../../types'
+import { rangeToTableSizeFilter } from '../../utils/table-size-range'
+import { TableSizeFilterSection } from './TableSizeFilterSection'
+
+/**
+ * jsdomはレイアウトを持たない（getBoundingClientRectが全て0）ので、MUI Sliderの
+ * ポインタ経路は矩形を与えないと座標→値の変換ができない。既存のPopup.test.tsxは
+ * fireEvent.change（隠しinput＝キーボードと同じ経路）しか叩いておらず、
+ * ポインタ経路は一切カバーされていなかった。
+ */
+const TRACK_WIDTH = 300
+
+const stubSliderRect = () => {
+  const root = document.querySelector('.MuiSlider-root')
+  if (!root) throw new Error('slider root not found')
+  root.getBoundingClientRect = () => ({
+    x: 0, y: 0, left: 0, top: 0, right: TRACK_WIDTH, bottom: 20,
+    width: TRACK_WIDTH, height: 20, toJSON: () => {},
+  })
+  return root
+}
+
+/** 値(1-4)をトラック上のx座標へ。min=1, max=4。 */
+const xForValue = (value: number) => ((value - 1) / 3) * TRACK_WIDTH
+
+const Harness = ({ initial }: { initial: TableSizeFilter }) => {
+  const [filter, setFilter] = useState(initial)
+  return (
+    <>
+      <TableSizeFilterSection
+        tableSizeFilter={filter}
+        handleTableSizeFilterChange={(_event, value) => {
+          if (!Array.isArray(value) || value.length !== 2) return
+          setFilter(rangeToTableSizeFilter([value[0]!, value[1]!]))
+        }}
+      />
+      <output data-testid="applied">{JSON.stringify(filter)}</output>
+    </>
+  )
+}
+
+const applied = () =>
+  JSON.parse(screen.getByTestId('applied').textContent!) as TableSizeFilter
+
+/**
+ * jsdomには`PointerEvent`が無く、`fireEvent.pointerDown`が作るイベントは
+ * `button`を持たない。MUIは`event.button !== 0`で即returnするので、それだと
+ * ハンドラへ到達すらしない（＝何をテストしても素通りで通ってしまう）。
+ * `button`を持つ`MouseEvent`をpointerdown名で投げる。
+ * `fireEvent`と違い生の`dispatchEvent`はactで包まれないので、ここで包む。
+ */
+const dispatchPointer = (
+  target: EventTarget,
+  type: 'pointerdown' | 'pointermove' | 'pointerup',
+  value: number
+) => {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: xForValue(value),
+    clientY: 10,
+    button: 0,
+  })
+  Object.defineProperty(event, 'pointerId', { value: 1 })
+  Object.defineProperty(event, 'pointerType', { value: 'mouse' })
+  act(() => {
+    target.dispatchEvent(event)
+  })
+}
+
+/** 移動を伴わない単発クリック（トラックパッドのタップ・静止したマウス）。 */
+const clickTrackAt = (root: Element, value: number) => {
+  dispatchPointer(root, 'pointerdown', value)
+  dispatchPointer(document, 'pointerup', value)
+}
+
+beforeAll(() => {
+  // Pointer Capture APIはjsdomに無い
+  Object.assign(Element.prototype, {
+    hasPointerCapture: () => false,
+    setPointerCapture: () => {},
+    releasePointerCapture: () => {},
+  })
+})
+
+describe('TableSizeFilterSection のポインタ操作', () => {
+  it('単一層（フルのみ）から1回のクリックで範囲を広げられる', () => {
+    // つまみが両方とも最大端に重なった状態。MUIのfindClosestは同値タイで
+    // 上側のつまみを選ぶので、disableSwapを付けていると小さい側への最初の
+    // クリックがクランプで握り潰され、無反応になっていた。
+    // 「フルのみ」はこのフィルタの主要な使い方なので、そこから抜けられない
+    // のは致命的に紛らわしい（見た目つまみは1つなので「固まった」と読める）。
+    render(<Harness initial={{ full: true, '4p': false, '3p': false, hu: false }} />)
+    const root = stubSliderRect()
+
+    clickTrackAt(root, 2) // 「3人」
+
+    expect(applied()).toEqual({ full: true, '4p': true, '3p': true, hu: false })
+  })
+
+  it('単一層（3人のみ）から左方向へ1回のクリックで広げられる', () => {
+    render(<Harness initial={{ full: false, '4p': false, '3p': true, hu: false }} />)
+    const root = stubSliderRect()
+
+    clickTrackAt(root, 1) // 「HU」
+
+    expect(applied()).toEqual({ full: false, '4p': false, '3p': true, hu: true })
+  })
+
+  it('つまみを越えて動かしても下限と上限が入れ替わらない', () => {
+    // disableSwapを外したので、区間の不変条件はMUI側の整列に依存する
+    // （setValueIndexが常にsort(asc)して返す）。ここを固定しておく。
+    render(<Harness initial={{ full: false, '4p': false, '3p': true, hu: true }} />)
+    const root = stubSliderRect()
+
+    // 下限つまみ(HU=1)を掴んで、上限(3人=2)を越えて「フル」(=4)まで動かす
+    dispatchPointer(root, 'pointerdown', 1)
+    dispatchPointer(document, 'pointermove', 4)
+    dispatchPointer(document, 'pointerup', 4)
+
+    const result = applied()
+    // どの層が選ばれるかは掴んだつまみ次第だが、連続した区間であることは崩れない
+    const selected = (['hu', '3p', '4p', 'full'] as const).map(layer => result[layer])
+    const first = selected.indexOf(true)
+    const last = selected.lastIndexOf(true)
+    expect(first).toBeGreaterThanOrEqual(0)
+    expect(selected.slice(first, last + 1).every(Boolean)).toBe(true)
+  })
+})

--- a/src/components/popup/TableSizeFilterSection.tsx
+++ b/src/components/popup/TableSizeFilterSection.tsx
@@ -1,55 +1,76 @@
 import Box from '@mui/material/Box'
+import Slider from '@mui/material/Slider'
 import Typography from '@mui/material/Typography'
 import type { TableSizeFilter } from '../../types'
+import {
+  TABLE_SIZE_SLIDER_MAX,
+  TABLE_SIZE_SLIDER_MIN,
+  tableSizeFilterToRange,
+} from '../../utils/table-size-range'
 import { SectionHeading } from './SectionHeading'
-import { ToggleChip } from './ToggleChip'
 
 interface TableSizeFilterSectionProps {
   tableSizeFilter: TableSizeFilter
-  handleTableSizeFilterChange: (layer: keyof TableSizeFilter) => (event: React.ChangeEvent<HTMLInputElement>) => void
+  handleTableSizeFilterChange: (event: Event, value: number | number[]) => void
 }
 
+/** 目盛りラベル。スライダー値（1始まり）は TABLE_SIZE_SLIDER_LAYERS と同じ並び。 */
+const MARKS = [
+  { value: 1, label: 'HU' },
+  { value: 2, label: '3人' },
+  { value: 3, label: '4人' },
+  { value: 4, label: 'フル' },
+]
+
+const VALUE_LABELS: Record<number, string> = {
+  1: 'HU (2人)',
+  2: '3人',
+  3: '4人 (ショート)',
+  4: 'フル',
+}
+
+/**
+ * テーブル人数フィルタ。層は人数の順に並んでいて、選びたいのは常にその
+ * 連続した一区間になる ―― 「HUとフルは対象だが4人は対象外」に意味のある
+ * 状況が無いため（sola）。層ごとのチェックボックスはその無意味な組み合わせ
+ * まで表現できてしまうので、ハンド数と同じスライダーへ寄せた。
+ *
+ * ただしハンド数（単一つまみ＝上限だけ）と違い、両端を持つレンジにしている。
+ * 単一つまみだと「N人以上」しか表現できず、短ハンド戦だけを見る
+ * （3人以下に限定する）といった絞り込みができないため。
+ */
 export const TableSizeFilterSection = ({
   tableSizeFilter,
   handleTableSizeFilterChange,
 }: TableSizeFilterSectionProps) => {
+  const range = tableSizeFilterToRange(tableSizeFilter)
+
   return (
     <>
       <SectionHeading>テーブル人数</SectionHeading>
       <Typography variant="caption" sx={{ display: 'block', color: 'text.secondary', mb: 1 }}>
         配られた人数でHUD統計の集計対象を絞り込みます
       </Typography>
-      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-        <ToggleChip
-          checked={tableSizeFilter.full}
-          onChange={handleTableSizeFilterChange('full')}
-          label="フル"
-          title="6maxは5〜6人 / 4maxは4人満席"
-        />
-        <ToggleChip
-          checked={tableSizeFilter['4p']}
-          onChange={handleTableSizeFilterChange('4p')}
-          label="4人 (ショート)"
-          title="6maxテーブルの4人時(ショート)"
-        />
-        <ToggleChip
-          checked={tableSizeFilter['3p']}
-          onChange={handleTableSizeFilterChange('3p')}
-          label="3人"
-          title="3人テーブル"
-        />
-        <ToggleChip
-          checked={tableSizeFilter.hu}
-          onChange={handleTableSizeFilterChange('hu')}
-          label="HU (2人)"
-          title="ヘッズアップ(2人)"
+      <Box sx={{ px: 1, mt: 1, mb: 0.5 }}>
+        <Slider
+          value={range}
+          onChange={handleTableSizeFilterChange}
+          getAriaLabel={(index) => (index === 0 ? 'テーブル人数の下限' : 'テーブル人数の上限')}
+          valueLabelDisplay="auto"
+          valueLabelFormat={(value) => VALUE_LABELS[value] ?? String(value)}
+          step={1}
+          marks={MARKS}
+          min={TABLE_SIZE_SLIDER_MIN}
+          max={TABLE_SIZE_SLIDER_MAX}
+          // つまみが入れ替わると「下限＞上限」の瞬間ができ、区間の意味が壊れる。
+          disableSwap
         />
       </Box>
       {/*
         「フル」の定義はテーブルサイズに依存する(classifyTableSizeLayer, table-size.ts):
-        6maxは5〜6人、4maxは4人(満席)。1チップの可視ラベルだけでこの分岐を
-        表現すると長すぎるかホバー頼みになるため、ここに常時表示のキャプション
-        として明記する(sola要件: 正しいこと AND 推測なしで発見できること)。
+        6maxは5〜6人、4maxは4人(満席)。目盛りラベルだけでこの分岐を表現すると
+        長すぎるかホバー頼みになるため、ここに常時表示のキャプションとして
+        明記する(sola要件: 正しいこと AND 推測なしで発見できること)。
       */}
       <Typography variant="caption" sx={{ display: 'block', color: 'text.secondary', mt: 1 }}>
         「フル」は6maxで5〜6人、4maxで4人(満席)を対象とします

--- a/src/components/popup/TableSizeFilterSection.tsx
+++ b/src/components/popup/TableSizeFilterSection.tsx
@@ -38,6 +38,13 @@ const VALUE_LABELS: Record<number, string> = {
  * ただしハンド数（単一つまみ＝上限だけ）と違い、両端を持つレンジにしている。
  * 単一つまみだと「N人以上」しか表現できず、短ハンド戦だけを見る
  * （3人以下に限定する）といった絞り込みができないため。
+ *
+ * `disableSwap` は付けない。つまみの入れ替わりを禁じると、単一層を選んで
+ * 両つまみが重なった状態（例: フルのみ）から小さい側へクリックしたときに、
+ * MUIが同値タイで上側のつまみを掴んでクランプし、最初の1回が無反応になる。
+ * 「下限＞上限」を防ぐためのオプションだが、MUIの `setValueIndex` は
+ * 常に `sort(asc)` した配列を返すので、入れ替えを許しても区間の不変条件は
+ * 保たれる（TableSizeFilterSection.test.tsx で固定）。
  */
 export const TableSizeFilterSection = ({
   tableSizeFilter,
@@ -62,8 +69,6 @@ export const TableSizeFilterSection = ({
           marks={MARKS}
           min={TABLE_SIZE_SLIDER_MIN}
           max={TABLE_SIZE_SLIDER_MAX}
-          // つまみが入れ替わると「下限＞上限」の瞬間ができ、区間の意味が壊れる。
-          disableSwap
         />
       </Box>
       {/*

--- a/src/utils/table-size-range.test.ts
+++ b/src/utils/table-size-range.test.ts
@@ -1,0 +1,59 @@
+import { DEFAULT_TABLE_SIZE_FILTER, type TableSizeFilter } from './table-size'
+import {
+  TABLE_SIZE_SLIDER_LAYERS,
+  TABLE_SIZE_SLIDER_MAX,
+  TABLE_SIZE_SLIDER_MIN,
+  rangeToTableSizeFilter,
+  tableSizeFilterToRange,
+} from './table-size-range'
+
+describe('table-size-range', () => {
+  it('スライダーの並びは人数の少ない順（左がHU、右がフル）', () => {
+    expect([...TABLE_SIZE_SLIDER_LAYERS]).toEqual(['hu', '3p', '4p', 'full'])
+    expect(TABLE_SIZE_SLIDER_MIN).toBe(1)
+    expect(TABLE_SIZE_SLIDER_MAX).toBe(4)
+  })
+
+  it('既定（全層）は両端いっぱい＝フィルタなし', () => {
+    expect(tableSizeFilterToRange(DEFAULT_TABLE_SIZE_FILTER)).toEqual([1, 4])
+  })
+
+  it.each<[string, TableSizeFilter, [number, number]]>([
+    ['HUのみ', { full: false, '4p': false, '3p': false, hu: true }, [1, 1]],
+    ['フルのみ', { full: true, '4p': false, '3p': false, hu: false }, [4, 4]],
+    ['3人以下', { full: false, '4p': false, '3p': true, hu: true }, [1, 2]],
+    ['4人以上', { full: true, '4p': true, '3p': false, hu: false }, [3, 4]],
+  ])('%s は連続した区間へ畳まれる', (_label, filter, expected) => {
+    expect(tableSizeFilterToRange(filter)).toEqual(expected)
+  })
+
+  it('全解除は全選択と同じ扱い（既存の「何も選ばれていない＝フィルタなし」規約）', () => {
+    expect(
+      tableSizeFilterToRange({ full: false, '4p': false, '3p': false, hu: false })
+    ).toEqual([1, 4])
+  })
+
+  it('連続していない旧設定は、選択層をすべて含む最小区間へ丸める', () => {
+    // 旧チェックボックスUIでのみ作れた状態（HUとフルだけ）。間の層が増える
+    // 方向へしか動かないので、選んだ層が消えることはない。
+    expect(
+      tableSizeFilterToRange({ full: true, '4p': false, '3p': false, hu: true })
+    ).toEqual([1, 4])
+  })
+
+  it('区間から層ごとのbooleanへ戻せる', () => {
+    expect(rangeToTableSizeFilter([2, 3])).toEqual({
+      full: false, '4p': true, '3p': true, hu: false,
+    })
+    expect(rangeToTableSizeFilter([1, 4])).toEqual(DEFAULT_TABLE_SIZE_FILTER)
+  })
+
+  it('連続した選択なら往復して元へ戻る', () => {
+    for (let min = TABLE_SIZE_SLIDER_MIN; min <= TABLE_SIZE_SLIDER_MAX; min++) {
+      for (let max = min; max <= TABLE_SIZE_SLIDER_MAX; max++) {
+        const range: [number, number] = [min, max]
+        expect(tableSizeFilterToRange(rangeToTableSizeFilter(range))).toEqual(range)
+      }
+    }
+  })
+})

--- a/src/utils/table-size-range.ts
+++ b/src/utils/table-size-range.ts
@@ -1,0 +1,63 @@
+/**
+ * テーブル人数フィルタの「連続した範囲」表現。
+ *
+ * 層は人数の順に並んでいて（HU < 3人 < 4人 < フル）、実際に選びたいのは
+ * 常にその連続した一区間になる ―― 「HUとフルは対象だが4人は対象外」という
+ * 選び方に意味のある状況が無いから（sola）。チェックボックスの多選択は
+ * その無意味な組み合わせまで表現できてしまうので、両端だけを持つ
+ * レンジとして扱う。
+ *
+ * 保存形式（`TableSizeFilter` の層ごとのboolean）は変えない。フィルタの
+ * 適用側（`selectedTableSizeLayers` / `matchesTableSizeFilter`）も
+ * そのまま使えるし、旧版と設定を共有しても壊れない。
+ */
+import {
+  ALL_TABLE_SIZE_LAYERS,
+  type TableSizeFilter,
+  type TableSizeLayer,
+} from './table-size'
+
+/**
+ * スライダーの目盛り順。左が少人数、右が満席。`ALL_TABLE_SIZE_LAYERS`
+ * （フル→HU）の逆順で、スライダーは左から右へ増えるのが自然なため。
+ */
+export const TABLE_SIZE_SLIDER_LAYERS: readonly TableSizeLayer[] = [
+  ...ALL_TABLE_SIZE_LAYERS,
+].reverse()
+
+/** スライダー値（1始まり）の範囲。目盛りラベルは呼び出し側が持つ。 */
+export const TABLE_SIZE_SLIDER_MIN = 1
+export const TABLE_SIZE_SLIDER_MAX = TABLE_SIZE_SLIDER_LAYERS.length
+
+/**
+ * 層ごとのbooleanを、スライダーの両端 `[min, max]` へ畳む。
+ *
+ * 連続していない選択（旧版のチェックボックスで作れてしまった状態）は、
+ * 選択されている層をすべて含む最小の区間へ丸める。間の層が増える方向へ
+ * しか動かないので、「選んだはずの層が消える」ことは起きない。
+ * 全解除は全選択と同じ扱い（`selectedTableSizeLayers` の既存の規約:
+ * 何も選ばれていない＝フィルタなし）。
+ */
+export const tableSizeFilterToRange = (
+  filter: TableSizeFilter
+): [number, number] => {
+  const selected = TABLE_SIZE_SLIDER_LAYERS
+    .map((layer, index) => (filter[layer] ? index + 1 : null))
+    .filter((value): value is number => value !== null)
+
+  if (selected.length === 0) return [TABLE_SIZE_SLIDER_MIN, TABLE_SIZE_SLIDER_MAX]
+  return [Math.min(...selected), Math.max(...selected)]
+}
+
+/** スライダーの両端から層ごとのbooleanへ戻す。 */
+export const rangeToTableSizeFilter = (
+  range: [number, number]
+): TableSizeFilter => {
+  const [min, max] = range
+  const filter = {} as TableSizeFilter
+  TABLE_SIZE_SLIDER_LAYERS.forEach((layer, index) => {
+    const value = index + 1
+    filter[layer] = value >= min && value <= max
+  })
+  return filter
+}


### PR DESCRIPTION
> テーブル人数がチェックボックスである意味がよくわからない。例えばHUとフルを同時に選択するけど4人は選択しない、そんな状況は起こり得ないはず。ハンド数同様のスライダーUIで良いのでは？

そのとおりで、層は人数の順（HU < 3人 < 4人 < フル）に並んでいるので、選びたいのは常に**連続した一区間**になります。チェックボックスはその無意味な組み合わせまで表現できてしまいます。

## Before / After

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/solavrc/pokerchase-hud/pr-assets/table-size-slider/before-dark.png" width="380"> | <img src="https://raw.githubusercontent.com/solavrc/pokerchase-hud/pr-assets/table-size-slider/after-dark.png" width="380"> |
| <img src="https://raw.githubusercontent.com/solavrc/pokerchase-hud/pr-assets/table-size-slider/before-light.png" width="380"> | <img src="https://raw.githubusercontent.com/solavrc/pokerchase-hud/pr-assets/table-size-slider/after-light.png" width="380"> |

すぐ下の「ハンド数」と同じ見た目になり、2行に折り返していたチップも消えました。

## 単一つまみではなくレンジにした理由

ハンド数は単一つまみ（上限だけ）ですが、こちらは両端を持つレンジにしています。単一つまみだと「N人以上」しか表現できず、**短ハンド戦だけを見る（3人以下に限定する）**といった絞り込みができないためです。

単一つまみの方がよければ言ってください。すぐ直せます。

## 保存形式は変えていない

`TableSizeFilter`（層ごとのboolean）はそのままです。フィルタの適用側（`selectedTableSizeLayers` / `matchesTableSizeFilter`）に変更はなく、旧版と設定を共有しても壊れません。

旧UIでのみ作れた**連続していない選択**（例: フル+HUのみ）は、選択層をすべて含む最小区間へ丸めます。間の層が増える方向へしか動かないので、選んだ層が消えることはありません。

## 検証

- `npm run typecheck` クリーン、`npm run test` 1684件全通過
- 変換ロジック（`src/utils/table-size-range.ts`）に単体テストを追加。連続した選択の往復・非連続な旧設定の丸め・全解除の扱いを網羅
- 実ブラウザでポップアップを開いて撮影し、既定が両端いっぱい（＝フィルタなし）であることを実測確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)