### PR TITLE
fix(observability): 空振りテストを直し手動リリースの識別子を明示する

### DIFF
--- a/docs/chrome-web-store-release.md
+++ b/docs/chrome-web-store-release.md
@@ -141,9 +141,21 @@ gh release view pokerchase-hud-vX.Y.Z --json tagName,publishedAt,assets
 Developer Dashboard ではアップロード後のバージョン、審査状態、公開状態を確認する。
 GitHub Release が存在することだけをもって、Web Store 公開済みとは記載しない。
 
-ローカルで同じ CRX を作成する場合は、先に通常の build を行い、秘密鍵のパスを渡す。
+ローカルで同じ CRX を作成する場合は、先に build を行い、秘密鍵のパスを渡す。
 
 ```sh
-npm run build
+SENTRY_ENVIRONMENT=production npm run build
 npm run pack:crx -- /path/to/privatekey.pem
 ```
+
+`SENTRY_ENVIRONMENT=production` は省略しないこと。未指定の build は
+`scripts/build-extension.ts` の定義により development 扱いとなり、
+`pokerchase-hud@<version>+dev.<sha>` という別リリースへイベントを送る。ここで作る CRX は
+Web Store へ提出する実際の利用者向けビルドなので、省略すると公開リリースの集計から外れ、
+アップロード済みのソースマップとも対応しなくなる。CI 経由の通常リリースでは
+`.github/workflows/build.yml` がこの変数を設定しているため、明示が必要なのは
+この手動・復旧手順だけである。
+
+ソースマップまでCIと揃える場合は `SENTRY_AUTH_TOKEN` も渡す。未設定でも build は通り、
+`[Sentry] Building a production release without SENTRY_AUTH_TOKEN` と警告してソースマップの
+アップロードだけをスキップする。

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -163,8 +163,16 @@ published release:
 | Build | `SENTRY_ENVIRONMENT` | Environment | Release |
 |---|---|---|---|
 | Release workflow | `production` | `production` | `pokerchase-hud@<manifest version>` |
+| Manual / recovery release | `production` (must be set by hand) | `production` | `pokerchase-hud@<manifest version>` |
 | Working build | unset | `development` | `pokerchase-hud@<manifest version>+dev.<short sha>` |
 | E2E | n/a | — | telemetry compiled out |
+
+The split is release-vs-working, not CI-vs-local. `.github/workflows/build.yml`
+sets `SENTRY_ENVIRONMENT` for the workflow path only, so the manual CRX
+procedure in
+[docs/chrome-web-store-release.md](chrome-web-store-release.md#release-artifact)
+has to set it explicitly — a plain `npm run build` submitted to the Web Store
+would report as a working build under a `+dev.<sha>` release nobody runs.
 
 `scripts/build-extension.ts` resolves the short commit and appends `-dirty`
 when the tree has uncommitted changes — the marker is the point: it says the

--- a/src/observability/sentry-build-identity.test.ts
+++ b/src/observability/sentry-build-identity.test.ts
@@ -5,7 +5,6 @@
  * scripts/build-extension.ts injects both values; jest exercises the same
  * process.env reads directly.
  */
-import * as Sentry from '@sentry/browser'
 import manifest from '../../manifest.json'
 
 jest.mock('@sentry/browser', () => ({
@@ -19,6 +18,34 @@ jest.mock('@sentry/browser', () => ({
   captureMessage: jest.fn()
 }))
 
+/**
+ * Everything startSentry() checks *after* the compile-out flag: stored consent
+ * and the host permission. Tests that want the flag to be the only variable
+ * must grant these -- test-setup defaults `permissions.contains` to false, so
+ * an ungranted run returns 'disabled' before the flag is ever consulted.
+ */
+const grantRuntimePreconditions = async () => {
+  await chrome.storage.local.set({ sentryTelemetryConsent: true })
+  ;(chrome.permissions.contains as jest.Mock).mockResolvedValue(true)
+}
+
+/**
+ * Loads sentry.ts inside an isolated module registry and returns that
+ * registry's own `init` mock. isolateModulesAsync re-runs the jest.mock
+ * factory, so an `init` captured outside is a different jest.fn() that the
+ * isolated code can never call -- asserting on it proves nothing.
+ */
+const initSentryIsolated = async (): Promise<{ init: jest.Mock, result: unknown }> => {
+  let init: jest.Mock | undefined
+  let result: unknown
+  await jest.isolateModulesAsync(async () => {
+    init = require('@sentry/browser').init
+    const { initSentry } = require('./sentry')
+    result = await initSentry('background')
+  })
+  return { init: init as jest.Mock, result }
+}
+
 const startBackgroundSentry = async (
   build: { release?: string, environment?: string }
 ) => {
@@ -28,16 +55,10 @@ const startBackgroundSentry = async (
   if (build.environment) process.env.SENTRY_ENVIRONMENT = build.environment
   else delete process.env.SENTRY_ENVIRONMENT
 
-  await chrome.storage.local.set({ sentryTelemetryConsent: true })
-  ;(chrome.permissions.contains as jest.Mock).mockResolvedValue(true)
+  await grantRuntimePreconditions()
 
-  let init: jest.Mock | undefined
-  await jest.isolateModulesAsync(async () => {
-    init = require('@sentry/browser').init
-    const { initSentry } = require('./sentry')
-    await initSentry('background')
-  })
-  return init as jest.Mock
+  const { init } = await initSentryIsolated()
+  return init
 }
 
 describe('Sentry build identity', () => {
@@ -88,14 +109,19 @@ describe('Sentry build identity', () => {
   })
 
   it('keeps Sentry unused when telemetry is compiled out', async () => {
+    // Grant consent and the host permission so the compile-out flag is the ONLY
+    // reason init can be skipped. Without them startSentry() returns 'disabled'
+    // at a later gate, and "init was not called" would still hold with the
+    // compile-out gate deleted.
+    await grantRuntimePreconditions()
     delete process.env.SENTRY_ENABLED
-    await chrome.storage.local.set({ sentryTelemetryConsent: true })
 
-    await jest.isolateModulesAsync(async () => {
-      const { initSentry } = require('./sentry')
-      await initSentry('background')
-    })
+    const { init, result } = await initSentryIsolated()
 
-    expect(Sentry.init).not.toHaveBeenCalled()
+    // Pin the reason, not just the effect: 'build_disabled' is returned by the
+    // compile-out gate alone, so removing that gate fails here even before the
+    // call-count assertion below.
+    expect(result).toBe('build_disabled')
+    expect(init).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## 概要

merged 済み PR への codex レビュー追試で [#311](https://github.com/solavrc/pokerchase-hud/pull/311) に出た P2 2件。どちらも実測で確認した。

## 1. 常に成功していたテスト

`sentry-build-identity.test.ts` の「テレメトリをコンパイル除外したとき Sentry を使わない」ケースは、**守っているはずの退行を入れても通っていた**。`telemetryEnabled()` を `true` にハードコードしても4件すべてグリーンのままになる。

原因は2つあり、**指摘された1つ目だけを直しても変異テストは通ったまま**だった:

1. `jest.isolateModulesAsync` がモジュールレジストリを作り直すため、冒頭 import の `Sentry.init` は隔離側が決して呼べない別の `jest.fn()` だった（先行3ケースが隔離ブロック内で `init` を捕まえているのはこのため）
2. `test-setup.ts` の `permissions.contains` の既定は `false` で、このケースは consent も権限も与えていなかった。`startSentry()` はコンパイル除外の判定より**後**のゲートで `'disabled'` を返すので、コンパイル除外のゲートを消しても「init が呼ばれない」は成立し続ける

前提を明示的に与えて `SENTRY_ENABLED` だけを変数にし、戻り値が `'build_disabled'` であることも検証する。これはコンパイル除外のゲートだけが返す値なので、ゲートを消すと呼び出し回数の検証より前に落ちる。

確認: `telemetryEnabled()` を `true` へ固定すると `Expected: "build_disabled" / Received: "started"` で落ちる。

## 2. 手動リリースの Sentry identity

[docs/chrome-web-store-release.md:147](https://github.com/solavrc/pokerchase-hud/blob/main/docs/chrome-web-store-release.md#L147) の手動 CRX 手順が素の `npm run build` で、`SENTRY_ENVIRONMENT=production` を設定していなかった。`.github/workflows/build.yml:68` だけが設定している。

この手順で作る CRX は Web Store へ提出する実際の利用者向けビルドなので、development 扱いで `+dev.<sha>` という別リリースへイベントを送っていた。公開リリースの集計から外れ、アップロード済みのソースマップとも対応しない。AGENTS.md の「Incident Diagnosis Practices」が依拠している観測性が、復旧リリースのときだけ静かに壊れる。

`docs/observability.md` の表が分岐を「Release workflow / Working build」と書いていたのが曖昧さの発生源なので、手動リリースの行を追加して **release-vs-working の軸であって CI-vs-local ではない**ことを明記した。

## 実行したコマンド

- `npm run typecheck` — pass
- `npm run test` — 164 suites / 1711 tests pass

## 補足

コードの動作変更はなし（テストとドキュメントのみ）。日本語コードコメントの指摘は、`AGENTS.md:65` と `CONTRIBUTING.md:379`/`414` が真逆のルールを定めている問題として別タスクで扱っているため、本PRでは触れていない。ドキュメントは各ファイルの既存言語に合わせた（`chrome-web-store-release.md` は日本語、`observability.md` は英語）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)