### PR TITLE
docs: file-organization.mdをv8スキーマ(統計台帳)へ追随させる

### DIFF
--- a/docs/file-organization.md
+++ b/docs/file-organization.md
@@ -138,7 +138,7 @@
     │   └── release-info.ts    # Fixed GitHub Releases URL + unread storage key
     │
     ├── db/
-    │   └── poker-chase-db.ts  # Dexie database definition (v7 schema: sequence-key Lake + replayDetails)
+    │   └── poker-chase-db.ts  # Dexie database definition (v8 schema: sequence-key Lake + replayDetails + stats ledger)
     │
     ├── replay/                # Replay API shared code (page world + service worker)
     │   ├── protocol.ts        # Message/constant contract, ledger reader, credential stripping
@@ -160,6 +160,9 @@
     │   ├── index.ts           # Module exports
     │   ├── registry.ts        # Statistics registry (auto-discovery)
     │   ├── compactStats.ts    # Compact-line + classifier required-stat forcing
+    │   ├── stat-ledger.ts     # Persistent incremental stats ledger (v8 stores, pending-derivation fences)
+    │   ├── hand-contribution.ts       # Per-hand counter contributions for the ledger
+    │   ├── counter-stat-results.ts    # Stat results computed from ledger counter aggregates
     │   ├── helpers.ts         # Common helper functions
     │   ├── utils.ts           # Formatting utilities
     │   └── core/              # Statistic definitions


### PR DESCRIPTION
## 概要

PR #362 (perf(stats): HUD統計を永続増分台帳へ移行) で Dexie v8(`statHandContributions` / `statPlayerAggregates`)が追加されたが、`docs/file-organization.md` の `poker-chase-db.ts` 注記が v7 のまま残っていたのを追随させる。PR #317 のリベース中に気づき、diff スコープを保つため同PRからは意図的に外していたもの。

## 変更内容

- `poker-chase-db.ts` の注記を「v8 schema: sequence-key Lake + replayDetails + stats ledger」に更新
- 同PRで追加された `src/stats/` の台帳モジュール3件(`stat-ledger.ts` / `hand-contribution.ts` / `counter-stat-results.ts`)を一覧に追記(`pending-hand-derivation` は独立ファイルではなく `stat-ledger.ts` 内のため追記なし)

## 確認

- docs/ と AGENTS.md を grep し、他に stale な現行スキーマ参照がないことを確認済み。`docs/architecture.md` / `docs/replay-api.md` に残る v7 言及は「replayDetails は v7 で追加」という歴史的記述で正確なまま。AGENTS.md(`Tables (v8)`)と `docs/architecture.md`(`v8: 永続統計台帳`)は既に v8 を記載済み
- `npm run typecheck` パス(docs-only 変更)

🤖 Generated with [Claude Code](https://claude.com/claude-code)