### PR TITLE
fix(ui): テーブル人数スライダーが層の名称を読み上げるようにする

### DIFF
--- a/src/components/popup/TableSizeFilterSection.test.tsx
+++ b/src/components/popup/TableSizeFilterSection.test.tsx
@@ -128,4 +128,27 @@ describe('TableSizeFilterSection のポインタ操作', () => {
     expect(first).toBeGreaterThanOrEqual(0)
     expect(selected.slice(first, last + 1).every(Boolean)).toBe(true)
   })
+
+  it('各つまみが人数ではなく層の名称を読み上げる', () => {
+    // aria-valuenow は 1〜4 のスライダー内部値でしかない。層ごとの
+    // チェックボックスだった頃はカテゴリ名を読めていたので、名称を出さないと
+    // アクセシビリティの後退になる。valueLabelFormat は視覚的なツールチップ
+    // だけを整形するため、ここは賄えない。
+    render(<Harness initial={{ hu: true, '3p': true, '4p': false, full: false }} />)
+
+    const lower = screen.getByRole('slider', { name: 'テーブル人数の下限' })
+    const upper = screen.getByRole('slider', { name: 'テーブル人数の上限' })
+
+    expect(lower).toHaveAttribute('aria-valuetext', 'HU (2人)')
+    expect(upper).toHaveAttribute('aria-valuetext', '3人')
+  })
+
+  it('全層を選んだときも両端の層名称を読み上げる', () => {
+    render(<Harness initial={{ hu: true, '3p': true, '4p': true, full: true }} />)
+
+    expect(screen.getByRole('slider', { name: 'テーブル人数の下限' }))
+      .toHaveAttribute('aria-valuetext', 'HU (2人)')
+    expect(screen.getByRole('slider', { name: 'テーブル人数の上限' }))
+      .toHaveAttribute('aria-valuetext', 'フル')
+  })
 })

--- a/src/components/popup/TableSizeFilterSection.tsx
+++ b/src/components/popup/TableSizeFilterSection.tsx
@@ -63,6 +63,11 @@ export const TableSizeFilterSection = ({
           value={range}
           onChange={handleTableSizeFilterChange}
           getAriaLabel={(index) => (index === 0 ? 'テーブル人数の下限' : 'テーブル人数の上限')}
+          // valueLabelFormat は視覚的なツールチップだけを整形するので、これが
+          // 無いとスクリーンリーダーには aria-valuenow の 1〜4 しか届かず、
+          // どの層を指しているのか判別できない。層ごとのチェックボックス
+          // だった頃はカテゴリ名を読めていたので、無いと後退になる。
+          getAriaValueText={(value) => VALUE_LABELS[value] ?? String(value)}
           valueLabelDisplay="auto"
           valueLabelFormat={(value) => VALUE_LABELS[value] ?? String(value)}
           step={1}


### PR DESCRIPTION
## 概要

merged 済み PR への codex レビュー追試で [#321](https://github.com/solavrc/pokerchase-hud/pull/321) に出た P2。アクセシビリティの後退。

つまみにフォーカスしても `aria-valuenow` の 1〜4 しか得られず、**HU・3人・4人・フルのどれを指しているのか判別できない**。`valueLabelFormat` は視覚的なツールチップだけを整形するので、ここは賄えない。

層ごとのチェックボックスだった頃はカテゴリ名と選択状態を読めていたので、[#321](https://github.com/solavrc/pokerchase-hud/pull/321) のレンジスライダー化で失われたことになる。

`getAriaValueText` で `VALUE_LABELS` の名称を公開する。

## テスト

2件追加。**`getAriaValueText` を外すと2件とも落ちることを確認済み**。

- `各つまみが人数ではなく層の名称を読み上げる`（下限=`HU (2人)` / 上限=`3人`）
- `全層を選んだときも両端の層名称を読み上げる`（下限=`HU (2人)` / 上限=`フル`）

## 実行したコマンド

- `npm run typecheck` — pass
- `npm run test` — 164 suites / 1713 tests pass

## 補足

これで #319 / #293 / #311 / #321 の追試で見つかった指摘10件のうち、日本語コードコメントの件を除く全件が対応済みになる（コメント言語は `AGENTS.md:65` と `CONTRIBUTING.md:379`/`414` の矛盾として別タスクで処理中）。転送フェーズ通知の残件は #333 に切り出し済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)