### PR TITLE
fix(ui): モックのベット額スライダーのはみ出しと◆のずれを直す

### DIFF
--- a/src/mockup/table-layout.test.ts
+++ b/src/mockup/table-layout.test.ts
@@ -1,0 +1,37 @@
+import { ACTION_BAR } from './table-layout'
+
+/**
+ * ベット額スライダーだけは実機スクリーンショットの実測値をそのまま使わず、
+ * 周囲のチップとの関係で決めている（sola指摘）。関係は目視でしか確認できない
+ * ので、ここで数値として固定する。プリセットの座標を後から動かしたときに
+ * 「はみ出し」と「◆のずれ」が黙って戻らないようにするのが目的。
+ */
+describe('betSliderInvariants', () => {
+  const right = (rect: { l: number, w: number }) => rect.l + rect.w
+  const allIn = ACTION_BAR.multipliers[ACTION_BAR.multipliers.length - 1]!
+
+  it('最後のプリセットはオールイン', () => {
+    // 右端の基準にしているので、並び替えられたら気付けるようにする
+    expect(allIn.label).toBe('オールイン')
+  })
+
+  it('トラックの右端はオールインの右端で止まる', () => {
+    expect(right(ACTION_BAR.slider)).toBeCloseTo(right(allIn), 5)
+  })
+
+  it('トラックは＋ボタンとバー枠からはみ出さない', () => {
+    // 実測値(93.9%)のままだと、＋ボタン(92.2%)もバー枠(93%)も越えていた
+    expect(right(ACTION_BAR.slider)).toBeLessThanOrEqual(right(ACTION_BAR.plus))
+    expect(right(ACTION_BAR.slider)).toBeLessThanOrEqual(right(ACTION_BAR.frame))
+  })
+
+  it('◆はトラックの上下中央に乗る', () => {
+    const trackCenter = ACTION_BAR.slider.t + ACTION_BAR.slider.h / 2
+    expect(ACTION_BAR.sliderKnob.t).toBeCloseTo(trackCenter, 5)
+  })
+
+  it('◆はトラックの左右の範囲に収まる', () => {
+    expect(ACTION_BAR.sliderKnob.l).toBeGreaterThanOrEqual(ACTION_BAR.slider.l)
+    expect(ACTION_BAR.sliderKnob.l).toBeLessThanOrEqual(right(ACTION_BAR.slider))
+  })
+})

--- a/src/mockup/table-layout.ts
+++ b/src/mockup/table-layout.ts
@@ -208,14 +208,28 @@ export const ACTION_BAR = {
   ] as Array<Rect & { label: string; wordLabel?: boolean }>,
   plus: { h: 11.2, l: 85.6, t: 84.7, w: 6.6 } as Rect,
   preAction: { h: 15.5, l: 1.7, t: 83.3, w: 8 } as Rect,
-  slider: { h: 1.5, l: 50.3, t: 93.9, w: 43.6 } as Rect,
+  /**
+   * Bet-size track. Its right edge stops at the オールイン preset's right edge
+   * (77.2 + 8.1 = 85.3%), not at the reference's own measured 93.9% -- that
+   * measurement ran the track out past both the ＋ button (right edge 92.2%)
+   * and the bar frame (93%), which reads as a bar poking out of the chrome
+   * rather than as part of it (sola). `betSliderInvariants` in
+   * `table-layout.test.ts` pins the relationship so a later edit to the
+   * presets cannot silently reintroduce the overhang.
+   */
+  slider: { h: 1.5, l: 50.3, t: 93.9, w: 35 } as Rect,
   /**
    * Centre of the slider's diamond handle. A centre, not a Rect: the handle is
    * a 45°-rotated square and so must be square in PIXELS, which a Rect cannot
    * express (its width and height are percentages of different axes). Its side
    * lives with the other diamonds in `styles.css`.
+   *
+   * `t` is the track's own vertical centre (93.9 + 1.5/2), not the reference's
+   * measured 95.08 -- the client draws the handle centred on the track, so the
+   * 0.43pt offset was measurement error, and at any real window height it
+   * renders as a handle sitting visibly below the bar it rides on.
    */
-  sliderKnob: { l: 83.52, t: 95.08 } as Point,
+  sliderKnob: { l: 83.52, t: 94.65 } as Point,
 } as const
 
 /** CSS positioning for a {@link Rect}, in percent-of-viewport units. */


### PR DESCRIPTION
> 右にはみ出して突き出している部分が気になる。オールインの終端部ぐらいで止めておいてください。
> あとスライダー上の◆は上下センタリングしてスライダーに乗せてね。

## Before

<img src="https://raw.githubusercontent.com/solavrc/pokerchase-hud/pr-assets/bet-slider/before.png" width="820">

トラックの右端が **93.9%** で、＋ボタン（右端92.2%）もバー枠（93%）も越えています。チップの一部ではなく、枠から突き出た棒に見えます。◆の中心は **95.08%** で、トラックの中心 **94.65%** より下 ―― 乗っているのではなくずり落ちて見えます。

## After

<img src="https://raw.githubusercontent.com/solavrc/pokerchase-hud/pr-assets/bet-slider/after.png" width="820">

- トラックの右端を **オールインの右端（77.2 + 8.1 = 85.3%）** で止めました
- ◆の中心を **トラックの上下中央（93.9 + 1.5/2 = 94.65%）** へ揃えました

実測（1512x860）: トラック右端 1289.7px = オールイン右端 1289.7px、トラック中心Y 814px = ◆中心Y 814px。

## 実測値から外れる箇所なのでテストで固定した

この2箇所は実機スクリーンショットの実測値（#312）をそのまま使わない例外になります。◆のずれは元の測定誤差と判断しました（クライアントは中央に描いているはず）。トラックのはみ出しは測定としては正しくても、モックとして見たときに破綻しています。

関係は目視でしか確認できないので、`src/mockup/table-layout.test.ts` で数値として固定しました。プリセットの座標を後から動かしたときに、はみ出しと◆のずれが黙って戻らないようにするのが目的です。

- トラックの右端 == オールインの右端
- トラックは＋ボタンとバー枠からはみ出さない
- ◆はトラックの上下中央に乗る / 左右の範囲に収まる
- 最後のプリセットがオールインであること（右端の基準にしているため、並び替えに気付けるように）

## 検証

`npm run typecheck` クリーン、`npm run test` 1679件全通過。実ブラウザでモックを開いて座標を実測確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)