### PR TITLE
fix(test): spectator-filter-refreshテストのpersistStateタイマーリークflakeを直す

### DIFF
--- a/src/background/message-router.spectator-filter-refresh.test.ts
+++ b/src/background/message-router.spectator-filter-refresh.test.ts
@@ -99,11 +99,35 @@ describe('message-router updateBattleTypeFilter -- spectator lastKnownStats refr
   })
 
   afterEach(async () => {
+    // Cancel PokerChaseService's pending 500ms-debounced persistState() timer
+    // -- without this, it can fire during a LATER test in this file (after
+    // the root beforeEach's storage reset but before that test's
+    // restoreState() read) and write this (now-defunct) service's
+    // playerId/latestEvtDeal into the shared chrome.storage.local mock,
+    // which the later test's `await service.ready` then restores. That leak
+    // broke the "latestEvtDeal not yet known" control test on slow CI runs
+    // (CI run 30687009635): the restored latestEvtDeal established the
+    // lineup mismatch and the refresh under test was skipped (0 write calls).
+    clearTimeout((service as unknown as { _persistStateTimer?: ReturnType<typeof setTimeout> })._persistStateTimer)
     jest.restoreAllMocks()
     delete (global as any).chrome.tabs
     setLastKnownStats([])
     db.close()
     await db.delete()
+  })
+
+  // Dispatch updateBattleTypeFilter and await the listener's sendResponse,
+  // which fires once setBattleTypeFilter()'s promise chain settles. The
+  // write() under test happens synchronously inside the listener, but
+  // draining the full handler deterministically (instead of hoping a single
+  // setTimeout(0) macrotask hop covers it) keeps the recalc chain from
+  // racing afterEach's db teardown.
+  const dispatchFilterUpdate = () => new Promise<void>(resolve => {
+    messageListener(
+      { action: 'updateBattleTypeFilter', filterOptions: FILTER_OPTIONS } as unknown as ChromeMessage,
+      {} as chrome.runtime.MessageSender,
+      jest.fn(() => { resolve() })
+    )
   })
 
   test('spectating a different table than the hero\'s last deal: the extra refresh is skipped (lineup mismatch)', async () => {
@@ -118,13 +142,7 @@ describe('message-router updateBattleTypeFilter -- spectator lastKnownStats refr
       { playerId: 40, statResults: [] } as any,
     ])
 
-    const sendResponse = jest.fn()
-    messageListener(
-      { action: 'updateBattleTypeFilter', filterOptions: FILTER_OPTIONS } as unknown as ChromeMessage,
-      {} as chrome.runtime.MessageSender,
-      sendResponse
-    )
-    await new Promise(resolve => setTimeout(resolve, 0))
+    await dispatchFilterUpdate()
 
     // The mismatched spectator refresh must not fire -- it would race
     // service.liveEvtDeal's hero-anchored re-sync from recalculateStats()
@@ -136,13 +154,7 @@ describe('message-router updateBattleTypeFilter -- spectator lastKnownStats refr
     service.latestEvtDeal = HERO_DEAL
     setLastKnownStats(HERO_DEAL.SeatUserIds.map(playerId => ({ playerId, statResults: [] } as any)))
 
-    const sendResponse = jest.fn()
-    messageListener(
-      { action: 'updateBattleTypeFilter', filterOptions: FILTER_OPTIONS } as unknown as ChromeMessage,
-      {} as chrome.runtime.MessageSender,
-      sendResponse
-    )
-    await new Promise(resolve => setTimeout(resolve, 0))
+    await dispatchFilterUpdate()
 
     expect(writeSpy).toHaveBeenCalledWith(HERO_DEAL.SeatUserIds)
   })
@@ -151,13 +163,7 @@ describe('message-router updateBattleTypeFilter -- spectator lastKnownStats refr
     // service.latestEvtDeal deliberately left unset.
     setLastKnownStats([{ playerId: 2, statResults: [] } as any])
 
-    const sendResponse = jest.fn()
-    messageListener(
-      { action: 'updateBattleTypeFilter', filterOptions: FILTER_OPTIONS } as unknown as ChromeMessage,
-      {} as chrome.runtime.MessageSender,
-      sendResponse
-    )
-    await new Promise(resolve => setTimeout(resolve, 0))
+    await dispatchFilterUpdate()
 
     expect(writeSpy).toHaveBeenCalledWith([2])
   })
@@ -177,13 +183,7 @@ describe('message-router updateBattleTypeFilter -- spectator lastKnownStats refr
       { playerId: 20, statResults: [] } as any,
     ])
 
-    const sendResponse = jest.fn()
-    messageListener(
-      { action: 'updateBattleTypeFilter', filterOptions: FILTER_OPTIONS } as unknown as ChromeMessage,
-      {} as chrome.runtime.MessageSender,
-      sendResponse
-    )
-    await new Promise(resolve => setTimeout(resolve, 0))
+    await dispatchFilterUpdate()
 
     expect(writeSpy).toHaveBeenCalledWith([10, 20])
   })


### PR DESCRIPTION
## 概要

CI run [30687009635](https://github.com/solavrc/pokerchase-hud/actions/runs/30687009635)（PR #331、ドキュメントのみの変更）で `message-router.spectator-filter-refresh.test.ts` の「control: latestEvtDeal not yet known」テストが writeSpy 0 calls で失敗し、コード同一のままリランでパスした flake の修正。

## 原因

当初仮説の「`setTimeout(0)` が1マクロタスクで足りない」ではない。`updateBattleTypeFilter` ハンドラの `write()` はリスナー内で**完全に同期**に呼ばれるため待ち時間は無関係。

真因は **`PokerChaseService` の 500ms デバウンス `persistState()` タイマーのテスト間リーク**:

1. テスト1/2 の `service.latestEvtDeal = HERO_DEAL` 代入が 500ms 後発火の永続化タイマーを仕込み、afterEach はこれを消さない
2. 遅い CI ではこのタイマーがテスト3の beforeEach 中 — test-setup.ts のルート beforeEach による storage モックリセット後、`await service.ready` の `restoreState()` read 前 — に発火し、旧 service の `{playerId, latestEvtDeal: HERO_DEAL}` を共有 `chrome.storage.local` モックへ書き込む
3. テスト3の `restoreState()` がそれを復元 → 「latestEvtDeal 未設定」の前提が崩れ、lineup `[2]` vs `[1..6]` の不一致が成立して refresh がスキップされ writeSpy 0 calls（CI の失敗シグネチャと完全一致）

beforeEach へ一時的に 700ms 遅延を挿入する再現実験で、ローカルでも同一テスト・同一シグネチャの失敗を確定的に再現し、修正適用後は同じ敵対的条件下でパスすることを確認してから遅延を除去した。

同一のリークは `import-export.full-rebuild.test.ts:125` / `cross-path-parity.test.ts:167` で既に対処済みのパターン。

## 変更内容

- afterEach で `_persistStateTimer` を `clearTimeout`（既存パターン踏襲、理由をコメント化）
- `setTimeout(0)` 待ちを廃止し、`sendResponse` の決着（`setBattleTypeFilter()` の Promise チェーン完了）を直接 await する `dispatchFilterUpdate()` ヘルパーへ置換。4テストの重複ディスパッチも1行に集約

## 検証

- 該当ファイル `--runInBand` で 10回連続 5/5 パス
- 700ms 遅延の敵対的条件下でも修正後はパス
- `npm run test` 全 164 スイート / 1711 テストパス、`npm run typecheck` パス

補足: タイマー未クリアで `PokerChaseService` を生成するテストファイルが他に約34件あり、同じ潜在 flake クラスを抱える（今回はスコープ外、別途一括対処予定）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)