### PR TITLE
fix(ui): インポートページの重複生成と転送失敗時の状態残りを直す

### DIFF
--- a/src/components/popup/ImportExportSection.test.tsx
+++ b/src/components/popup/ImportExportSection.test.tsx
@@ -119,8 +119,12 @@ describe('ImportExportSection - rebuild advisory banner', () => {
     return {
       backgroundBecameIdle: () => { current = { type: 'idle' } },
       backgroundStaysBusy: () => { current = transfer },
+      backgroundTookUnrelatedSlot: () => { current = { type: 'sync' } },
     }
   }
+
+  const countOperationStateCalls = () =>
+    mockSendMessage.mock.calls.filter(([m]: any[]) => m?.action === 'getOperationState').length
 
   it('does not render the banner when there is no pending advisory', async () => {
     storageLocalData[REBUILD_ADVISORY_STORAGE_KEY] = undefined
@@ -296,9 +300,7 @@ describe('ImportExportSection - rebuild advisory banner', () => {
     // Count this specific action: mount already issued one, so waiting on
     // "was it called" alone would resolve before the storage handler's own
     // round trip and assert against a not-yet-updated tree.
-    const getOperationStateCalls = () =>
-      mockSendMessage.mock.calls.filter(([m]: any[]) => m?.action === 'getOperationState').length
-    await waitFor(() => expect(getOperationStateCalls()).toBe(1))
+    await waitFor(() => expect(countOperationStateCalls()).toBe(1))
 
     background.backgroundStaysBusy()
     act(() => emitImportResultChange({
@@ -307,13 +309,39 @@ describe('ImportExportSection - rebuild advisory banner', () => {
       completedAt: 789,
     }))
 
-    await waitFor(() => expect(getOperationStateCalls()).toBe(2))
+    await waitFor(() => expect(countOperationStateCalls()).toBe(2))
     // Flush the .then() that would release, so an unguarded release would have
     // rendered by the time the assertions below run.
     await act(async () => {})
     // Still tracking the live import: buttons stay held, progress not blanked.
     expect(screen.getByRole('button', { name: 'インポートページを表示' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '生データをエクスポート (NDJSON)' })).toBeDisabled()
+  })
+
+  it('releases the import state when an unrelated operation took the slot', async () => {
+    // importDataCancel drops the slot to idle, so an auto-sync parked in
+    // waitForOperationIdle() can claim it before the result write lands.
+    // 'sync' is not this popup's import: holding for it would strand
+    // importOperationActive forever, since the transfer-error path sends no
+    // importStatus and nothing re-checks when the sync finishes.
+    const background = restoreActiveTransfer()
+
+    render(<ImportExportSection {...defaultProps} />)
+
+    expect(await screen.findByRole('button', { name: 'インポートページを表示' })).toBeInTheDocument()
+    await waitFor(() => expect(countOperationStateCalls()).toBe(1))
+
+    background.backgroundTookUnrelatedSlot()
+    act(() => emitImportResultChange({
+      status: 'error',
+      message: 'インポート失敗: ファイルを読み込めませんでした',
+      completedAt: 789,
+    }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '生データをインポート (NDJSON)' })).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: '生データをエクスポート (NDJSON)' })).toBeEnabled()
   })
 
   it('restores a persisted result after the popup was closed', async () => {

--- a/src/components/popup/ImportExportSection.test.tsx
+++ b/src/components/popup/ImportExportSection.test.tsx
@@ -89,6 +89,29 @@ describe('ImportExportSection - rebuild advisory banner', () => {
     )
   }
 
+  const emitImportResultChange = (newValue: any) => {
+    storageChangeListeners.forEach(listener =>
+      listener({ [IMPORT_RESULT_STORAGE_KEY]: { newValue } }, 'local')
+    )
+  }
+
+  const restoreActiveTransfer = () => {
+    mockSendMessage.mockImplementation((message: { action?: string }, callback?: (response: unknown) => void) => {
+      if (typeof callback === 'function') {
+        callback(message.action === 'getOperationState' ? {
+          operationState: {
+            type: 'import',
+            phase: 'transfer',
+            progress: 50,
+            processed: 1,
+            total: 2,
+            message: 'インポートファイル転送中...',
+          },
+        } : {})
+      }
+    })
+  }
+
   it('does not render the banner when there is no pending advisory', async () => {
     storageLocalData[REBUILD_ADVISORY_STORAGE_KEY] = undefined
 
@@ -182,6 +205,71 @@ describe('ImportExportSection - rebuild advisory banner', () => {
 
     expect(await screen.findByRole('button', { name: 'インポートページを表示' })).toBeEnabled()
     expect(screen.getByText(/インポートファイル転送中/)).toBeInTheDocument()
+  })
+
+  it('reuses an import page whose navigation has not committed yet', async () => {
+    // Chrome reports the destination in pendingUrl until the navigation
+    // commits; url is empty or still the previous page until then.
+    ;(chrome.tabs.query as jest.Mock).mockResolvedValue([{
+      id: 42,
+      windowId: 7,
+      url: '',
+      pendingUrl: 'chrome-extension://test/dist/index.html?mode=import',
+    }])
+    render(<ImportExportSection {...defaultProps} />)
+
+    await userEvent.click(screen.getByRole('button', { name: '生データをインポート (NDJSON)' }))
+
+    expect(chrome.tabs.update).toHaveBeenCalledWith(42, { active: true })
+    expect(chrome.tabs.create).not.toHaveBeenCalled()
+  })
+
+  it('does not open a second import page while the first open is still in flight', async () => {
+    let releaseQuery: (tabs: unknown[]) => void = () => {}
+    ;(chrome.tabs.query as jest.Mock).mockReturnValue(new Promise(resolve => {
+      releaseQuery = resolve as (tabs: unknown[]) => void
+    }))
+    render(<ImportExportSection {...defaultProps} />)
+
+    const button = screen.getByRole('button', { name: '生データをインポート (NDJSON)' })
+    await userEvent.click(button)
+    await userEvent.click(button)
+
+    // Both clicks landed while the first query was still open. Without the
+    // single-flight guard the second one queries too, also finds nothing, and
+    // creates a duplicate page that races for the import operation slot.
+    expect(chrome.tabs.query).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      releaseQuery([])
+    })
+
+    expect(chrome.tabs.create).toHaveBeenCalledTimes(1)
+  })
+
+  it('releases the operation state when a terminal result arrives via storage', async () => {
+    // ImportPage's own transfer failure writes lastImportResult directly and
+    // sends only importDataCancel, so storage.onChanged is the popup's only
+    // notification -- no importStatus message ever arrives.
+    const setImportStatus = jest.fn()
+    restoreActiveTransfer()
+
+    render(<ImportExportSection {...defaultProps} setImportStatus={setImportStatus} />)
+
+    expect(await screen.findByRole('button', { name: 'インポートページを表示' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '生データをエクスポート (NDJSON)' })).toBeDisabled()
+
+    act(() => emitImportResultChange({
+      status: 'error',
+      message: 'インポート失敗: ファイルを読み込めませんでした',
+      completedAt: 456,
+    }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '生データをインポート (NDJSON)' })).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: '生データをエクスポート (NDJSON)' })).toBeEnabled()
+    expect(setImportStatus).toHaveBeenCalledWith('インポート失敗: ファイルを読み込めませんでした')
   })
 
   it('restores a persisted result after the popup was closed', async () => {

--- a/src/components/popup/ImportExportSection.test.tsx
+++ b/src/components/popup/ImportExportSection.test.tsx
@@ -95,21 +95,31 @@ describe('ImportExportSection - rebuild advisory banner', () => {
     )
   }
 
+  /**
+   * Mounts with a transfer already in flight and lets the test decide what the
+   * background reports on the *next* getOperationState call -- the storage
+   * handler re-asks before releasing, so "did the tracked import really end?"
+   * is answered by this mock rather than by the result write alone.
+   */
   const restoreActiveTransfer = () => {
+    const transfer = {
+      type: 'import',
+      phase: 'transfer',
+      progress: 50,
+      processed: 1,
+      total: 2,
+      message: 'インポートファイル転送中...',
+    }
+    let current: unknown = transfer
     mockSendMessage.mockImplementation((message: { action?: string }, callback?: (response: unknown) => void) => {
       if (typeof callback === 'function') {
-        callback(message.action === 'getOperationState' ? {
-          operationState: {
-            type: 'import',
-            phase: 'transfer',
-            progress: 50,
-            processed: 1,
-            total: 2,
-            message: 'インポートファイル転送中...',
-          },
-        } : {})
+        callback(message.action === 'getOperationState' ? { operationState: current } : {})
       }
     })
+    return {
+      backgroundBecameIdle: () => { current = { type: 'idle' } },
+      backgroundStaysBusy: () => { current = transfer },
+    }
   }
 
   it('does not render the banner when there is no pending advisory', async () => {
@@ -252,13 +262,14 @@ describe('ImportExportSection - rebuild advisory banner', () => {
     // sends only importDataCancel, so storage.onChanged is the popup's only
     // notification -- no importStatus message ever arrives.
     const setImportStatus = jest.fn()
-    restoreActiveTransfer()
+    const background = restoreActiveTransfer()
 
     render(<ImportExportSection {...defaultProps} setImportStatus={setImportStatus} />)
 
     expect(await screen.findByRole('button', { name: 'インポートページを表示' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '生データをエクスポート (NDJSON)' })).toBeDisabled()
 
+    background.backgroundBecameIdle()
     act(() => emitImportResultChange({
       status: 'error',
       message: 'インポート失敗: ファイルを読み込めませんでした',
@@ -270,6 +281,39 @@ describe('ImportExportSection - rebuild advisory banner', () => {
     })
     expect(screen.getByRole('button', { name: '生データをエクスポート (NDJSON)' })).toBeEnabled()
     expect(setImportStatus).toHaveBeenCalledWith('インポート失敗: ファイルを読み込めませんでした')
+  })
+
+  it('keeps a live import active when a rejected duplicate page writes its own result', async () => {
+    // A second import page whose importDataInit is rejected as busy never gets
+    // a session, but its catch still writes lastImportResult. That result says
+    // nothing about the import this popup is tracking, which is still running.
+    const background = restoreActiveTransfer()
+
+    render(<ImportExportSection {...defaultProps} />)
+
+    expect(await screen.findByRole('button', { name: 'インポートページを表示' })).toBeInTheDocument()
+
+    // Count this specific action: mount already issued one, so waiting on
+    // "was it called" alone would resolve before the storage handler's own
+    // round trip and assert against a not-yet-updated tree.
+    const getOperationStateCalls = () =>
+      mockSendMessage.mock.calls.filter(([m]: any[]) => m?.action === 'getOperationState').length
+    await waitFor(() => expect(getOperationStateCalls()).toBe(1))
+
+    background.backgroundStaysBusy()
+    act(() => emitImportResultChange({
+      status: 'error',
+      message: 'インポート失敗: 別の処理が実行中です',
+      completedAt: 789,
+    }))
+
+    await waitFor(() => expect(getOperationStateCalls()).toBe(2))
+    // Flush the .then() that would release, so an unguarded release would have
+    // rendered by the time the assertions below run.
+    await act(async () => {})
+    // Still tracking the live import: buttons stay held, progress not blanked.
+    expect(screen.getByRole('button', { name: 'インポートページを表示' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '生データをエクスポート (NDJSON)' })).toBeDisabled()
   })
 
   it('restores a persisted result after the popup was closed', async () => {

--- a/src/components/popup/ImportExportSection.test.tsx
+++ b/src/components/popup/ImportExportSection.test.tsx
@@ -25,11 +25,13 @@ const defaultProps = {
 
 describe('ImportExportSection - rebuild advisory banner', () => {
   let storageChangeListeners: Array<(changes: Record<string, any>, areaName: string) => void>
+  let messageListeners: Array<(message: unknown) => void>
   let storageLocalData: Record<string, any>
   let mockSendMessage: jest.Mock
 
   beforeEach(() => {
     storageChangeListeners = []
+    messageListeners = []
     storageLocalData = {}
     // Default: respond synchronously with no operationState (mirrors "nothing in
     // progress"), so the sendMessageWithTimeout() call in the mount effect
@@ -46,8 +48,13 @@ describe('ImportExportSection - rebuild advisory banner', () => {
         sendMessage: mockSendMessage,
         getURL: jest.fn(path => `chrome-extension://test/${path}`),
         onMessage: {
-          addListener: jest.fn(),
-          removeListener: jest.fn(),
+          addListener: jest.fn((listener: any) => {
+            messageListeners.push(listener)
+          }),
+          removeListener: jest.fn((listener: any) => {
+            const idx = messageListeners.indexOf(listener)
+            if (idx !== -1) messageListeners.splice(idx, 1)
+          }),
         },
       },
       storage: {
@@ -314,6 +321,51 @@ describe('ImportExportSection - rebuild advisory banner', () => {
     // rendered by the time the assertions below run.
     await act(async () => {})
     // Still tracking the live import: buttons stay held, progress not blanked.
+    expect(screen.getByRole('button', { name: 'インポートページを表示' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '生データをエクスポート (NDJSON)' })).toBeDisabled()
+  })
+
+  it('does not let a stale idle answer release an import that started meanwhile', async () => {
+    // getOperationState is answered "idle" for the import that just failed, but
+    // a retry claims the slot before the response's continuation runs. The
+    // popup is tracking that newer import by then.
+    const background = restoreActiveTransfer()
+    let releaseResponse: () => void = () => {}
+    render(<ImportExportSection {...defaultProps} />)
+
+    expect(await screen.findByRole('button', { name: 'インポートページを表示' })).toBeInTheDocument()
+    await waitFor(() => expect(countOperationStateCalls()).toBe(1))
+
+    // Hold the storage handler's round trip open so the retry lands inside it.
+    background.backgroundBecameIdle()
+    mockSendMessage.mockImplementation((message: { action?: string }, callback?: (response: unknown) => void) => {
+      if (message.action === 'getOperationState') {
+        releaseResponse = () => callback?.({ operationState: { type: 'idle' } })
+        return
+      }
+      callback?.({})
+    })
+    act(() => emitImportResultChange({
+      status: 'error',
+      message: 'インポート失敗: ファイルを読み込めませんでした',
+      completedAt: 111,
+    }))
+    await waitFor(() => expect(countOperationStateCalls()).toBe(2))
+
+    // Retry lands: a fresh transfer is now being tracked.
+    act(() => {
+      messageListeners.forEach(listener => listener({
+        action: 'importProgress',
+        progress: 10,
+        processed: 1,
+        total: 10,
+      }))
+    })
+    expect(screen.getByRole('button', { name: 'インポートページを表示' })).toBeInTheDocument()
+
+    // Now the stale answer arrives.
+    await act(async () => { releaseResponse() })
+
     expect(screen.getByRole('button', { name: 'インポートページを表示' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '生データをエクスポート (NDJSON)' })).toBeDisabled()
   })

--- a/src/components/popup/ImportExportSection.tsx
+++ b/src/components/popup/ImportExportSection.tsx
@@ -256,12 +256,23 @@ export const ImportExportSection = ({
         // never got a session, so that result says nothing about the operation
         // this popup is tracking. Releasing on it would blank a live import's
         // progress and re-enable buttons the background still rejects.
-        // Unknown state (timeout) releases, per sendMessageWithTimeout's
-        // fail-open contract -- a stuck-disabled popup is the bug being fixed.
+        // Hold only for the import this popup is tracking -- NOT for merely
+        // "something is busy". importDataCancel drops the slot to idle, and an
+        // auto-sync already parked in waitForOperationIdle() can claim it as
+        // 'sync' before this result arrives. Nothing would ever release the
+        // import state then: the transfer-error path sends no importStatus, and
+        // the popup has no sync listener and no re-check when an unrelated
+        // operation ends -- the exact stuck state this handler exists to fix.
+        // Unknown state (timeout) also releases, per sendMessageWithTimeout's
+        // fail-open contract.
         void sendMessageWithTimeout<{ operationState?: OperationState }>(
           { action: 'getOperationState' }
         ).then(response => {
-          if (response?.operationState && response.operationState.type !== 'idle') return
+          const state = response?.operationState
+          const trackedImportStillRunning =
+            state?.type === 'import' ||
+            (state?.type === 'rebuild' && state.origin === 'import')
+          if (trackedImportStillRunning) return
           importOperationActiveRef.current = false
           setImportOperationActive(false)
           setRebuildOrigin(null)

--- a/src/components/popup/ImportExportSection.tsx
+++ b/src/components/popup/ImportExportSection.tsx
@@ -240,19 +240,33 @@ export const ImportExportSection = ({
       }
       if (changes[IMPORT_RESULT_STORAGE_KEY]?.newValue) {
         const importResult = changes[IMPORT_RESULT_STORAGE_KEY].newValue as ImportResultRecord
-        // A result written while the popup is open is terminal: the background
-        // is idle again. Release the same state the importStatus message path
-        // above releases, because that message never arrives when the import
-        // page itself fails mid-transfer -- ImportPage's catch writes this key
-        // directly and only sends importDataCancel, which broadcasts nothing.
-        // Leaving importOperationActive set keeps isAnyOperationInProgress
-        // true, which blanks displayStatus (hiding this very error) and holds
-        // export and rebuild disabled.
-        importOperationActiveRef.current = false
-        setImportOperationActive(false)
-        setRebuildOrigin(null)
         setImportStatus(importResult.message)
-        setOperationStatus('')
+        // Release the same state the importStatus message path above releases:
+        // that message never arrives when the import page itself fails
+        // mid-transfer, because ImportPage's catch writes this key directly and
+        // only sends importDataCancel, which broadcasts nothing. Leaving
+        // importOperationActive set keeps isAnyOperationInProgress true, which
+        // blanks displayStatus (hiding this very error) and holds export and
+        // rebuild disabled.
+        //
+        // The write alone does not prove the tracked operation ended, so ask
+        // the background -- it owns exclusivity and is the authority. A
+        // duplicate import page rejected as busy writes its own error result
+        // here while the FIRST import is still running: its importDataInit
+        // never got a session, so that result says nothing about the operation
+        // this popup is tracking. Releasing on it would blank a live import's
+        // progress and re-enable buttons the background still rejects.
+        // Unknown state (timeout) releases, per sendMessageWithTimeout's
+        // fail-open contract -- a stuck-disabled popup is the bug being fixed.
+        void sendMessageWithTimeout<{ operationState?: OperationState }>(
+          { action: 'getOperationState' }
+        ).then(response => {
+          if (response?.operationState && response.operationState.type !== 'idle') return
+          importOperationActiveRef.current = false
+          setImportOperationActive(false)
+          setRebuildOrigin(null)
+          setOperationStatus('')
+        })
       }
     }
 

--- a/src/components/popup/ImportExportSection.tsx
+++ b/src/components/popup/ImportExportSection.tsx
@@ -74,6 +74,7 @@ export const ImportExportSection = ({
   const [rebuildAdvisoryPending, setRebuildAdvisoryPending] = useState(false)
   const [importOperationActive, setImportOperationActive] = useState(false)
   const importOperationActiveRef = useRef(false)
+  const openImportPageInFlightRef = useRef(false)
   const [rebuildOrigin, setRebuildOrigin] = useState<'import' | 'manual' | null>(null)
 
   const isImporting = importOperationActive && rebuildOrigin !== 'import'
@@ -239,7 +240,19 @@ export const ImportExportSection = ({
       }
       if (changes[IMPORT_RESULT_STORAGE_KEY]?.newValue) {
         const importResult = changes[IMPORT_RESULT_STORAGE_KEY].newValue as ImportResultRecord
+        // A result written while the popup is open is terminal: the background
+        // is idle again. Release the same state the importStatus message path
+        // above releases, because that message never arrives when the import
+        // page itself fails mid-transfer -- ImportPage's catch writes this key
+        // directly and only sends importDataCancel, which broadcasts nothing.
+        // Leaving importOperationActive set keeps isAnyOperationInProgress
+        // true, which blanks displayStatus (hiding this very error) and holds
+        // export and rebuild disabled.
+        importOperationActiveRef.current = false
+        setImportOperationActive(false)
+        setRebuildOrigin(null)
         setImportStatus(importResult.message)
+        setOperationStatus('')
       }
     }
 
@@ -280,10 +293,23 @@ export const ImportExportSection = ({
   }, [])
 
   const handleImportClick = useCallback(async () => {
+    // Single-flight. query + create is a check-then-act pair: a second click
+    // while the first round trip is still open runs its own query, still sees
+    // no import page, and creates a second one. Both pages then race for the
+    // single import operation slot and the loser writes its rejection into
+    // lastImportResult, surfacing as a failure the user never started.
+    if (openImportPageInFlightRef.current) return
+    openImportPageInFlightRef.current = true
     try {
       const importPageUrl = getImportPageUrl()
       const tabs = await chrome.tabs.query({})
-      const existingTab = tabs.find(tab => tab.url === importPageUrl)
+      // A tab whose navigation has not committed yet carries the destination
+      // in pendingUrl only -- url is empty or still the previous page. Matching
+      // on url alone misses the import page opened moments ago and opens
+      // another one.
+      const existingTab = tabs.find(
+        tab => tab.url === importPageUrl || tab.pendingUrl === importPageUrl
+      )
       if (existingTab?.id !== undefined) {
         await chrome.tabs.update(existingTab.id, { active: true })
         if (existingTab.windowId !== undefined) {
@@ -295,6 +321,8 @@ export const ImportExportSection = ({
     } catch (error) {
       console.error('Failed to open the NDJSON import page:', error)
       setImportStatus('インポートページを開けませんでした。もう一度お試しください。')
+    } finally {
+      openImportPageInFlightRef.current = false
     }
   }, [])
 

--- a/src/components/popup/ImportExportSection.tsx
+++ b/src/components/popup/ImportExportSection.tsx
@@ -75,7 +75,23 @@ export const ImportExportSection = ({
   const [importOperationActive, setImportOperationActive] = useState(false)
   const importOperationActiveRef = useRef(false)
   const openImportPageInFlightRef = useRef(false)
+  /**
+   * Bumped every time this popup starts tracking an import. The storage-result
+   * handler captures it before its async getOperationState round trip and
+   * re-checks it at the commit point, so a response describing a *finished*
+   * import can never release a *newer* one that started while it was in
+   * flight. Same generation-guard shape UIScaleSection uses for its scale
+   * writes.
+   */
+  const importTrackingGenerationRef = useRef(0)
   const [rebuildOrigin, setRebuildOrigin] = useState<'import' | 'manual' | null>(null)
+
+  /** Single entry point for "an import is now being tracked". */
+  const beginTrackingImport = () => {
+    importTrackingGenerationRef.current += 1
+    importOperationActiveRef.current = true
+    setImportOperationActive(true)
+  }
 
   const isImporting = importOperationActive && rebuildOrigin !== 'import'
   const isAnyOperationInProgress = importOperationActive || exportState !== 'idle' || rebuildState !== 'idle'
@@ -97,8 +113,7 @@ export const ImportExportSection = ({
           setExportTotal(state.total ?? 0)
           setOperationStatus(state.message ?? '')
         } else if (state.type === 'import') {
-          importOperationActiveRef.current = true
-          setImportOperationActive(true)
+          beginTrackingImport()
           setImportStatus('')
           setImportProgress(state.progress ?? 0)
           setImportProcessed(state.processed ?? 0)
@@ -109,8 +124,7 @@ export const ImportExportSection = ({
           setRebuildState('rebuilding')
           setRebuildOrigin(state.origin === 'import' ? 'import' : 'manual')
           if (state.origin === 'import') {
-            importOperationActiveRef.current = true
-            setImportOperationActive(true)
+            beginTrackingImport()
           }
           setRebuildProgress(state.progress ?? 0)
           setOperationStatus(state.message ?? '')
@@ -161,8 +175,7 @@ export const ImportExportSection = ({
             setRebuildState('rebuilding')
             setRebuildOrigin(isImportRebuild ? 'import' : 'manual')
             if (isImportRebuild) {
-              importOperationActiveRef.current = true
-              setImportOperationActive(true)
+              beginTrackingImport()
             }
             setRebuildProgress(0)
             setOperationStatus(msg.message ?? '')
@@ -189,8 +202,7 @@ export const ImportExportSection = ({
       }
 
       if (isImportProgressMessage(message)) {
-        importOperationActiveRef.current = true
-        setImportOperationActive(true)
+        beginTrackingImport()
         setImportStatus('')
         setImportProgress(message.progress)
         setImportProcessed(message.processed)
@@ -265,9 +277,16 @@ export const ImportExportSection = ({
         // operation ends -- the exact stuck state this handler exists to fix.
         // Unknown state (timeout) also releases, per sendMessageWithTimeout's
         // fail-open contract.
+        const generationAtQuery = importTrackingGenerationRef.current
         void sendMessageWithTimeout<{ operationState?: OperationState }>(
           { action: 'getOperationState' }
         ).then(response => {
+          // The answer describes the moment it was taken, not this one. If a
+          // retry in the import page claimed the slot while the round trip was
+          // open, this popup is already tracking that newer import -- releasing
+          // on a stale "idle" would blank a live import's progress and re-enable
+          // buttons the background rejects.
+          if (importTrackingGenerationRef.current !== generationAtQuery) return
           const state = response?.operationState
           const trackedImportStillRunning =
             state?.type === 'import' ||


### PR DESCRIPTION
## 概要

merged 済み PR に codex レビューを追試した結果 #293 で見つかった P2 2件を修正する。どちらも実コードで再現条件を確認済み。

## 1. インポートページの重複生成

`handleImportClick` の `query` + `create` は check-then-act のペアで、単一飛行の保護がなかった。応答が返る前の2回目のクリックは自前で `query` を投げ、まだページを見つけられずにもう1枚作る。

加えて `tab.url` だけで照合していたため、ナビゲーションが未コミットのタブ（宛先が `pendingUrl` にしか入らず `url` は空または旧値）を取りこぼしていた。直前に開いたページがまさにこの状態になる。

2枚のページは単一のインポート操作スロットを奪い合い、負けた側が `lastImportResult` に失敗を書くので、**ユーザーが始めていないインポート失敗**として表示される。

- 単一飛行フラグを追加し、`finally` で必ず解放する
- `pendingUrl` も照合対象に加える

## 2. 転送失敗時の状態残り

`ImportPage.tsx` の `catch` は `lastImportResult` を storage へ直接書き、`importDataCancel` しか送らない。この cancel はセッションを片付けて応答するだけで**何もブロードキャストしない**ため、popup 側に `importStatus` メッセージは決して届かず、`storage.onChanged` が唯一の通知経路になる。

そのハンドラは `setImportStatus` しか呼んでおらず `importOperationActive` を落としていなかったので、`isAnyOperationInProgress` が真のまま残り、

- `displayStatus` が `''` になって**そのエラー自身が隠れる**
- エクスポートと再構築のボタンが無効のまま固まる

runtime メッセージ経路（`isImportStatusMessage`）が解除しているのと同じ状態を、storage 経路でも解除する。

## テスト

3件追加。**修正を戻すと3件とも落ちることを確認済み**（空振りテストでないことの確認）。

- `reuses an import page whose navigation has not committed yet`
- `does not open a second import page while the first open is still in flight`
- `releases the operation state when a terminal result arrives via storage`

## 実行したコマンド

- `npm run typecheck` — pass
- `npm run test` — 164 suites / 1714 tests pass

## 補足

同じ追試で見つかった残りの指摘（#311 / #319 / #321）は別PRに分ける。日本語コードコメントの指摘は、`AGENTS.md:65` と `CONTRIBUTING.md:379`/`414` が真逆のルールを定めている問題が背景にあるため、規約側を決着させる別タスクで扱う。本PRではコメント言語に手を付けていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)