### PR TITLE
fix(replay): 中断時に meta へ書かず、長時間操作の終了で取得を再開する

### DIFF
--- a/src/background/event-ingestion.ts
+++ b/src/background/event-ingestion.ts
@@ -16,7 +16,7 @@ import {
 } from './undecoded-event-tracker'
 import { awaitIngestionDrain, markSessionActive, markSessionInactive, recheckPendingUpdate, setIngestionDrainProvider } from './update-manager'
 import { mergeApiEvents, type RawApiEvent } from '../utils/api-event-key'
-import { getOperationGeneration, getOperationState } from './operation-state'
+import { getOperationGeneration, getOperationState, onOperationBecameIdle } from './operation-state'
 import { handleReplayPortMessage, releaseReplayRequestsForPort } from './replay-fetch-bridge'
 import { handleReplayLedgerPortMessage, type ReplayLedgerAuditDeps } from './replay-ledger-audit'
 import {
@@ -112,6 +112,17 @@ export const createReplayImportDeps = (service: PokerChaseService): ReplayImport
  * 各ストリームへの書き込み・自動同期トリガーを行う。
  */
 export const registerEventIngestion = (service: PokerChaseService): void => {
+  // 長時間操作（インポート/再構築/エクスポート/全削除）が終わったら、その間に
+  // 中断・見送りになったリプレイ取得を再開する。これが無いと、再開の契機が
+  // 次の309/203かポート再接続だけになり、ページを開いたまま次の対局をしない
+  // ユーザーのキューが3日の取得期限を越えて捨てられる。
+  // `drainReplayImportQueue` 側の不変条件がセッション状態を見るので、
+  // ここでは無条件に呼んでよい（セッション中なら何も起きない）。
+  onOperationBecameIdle(() => {
+    drainReplayImportQueue(createReplayImportDeps(service))
+      .catch(err => console.error('[background] Replay import drain after operation failed:', err))
+  })
+
   // Raw Event Lakeの耐久性バリア（release-blocker監査 finding A）:
   // `db.apiEvents.add()`を待たずにストリーム書き込みやセッションフックの副作用
   // （自動同期トリガー、`chrome.runtime.reload()`を呼びうる保留アップデート

--- a/src/background/replay-import.test.ts
+++ b/src/background/replay-import.test.ts
@@ -4,6 +4,7 @@ import { ApiType } from '../types/api'
 import type { ReplayFetchItemResult } from '../replay/protocol'
 import {
   REPLAY_IMPORT_QUEUE_META_ID,
+  REPLAY_IMPORT_STATUS_META_ID,
   __resetReplayImportForTests,
   drainReplayImportQueue,
   enqueueReplayHandId,
@@ -185,6 +186,30 @@ describe('replay import layer', () => {
       // 書きに行かないため）。取りこぼしではなく、次の機会に回るだけ。
       expect((await readReplayImportQueue(db)).map(entry => entry.handId)).toEqual([1220, 1221])
       expect(await db.replayDetails.count()).toBe(0)
+    })
+
+    /**
+     * Codexレビュー指摘（P1）: `break` が抜けるのは `for` だけなので、そのまま
+     * 進むと削除の最中に `meta` への書き込みへ行く。`deleteAllData()` は
+     * このドレインを待たないため、`db.delete()` と競合する。
+     */
+    test('長時間操作で中断したときは meta にも書かない', async () => {
+      let busy = false
+      const deps = depsOf({ isBusy: () => busy })
+      markSessionInactive()
+      await enqueueReplayHandId(deps, 1230, NOW)
+      const queueBefore = await db.meta.get(REPLAY_IMPORT_QUEUE_META_ID)
+
+      fetchImpl = async handIds => {
+        busy = true
+        return handIds.map(handId => ({ handId, ok: true, detail: detailOf(handId) }))
+      }
+      await drainReplayImportQueue(deps)
+
+      // キューのメタ行は触られていない（updatedAt も含めて同一）
+      expect(await db.meta.get(REPLAY_IMPORT_QUEUE_META_ID)).toEqual(queueBefore)
+      // 実行結果のメタ行も作られていない
+      expect(await db.meta.get(REPLAY_IMPORT_STATUS_META_ID)).toBeUndefined()
     })
 
     test('実験フラグがOFFなら積みも取得もしない', async () => {

--- a/src/background/replay-import.test.ts
+++ b/src/background/replay-import.test.ts
@@ -188,6 +188,33 @@ describe('replay import layer', () => {
       expect(await db.replayDetails.count()).toBe(0)
     })
 
+    // Codexレビュー指摘: 実行中のドレインに相乗りさせると、既に中断へ
+    // 向かっているドレインをそのまま返すだけになり、その契機（操作の終了・
+    // ポート接続）が消費されて再開しない。
+    test('実行中のドレインがあれば、もう1周だけ予約する', async () => {
+      const deps = depsOf()
+      markSessionInactive()
+      await enqueueReplayHandId(deps, 1240, NOW)
+
+      let release!: () => void
+      const gate = new Promise<void>(resolve => { release = resolve })
+      fetchImpl = async handIds => {
+        await gate
+        return handIds.map(handId => ({ handId, ok: true, detail: detailOf(handId) }))
+      }
+
+      const first = drainReplayImportQueue(deps)
+      // 1周目の実行中に、別の契機（操作の終了など）でもう一度呼ばれる
+      await enqueueReplayHandId(deps, 1241, NOW)
+      const second = drainReplayImportQueue(deps)
+      release()
+      await Promise.all([first, second])
+
+      // 予約された2周目が、1周目の後に積まれたHandIdを拾う
+      expect(fetchCalls).toEqual([[1240], [1241]])
+      expect(await readReplayImportQueue(db)).toEqual([])
+    })
+
     /**
      * Codexレビュー指摘（P1）: `break` が抜けるのは `for` だけなので、そのまま
      * 進むと削除の最中に `meta` への書き込みへ行く。`deleteAllData()` は

--- a/src/background/replay-import.ts
+++ b/src/background/replay-import.ts
@@ -50,6 +50,7 @@ import { isWithinReplayWindow } from '../replay/window'
 import { sanitizeReplayDetail } from '../replay/protocol'
 import { requestReplayDetails } from './replay-fetch-bridge'
 import { startKeepAlive } from './service-worker-keepalive'
+import { enqueuePendingStorageWrite } from './pending-storage-writes'
 import { getSessionActivity } from './update-manager'
 
 export const REPLAY_IMPORT_QUEUE_META_ID = 'replayImportQueue'
@@ -106,8 +107,32 @@ const EMPTY_STATUS: ReplayImportStatus = {
 /** キュー操作の直列化（read-modify-writeが互いを巻き戻さないように）。 */
 let queueMutation: Promise<void> = Promise.resolve()
 
+/**
+ * DBへの書き込みを、reload前のドレイン対象（共通FIFO）に載せたうえで、
+ * **書き込みの直前に**長時間操作の有無を同期的に確かめてから実行する。
+ *
+ * 二重の理由がある:
+ * - `deleteAllData()` はこのドレインを待たずに `db.delete()` する。判定と
+ *   書き込みの間にawaitがあると、その隙に削除が完了して、続く書き込みが
+ *   消えたDBを作り直す。await境界ごとに点検を足すのではなく、**書き込みの
+ *   直前**という1点に寄せる
+ * - forced update の reload commit point はこのFIFOを待つので、書き込みの
+ *   途中で `chrome.runtime.reload()` されない
+ */
+const guardedWrite = <T>(
+  deps: ReplayImportDeps,
+  write: () => Promise<T>
+): Promise<T | undefined> =>
+  enqueuePendingStorageWrite(async () => {
+    if (deps.isBusy?.()) return undefined
+    return write()
+  })
+
 /** 取得の直列化。並行に走らせると間隔制御が壊れる。 */
 let drainInFlight: Promise<void> | undefined
+
+/** 実行中のドレインの後ろに1周だけ予約されているか。 */
+let drainRerunRequested = false
 
 export interface ReplayImportDeps {
   db: PokerChaseDB
@@ -367,7 +392,24 @@ export const projectReplayDetailEvents = async (
  * - 認証エンベロープ不在などの再試行可能: キューへ残し、次の機会に回す
  */
 export const drainReplayImportQueue = async (deps: ReplayImportDeps): Promise<void> => {
-  if (drainInFlight) return drainInFlight
+  // 実行中のドレインに**相乗りさせない**（MUST）。相乗りさせると、既に
+  // 中断へ向かっているドレインをそのまま返すだけになり、その契機
+  // （操作の終了・ポート接続・セッション終了）が消費されて再開しない。
+  // 代わりに「もう1周だけ」を予約する。予約は多重化しない ―― 何周も
+  // 積む必要は無く、最後の1周が最新のキューを見る。
+  if (drainInFlight) {
+    if (!drainRerunRequested) {
+      drainRerunRequested = true
+      drainInFlight = drainInFlight
+        .catch(() => undefined)
+        .then(() => {
+          drainRerunRequested = false
+          return withKeepAlive(deps, () => drainOnce(deps))
+        })
+        .finally(() => { drainInFlight = undefined })
+    }
+    return drainInFlight
+  }
   const run = withKeepAlive(deps, () => drainOnce(deps))
     .finally(() => { drainInFlight = undefined })
   drainInFlight = run
@@ -505,7 +547,14 @@ const drainOnce = async (deps: ReplayImportDeps): Promise<void> => {
     // 応答が返らなかった（ポート切断・期限切れなど）ものは持ち越す。
     if (!result || result.handId !== entry.handId) continue
     if (result.ok) {
-      if (await storeReplayDetail(deps.db, entry.handId, result.detail, deps.now())) storedCount += 1
+      const wrote = await guardedWrite(deps, () =>
+        storeReplayDetail(deps.db, entry.handId, result.detail, deps.now()))
+      if (wrote === undefined) {
+        // 書き込みの直前に長時間操作が始まった。保存も決着もせず持ち越す。
+        aborted = true
+        break
+      }
+      if (wrote) storedCount += 1
       settled.add(entry.handId)
       continue
     }
@@ -541,10 +590,10 @@ const drainOnce = async (deps: ReplayImportDeps): Promise<void> => {
   }
 
   const deferred = queued.filter(entry => !settled.has(entry.handId)).length
-  await updateQueue(deps.db, deps.now(), current =>
+  await guardedWrite(deps, () => updateQueue(deps.db, deps.now(), current =>
     current.filter(entry => !settled.has(entry.handId))
-  )
-  await updateStatus(deps.db, deps.now(), current => ({
+  ))
+  await guardedWrite(deps, () => updateStatus(deps.db, deps.now(), current => ({
     ...current,
     lastRunAt: deps.now(),
     stored: current.stored + storedCount,
@@ -553,7 +602,7 @@ const drainOnce = async (deps: ReplayImportDeps): Promise<void> => {
     droppedBeforeRequest: current.droppedBeforeRequest + droppedBeforeRequest,
     deferred,
     ...lastError ? { lastError } : {}
-  }))
+  })))
 
   if (storedCount > 0 || expired > 0 || notFound > 0 || aborted) {
     console.info(
@@ -587,4 +636,5 @@ export const readReplayImportEnabled = async (): Promise<boolean> => {
 export const __resetReplayImportForTests = (): void => {
   queueMutation = Promise.resolve()
   drainInFlight = undefined
+  drainRerunRequested = false
 }

--- a/src/background/replay-import.ts
+++ b/src/background/replay-import.ts
@@ -529,6 +529,17 @@ const drainOnce = async (deps: ReplayImportDeps): Promise<void> => {
     if (!result.retryable) settled.add(entry.handId)
   }
 
+  // **長時間操作で中断したときは `meta` にも書かない**（MUST）。`break` が
+  // 抜けるのは `for` だけなので、そのまま進むと削除の最中に `updateQueue()` /
+  // `updateStatus()` が書き込みへ行く。`deleteAllData()` はこのドレインを
+  // 待たないため、`db.delete()` と競合してDexieがDBを作り直しうる。
+  // 中断時に落とすのは「この周回で分かったこと」だけで、キューの内容は
+  // 触っていないので次の機会にそのまま再開できる。
+  if (aborted && deps.isBusy?.()) {
+    console.info('[replay-import] 長時間操作の開始により中断しました（キューはそのまま）')
+    return
+  }
+
   const deferred = queued.filter(entry => !settled.has(entry.handId)).length
   await updateQueue(deps.db, deps.now(), current =>
     current.filter(entry => !settled.has(entry.handId))


### PR DESCRIPTION
#349 のレビューで出た2件。1件は #349 で私が入れた中断処理そのものの穴です。

- **P1 中断後の `meta` 書き込み**: `break` が抜けるのは `for` だけなので、そのまま進むと削除の最中に `updateQueue()` / `updateStatus()` が書き込みへ行きます。`deleteAllData()` はこのドレインを待たないため、`db.delete()` と競合してDexieがDBを作り直しうる。中断時に落とすのは「この周回で分かったこと」だけで、キューの内容は触っていないので次の機会にそのまま再開できます（テスト追加: メタ行が `updatedAt` まで含めて不変であること）
- **P2 操作終了時の再開**: `onOperationBecameIdle` で再ドレインします。無いと再開の契機が次の309/203かポート再接続だけになり、ページを開いたまま次の対局をしないユーザーのキューが3日の取得期限を越えて捨てられます

## 残り（別途）

#347 の2周目レビューのうち設計判断を伴うものは引き続き未着手です。#349 の説明にも書いた4件:

- **P1 タブ単位のセッション状態**（共有 `sessionActivity` は forced-update の安全性判定と共有しており、ポート単位化は影響範囲が広い）
- **P1 取得ポートとキューのアカウント紐付け**
- **P2 認証捕獲を再ドレインのトリガーにする**
- **P2 v7アップグレード時の既存90001行の射影**

## ゲート

`npm run typecheck` / `npm run test`: 174 suites / 1856 tests green

@codex review