### PR TITLE
fix(ui): 配置リセットの部分適用・採番順・モック不整合を直す

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -744,9 +744,17 @@ v3 added composite indexes for player-specific queries. v6 changes the Raw Lake 
   not access the restricted local area directly.
 - **Layout reset is one operation over every device-local appearance key**:
   the popup's 「位置とサイズをリセット」 (`UIScaleSection.tsx`) sends a single
-  `resetDeviceUILayout`, and the background removes `handLogLayout`, every
-  `hudPosition_*` key, *and* `uiScale` in one `chrome.storage.local.remove`
-  call so they cannot diverge. Scale is in scope because the button means
+  `resetDeviceUILayout`, and the background removes `handLogLayout` and every
+  `hudPosition_*` key in one `chrome.storage.local.remove` call, then writes
+  `uiScale` back to its default in a `set` — a *missing* local `uiScale` means
+  "not migrated to device-local" (`getDeviceUILayout`'s `needsScaleMigration`),
+  so removing it would re-migrate from the legacy synced value and resurrect
+  the pre-reset scale. There is no atomic remove+set in `chrome.storage`, so
+  the reachable guarantee is not "both or neither" but **whatever persisted is
+  always broadcast**: if the `set` fails after the `remove` succeeded, the
+  layout reset is still delivered to open tabs and the response reports the
+  failure, so storage and open tabs never disagree and the (idempotent)
+  operation can just be retried. Scale is in scope because the button means
   "back to the default look" (sola): leaving a large scale behind returns the
   panels to default positions computed for a size they no longer are, so the
   hand log's default slot above the seat plate stops fitting. Keys come from `HUD_POSITION_STORAGE_KEYS`

--- a/src/background/message-router.device-layout.test.ts
+++ b/src/background/message-router.device-layout.test.ts
@@ -293,6 +293,51 @@ describe('message-router device-local UI layout', () => {
     })
   })
 
+  it('倍率書き込みが失敗しても、永続化済みの配置リセットは配信する', async () => {
+    // chrome.storageにremove+setの原子的な操作はない。removeが成功した後に
+    // setが失敗したとき配信まで止めると、storageは既定なのに開いているタブは
+    // 古い配置のまま、という食い違いが次のリロードまで残る。永続化できた分は
+    // 必ず配信し、失敗はレスポンスで返して再実行させる（操作は冪等）。
+    ;(chrome.tabs.query as jest.Mock).mockImplementation((_query, callback) => {
+      callback([{ id: 42 }])
+    })
+    await chrome.storage.local.set({
+      [hudPositionStorageKey(0)]: { top: '12%', left: '20%' },
+    })
+    const realSet = chrome.storage.local.set
+    ;(chrome.storage.local as any).set = jest.fn((_items: any, callback?: () => void) => {
+      ;(chrome.runtime as any).lastError = { message: 'scale write failed' }
+      callback?.()
+      delete (chrome.runtime as any).lastError
+    })
+    const resetResponse = jest.fn()
+
+    try {
+      listener({ action: 'resetDeviceUILayout' }, {}, resetResponse)
+      await getPendingStorageWriteTail()
+      await new Promise(resolve => setTimeout(resolve, 0))
+    } finally {
+      ;(chrome.storage.local as any).set = realSet
+    }
+
+    // 失敗として返す（ユーザーは再実行できる）。
+    expect(resetResponse).toHaveBeenCalledWith({
+      success: false,
+      error: 'scale write failed',
+    })
+    // 配置のリセットは永続化されているので、タブへも必ず届いている。
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+      action: 'resetUILayout',
+    })
+    // 倍率は書けていないので配信もしない（storageとタブが食い違わない）。
+    expect(chrome.tabs.sendMessage).not.toHaveBeenCalledWith(42, expect.objectContaining({
+      action: 'updateDeviceUIScale',
+    }))
+    expect(await chrome.storage.local.get(hudPositionStorageKey(0))).toEqual({
+      [hudPositionStorageKey(0)]: undefined,
+    })
+  })
+
   it('端末ローカルの倍率も消して既定倍率を全ゲームタブへ配信する', async () => {
     // 「既定の見た目へ戻す」操作なので倍率も対象（sola指定）。倍率を残すと
     // 大きい倍率のままパネルが既定位置へ戻り、既定位置が前提とする余白に

--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -139,8 +139,16 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
     pendingReads.forEach(read => read())
   }
 
+  /**
+   * `operation` signals completion by invoking its callback. It MAY pass an
+   * error explicitly; otherwise `chrome.runtime.lastError` is read at that
+   * moment. The explicit form exists for multi-write operations that must
+   * publish their own state before reporting: any chrome API call in between
+   * (a broadcast, a follow-up write) overwrites `lastError`, so an operation
+   * that does more than one thing has to carry its own error forward.
+   */
   const enqueueHandLogLayoutWrite = (
-    operation: (callback: () => void) => void,
+    operation: (callback: (explicitError?: chrome.runtime.LastError) => void) => void,
     sendResponse: (response: MessageResponse) => void,
     failureMessage: string,
     afterSuccessfulWrite?: (complete: () => void) => void
@@ -151,8 +159,8 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
 
     void enqueuePendingStorageWrite(() =>
       new Promise<chrome.runtime.LastError | undefined>((resolve) => {
-        operation(() => {
-          const error = chrome.runtime.lastError
+        operation((explicitError) => {
+          const error = explicitError ?? chrome.runtime.lastError
           if (error || !afterSuccessfulWrite) {
             resolve(error)
             return
@@ -482,37 +490,53 @@ export const registerMessageRouter = (service: PokerChaseService, db: PokerChase
       // 世代を上げるのは、この時点で読み込み中の移行（古い世代を掴んでいる）に
       // 書き戻させないため。
       deviceScaleWriteGeneration += 1
+      // chrome.storageにremoveとsetをまとめて行う原子的な操作はない。到達
+      // できるのは「成功したぶんは必ずタブへ配信し、storageと開いているタブが
+      // 食い違わない」状態まで。操作全体は冪等なので、失敗を返せばユーザーの
+      // 再実行で残りが揃う。
+      // 倍率はresetUILayoutとは別経路で反映する。ゲームタブ側の倍率は
+      // App.tsxがuiConfig.scaleとして持っており、既存のscale配信
+      // （updateDeviceUIScale）がその唯一の更新経路だから。
+      // resetUILayoutにscaleを相乗りさせると、HandLog/useDraggableの
+      // リセットとscale更新が1つのメッセージに同居して責務が混ざる。
       enqueueHandLogLayoutWrite(
         callback => chrome.storage.local.remove(
           [HAND_LOG_LAYOUT_STORAGE_KEY, ...HUD_POSITION_STORAGE_KEYS],
           () => {
-            // removeが失敗したらlastErrorが立っている間に抜ける。
-            // 続けてsetを呼ぶとlastErrorが上書きされ、失敗が成功に見える。
-            if (chrome.runtime.lastError) {
-              callback()
+            // removeが失敗したときは何も書けていないので、配信もせずに抜ける。
+            const removeError = chrome.runtime.lastError
+            if (removeError) {
+              callback(removeError)
               return
             }
             chrome.storage.local.set(
               { [UI_SCALE_STORAGE_KEY]: DEFAULT_UI_CONFIG.scale },
-              callback
+              () => {
+                // 以降はchrome APIを呼ぶたびlastErrorが上書きされるので、
+                // ここで捕まえてcallbackへ明示的に渡す。
+                const scaleError = chrome.runtime.lastError
+                // 配置の削除はもう永続化されている。倍率の書き込みが失敗した
+                // 場合でも配置のリセットだけは配信する。配信しないと、storage
+                // は既定なのに開いているタブは古い配置のまま、という食い違いが
+                // 次のリロードまで残るため。
+                broadcastToGameTabs({ action: 'resetUILayout' }, () => {
+                  if (scaleError) {
+                    callback(scaleError)
+                    return
+                  }
+                  broadcastToGameTabs({
+                    action: 'updateDeviceUIScale',
+                    scale: DEFAULT_UI_CONFIG.scale,
+                  }, () => callback())
+                })
+              }
             )
           }
         ),
         sendResponse,
-        'Failed to reset UI layout',
-        complete => {
-          // 倍率はresetUILayoutとは別経路で反映する。ゲームタブ側の倍率は
-          // App.tsxがuiConfig.scaleとして持っており、既存のscale配信
-          // （updateDeviceUIScale）がその唯一の更新経路だから。
-          // resetUILayoutにscaleを相乗りさせると、HandLog/useDraggableの
-          // リセットとscale更新が1つのメッセージに同居して責務が混ざる。
-          broadcastToGameTabs({ action: 'resetUILayout' }, () => {
-            broadcastToGameTabs({
-              action: 'updateDeviceUIScale',
-              scale: DEFAULT_UI_CONFIG.scale,
-            }, complete)
-          })
-        }
+        'Failed to reset UI layout'
+        // afterSuccessfulWriteは使わない。この操作は部分的な成功も配信する
+        // 必要があり、成功時だけ呼ばれるフックでは表現できない。
       )
       return true
     } else if (request.action === 'exportData') {

--- a/src/components/popup/UIScaleSection.test.tsx
+++ b/src/components/popup/UIScaleSection.test.tsx
@@ -84,6 +84,45 @@ describe('UIScaleSection', () => {
     )
   })
 
+  it('リセット応答が遅れても、その間に押した倍率変更を捨てない', async () => {
+    // リセットの採番はクリック時点で行う。完了時点で採番すると、応答待ちの
+    // 間に押した + の方が小さいIDになり、永続化に成功した後発の倍率が
+    // stale判定で捨てられる。
+    const user = userEvent.setup()
+    let completeReset: (() => void) | undefined
+    mockChromeRuntimeSendMessage.mockImplementation((message: any, callback: any) => {
+      if (message.action === 'resetDeviceUILayout') {
+        completeReset = () => callback({ success: true })
+        return
+      }
+      callback({ success: true })
+    })
+    render(
+      <UIScaleSection
+        {...defaultProps}
+        uiConfig={{ ...DEFAULT_UI_CONFIG, scale: 1.6 }}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: '位置とサイズをリセット' }))
+    expect(completeReset).toBeDefined()
+
+    // リセット応答より先に倍率を上げ、その書き込みは成功する。
+    await user.click(screen.getByRole('button', { name: '+' }))
+    expect(mockChromeRuntimeSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'setDeviceUIScale' }),
+      expect.any(Function)
+    )
+    const appliedScale = mockSetUIConfig.mock.calls.at(-1)?.[0]?.scale
+    expect(appliedScale).toBeGreaterThan(1.6)
+
+    // 遅れて届いたリセット応答は、後発の倍率を上書きしない。
+    mockSetUIConfig.mockClear()
+    completeReset?.()
+
+    expect(mockSetUIConfig).not.toHaveBeenCalled()
+  })
+
   it('リセットが失敗した場合は倍率表示を戻さない', async () => {
     const user = userEvent.setup()
     mockChromeRuntimeSendMessage.mockImplementation((_message, callback) => {

--- a/src/components/popup/UIScaleSection.tsx
+++ b/src/components/popup/UIScaleSection.tsx
@@ -180,6 +180,11 @@ export const UIScaleSection = ({
           variant="text"
           title="HUDパネルとハンドログの位置・サイズ・倍率を既定へ戻す"
           onClick={() => {
+            // Take the id at click time, like updateLocalScale does. Issuing it
+            // on completion instead would stamp the reset as newer than a +/-
+            // clicked while it was still in flight, and that later scale would
+            // be discarded by the stale check even though it persisted.
+            const requestId = ++nextScaleRequestIdRef.current
             // Persistence and live-tab delivery both run in the background so
             // closing the action popup cannot interrupt the reset.
             resetUILayout(() => {
@@ -187,7 +192,8 @@ export const UIScaleSection = ({
               // updateDeviceUIScaleで配信される。ポップアップ自身は購読して
               // いないので、成功応答を受けてここで既定へ戻す。
               // 進行中のscale書き込みがあれば、その基準もここへ寄せる。
-              latestAppliedScaleRequestIdRef.current = ++nextScaleRequestIdRef.current
+              if (requestId < latestAppliedScaleRequestIdRef.current) return
+              latestAppliedScaleRequestIdRef.current = requestId
               latestAppliedScaleRef.current = DEFAULT_UI_CONFIG.scale
               pendingScaleRef.current = DEFAULT_UI_CONFIG.scale
               setUIConfig({

--- a/src/mockup/mock-chrome.test.ts
+++ b/src/mockup/mock-chrome.test.ts
@@ -1,4 +1,5 @@
 import { installChromeMock } from './mock-chrome'
+import { DEFAULT_UI_CONFIG } from '../types/hand-log'
 
 describe('visual mock chrome layout storage', () => {
   it('端末ローカルのHUD位置とscaleをruntime message経由で保存・読込する', () => {
@@ -42,6 +43,35 @@ describe('visual mock chrome layout storage', () => {
     expect(response).toHaveBeenLastCalledWith({
       success: true,
       scale: 1.4,
+    })
+  })
+
+  it('位置とサイズのリセットで倍率も既定へ戻す', () => {
+    // 本番の resetDeviceUILayout は倍率も既定へ書き戻す。モックが位置だけを
+    // 消すと、ポップアップの表示は100%へ戻るのに背後のHUDは前の倍率のまま
+    // という、本番には存在しない状態になり、mockupでこの操作を検証できない。
+    installChromeMock()
+
+    chrome.runtime.sendMessage({ action: 'setDeviceUIScale', scale: 1.4 }, jest.fn())
+    chrome.runtime.sendMessage({
+      action: 'setDeviceHudPosition',
+      seatIndex: 2,
+      position: { top: '30%', left: '40%' },
+    }, jest.fn())
+
+    const resetResponse = jest.fn()
+    chrome.runtime.sendMessage({ action: 'resetDeviceUILayout' }, resetResponse)
+    expect(resetResponse).toHaveBeenCalledWith({ success: true })
+
+    const response = jest.fn()
+    chrome.runtime.sendMessage({
+      action: 'getDeviceUILayout',
+      seatIndex: 2,
+    }, response)
+
+    expect(response).toHaveBeenCalledWith({
+      success: true,
+      scale: DEFAULT_UI_CONFIG.scale,
     })
   })
 })

--- a/src/mockup/mock-chrome.ts
+++ b/src/mockup/mock-chrome.ts
@@ -1,5 +1,5 @@
 import { MESSAGE_ACTIONS } from '../types/messages'
-import type { UIConfig } from '../types/hand-log'
+import { DEFAULT_UI_CONFIG, type UIConfig } from '../types/hand-log'
 import {
   POPUP_THEME_LOCAL_STORAGE_KEY,
   POPUP_THEME_STORAGE_KEY,
@@ -211,15 +211,25 @@ export const installChromeMock = (): MockChromeController => {
           localStorage.remove(
             [HAND_LOG_LAYOUT_STORAGE_KEY, ...HUD_POSITION_STORAGE_KEYS],
             () => {
-              // Clearing storage is not enough: neither `HandLog` nor
-              // `useDraggable` watches storage -- they reset on these window
-              // events. The real background sends one `resetUILayout` message
-              // to the game tab, where `content_script.ts` fans it out into
-              // exactly these two -- without them the popup's
-              // 位置とサイズをリセット button would do nothing visible.
-              window.dispatchEvent(new CustomEvent(MESSAGE_ACTIONS.RESET_HAND_LOG_LAYOUT))
-              window.dispatchEvent(new CustomEvent(MESSAGE_ACTIONS.RESET_HUD_POSITIONS))
-              callback?.({ success: true })
+              // Scale is part of the reset too, and it is written back to the
+              // default rather than removed -- a missing local uiScale means
+              // "not migrated to device-local" and would re-migrate from the
+              // legacy synced value, resurrecting the pre-reset scale. Mirror
+              // the real handler exactly: without this the mock resets only the
+              // positions, the popup snaps back to 100% while the HUD behind it
+              // keeps the old scale, and 位置とサイズをリセット cannot be
+              // verified here at all.
+              localStorage.set({ [UI_SCALE_STORAGE_KEY]: DEFAULT_UI_CONFIG.scale }, () => {
+                // Clearing storage is not enough: neither `HandLog` nor
+                // `useDraggable` watches storage -- they reset on these window
+                // events. The real background sends one `resetUILayout` message
+                // to the game tab, where `content_script.ts` fans it out into
+                // exactly these two -- without them the popup's
+                // 位置とサイズをリセット button would do nothing visible.
+                window.dispatchEvent(new CustomEvent(MESSAGE_ACTIONS.RESET_HAND_LOG_LAYOUT))
+                window.dispatchEvent(new CustomEvent(MESSAGE_ACTIONS.RESET_HUD_POSITIONS))
+                callback?.({ success: true })
+              })
             }
           )
           return


### PR DESCRIPTION
## 概要

merged 済み PR への codex レビュー追試で [#319](https://github.com/solavrc/pokerchase-hud/pull/319) に出た P2 3件。**いずれも変異テストで、修正を戻すと対応するテストが落ちることを確認済み**。

## 1. 倍率書き込みが失敗したときの部分適用

`remove` が成功した後に `set` が失敗すると、配置は削除済みなのに配信まで止まるため、**storage は既定なのに開いているタブは古い配置のまま**という食い違いが次のリロードまで残っていた。

`chrome.storage` に remove+set の原子的な操作はないので「両方かゼロか」にはできない。到達できるのは **「永続化できた分は必ず配信する」** ところまでで、失敗はレスポンスで返して再実行させる（操作は冪等）。これで storage と開いているタブが食い違う状態はなくなる。

これに伴い `enqueueHandLogLayoutWrite` の `operation` が明示的にエラーを渡せるようにした。配信を挟むと `chrome.runtime.lastError` が上書きされるため、複数回書き込む操作は自前でエラーを持ち回る必要がある。既存の呼び出し（`setDeviceHandLogLayout`）は引数なしの callback のままで、従来どおり `lastError` へフォールバックする。

## 2. リセット時の倍率採番順

完了時点で新しい ID を採番していたため、応答待ちの間に押した `+`/`-` の方が小さい ID になり、**永続化に成功した後発の倍率が stale 判定で捨てられて**いた。`updateLocalScale` と同じくクリック時点で採番する。

## 3. モックが倍率を既定へ戻さない

本番の `resetDeviceUILayout` は倍率も既定へ書き戻すが、モックは位置だけを消していた。ポップアップの表示は100%へ戻るのに背後の HUD は前の倍率のまま、という**本番に存在しない状態**になり、`npm run mockup` でこの操作を検証できていなかった。

## AGENTS.md の記述が実装とずれていた

作業中に見つけた別件。該当箇所は「`handLogLayout`、`hudPosition_*`、`uiScale` を1回の `chrome.storage.local.remove` で消す」と書いていたが、[#319](https://github.com/solavrc/pokerchase-hud/pull/319) 以降 `uiScale` は remove ではなく既定値の `set` になっている（キー欠落は「端末ローカルへ未移行」を意味し、消すと同期側の旧倍率から復活するため）。保証の内容も上記1に合わせて書き直した。

## 実行したコマンド

- `npm run typecheck` — pass
- `npm run test` — 164 suites / 1714 tests pass

## 補足

日本語コードコメントの指摘は、`AGENTS.md:65` と `CONTRIBUTING.md:379`/`414` が真逆のルールを定めている問題として別タスクで扱っているため、本PRでは触れていない。既存コメントの言語に合わせている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)