### PR TITLE
chore: 統計カラー廃止の取り残しを掃除する

### DIFF
--- a/src/background/message-router.device-layout.test.ts
+++ b/src/background/message-router.device-layout.test.ts
@@ -636,6 +636,10 @@ describe('message-router device-local UI layout', () => {
   })
 
   it('ショートカットpatchを保存時点の最新同期設定へmergeする', async () => {
+    // hudColorCodingは#320で廃止した旧キー。実ユーザーのstorage.syncには
+    // 残り続けるので、patch mergeが「UIConfigの型に無いキー」を落とさない
+    // ことをここで固定する（落とすと、旧版と設定を共有している端末の
+    // 設定が同期のたびに削られる）。
     await chrome.storage.sync.set({
       uiConfig: {
         ...DEFAULT_UI_CONFIG,

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -318,7 +318,7 @@ describe('App', () => {
   it('uiConfigにhudDisplayModeが渡された場合、そのままHudへ伝播する', async () => {
     (global.chrome.storage.sync.get as jest.Mock).mockImplementation((_, callback) => {
       callback({
-        uiConfig: { ...DEFAULT_UI_CONFIG, hudDisplayMode: 'full', hudColorCoding: false },
+        uiConfig: { ...DEFAULT_UI_CONFIG, hudDisplayMode: 'full' },
       })
     })
 

--- a/src/components/Hud.test.tsx
+++ b/src/components/Hud.test.tsx
@@ -948,7 +948,7 @@ describe('Hud', () => {
       expect(screen.getByText('30')).toBeInTheDocument()
     })
 
-    it('hudColorCoding=trueをcompact/fullどちらのStatDisplayにも伝播する', () => {
+    it('しきい値カラーをcompact/fullどちらのStatDisplayにも適用する', () => {
       const highVpipStats = {
         playerId: 123,
         statResults: [


### PR DESCRIPTION
#320 で `UIConfig.hudColorCoding` を廃止した際の掃除漏れです。動作には影響しませんが、テスト名が実態と食い違っていて誤読を招きます。

## 直したもの

**`Hud.test.tsx`** — テスト名が `hudColorCoding=trueを...伝播する` のままでした。そのプロップはもう存在しません。中身は「しきい値カラーが compact / full 両方で適用される」ことの検証として**そのまま有効**なので、名前だけ実態に合わせました。

**`App.test.tsx`** — モックの `uiConfig` に `hudColorCoding: false` が残っていました。このテストの主題は `hudDisplayMode` の伝播で、無関係なキーなので落としました。

## 残したもの（あえて）

`message-router.device-layout.test.ts` の2箇所は**残しています**。

あれは「`UIConfig` の型に無いキーが patch merge で消えない」ことを固定しているテストです。`hudColorCoding` は #320 で型から消しましたが、**実ユーザーの `chrome.storage.sync` には残り続ける**ので、題材としてむしろ正しい。ここを落とすと、旧版と設定を共有している端末の設定が同期のたびに削られる回帰を検出できなくなります。

取り残しに見えないよう、なぜそこに居るのかをコメントで明示しました。

## 検証

`npm run typecheck` クリーン、`npm run test` 1711件全通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)